### PR TITLE
Prevent modification of express checkout payment methods on upgrades

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@
 * Tweak - Hide pay and cancel actions for pending orders processed via Checkout Session in order received page and My Account orders list
 * Fix - Improve default layout when Optimized Checkout is disabled
 * Fix - Improve performance of CSS style lookups
+* Fix - Prevent incorrect re-enablement of express checkout methods during upgrades
 
 = 10.5.2 - 2026-03-13 =
 * Fix - Ensure that we enqueue all needed scripts on payment pages

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -592,7 +592,7 @@ class WC_Stripe_Payment_Method_Configurations {
 		}
 
 		// Add default express checkout methods to the list if express checkout is enabled
-		if ( ! empty( $stripe_settings['express_checkout'] ) && 'yes' === $stripe_settings['express_checkout'] ) {
+		if ( ! empty( $stripe_settings['express_checkout'] ) && 'yes' === $stripe_settings['express_checkout'] && 'yes' !== ( $stripe_settings['skip_pmc_express_checkout_migration'] ?? 'no' ) ) {
 			$enabled_payment_methods = array_merge(
 				$enabled_payment_methods,
 				[ WC_Stripe_Payment_Methods::GOOGLE_PAY, WC_Stripe_Payment_Methods::APPLE_PAY ]

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -618,9 +618,8 @@ class WC_Stripe_Payment_Method_Configurations {
 					$available_payment_method_ids[] = $payment_method_id;
 				}
 
-				// We want to also include payment methods enabled in the PMC, except for express payment methods.
+				// Add all payment methods enabled in the PMC that are not enabled locally.
 				if (
-					! in_array( $payment_method_id, WC_Stripe_Payment_Methods::EXPRESS_PAYMENT_METHODS, true ) &&
 					! in_array( $payment_method_id, $enabled_payment_methods, true ) &&
 					isset( $payment_method->display_preference->value ) && 'on' === $payment_method->display_preference->value
 				) {

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -592,7 +592,11 @@ class WC_Stripe_Payment_Method_Configurations {
 		}
 
 		// Add default express checkout methods to the list if express checkout is enabled
-		if ( ! empty( $stripe_settings['express_checkout'] ) && 'yes' === $stripe_settings['express_checkout'] && 'yes' !== ( $stripe_settings['skip_pmc_express_checkout_migration'] ?? 'no' ) ) {
+		if (
+			! empty( $stripe_settings['express_checkout'] ) &&
+			'yes' === $stripe_settings['express_checkout'] &&
+			'yes' !== ( $stripe_settings['skip_pmc_express_checkout_migration'] ?? 'no' )
+		) {
 			$enabled_payment_methods = array_merge(
 				$enabled_payment_methods,
 				[ WC_Stripe_Payment_Methods::GOOGLE_PAY, WC_Stripe_Payment_Methods::APPLE_PAY ]

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -595,7 +595,7 @@ class WC_Stripe_Payment_Method_Configurations {
 		if (
 			! empty( $stripe_settings['express_checkout'] ) &&
 			'yes' === $stripe_settings['express_checkout'] &&
-			'yes' !== ( $stripe_settings['skip_pmc_express_checkout_migration'] ?? 'no' )
+			'yes' !== ( $stripe_settings['skip_pmc_express_checkout_defaults'] ?? 'no' )
 		) {
 			$enabled_payment_methods = array_merge(
 				$enabled_payment_methods,

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -429,6 +429,7 @@ class WC_Stripe {
 		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 		if ( isset( $stripe_settings['pmc_enabled'] ) && 'no' === $stripe_settings['pmc_enabled'] ) {
 			unset( $stripe_settings['pmc_enabled'] );
+			$stripe_settings['skip_pmc_express_checkout_migration'] = 'yes';
 			WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 			WC_Stripe_Logger::error( 'Settings synchronization eligibility will be re-checked after upgrade' );
 		}

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -429,7 +429,7 @@ class WC_Stripe {
 		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 		if ( isset( $stripe_settings['pmc_enabled'] ) && 'no' === $stripe_settings['pmc_enabled'] ) {
 			unset( $stripe_settings['pmc_enabled'] );
-			$stripe_settings['skip_pmc_express_checkout_migration'] = 'yes';
+			$stripe_settings['skip_pmc_express_checkout_defaults'] = 'yes';
 			WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 			WC_Stripe_Logger::error( 'Settings synchronization eligibility will be re-checked after upgrade' );
 		}

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -430,7 +430,7 @@ class WC_Stripe {
 		if ( isset( $stripe_settings['pmc_enabled'] ) && 'no' === $stripe_settings['pmc_enabled'] ) {
 			unset( $stripe_settings['pmc_enabled'] );
 			WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
-			WC_Stripe_Logger::warning( 'Settings synchronization eligibility will be re-checked after upgrade' );
+			WC_Stripe_Logger::error( 'Settings synchronization eligibility will be re-checked after upgrade' );
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -157,5 +157,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Hide pay and cancel actions for pending orders processed via Checkout Session in order received page and My Account orders list
 * Fix - Improve default layout when Optimized Checkout is disabled
 * Fix - Improve performance of CSS style lookups
+* Fix - Prevent incorrect re-enablement of express checkout methods during upgrades
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/admin/migrations/class-migrate-payment-methods-from-db-to-pmc-test.php
+++ b/tests/phpunit/admin/migrations/class-migrate-payment-methods-from-db-to-pmc-test.php
@@ -249,9 +249,9 @@ class Migrate_Payment_Methods_From_DB_To_PMC_Test extends WC_Mock_Stripe_API_Uni
 	}
 
 	/**
-	 * Test that express payment methods enabled in the PMC are replicated even when skip_pmc_express_checkout_migration is set.
+	 * Test that express payment methods enabled in the PMC are replicated even when skip_pmc_express_checkout_defaults is set.
 	 *
-	 * The skip flag only prevents express methods from being auto-added via the express_checkout setting.
+	 * The skip flag only prevents express methods from being defaulted on.
 	 * Methods already enabled in the PMC should still be replicated regardless of the skip flag.
 	 *
 	 * @return void
@@ -260,7 +260,7 @@ class Migrate_Payment_Methods_From_DB_To_PMC_Test extends WC_Mock_Stripe_API_Uni
 		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 		$stripe_settings['test_connection_type']                      = 'connect';
 		$stripe_settings['express_checkout']                          = 'yes';
-		$stripe_settings['skip_pmc_express_checkout_migration']       = 'yes';
+		$stripe_settings['skip_pmc_express_checkout_defaults']        = 'yes';
 		$stripe_settings['upe_checkout_experience_accepted_payments'] = [ 'card' ];
 		unset( $stripe_settings['pmc_enabled'] );
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
@@ -284,11 +284,11 @@ class Migrate_Payment_Methods_From_DB_To_PMC_Test extends WC_Mock_Stripe_API_Uni
 	}
 
 	/**
-	 * Test that the default express checkout methods are not added to PMC when skip_pmc_express_checkout_migration is 'yes'.
+	 * Test that the default express checkout methods are not added to PMC when skip_pmc_express_checkout_defaults is 'yes'.
 	 *
 	 * This covers the scenario where a merchant had PMC explicitly disabled (pmc_enabled = 'no') before the
-	 * upgrade, the install routine cleared the flag and set skip_pmc_express_checkout_migration = 'yes' to
-	 * prevent Google Pay / Apple Pay from being auto-enabled into the PMC during the first migration run.
+	 * upgrade, the install routine cleared the flag and set skip_pmc_express_checkout_defaults = 'yes' to
+	 * prevent express checkout methods from being auto-enabled during the first migration run.
 	 *
 	 * @return void
 	 */
@@ -297,7 +297,7 @@ class Migrate_Payment_Methods_From_DB_To_PMC_Test extends WC_Mock_Stripe_API_Uni
 		$stripe_settings['test_connection_type']                      = 'connect';
 		$stripe_settings['express_checkout']                          = 'yes';
 		$stripe_settings['upe_checkout_experience_accepted_payments'] = [ 'card', 'sepa_debit' ];
-		$stripe_settings['skip_pmc_express_checkout_migration']       = 'yes';
+		$stripe_settings['skip_pmc_express_checkout_defaults']        = 'yes';
 		unset( $stripe_settings['pmc_enabled'] );
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 

--- a/tests/phpunit/admin/migrations/class-migrate-payment-methods-from-db-to-pmc-test.php
+++ b/tests/phpunit/admin/migrations/class-migrate-payment-methods-from-db-to-pmc-test.php
@@ -216,4 +216,33 @@ class Migrate_Payment_Methods_From_DB_To_PMC_Test extends WC_Mock_Stripe_API_Uni
 		$this->assertArrayHasKey( 'pmc_enabled', $updated_settings );
 		$this->assertEquals( 'yes', $updated_settings['pmc_enabled'] );
 	}
+
+	/**
+	 * Test that express checkout methods are not added to PMC when skip_pmc_express_checkout_migration is 'yes'.
+	 *
+	 * This covers the scenario where a merchant had PMC explicitly disabled (pmc_enabled = 'no') before the
+	 * upgrade, the install routine cleared the flag and set skip_pmc_express_checkout_migration = 'yes' to
+	 * prevent Google Pay / Apple Pay from being auto-enabled into the PMC during the first migration run.
+	 *
+	 * @return void
+	 */
+	public function test_migration_skips_express_checkout_methods_when_skip_flag_is_set() {
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['test_connection_type']                      = 'connect';
+		$stripe_settings['express_checkout']                          = 'yes';
+		$stripe_settings['upe_checkout_experience_accepted_payments'] = [ 'card', 'sepa_debit' ];
+		$stripe_settings['skip_pmc_express_checkout_migration']       = 'yes';
+		unset( $stripe_settings['pmc_enabled'] );
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		// Google Pay and Apple Pay should NOT be included — only the UPE methods.
+		$this->mock_payment_method_configurations( [], [ 'card', 'sepa_debit', 'google_pay', 'apple_pay' ] );
+		$this->expect_payment_method_configurations_update( [ 'card', 'sepa_debit' ], [ 'google_pay', 'apple_pay' ] );
+
+		$this->pmc->maybe_migrate_payment_methods_from_db_to_pmc();
+
+		$updated_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertArrayHasKey( 'pmc_enabled', $updated_settings );
+		$this->assertEquals( 'yes', $updated_settings['pmc_enabled'] );
+	}
 }

--- a/tests/phpunit/admin/migrations/class-migrate-payment-methods-from-db-to-pmc-test.php
+++ b/tests/phpunit/admin/migrations/class-migrate-payment-methods-from-db-to-pmc-test.php
@@ -218,7 +218,73 @@ class Migrate_Payment_Methods_From_DB_To_PMC_Test extends WC_Mock_Stripe_API_Uni
 	}
 
 	/**
-	 * Test that express checkout methods are not added to PMC when skip_pmc_express_checkout_migration is 'yes'.
+	 * Test that express payment methods enabled in the PMC are replicated to local during migration.
+	 *
+	 * @return void
+	 */
+	public function test_migration_replicates_express_methods_enabled_in_pmc() {
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['test_connection_type']                      = 'connect';
+		$stripe_settings['upe_checkout_experience_accepted_payments'] = [ 'card', 'sepa_debit' ];
+		unset( $stripe_settings['pmc_enabled'] );
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		// PMC has google_pay and apple_pay enabled, but they are NOT in local UPE settings.
+		$this->mock_payment_method_configurations(
+			[ 'google_pay', 'apple_pay', 'amazon_pay' ], // enabled in PMC
+			[ 'card', 'sepa_debit', 'link' ]             // disabled in PMC
+		);
+
+		// All three non-link express checkout payment methods should be replicated from PMC into the local enabled list.
+		$this->expect_payment_method_configurations_update(
+			[ 'card', 'sepa_debit', 'google_pay', 'apple_pay', 'amazon_pay' ],
+			[ 'link' ]
+		);
+
+		$this->pmc->maybe_migrate_payment_methods_from_db_to_pmc();
+
+		$updated_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertArrayHasKey( 'pmc_enabled', $updated_settings );
+		$this->assertEquals( 'yes', $updated_settings['pmc_enabled'] );
+	}
+
+	/**
+	 * Test that express payment methods enabled in the PMC are replicated even when skip_pmc_express_checkout_migration is set.
+	 *
+	 * The skip flag only prevents express methods from being auto-added via the express_checkout setting.
+	 * Methods already enabled in the PMC should still be replicated regardless of the skip flag.
+	 *
+	 * @return void
+	 */
+	public function test_migration_replicates_express_methods_from_pmc_even_with_skip_flag() {
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['test_connection_type']                      = 'connect';
+		$stripe_settings['express_checkout']                          = 'yes';
+		$stripe_settings['skip_pmc_express_checkout_migration']       = 'yes';
+		$stripe_settings['upe_checkout_experience_accepted_payments'] = [ 'card' ];
+		unset( $stripe_settings['pmc_enabled'] );
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		$this->mock_payment_method_configurations(
+			[ 'google_pay', 'link', 'apple_pay' ], // enabled in PMC
+			[ 'card', 'amazon_pay' ]               // disabled in PMC
+		);
+
+		// Apple Pay, Google Pay, and Link should be enabled; Amazon Pay should be disabled.
+		$this->expect_payment_method_configurations_update(
+			[ 'card', 'google_pay', 'link', 'apple_pay' ],
+			[ 'amazon_pay' ]
+		);
+
+		$this->pmc->maybe_migrate_payment_methods_from_db_to_pmc();
+
+		$updated_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertArrayHasKey( 'pmc_enabled', $updated_settings );
+		$this->assertEquals( 'yes', $updated_settings['pmc_enabled'] );
+	}
+
+	/**
+	 * Test that the default express checkout methods are not added to PMC when skip_pmc_express_checkout_migration is 'yes'.
 	 *
 	 * This covers the scenario where a merchant had PMC explicitly disabled (pmc_enabled = 'no') before the
 	 * upgrade, the install routine cleared the flag and set skip_pmc_express_checkout_migration = 'yes' to

--- a/tests/phpunit/class-wc-stripe-test.php
+++ b/tests/phpunit/class-wc-stripe-test.php
@@ -205,9 +205,9 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 					'pmc_enabled' => 'no',
 				],
 				'expected settings' => [
-					'pmc_enabled'                          => null,
-					'optimized_checkout_element'           => null,
-					'skip_pmc_express_checkout_migration'  => 'yes',
+					'pmc_enabled'                        => null,
+					'optimized_checkout_element'         => null,
+					'skip_pmc_express_checkout_defaults' => 'yes',
 				],
 			],
 			'will not enable OCS by default due to OCS being set'  => [
@@ -216,9 +216,9 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 					'optimized_checkout_element' => 'no',
 				],
 				'expected settings' => [
-					'pmc_enabled'                         => 'yes',
-					'optimized_checkout_element'          => 'no',
-					'skip_pmc_express_checkout_migration' => null,
+					'pmc_enabled'                        => 'yes',
+					'optimized_checkout_element'         => 'no',
+					'skip_pmc_express_checkout_defaults' => null,
 				],
 			],
 		];

--- a/tests/phpunit/class-wc-stripe-test.php
+++ b/tests/phpunit/class-wc-stripe-test.php
@@ -194,7 +194,7 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
-	 * Data provider for `test_install_settings`.
+	 * Data provider for {@see test_install_settings_update()}.
 	 *
 	 * @return array
 	 */
@@ -205,8 +205,9 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 					'pmc_enabled' => 'no',
 				],
 				'expected settings' => [
-					'pmc_enabled'                => null,
-					'optimized_checkout_element' => null,
+					'pmc_enabled'                          => null,
+					'optimized_checkout_element'           => null,
+					'skip_pmc_express_checkout_migration'  => 'yes',
 				],
 			],
 			'will not enable OCS by default due to OCS being set'  => [
@@ -215,8 +216,9 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 					'optimized_checkout_element' => 'no',
 				],
 				'expected settings' => [
-					'pmc_enabled'                => 'yes',
-					'optimized_checkout_element' => 'no',
+					'pmc_enabled'                         => 'yes',
+					'optimized_checkout_element'          => 'no',
+					'skip_pmc_express_checkout_migration' => null,
 				],
 			],
 		];


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR addresses two possible causes of unexpected re-enablement of express checkout methods on upgrades.

The underlying issues are:
* When we are upgrading and we detect that setting synchronization is disabled (via the `pmc_enabled` sub-setting being set to `'no'`, we remove the `pmc_enabled` sub-setting to see if the new version can successfully enable settings synchronisation.
* The logic that attempts to enable settings synchronization mostly lives in `WC_Stripe_Payment_Method_Configurations::maybe_migrate_payment_methods_from_db_to_pmc()`, which includes the following block of code that auto-enables express checkout methods:

https://github.com/woocommerce/woocommerce-gateway-stripe/blob/e2087af6ace561dd0dcda02b23ec5b76cb2f6827/includes/class-wc-stripe-payment-method-configurations.php#L594-L605

* The logic that replicates the PMC configuration into the local data was skipping express checkout payment methods, so previously enabled express checkout methods could end up disabled.

This PR sets a new `skip_pmc_express_checkout_defaults` sub-setting during the upgrade process when `pmc_enabled` is reset so that we continue to perform the existing settings synchronization checks for new installs or sites where we haven't attempted to (re)enable settings synchronization, but we don't default any express checkout methods on.

The PR also ensures that when we pick a PMC, any express checkout payment methods that were enabled in the PMC are kept enabled.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

* Install version 10.5.1 or older on a test site - note that there were infinite loop issues in 10.4.0 and 10.5.0 to be wary of
* Make some changes to the express checkout payment methods, e.g. to disable either Apple Pay/Google Pay or Amazon Pay (note that Amazon Pay is only available in 10.4.0 and newer)
* Ensure that the `pmc_enabled` sub-setting is set to `no`, e.g. `wp option patch update woocommerce_stripe_settings pmc_enabled no`
* Upload and activate a plugin zip built using the code from this branch
* Confirm that all disabled express checkout payment methods remain disabled, and all enabled express checkout payment methods remain enabled
* Confirm that the `skip_pmc_express_checkout_defaults` sub-setting is `'yes'`: `wp option pluck woocommerce_stripe_settings skip_pmc_express_checkout_defaults`
* Check the Stripe log under _WooCommerce_ > _Status_ > _Logs_ and verify that you see an error recorded with the following text: `Settings synchronization eligibility will be re-checked after upgrade`

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
