### PR TITLE
Fix PHPStan issues after #5128

### DIFF
--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1219,9 +1219,9 @@ class WC_Stripe_Helper {
 			return true;
 		}
 
-		$subscriptions_available = class_exists( 'WC_Subscriptions_Product' ) && method_exists( 'WC_Subscriptions_Product', 'is_subscription' ); // @phpstan-ignore function.impossibleType
-		$pre_orders_available    = class_exists( 'WC_Pre_Orders_Product' ) && method_exists( 'WC_Pre_Orders_Product', 'product_is_charged_upon_release' ); // @phpstan-ignore function.impossibleType
-		$deposits_available      = class_exists( 'WC_Deposits_Product_Manager' ) && method_exists( 'WC_Deposits_Product_Manager', 'deposits_enabled' ); // @phpstan-ignore function.impossibleType
+		$subscriptions_available = class_exists( 'WC_Subscriptions_Product' ) && method_exists( 'WC_Subscriptions_Product', 'is_subscription' );
+		$pre_orders_available    = class_exists( 'WC_Pre_Orders_Product' ) && method_exists( 'WC_Pre_Orders_Product', 'product_is_charged_upon_release' );
+		$deposits_available      = class_exists( 'WC_Deposits_Product_Manager' ) && method_exists( 'WC_Deposits_Product_Manager', 'deposits_enabled' );
 
 		// Use a single loop over cart items to check all cases where adaptive pricing is unsupported:
 		// subscriptions, pre-orders charged upon release, and deposits.
@@ -1233,17 +1233,17 @@ class WC_Stripe_Helper {
 			}
 
 			// Subscriptions are not supported with adaptive pricing.
-			if ( $subscriptions_available && WC_Subscriptions_Product::is_subscription( $product ) ) { // @phpstan-ignore class.notFound (guarded by class_exists() and method_exists() checks above)
+			if ( $subscriptions_available && WC_Subscriptions_Product::is_subscription( $product ) ) {
 				return false;
 			}
 
 			// Pre-order (charge upon release) is not supported with adaptive pricing.
-			if ( $pre_orders_available && WC_Pre_Orders_Product::product_is_charged_upon_release( $product ) ) { // @phpstan-ignore class.notFound (guarded by class_exists() and method_exists() checks above)
+			if ( $pre_orders_available && WC_Pre_Orders_Product::product_is_charged_upon_release( $product ) ) {
 				return false;
 			}
 
 			// Deposits are not supported with adaptive pricing.
-			if ( $deposits_available && WC_Deposits_Product_Manager::deposits_enabled( $product->get_id() ) && ! empty( $cart_item['is_deposit'] ) ) { // @phpstan-ignore class.notFound (guarded by class_exists() and method_exists() checks above)
+			if ( $deposits_available && WC_Deposits_Product_Manager::deposits_enabled( $product->get_id() ) && ! empty( $cart_item['is_deposit'] ) ) {
 				return false;
 			}
 		}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -457,32 +457,26 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Call to static method cart_contains_switches\(\) on an unknown class WC_Subscriptions_Switcher\.$#'
-			identifier: class.notFound
-			count: 2
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Call to static method get_interval\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Pre_Orders_Product\:\:product_is_charged_upfront\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Call to static method get_period\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Call to static method get_price\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Call to static method update_payment_method\(\) on an unknown class WC_Subscriptions_Change_Payment_Gateway\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
@@ -673,8 +667,8 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Function wcs_get_subscription not found\.$#'
-			identifier: function.notFound
+			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
@@ -783,6 +777,12 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Payment_Gateway\:\:get_upe_enabled_payment_method_ids\(\) has parameter \$force_refresh with no type specified\.$#'
 			identifier: missingType.parameter
+			count: 1
+			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
+
+		-
+			message: '#^Method WC_Stripe_Payment_Gateway\:\:is_changing_payment_method_for_subscription\(\) should return bool but returns bool\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
@@ -1003,6 +1003,12 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
+			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
+
+		-
 			message: '#^Parameter \#1 \$order of method WC_Payment_Gateway\:\:get_return_url\(\) expects WC_Order\|null, bool\|WC_Order\|WC_Order_Refund given\.$#'
 			identifier: argument.type
 			count: 1
@@ -1135,6 +1141,12 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
+			message: '#^Parameter \#1 \$product of static method WC_Pre_Orders_Product\:\:product_is_charged_upon_release\(\) expects WC_Product, object given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
+
+		-
 			message: '#^Parameter \#1 \$response of method WC_Stripe_Payment_Gateway\:\:get_localized_error_message_from_response\(\) expects stdClass, WP_Error given\.$#'
 			identifier: argument.type
 			count: 1
@@ -1240,6 +1252,12 @@ parameters:
 			message: '#^Parameter \#2 \$value of method WC_Data\:\:update_meta_data\(\) expects array\|string, int\<301, max\> given\.$#'
 			identifier: argument.type
 			count: 2
+			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
+
+		-
+			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
+			identifier: arguments.count
+			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
@@ -1639,12 +1657,6 @@ parameters:
 			path: includes/admin/class-wc-stripe-admin-notices.php
 
 		-
-			message: '#^Function wcs_get_subscription not found\.$#'
-			identifier: function.notFound
-			count: 2
-			path: includes/admin/class-wc-stripe-admin-notices.php
-
-		-
 			message: '#^Parameter \#1 \$nonce of function wp_verify_nonce expects string, array\|string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -1747,6 +1759,12 @@ parameters:
 			path: includes/admin/class-wc-stripe-privacy.php
 
 		-
+			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/admin/class-wc-stripe-privacy.php
+
+		-
 			message: '#^Parameter \#1 \$order of method WC_Stripe_Privacy\:\:maybe_handle_order\(\) expects WC_Order, bool\|WC_Order\|WC_Order_Refund given\.$#'
 			identifier: argument.type
 			count: 1
@@ -1843,12 +1861,6 @@ parameters:
 			path: includes/admin/class-wc-stripe-settings-controller.php
 
 		-
-			message: '#^Function wcs_get_subscription not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: includes/admin/class-wc-stripe-subscription-detached-bulk-action.php
-
-		-
 			message: '#^Variable \$this might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
@@ -1891,14 +1903,14 @@ parameters:
 			path: includes/class-wc-stripe-account.php
 
 		-
-			message: '#^Call to function method_exists\(\) with ''WCS_Staging'' and ''is_duplicate_site'' will always evaluate to false\.$#'
-			identifier: function.impossibleType
+			message: '#^Call to an undefined static method WC_Subscriptions\:\:is_duplicate_site\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/class-wc-stripe-api.php
 
 		-
-			message: '#^Call to function method_exists\(\) with ''WC_Subscriptions'' and ''is_duplicate_site'' will always evaluate to false\.$#'
-			identifier: function.impossibleType
+			message: '#^Call to function method_exists\(\) with ''WCS_Staging'' and ''is_duplicate_site'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: includes/class-wc-stripe-api.php
 
@@ -2383,6 +2395,24 @@ parameters:
 			path: includes/class-wc-stripe-helper.php
 
 		-
+			message: '#^Call to function method_exists\(\) with ''WC_Deposits_Product…'' and ''deposits_enabled'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: includes/class-wc-stripe-helper.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''WC_Pre_Orders…'' and ''product_is_charged…'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: includes/class-wc-stripe-helper.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''WC_Subscriptions…'' and ''is_subscription'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: includes/class-wc-stripe-helper.php
+
+		-
 			message: '#^Cannot call method get_status\(\) on WC_Order\|WC_Order_Refund\|true\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -2659,12 +2689,6 @@ parameters:
 			path: includes/class-wc-stripe-intent-controller.php
 
 		-
-			message: '#^Function wcs_get_subscription not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
 			message: '#^Method WC_Stripe_Intent_Controller\:\:create_and_confirm_payment_intent\(\) should return stdClass but returns array\|stdClass\.$#'
 			identifier: return.type
 			count: 1
@@ -2804,6 +2828,12 @@ parameters:
 
 		-
 			message: '#^Parameter \#2 \$redirect_url of method WC_Stripe_Intent_Controller\:\:handle_error\(\) expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/class-wc-stripe-intent-controller.php
+
+		-
+			message: '#^Parameter \#2 \$user of method WC_Stripe_UPE_Payment_Gateway\:\:create_token_from_setup_intent\(\) expects WP_User, WP_User\|false given\.$#'
 			identifier: argument.type
 			count: 1
 			path: includes/class-wc-stripe-intent-controller.php
@@ -4093,21 +4123,9 @@ parameters:
 			path: includes/compat/class-wc-stripe-subscriptions-helper.php
 
 		-
-			message: '#^Function wcs_get_subscriptions not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: includes/compat/class-wc-stripe-subscriptions-helper.php
-
-		-
 			message: '#^Call to sprintf contains 0 placeholders, 1 value given\.$#'
 			identifier: argument.sprintf
 			count: 2
-			path: includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
-
-		-
-			message: '#^Function wcs_get_subscription not found\.$#'
-			identifier: function.notFound
-			count: 1
 			path: includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
 
 		-
@@ -4312,12 +4330,6 @@ parameters:
 			message: '#^Cannot access offset ''pending'' on non\-empty\-array\|true\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
-			path: includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
-
-		-
-			message: '#^Function wcs_get_subscription not found\.$#'
-			identifier: function.notFound
-			count: 1
 			path: includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
 
 		-
@@ -4627,8 +4639,38 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
 
 		-
-			message: '#^Call to function method_exists\(\) with ''WC_Subscriptions…'' and ''get_recurring…'' will always evaluate to false\.$#'
-			identifier: function.impossibleType
+			message: '#^Call to an undefined static method WC_Deposits_Product_Manager\:\:get_deposit_amount\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+
+		-
+			message: '#^Call to an undefined static method WC_Deposits_Product_Manager\:\:get_deposit_selected_type\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+
+		-
+			message: '#^Call to an undefined static method WC_Deposits_Product_Manager\:\:get_deposit_type\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+
+		-
+			message: '#^Call to an undefined static method WC_Pre_Orders_Product\:\:product_is_charged_upfront\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+
+		-
+			message: '#^Call to an undefined static method WC_Subscriptions_Cart\:\:get_recurring_shipping_package_key\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+
+		-
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_sign_up_fee\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
 
@@ -4748,6 +4790,12 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$product of method WC_Stripe_Express_Checkout_Helper\:\:is_pre_order_product_charged_upon_release\(\) expects object, object\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+
+		-
+			message: '#^Parameter \#1 \$product of static method WC_Pre_Orders_Product\:\:product_is_charged_upon_release\(\) expects WC_Product, object given\.$#'
 			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -5983,32 +6031,20 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
 
 		-
-			message: '#^Call to static method cart_contains_switches\(\) on an unknown class WC_Subscriptions_Switcher\.$#'
-			identifier: class.notFound
-			count: 2
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
-
-		-
-			message: '#^Call to static method get_interval\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
 
 		-
-			message: '#^Call to static method get_period\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
 
 		-
-			message: '#^Call to static method get_price\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
-
-		-
-			message: '#^Call to static method update_payment_method\(\) on an unknown class WC_Subscriptions_Change_Payment_Gateway\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
 
@@ -6019,8 +6055,14 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
 
 		-
-			message: '#^Function wcs_get_subscription not found\.$#'
-			identifier: function.notFound
+			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
+
+		-
+			message: '#^Method WC_Stripe_UPE_Payment_Method_ACH\:\:is_changing_payment_method_for_subscription\(\) should return bool but returns bool\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
 
@@ -6033,6 +6075,12 @@ parameters:
 		-
 			message: '#^PHPDoc tag @extends has invalid value \(WC_Stripe_UPE_Payment_Method\)\: Unexpected token "\\n ", expected ''\<'' at offset 111 on line 4$#'
 			identifier: phpDoc.parseError
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
+
+		-
+			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
 
@@ -6099,6 +6147,12 @@ parameters:
 		-
 			message: '#^Return type \(WC_Payment_Token_ACH\|null\) of method WC_Stripe_UPE_Payment_Method_ACH\:\:create_payment_token_for_user\(\) should be compatible with return type \(WC_Payment_Token_SEPA\) of method WC_Stripe_UPE_Payment_Method\:\:create_payment_token_for_user\(\)$#'
 			identifier: method.childReturnType
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
+
+		-
+			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
+			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
 
@@ -6331,32 +6385,20 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
 
 		-
-			message: '#^Call to static method cart_contains_switches\(\) on an unknown class WC_Subscriptions_Switcher\.$#'
-			identifier: class.notFound
-			count: 2
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
-
-		-
-			message: '#^Call to static method get_interval\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
 
 		-
-			message: '#^Call to static method get_period\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
 
 		-
-			message: '#^Call to static method get_price\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
-
-		-
-			message: '#^Call to static method update_payment_method\(\) on an unknown class WC_Subscriptions_Change_Payment_Gateway\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
 
@@ -6367,14 +6409,26 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
 
 		-
-			message: '#^Function wcs_get_subscription not found\.$#'
-			identifier: function.notFound
+			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
+
+		-
+			message: '#^Method WC_Stripe_UPE_Payment_Method_ACSS\:\:is_changing_payment_method_for_subscription\(\) should return bool but returns bool\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
 
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_ACSS\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
+
+		-
+			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
 
@@ -6441,6 +6495,12 @@ parameters:
 		-
 			message: '#^Return type \(WC_Payment_Token_ACSS\|null\) of method WC_Stripe_UPE_Payment_Method_ACSS\:\:create_payment_token_for_user\(\) should be compatible with return type \(WC_Payment_Token_SEPA\) of method WC_Stripe_UPE_Payment_Method\:\:create_payment_token_for_user\(\)$#'
 			identifier: method.childReturnType
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
+
+		-
+			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
+			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
 
@@ -6679,32 +6739,20 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
 
 		-
-			message: '#^Call to static method cart_contains_switches\(\) on an unknown class WC_Subscriptions_Switcher\.$#'
-			identifier: class.notFound
-			count: 2
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
-
-		-
-			message: '#^Call to static method get_interval\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
 
 		-
-			message: '#^Call to static method get_period\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
 
 		-
-			message: '#^Call to static method get_price\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
-
-		-
-			message: '#^Call to static method update_payment_method\(\) on an unknown class WC_Subscriptions_Change_Payment_Gateway\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
 
@@ -6715,14 +6763,26 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
 
 		-
-			message: '#^Function wcs_get_subscription not found\.$#'
-			identifier: function.notFound
+			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
+
+		-
+			message: '#^Method WC_Stripe_UPE_Payment_Method_Amazon_Pay\:\:is_changing_payment_method_for_subscription\(\) should return bool but returns bool\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
 
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Amazon_Pay\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
+
+		-
+			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
 
@@ -6789,6 +6849,12 @@ parameters:
 		-
 			message: '#^Return type \(WC_Payment_Token_Amazon_Pay\) of method WC_Stripe_UPE_Payment_Method_Amazon_Pay\:\:create_payment_token_for_user\(\) should be compatible with return type \(WC_Payment_Token_SEPA\) of method WC_Stripe_UPE_Payment_Method\:\:create_payment_token_for_user\(\)$#'
 			identifier: method.childReturnType
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
+
+		-
+			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
+			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
 
@@ -7027,32 +7093,20 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
 
 		-
-			message: '#^Call to static method cart_contains_switches\(\) on an unknown class WC_Subscriptions_Switcher\.$#'
-			identifier: class.notFound
-			count: 2
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
-
-		-
-			message: '#^Call to static method get_interval\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
 
 		-
-			message: '#^Call to static method get_period\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
 
 		-
-			message: '#^Call to static method get_price\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
-
-		-
-			message: '#^Call to static method update_payment_method\(\) on an unknown class WC_Subscriptions_Change_Payment_Gateway\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
 
@@ -7069,14 +7123,26 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
 
 		-
-			message: '#^Function wcs_get_subscription not found\.$#'
-			identifier: function.notFound
+			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+
+		-
+			message: '#^Method WC_Stripe_UPE_Payment_Method_Bacs_Debit\:\:is_changing_payment_method_for_subscription\(\) should return bool but returns bool\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
 
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Bacs_Debit\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+
+		-
+			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
 
@@ -7137,6 +7203,12 @@ parameters:
 		-
 			message: '#^Property WC_Stripe_UPE_Payment_Method\:\:\$stripe_id \(string\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+
+		-
+			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
+			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
 
@@ -7369,32 +7441,20 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
 
 		-
-			message: '#^Call to static method cart_contains_switches\(\) on an unknown class WC_Subscriptions_Switcher\.$#'
-			identifier: class.notFound
-			count: 2
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
-
-		-
-			message: '#^Call to static method get_interval\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
 
 		-
-			message: '#^Call to static method get_period\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
 
 		-
-			message: '#^Call to static method get_price\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
-
-		-
-			message: '#^Call to static method update_payment_method\(\) on an unknown class WC_Subscriptions_Change_Payment_Gateway\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
 
@@ -7405,14 +7465,26 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
 
 		-
-			message: '#^Function wcs_get_subscription not found\.$#'
-			identifier: function.notFound
+			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
+
+		-
+			message: '#^Method WC_Stripe_UPE_Payment_Method_Bancontact\:\:is_changing_payment_method_for_subscription\(\) should return bool but returns bool\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
 
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Bancontact\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
+
+		-
+			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
 
@@ -7473,6 +7545,12 @@ parameters:
 		-
 			message: '#^Property WC_Stripe_UPE_Payment_Method\:\:\$stripe_id \(string\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
+
+		-
+			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
+			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
 
@@ -7705,32 +7783,20 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
 
 		-
-			message: '#^Call to static method cart_contains_switches\(\) on an unknown class WC_Subscriptions_Switcher\.$#'
-			identifier: class.notFound
-			count: 2
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
-
-		-
-			message: '#^Call to static method get_interval\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
 
 		-
-			message: '#^Call to static method get_period\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
 
 		-
-			message: '#^Call to static method get_price\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
-
-		-
-			message: '#^Call to static method update_payment_method\(\) on an unknown class WC_Subscriptions_Change_Payment_Gateway\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
 
@@ -7741,8 +7807,14 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
 
 		-
-			message: '#^Function wcs_get_subscription not found\.$#'
-			identifier: function.notFound
+			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
+
+		-
+			message: '#^Method WC_Stripe_UPE_Payment_Method_Becs_Debit\:\:is_changing_payment_method_for_subscription\(\) should return bool but returns bool\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
 
@@ -7755,6 +7827,12 @@ parameters:
 		-
 			message: '#^PHPDoc tag @extends has invalid value \(WC_Stripe_UPE_Payment_Method\)\: Unexpected token "\\n ", expected ''\<'' at offset 112 on line 4$#'
 			identifier: phpDoc.parseError
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
+
+		-
+			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
 
@@ -7821,6 +7899,12 @@ parameters:
 		-
 			message: '#^Return type \(WC_Payment_Token_Becs_Debit\|null\) of method WC_Stripe_UPE_Payment_Method_Becs_Debit\:\:create_payment_token_for_user\(\) should be compatible with return type \(WC_Payment_Token_SEPA\) of method WC_Stripe_UPE_Payment_Method\:\:create_payment_token_for_user\(\)$#'
 			identifier: method.childReturnType
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
+
+		-
+			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
+			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
 
@@ -8071,32 +8155,20 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
 
 		-
-			message: '#^Call to static method cart_contains_switches\(\) on an unknown class WC_Subscriptions_Switcher\.$#'
-			identifier: class.notFound
-			count: 2
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
-
-		-
-			message: '#^Call to static method get_interval\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
 
 		-
-			message: '#^Call to static method get_period\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
 
 		-
-			message: '#^Call to static method get_price\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
-
-		-
-			message: '#^Call to static method update_payment_method\(\) on an unknown class WC_Subscriptions_Change_Payment_Gateway\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
 
@@ -8107,14 +8179,26 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
 
 		-
-			message: '#^Function wcs_get_subscription not found\.$#'
-			identifier: function.notFound
+			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
+
+		-
+			message: '#^Method WC_Stripe_UPE_Payment_Method_Cash_App_Pay\:\:is_changing_payment_method_for_subscription\(\) should return bool but returns bool\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
 
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Cash_App_Pay\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
+
+		-
+			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
 
@@ -8175,6 +8259,12 @@ parameters:
 		-
 			message: '#^Property WC_Stripe_UPE_Payment_Method\:\:\$stripe_id \(string\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
+
+		-
+			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
+			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
 
@@ -8413,32 +8503,20 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
 
 		-
-			message: '#^Call to static method cart_contains_switches\(\) on an unknown class WC_Subscriptions_Switcher\.$#'
-			identifier: class.notFound
-			count: 2
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
-
-		-
-			message: '#^Call to static method get_interval\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
 
 		-
-			message: '#^Call to static method get_period\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
 
 		-
-			message: '#^Call to static method get_price\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
-
-		-
-			message: '#^Call to static method update_payment_method\(\) on an unknown class WC_Subscriptions_Change_Payment_Gateway\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
 
@@ -8449,14 +8527,26 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
 
 		-
-			message: '#^Function wcs_get_subscription not found\.$#'
-			identifier: function.notFound
+			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
+
+		-
+			message: '#^Method WC_Stripe_UPE_Payment_Method_CC\:\:is_changing_payment_method_for_subscription\(\) should return bool but returns bool\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
 
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_CC\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
+
+		-
+			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
 
@@ -8535,6 +8625,12 @@ parameters:
 		-
 			message: '#^Return type \(WC_Stripe_Payment_Token_CC\) of method WC_Stripe_UPE_Payment_Method_CC\:\:create_payment_token_for_user\(\) should be compatible with return type \(WC_Payment_Token_SEPA\) of method WC_Stripe_UPE_Payment_Method\:\:create_payment_token_for_user\(\)$#'
 			identifier: method.childReturnType
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
+
+		-
+			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
+			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
 
@@ -8767,32 +8863,20 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
 
 		-
-			message: '#^Call to static method cart_contains_switches\(\) on an unknown class WC_Subscriptions_Switcher\.$#'
-			identifier: class.notFound
-			count: 2
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
-
-		-
-			message: '#^Call to static method get_interval\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
 
 		-
-			message: '#^Call to static method get_period\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
 
 		-
-			message: '#^Call to static method get_price\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
-
-		-
-			message: '#^Call to static method update_payment_method\(\) on an unknown class WC_Subscriptions_Change_Payment_Gateway\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
 
@@ -8803,14 +8887,26 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
 
 		-
-			message: '#^Function wcs_get_subscription not found\.$#'
-			identifier: function.notFound
+			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
+
+		-
+			message: '#^Method WC_Stripe_UPE_Payment_Method_Ideal\:\:is_changing_payment_method_for_subscription\(\) should return bool but returns bool\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
 
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Ideal\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
+
+		-
+			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
 
@@ -8871,6 +8967,12 @@ parameters:
 		-
 			message: '#^Property WC_Stripe_UPE_Payment_Method\:\:\$stripe_id \(string\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
+
+		-
+			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
+			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
 
@@ -9103,32 +9205,20 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
 
 		-
-			message: '#^Call to static method cart_contains_switches\(\) on an unknown class WC_Subscriptions_Switcher\.$#'
-			identifier: class.notFound
-			count: 2
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
-
-		-
-			message: '#^Call to static method get_interval\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
 
 		-
-			message: '#^Call to static method get_period\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
 
 		-
-			message: '#^Call to static method get_price\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
-
-		-
-			message: '#^Call to static method update_payment_method\(\) on an unknown class WC_Subscriptions_Change_Payment_Gateway\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
 
@@ -9139,14 +9229,26 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
 
 		-
-			message: '#^Function wcs_get_subscription not found\.$#'
-			identifier: function.notFound
+			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
+
+		-
+			message: '#^Method WC_Stripe_UPE_Payment_Method_Klarna\:\:is_changing_payment_method_for_subscription\(\) should return bool but returns bool\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
 
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Klarna\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
+
+		-
+			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
 
@@ -9207,6 +9309,12 @@ parameters:
 		-
 			message: '#^Property WC_Stripe_UPE_Payment_Method\:\:\$stripe_id \(string\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
+
+		-
+			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
+			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
 
@@ -9493,32 +9601,20 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
 
 		-
-			message: '#^Call to static method cart_contains_switches\(\) on an unknown class WC_Subscriptions_Switcher\.$#'
-			identifier: class.notFound
-			count: 2
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
-
-		-
-			message: '#^Call to static method get_interval\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
 
 		-
-			message: '#^Call to static method get_period\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
 
 		-
-			message: '#^Call to static method get_price\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
-
-		-
-			message: '#^Call to static method update_payment_method\(\) on an unknown class WC_Subscriptions_Change_Payment_Gateway\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
 
@@ -9541,14 +9637,26 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
 
 		-
-			message: '#^Function wcs_get_subscription not found\.$#'
-			identifier: function.notFound
+			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
+
+		-
+			message: '#^Method WC_Stripe_UPE_Payment_Method_OC\:\:is_changing_payment_method_for_subscription\(\) should return bool but returns bool\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
 
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_OC\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
+
+		-
+			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
 
@@ -9615,6 +9723,12 @@ parameters:
 		-
 			message: '#^Property WC_Stripe_UPE_Payment_Method\:\:\$stripe_id \(string\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
+
+		-
+			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
+			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
 
@@ -9853,32 +9967,20 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
 
 		-
-			message: '#^Call to static method cart_contains_switches\(\) on an unknown class WC_Subscriptions_Switcher\.$#'
-			identifier: class.notFound
-			count: 2
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
-
-		-
-			message: '#^Call to static method get_interval\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
 
 		-
-			message: '#^Call to static method get_period\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
 
 		-
-			message: '#^Call to static method get_price\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
-
-		-
-			message: '#^Call to static method update_payment_method\(\) on an unknown class WC_Subscriptions_Change_Payment_Gateway\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
 
@@ -9889,8 +9991,14 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
 
 		-
-			message: '#^Function wcs_get_subscription not found\.$#'
-			identifier: function.notFound
+			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
+
+		-
+			message: '#^Method WC_Stripe_UPE_Payment_Method_Sepa\:\:is_changing_payment_method_for_subscription\(\) should return bool but returns bool\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
 
@@ -9903,6 +10011,12 @@ parameters:
 		-
 			message: '#^PHPDoc tag @param references unknown parameter\: \$token_service$#'
 			identifier: parameter.notFound
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
+
+		-
+			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
 
@@ -9963,6 +10077,12 @@ parameters:
 		-
 			message: '#^Property WC_Stripe_UPE_Payment_Method\:\:\$stripe_id \(string\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
+
+		-
+			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
+			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
 
@@ -10195,32 +10315,20 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
 
 		-
-			message: '#^Call to static method cart_contains_switches\(\) on an unknown class WC_Subscriptions_Switcher\.$#'
-			identifier: class.notFound
-			count: 2
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
-
-		-
-			message: '#^Call to static method get_interval\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
 
 		-
-			message: '#^Call to static method get_period\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
 
 		-
-			message: '#^Call to static method get_price\(\) on an unknown class WC_Subscriptions_Product\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
-
-		-
-			message: '#^Call to static method update_payment_method\(\) on an unknown class WC_Subscriptions_Change_Payment_Gateway\.$#'
-			identifier: class.notFound
+			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
 
@@ -10231,14 +10339,26 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
 
 		-
-			message: '#^Function wcs_get_subscription not found\.$#'
-			identifier: function.notFound
+			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
+
+		-
+			message: '#^Method WC_Stripe_UPE_Payment_Method_Sofort\:\:is_changing_payment_method_for_subscription\(\) should return bool but returns bool\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
 
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Sofort\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
+
+		-
+			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
 
@@ -10303,6 +10423,12 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
 
 		-
+			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
+
+		-
 			message: '#^Variable \$order_helper in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.variable
 			count: 1
@@ -10329,6 +10455,12 @@ parameters:
 		-
 			message: '#^Call to an undefined method WC_Stripe_UPE_Payment_Method\:\:is_automatic_capture_enabled\(\)\.$#'
 			identifier: method.notFound
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
+
+		-
+			message: '#^Call to an undefined static method WC_Pre_Orders_Product\:\:product_is_charged_upfront\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
 
@@ -10381,6 +10513,12 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
 
 		-
+			message: '#^Method WC_Stripe_UPE_Payment_Method\:\:is_changing_payment_method_for_subscription\(\) should return bool but returns bool\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
+
+		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method\:\:process_payment\(\) should return array but returns array\|null\.$#'
 			identifier: return.type
 			count: 1
@@ -10406,6 +10544,12 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$order_id of method WC_Stripe_UPE_Payment_Method\:\:get_pre_order_product_from_order\(\) expects int, WC_Order given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
+
+		-
+			message: '#^Parameter \#1 \$product of static method WC_Pre_Orders_Product\:\:product_is_charged_upon_release\(\) expects WC_Product, object given\.$#'
 			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -457,30 +457,6 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Call to an undefined static method WC_Pre_Orders_Product\:\:product_is_charged_upfront\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
 			message: '#^Cannot access property \$client_secret on array\|stdClass\.$#'
 			identifier: property.nonObject
 			count: 1
@@ -663,12 +639,6 @@ parameters:
 		-
 			message: '#^Cannot call method update_status\(\) on WC_Order\|WC_Order_Refund\|true\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
@@ -1003,12 +973,6 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
 			message: '#^Parameter \#1 \$order of method WC_Payment_Gateway\:\:get_return_url\(\) expects WC_Order\|null, bool\|WC_Order\|WC_Order_Refund given\.$#'
 			identifier: argument.type
 			count: 1
@@ -1141,12 +1105,6 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Parameter \#1 \$product of static method WC_Pre_Orders_Product\:\:product_is_charged_upon_release\(\) expects WC_Product, object given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
 			message: '#^Parameter \#1 \$response of method WC_Stripe_Payment_Gateway\:\:get_localized_error_message_from_response\(\) expects stdClass, WP_Error given\.$#'
 			identifier: argument.type
 			count: 1
@@ -1207,6 +1165,12 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
+			message: '#^Parameter \#1 \$total of static method WC_Stripe_Helper\:\:get_stripe_amount\(\) expects float, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
+
+		-
 			message: '#^Parameter \#1 \$user_id of class WC_Stripe_Customer constructor expects int, string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -1252,12 +1216,6 @@ parameters:
 			message: '#^Parameter \#2 \$value of method WC_Data\:\:update_meta_data\(\) expects array\|string, int\<301, max\> given\.$#'
 			identifier: argument.type
 			count: 2
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
-			identifier: arguments.count
-			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
@@ -1759,12 +1717,6 @@ parameters:
 			path: includes/admin/class-wc-stripe-privacy.php
 
 		-
-			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/admin/class-wc-stripe-privacy.php
-
-		-
 			message: '#^Parameter \#1 \$order of method WC_Stripe_Privacy\:\:maybe_handle_order\(\) expects WC_Order, bool\|WC_Order\|WC_Order_Refund given\.$#'
 			identifier: argument.type
 			count: 1
@@ -1903,13 +1855,13 @@ parameters:
 			path: includes/class-wc-stripe-account.php
 
 		-
-			message: '#^Call to an undefined static method WC_Subscriptions\:\:is_duplicate_site\(\)\.$#'
-			identifier: staticMethod.notFound
+			message: '#^Call to function method_exists\(\) with ''WCS_Staging'' and ''is_duplicate_site'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: includes/class-wc-stripe-api.php
 
 		-
-			message: '#^Call to function method_exists\(\) with ''WCS_Staging'' and ''is_duplicate_site'' will always evaluate to true\.$#'
+			message: '#^Call to function method_exists\(\) with ''WC_Subscriptions'' and ''is_duplicate_site'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: includes/class-wc-stripe-api.php
@@ -4639,38 +4591,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
 
 		-
-			message: '#^Call to an undefined static method WC_Deposits_Product_Manager\:\:get_deposit_amount\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Call to an undefined static method WC_Deposits_Product_Manager\:\:get_deposit_selected_type\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Call to an undefined static method WC_Deposits_Product_Manager\:\:get_deposit_type\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Call to an undefined static method WC_Pre_Orders_Product\:\:product_is_charged_upfront\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Cart\:\:get_recurring_shipping_package_key\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_sign_up_fee\(\)\.$#'
-			identifier: staticMethod.notFound
+			message: '#^Call to function method_exists\(\) with ''WC_Subscriptions…'' and ''get_recurring…'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
 
@@ -4790,12 +4712,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$product of method WC_Stripe_Express_Checkout_Helper\:\:is_pre_order_product_charged_upon_release\(\) expects object, object\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Parameter \#1 \$product of static method WC_Pre_Orders_Product\:\:product_is_charged_upon_release\(\) expects WC_Product, object given\.$#'
 			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -6031,32 +5947,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
 
 		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
-
-		-
 			message: '#^Cannot call method save\(\) on bool\|WC_Order\|WC_Order_Refund\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
-
-		-
-			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
 
@@ -6075,12 +5967,6 @@ parameters:
 		-
 			message: '#^PHPDoc tag @extends has invalid value \(WC_Stripe_UPE_Payment_Method\)\: Unexpected token "\\n ", expected ''\<'' at offset 111 on line 4$#'
 			identifier: phpDoc.parseError
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
-
-		-
-			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
-			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
 
@@ -6121,6 +6007,12 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
 
 		-
+			message: '#^Parameter \#1 \$total of static method WC_Stripe_Helper\:\:get_stripe_amount\(\) expects float, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
+
+		-
 			message: '#^Parameter \#2 \$callback of function add_filter expects callable\(\)\: mixed, array\{\$this\(WC_Stripe_UPE_Payment_Method_ACH\), ''change_idempotency…''\} given\.$#'
 			identifier: argument.type
 			count: 1
@@ -6147,12 +6039,6 @@ parameters:
 		-
 			message: '#^Return type \(WC_Payment_Token_ACH\|null\) of method WC_Stripe_UPE_Payment_Method_ACH\:\:create_payment_token_for_user\(\) should be compatible with return type \(WC_Payment_Token_SEPA\) of method WC_Stripe_UPE_Payment_Method\:\:create_payment_token_for_user\(\)$#'
 			identifier: method.childReturnType
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
-
-		-
-			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
 
@@ -6385,32 +6271,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
 
 		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
-
-		-
 			message: '#^Cannot call method save\(\) on bool\|WC_Order\|WC_Order_Refund\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
-
-		-
-			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
 
@@ -6423,12 +6285,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_ACSS\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
-
-		-
-			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
-			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
 
@@ -6469,6 +6325,12 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
 
 		-
+			message: '#^Parameter \#1 \$total of static method WC_Stripe_Helper\:\:get_stripe_amount\(\) expects float, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
+
+		-
 			message: '#^Parameter \#2 \$callback of function add_filter expects callable\(\)\: mixed, array\{\$this\(WC_Stripe_UPE_Payment_Method_ACSS\), ''change_idempotency…''\} given\.$#'
 			identifier: argument.type
 			count: 1
@@ -6495,12 +6357,6 @@ parameters:
 		-
 			message: '#^Return type \(WC_Payment_Token_ACSS\|null\) of method WC_Stripe_UPE_Payment_Method_ACSS\:\:create_payment_token_for_user\(\) should be compatible with return type \(WC_Payment_Token_SEPA\) of method WC_Stripe_UPE_Payment_Method\:\:create_payment_token_for_user\(\)$#'
 			identifier: method.childReturnType
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
-
-		-
-			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
 
@@ -6739,32 +6595,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
 
 		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
-
-		-
 			message: '#^Cannot call method save\(\) on bool\|WC_Order\|WC_Order_Refund\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
-
-		-
-			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
 
@@ -6777,12 +6609,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Amazon_Pay\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
-
-		-
-			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
-			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
 
@@ -6823,6 +6649,12 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
 
 		-
+			message: '#^Parameter \#1 \$total of static method WC_Stripe_Helper\:\:get_stripe_amount\(\) expects float, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
+
+		-
 			message: '#^Parameter \#2 \$callback of function add_filter expects callable\(\)\: mixed, array\{\$this\(WC_Stripe_UPE_Payment_Method_Amazon_Pay\), ''change_idempotency…''\} given\.$#'
 			identifier: argument.type
 			count: 1
@@ -6849,12 +6681,6 @@ parameters:
 		-
 			message: '#^Return type \(WC_Payment_Token_Amazon_Pay\) of method WC_Stripe_UPE_Payment_Method_Amazon_Pay\:\:create_payment_token_for_user\(\) should be compatible with return type \(WC_Payment_Token_SEPA\) of method WC_Stripe_UPE_Payment_Method\:\:create_payment_token_for_user\(\)$#'
 			identifier: method.childReturnType
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
-
-		-
-			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
 
@@ -7093,24 +6919,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
 
 		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
-
-		-
 			message: '#^Cannot call method save\(\) on bool\|WC_Order\|WC_Order_Refund\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -7123,12 +6931,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
 
 		-
-			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Bacs_Debit\:\:is_changing_payment_method_for_subscription\(\) should return bool but returns bool\|null\.$#'
 			identifier: return.type
 			count: 1
@@ -7137,12 +6939,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Bacs_Debit\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
-
-		-
-			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
-			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
 
@@ -7183,6 +6979,12 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
 
 		-
+			message: '#^Parameter \#1 \$total of static method WC_Stripe_Helper\:\:get_stripe_amount\(\) expects float, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+
+		-
 			message: '#^Parameter \#2 \$callback of function add_filter expects callable\(\)\: mixed, array\{\$this\(WC_Stripe_UPE_Payment_Method_Bacs_Debit\), ''change_idempotency…''\} given\.$#'
 			identifier: argument.type
 			count: 1
@@ -7203,12 +7005,6 @@ parameters:
 		-
 			message: '#^Property WC_Stripe_UPE_Payment_Method\:\:\$stripe_id \(string\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
-
-		-
-			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
 
@@ -7441,32 +7237,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
 
 		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
-
-		-
 			message: '#^Cannot call method save\(\) on bool\|WC_Order\|WC_Order_Refund\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
-
-		-
-			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
 
@@ -7479,12 +7251,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Bancontact\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
-
-		-
-			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
-			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
 
@@ -7525,6 +7291,12 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
 
 		-
+			message: '#^Parameter \#1 \$total of static method WC_Stripe_Helper\:\:get_stripe_amount\(\) expects float, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
+
+		-
 			message: '#^Parameter \#2 \$callback of function add_filter expects callable\(\)\: mixed, array\{\$this\(WC_Stripe_UPE_Payment_Method_Bancontact\), ''change_idempotency…''\} given\.$#'
 			identifier: argument.type
 			count: 1
@@ -7545,12 +7317,6 @@ parameters:
 		-
 			message: '#^Property WC_Stripe_UPE_Payment_Method\:\:\$stripe_id \(string\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
-
-		-
-			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
 
@@ -7783,32 +7549,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
 
 		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
-
-		-
 			message: '#^Cannot call method save\(\) on bool\|WC_Order\|WC_Order_Refund\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
-
-		-
-			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
 
@@ -7827,12 +7569,6 @@ parameters:
 		-
 			message: '#^PHPDoc tag @extends has invalid value \(WC_Stripe_UPE_Payment_Method\)\: Unexpected token "\\n ", expected ''\<'' at offset 112 on line 4$#'
 			identifier: phpDoc.parseError
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
-
-		-
-			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
-			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
 
@@ -7873,6 +7609,12 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
 
 		-
+			message: '#^Parameter \#1 \$total of static method WC_Stripe_Helper\:\:get_stripe_amount\(\) expects float, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
+
+		-
 			message: '#^Parameter \#2 \$callback of function add_filter expects callable\(\)\: mixed, array\{\$this\(WC_Stripe_UPE_Payment_Method_Becs_Debit\), ''change_idempotency…''\} given\.$#'
 			identifier: argument.type
 			count: 1
@@ -7899,12 +7641,6 @@ parameters:
 		-
 			message: '#^Return type \(WC_Payment_Token_Becs_Debit\|null\) of method WC_Stripe_UPE_Payment_Method_Becs_Debit\:\:create_payment_token_for_user\(\) should be compatible with return type \(WC_Payment_Token_SEPA\) of method WC_Stripe_UPE_Payment_Method\:\:create_payment_token_for_user\(\)$#'
 			identifier: method.childReturnType
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
-
-		-
-			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
 
@@ -8155,32 +7891,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
 
 		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
-
-		-
 			message: '#^Cannot call method save\(\) on bool\|WC_Order\|WC_Order_Refund\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
-
-		-
-			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
 
@@ -8193,12 +7905,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Cash_App_Pay\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
-
-		-
-			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
-			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
 
@@ -8239,6 +7945,12 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
 
 		-
+			message: '#^Parameter \#1 \$total of static method WC_Stripe_Helper\:\:get_stripe_amount\(\) expects float, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
+
+		-
 			message: '#^Parameter \#2 \$callback of function add_filter expects callable\(\)\: mixed, array\{\$this\(WC_Stripe_UPE_Payment_Method_Cash_App_Pay\), ''change_idempotency…''\} given\.$#'
 			identifier: argument.type
 			count: 1
@@ -8259,12 +7971,6 @@ parameters:
 		-
 			message: '#^Property WC_Stripe_UPE_Payment_Method\:\:\$stripe_id \(string\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
-
-		-
-			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
 
@@ -8503,32 +8209,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
 
 		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
-
-		-
 			message: '#^Cannot call method save\(\) on bool\|WC_Order\|WC_Order_Refund\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
-
-		-
-			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
 
@@ -8541,12 +8223,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_CC\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
-
-		-
-			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
-			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
 
@@ -8582,6 +8258,12 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$order of method WC_Stripe_Order_Helper\:\:update_stripe_source_id\(\) expects WC_Order\|null, bool\|WC_Order\|WC_Order_Refund given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
+
+		-
+			message: '#^Parameter \#1 \$total of static method WC_Stripe_Helper\:\:get_stripe_amount\(\) expects float, string given\.$#'
 			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
@@ -8625,12 +8307,6 @@ parameters:
 		-
 			message: '#^Return type \(WC_Stripe_Payment_Token_CC\) of method WC_Stripe_UPE_Payment_Method_CC\:\:create_payment_token_for_user\(\) should be compatible with return type \(WC_Payment_Token_SEPA\) of method WC_Stripe_UPE_Payment_Method\:\:create_payment_token_for_user\(\)$#'
 			identifier: method.childReturnType
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
-
-		-
-			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
 
@@ -8863,32 +8539,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
 
 		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
-
-		-
 			message: '#^Cannot call method save\(\) on bool\|WC_Order\|WC_Order_Refund\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
-
-		-
-			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
 
@@ -8901,12 +8553,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Ideal\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
-
-		-
-			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
-			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
 
@@ -8947,6 +8593,12 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
 
 		-
+			message: '#^Parameter \#1 \$total of static method WC_Stripe_Helper\:\:get_stripe_amount\(\) expects float, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
+
+		-
 			message: '#^Parameter \#2 \$callback of function add_filter expects callable\(\)\: mixed, array\{\$this\(WC_Stripe_UPE_Payment_Method_Ideal\), ''change_idempotency…''\} given\.$#'
 			identifier: argument.type
 			count: 1
@@ -8967,12 +8619,6 @@ parameters:
 		-
 			message: '#^Property WC_Stripe_UPE_Payment_Method\:\:\$stripe_id \(string\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
-
-		-
-			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
 
@@ -9205,32 +8851,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
 
 		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
-
-		-
 			message: '#^Cannot call method save\(\) on bool\|WC_Order\|WC_Order_Refund\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
-
-		-
-			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
 
@@ -9243,12 +8865,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Klarna\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
-
-		-
-			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
-			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
 
@@ -9289,6 +8905,12 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
 
 		-
+			message: '#^Parameter \#1 \$total of static method WC_Stripe_Helper\:\:get_stripe_amount\(\) expects float, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
+
+		-
 			message: '#^Parameter \#2 \$callback of function add_filter expects callable\(\)\: mixed, array\{\$this\(WC_Stripe_UPE_Payment_Method_Klarna\), ''change_idempotency…''\} given\.$#'
 			identifier: argument.type
 			count: 1
@@ -9309,12 +8931,6 @@ parameters:
 		-
 			message: '#^Property WC_Stripe_UPE_Payment_Method\:\:\$stripe_id \(string\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
-
-		-
-			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
 
@@ -9601,24 +9217,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
 
 		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
-
-		-
 			message: '#^Cannot access property \$type on array\|stdClass\|true\.$#'
 			identifier: property.nonObject
 			count: 1
@@ -9637,12 +9235,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
 
 		-
-			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_OC\:\:is_changing_payment_method_for_subscription\(\) should return bool but returns bool\|null\.$#'
 			identifier: return.type
 			count: 1
@@ -9651,12 +9243,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_OC\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
-
-		-
-			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
-			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
 
@@ -9697,6 +9283,12 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
 
 		-
+			message: '#^Parameter \#1 \$total of static method WC_Stripe_Helper\:\:get_stripe_amount\(\) expects float, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
+
+		-
 			message: '#^Parameter \#2 \$callback of function add_filter expects callable\(\)\: mixed, array\{\$this\(WC_Stripe_UPE_Payment_Method_OC\), ''change_idempotency…''\} given\.$#'
 			identifier: argument.type
 			count: 1
@@ -9723,12 +9315,6 @@ parameters:
 		-
 			message: '#^Property WC_Stripe_UPE_Payment_Method\:\:\$stripe_id \(string\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
-
-		-
-			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
 
@@ -9967,32 +9553,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
 
 		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
-
-		-
 			message: '#^Cannot call method save\(\) on bool\|WC_Order\|WC_Order_Refund\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
-
-		-
-			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
 
@@ -10011,12 +9573,6 @@ parameters:
 		-
 			message: '#^PHPDoc tag @param references unknown parameter\: \$token_service$#'
 			identifier: parameter.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
-
-		-
-			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
-			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
 
@@ -10057,6 +9613,12 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
 
 		-
+			message: '#^Parameter \#1 \$total of static method WC_Stripe_Helper\:\:get_stripe_amount\(\) expects float, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
+
+		-
 			message: '#^Parameter \#2 \$callback of function add_filter expects callable\(\)\: mixed, array\{\$this\(WC_Stripe_UPE_Payment_Method_Sepa\), ''change_idempotency…''\} given\.$#'
 			identifier: argument.type
 			count: 1
@@ -10077,12 +9639,6 @@ parameters:
 		-
 			message: '#^Property WC_Stripe_UPE_Payment_Method\:\:\$stripe_id \(string\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
-
-		-
-			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
 
@@ -10315,32 +9871,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
 
 		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_interval\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_period\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
-
-		-
-			message: '#^Call to an undefined static method WC_Subscriptions_Product\:\:get_price\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
-
-		-
 			message: '#^Cannot call method save\(\) on bool\|WC_Order\|WC_Order_Refund\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
-
-		-
-			message: '#^Function wcs_get_subscriptions_for_order invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
 
@@ -10353,12 +9885,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Sofort\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
-
-		-
-			message: '#^Parameter \#1 \$order of function wcs_get_subscriptions_for_order expects WC_Order, int given\.$#'
-			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
 
@@ -10399,6 +9925,12 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
 
 		-
+			message: '#^Parameter \#1 \$total of static method WC_Stripe_Helper\:\:get_stripe_amount\(\) expects float, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
+
+		-
 			message: '#^Parameter \#2 \$callback of function add_filter expects callable\(\)\: mixed, array\{\$this\(WC_Stripe_UPE_Payment_Method_Sofort\), ''change_idempotency…''\} given\.$#'
 			identifier: argument.type
 			count: 1
@@ -10419,12 +9951,6 @@ parameters:
 		-
 			message: '#^Property WC_Stripe_UPE_Payment_Method\:\:\$stripe_id \(string\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
-
-		-
-			message: '#^Static method WC_Subscriptions_Change_Payment_Gateway\:\:update_payment_method\(\) invoked with 3 parameters, 2 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
 
@@ -10455,12 +9981,6 @@ parameters:
 		-
 			message: '#^Call to an undefined method WC_Stripe_UPE_Payment_Method\:\:is_automatic_capture_enabled\(\)\.$#'
 			identifier: method.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
-
-		-
-			message: '#^Call to an undefined static method WC_Pre_Orders_Product\:\:product_is_charged_upfront\(\)\.$#'
-			identifier: staticMethod.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
 
@@ -10544,12 +10064,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$order_id of method WC_Stripe_UPE_Payment_Method\:\:get_pre_order_product_from_order\(\) expects int, WC_Order given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
-
-		-
-			message: '#^Parameter \#1 \$product of static method WC_Pre_Orders_Product\:\:product_is_charged_upon_release\(\) expects WC_Product, object given\.$#'
 			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,6 +15,7 @@ parameters:
 		- vendor/php-stubs/woocommerce-stubs/woocommerce-packages-stubs.php
 	scanDirectories:
 		- phpstan-stubs
+		- tests/phpunit/helpers
 	treatPhpDocTypesAsCertain: false
 	parallel:
 		maximumNumberOfProcesses: 4

--- a/tests/phpunit/helpers/class-wc-deposits-product-manager.php
+++ b/tests/phpunit/helpers/class-wc-deposits-product-manager.php
@@ -32,4 +32,37 @@ class WC_Deposits_Product_Manager {
 	public static function deposits_enabled( $product_id ): bool {
 		return self::$deposits_enabled_result;
 	}
+
+	/**
+	 * Stub: get the deposit type for a product.
+	 *
+	 * @param int $product_id The product ID.
+	 * @return string
+	 */
+	public static function get_deposit_type( $product_id ): string {
+		return '';
+	}
+
+	/**
+	 * Stub: get the selected deposit type for a product.
+	 *
+	 * @param int $product_id The product ID.
+	 * @return string
+	 */
+	public static function get_deposit_selected_type( $product_id ): string {
+		return '';
+	}
+
+	/**
+	 * Stub: get the deposit amount for a product.
+	 *
+	 * @param mixed  $product      The product or product ID.
+	 * @param int    $plan_id      Optional plan ID.
+	 * @param string $context      Optional context.
+	 * @param mixed  $product_price Optional product price.
+	 * @return string
+	 */
+	public static function get_deposit_amount( $product = 0, $plan_id = 0, $context = '', $product_price = null ): string {
+		return '0';
+	}
 }

--- a/tests/phpunit/helpers/class-wc-pre-orders-product.php
+++ b/tests/phpunit/helpers/class-wc-pre-orders-product.php
@@ -30,10 +30,20 @@ class WC_Pre_Orders_Product {
 	/**
 	 * Determine if a product is charged upon release (pre-order).
 	 *
-	 * @param WC_Product $product The product to check.
+	 * @param WC_Product|object $product The product to check.
 	 * @return bool
 	 */
 	public static function product_is_charged_upon_release( $product ): bool {
 		return self::$product_is_charged_upon_release_result;
+	}
+
+	/**
+	 * Stub: determine if a product is charged upfront (pre-order).
+	 *
+	 * @param WC_Product|object $product The product to check.
+	 * @return bool
+	 */
+	public static function product_is_charged_upfront( $product ): bool {
+		return false;
 	}
 }

--- a/tests/phpunit/helpers/class-wc-subscriptions-cart.php
+++ b/tests/phpunit/helpers/class-wc-subscriptions-cart.php
@@ -38,4 +38,15 @@ class WC_Subscriptions_Cart {
 	public static function set_cart_contains_free_trial( $result ) {
 		self::$cart_contains_free_trial_result = $result;
 	}
+
+	/**
+	 * Stub: get the recurring shipping package key.
+	 *
+	 * @param string $package_key The package key.
+	 * @param int    $recurring_cart_key The recurring cart key.
+	 * @return string
+	 */
+	public static function get_recurring_shipping_package_key( $package_key = '', $recurring_cart_key = 0 ): string {
+		return $package_key;
+	}
 }

--- a/tests/phpunit/helpers/class-wc-subscriptions-change-payment-gateway.php
+++ b/tests/phpunit/helpers/class-wc-subscriptions-change-payment-gateway.php
@@ -11,7 +11,7 @@ class WC_Subscriptions_Change_Payment_Gateway {
 	 * @param WC_Subscription $subscription Subscription to update.
 	 * @param string          $gateway_id   Gateway ID.
 	 */
-	public static function update_payment_method( $subscription, $gateway_id ) {}
+	public static function update_payment_method( $subscription, $gateway_id, $token = null ) {}
 
 	/**
 	 * Stub: will_subscription_update_all_payment_methods.

--- a/tests/phpunit/helpers/class-wc-subscriptions-helpers.php
+++ b/tests/phpunit/helpers/class-wc-subscriptions-helpers.php
@@ -6,10 +6,11 @@
 /**
  * A function to mock wcs_get_subscriptions_for_order.
  *
- * @param WC_Order $order
+ * @param WC_Order|int $order  The order or order ID.
+ * @param array        $args   Optional arguments.
  * @return array
  */
-function wcs_get_subscriptions_for_order( $order ) {
+function wcs_get_subscriptions_for_order( $order, $args = [] ) {
 	if ( ! WC_Subscriptions_Helpers::$wcs_get_subscriptions_for_order ) {
 		return [];
 	}

--- a/tests/phpunit/helpers/class-wc-subscriptions-product.php
+++ b/tests/phpunit/helpers/class-wc-subscriptions-product.php
@@ -81,4 +81,44 @@ class WC_Subscriptions_Product {
 	public static function set_is_subscription( bool $result ): void {
 		self::$is_subscription_result = $result;
 	}
+
+	/**
+	 * Stub: get the subscription interval.
+	 *
+	 * @param \WC_Product|null $product The product.
+	 * @return string
+	 */
+	public static function get_interval( $product = null ): string {
+		return '1';
+	}
+
+	/**
+	 * Stub: get the subscription period.
+	 *
+	 * @param \WC_Product|null $product The product.
+	 * @return string
+	 */
+	public static function get_period( $product = null ): string {
+		return 'month';
+	}
+
+	/**
+	 * Stub: get the subscription price.
+	 *
+	 * @param \WC_Product|null $product The product.
+	 * @return string
+	 */
+	public static function get_price( $product = null ): string {
+		return '0';
+	}
+
+	/**
+	 * Stub: get the subscription sign-up fee.
+	 *
+	 * @param mixed $product The product.
+	 * @return string
+	 */
+	public static function get_sign_up_fee( $product = null ): string {
+		return '0';
+	}
 }

--- a/tests/phpunit/helpers/class-wc-subscriptions.php
+++ b/tests/phpunit/helpers/class-wc-subscriptions.php
@@ -39,4 +39,13 @@ class WC_Subscriptions {
 	public static function set_wcs_get_subscription( $callback ) {
 		self::$wcs_get_subscription = $callback;
 	}
+
+	/**
+	 * Stub: check if the current site is a duplicate/staging site.
+	 *
+	 * @return bool
+	 */
+	public static function is_duplicate_site(): bool {
+		return false;
+	}
 }


### PR DESCRIPTION
#5128 changed how classes are autoloaded and this led to inconsistencies in the PHPStan baseline. This PR addresses them.

Here is Claude's explanation:

> **Root cause:** The rename commit (`c4e1f5671`) changed `autoload-dev` from PSR-4 to `classmap`, which made PHPStan discover the test stub classes (`WC_Subscriptions_Product`, `WC_Pre_Orders_Product`, etc.). This caused:
> 
> 1. **91 stale baseline entries** — old "class not found" / "function not found" suppressions that no longer match because the classes are now visible
> 2. **~119 new errors** — the stubs have incomplete method signatures, causing type mismatch errors (these are now baselined)
> 3. **6 inline `@phpstan-ignore` comments** in `class-wc-stripe-helper.php` that suppressed errors that no longer occur — removed
> 
> **Changes on `develop`:**
> - `phpstan-baseline.neon` — regenerated (old: stale suppressions, new: stub type mismatches)
> - `includes/class-wc-stripe-helper.php` — removed 6 stale `@phpstan-ignore` inline comments

Note that the stubs having incomplete signatures, causing type mismatches, is not ideal, so I pushed https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5138/commits/ac14449f103983e2d9780044ec22c08470b79fe3, fixing stubs and making the PR net negative in terms of changed lines.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Internal changes, nothing to be released.

</details>