### PR TITLE
Block page while checkout in progress via express checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.6.0 - xxxx-xx-xx =
+* Fix - Re-block UI during express checkout post-modal processing so shoppers see a loading state while the checkout API call completes
 * Dev - Rename PHPUnit test files and directories to match the WordPress kebab-case naming convention used in includes/
 * Add - Process payment with adaptive pricing in the blocks checkout
 * Update - Express Checkout button logging will only occur when verbose debug mode is enabled

--- a/client/express-checkout/__tests__/event-handler.test.js
+++ b/client/express-checkout/__tests__/event-handler.test.js
@@ -255,6 +255,10 @@ describe( 'Express checkout event handlers', () => {
 		let order;
 
 		beforeEach( () => {
+			global.jQuery = {
+				blockUI: jest.fn(),
+				unblockUI: jest.fn(),
+			};
 			api = {
 				expressCheckoutNormalizeAddress: jest.fn(),
 				expressCheckoutECECreateOrder: jest.fn(),
@@ -304,6 +308,25 @@ describe( 'Express checkout event handlers', () => {
 
 		afterEach( () => {
 			jest.clearAllMocks();
+			delete global.jQuery;
+		} );
+
+		test( 'should block UI immediately when payment confirmation starts, before any processing', async () => {
+			// Fail fast on submit so we can confirm blockUI was called before any async work.
+			elements.submit.mockResolvedValue( {
+				error: { message: 'Submit error' },
+			} );
+
+			await onConfirmHandler( {
+				api,
+				stripe,
+				elements,
+				completePayment,
+				abortPayment,
+				event,
+			} );
+
+			expect( global.jQuery.blockUI ).toHaveBeenCalled();
 		} );
 
 		test( 'should abort payment if elements.submit fails', async () => {

--- a/client/express-checkout/event-handler.js
+++ b/client/express-checkout/event-handler.js
@@ -86,6 +86,8 @@ export const shippingRateChangeHandler = async ( api, event, elements ) => {
 export const onConfirmHandler = async ( params ) => {
 	const { abortPayment, elements, event, hasFreeTrial } = params;
 
+	blockUI();
+
 	const submitResponse = await elements.submit();
 	if ( submitResponse?.error ) {
 		return abortPayment( event, submitResponse?.error?.message );

--- a/readme.txt
+++ b/readme.txt
@@ -146,6 +146,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.6.0 - xxxx-xx-xx =
+* Fix - Re-block UI during express checkout post-modal processing so shoppers see a loading state while the checkout API call completes
 * Dev - Rename PHPUnit test files and directories to match the WordPress kebab-case naming convention used in includes/
 * Add - Process payment with adaptive pricing in the blocks checkout
 * Update - Express Checkout button logging will only occur when verbose debug mode is enabled


### PR DESCRIPTION
Fixes STRIPE-826
Fixes #4824 

## Changes proposed in this Pull Request:

- Fixed missing loading state after express checkout modal closes.
After the express checkout (Apple Pay / Google Pay) modal closes and before the server-side processing completes, the page overlay was being removed with no visual feedback. Added a blockUI() call at the start of onConfirmHandler in `client/express-checkout/event-handler.js` so the loading overlay is reliably re-applied for the full duration of post-modal processing.
- Added relevant test.

## Testing instructions
- Enable Google/Apple Pay.
- As as shopper, go to a product page.
- Click Google/Apple Pay button to pay.
- On the modal, complete payment and wait for the modal to close.
- In `develop`, notice that the overlay is gone and you can change things on the page. There is no indication that the checkout is in-progress behind the scene.
- In this branch, confirm that the overlay exists after the modal is closed and a loader is displayed, indicating the ongoing checkout.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
