### PR TITLE
Fix phpstan failures

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Dev - Remove unused frontend code: legacy blocks payment request API helpers, related normalize utilities, and unused Stripe icon component
 * Add - Allow additional font domains to be included in Stripe fonts
 * Fix - Add order and payment method validation to prevent errors
+* Dev - Exclude tests from PHPStan analyseAndScan to fix run after autoload-dev classmap change
 
 = 10.5.2 - 2026-03-13 =
 * Fix - Ensure that we enqueue all needed scripts on payment pages

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,6 +9,9 @@ parameters:
 	paths:
 		- woocommerce-gateway-stripe.php
 		- includes/
+	excludePaths:
+		analyseAndScan:
+			- tests/
 	bootstrapFiles:
 		- vendor/autoload.php
 		- vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php

--- a/readme.txt
+++ b/readme.txt
@@ -153,5 +153,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Remove unused frontend code: legacy blocks payment request API helpers, related normalize utilities, and unused Stripe icon component
 * Add - Allow additional font domains to be included in Stripe fonts
 * Fix - Add order and payment method validation to prevent errors
+* Dev - Exclude tests from PHPStan analyseAndScan to fix run after autoload-dev classmap change
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:
Excluding `tests/` from PHPStan `analyseAndScan` to fix post-autoloader failure.

With `autoload-dev` using a classmap for `tests/phpunit/`, the bootstrap was loading test classes and causing failures. Excluding `tests/` via `excludePaths.analyseAndScan` prevents PHPStan from loading or scanning test files; only plugin code (main file and includes/) is analysed.

## Testing instructions
- Code review.
- Verify that PHPStan is passing.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
