### PR TITLE
Fix address fallback in generate_customer_request for auto-account creation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.6.0 - xxxx-xx-xx =
+* Fix - Resolve intermittent "Missing required customer field: address->line1" error during checkout with auto-account creation
 * Add - Include specific information on converted currency for adaptive pricing in the order received page and order details page
 * Add - Support express checkout for free trial subscription products that require shipping
 * Fix - Re-block UI during express checkout post-modal processing so shoppers see a loading state while the checkout API call completes

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -177,6 +177,14 @@ class WC_Stripe_Customer {
 				$billing_last_name = get_user_meta( $user->ID, 'last_name', true );
 			}
 
+			// If still empty, fall back to POST/order data (e.g. during auto-account creation).
+			if ( empty( $billing_first_name ) ) {
+				$billing_first_name = $this->get_billing_data_field( 'billing_first_name', $order );
+			}
+			if ( empty( $billing_last_name ) ) {
+				$billing_last_name = $this->get_billing_data_field( 'billing_last_name', $order );
+			}
+
 			$email = $user->user_email;
 
 			// If the user email is not set, use the billing email.
@@ -229,11 +237,14 @@ class WC_Stripe_Customer {
 			'country'     => 'billing_country',
 		];
 		foreach ( $address_fields as $key => $field ) {
+			$value = '';
 			if ( $user ) {
-				$defaults['address'][ $key ] = get_user_meta( $user->ID, $field, true );
-			} else {
-				$defaults['address'][ $key ] = $this->get_billing_data_field( $field, $order );
+				$value = get_user_meta( $user->ID, $field, true );
 			}
+			if ( empty( $value ) ) {
+				$value = $this->get_billing_data_field( $field, $order );
+			}
+			$defaults['address'][ $key ] = $value;
 		}
 
 		return wp_parse_args( $args, $defaults );

--- a/readme.txt
+++ b/readme.txt
@@ -146,6 +146,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.6.0 - xxxx-xx-xx =
+* Fix - Resolve intermittent "Missing required customer field: address->line1" error during checkout with auto-account creation
 * Add - New promotional banner to highlight the Stripe Tax extension for OCS-enabled merchants
 * Add - Include specific information on converted currency for adaptive pricing in the order received page and order details page
 * Add - Support express checkout for free trial subscription products that require shipping

--- a/tests/phpunit/class-wc-stripe-customer-test.php
+++ b/tests/phpunit/class-wc-stripe-customer-test.php
@@ -381,6 +381,120 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that generate_customer_request falls back to order data when user meta is empty.
+	 *
+	 * This covers the race condition in issue #4697: during auto-account-creation flows,
+	 * the user exists but billing meta hasn't been saved yet. The address fields should
+	 * fall back to order data (or $_POST) instead of being empty.
+	 */
+	public function test_generate_customer_request_falls_back_to_order_when_user_meta_empty() {
+		// Create a user with name but no billing address meta.
+		$user_id = $this->factory->user->create( [ 'user_email' => 'test@example.com' ] );
+		update_user_meta( $user_id, 'first_name', 'Test' );
+		update_user_meta( $user_id, 'last_name', 'User' );
+		wp_set_current_user( $user_id );
+
+		$mock_order = $this->create_mock_order(
+			[
+				'address_1' => '123 Main St',
+				'city'      => 'Springfield',
+				'postcode'  => '62704',
+				'country'   => 'US',
+				'state'     => 'IL',
+			]
+		);
+
+		$customer = new \WC_Stripe_Customer( $user_id );
+
+		// Capture the args passed to the Stripe API via the filter.
+		$captured_args  = null;
+		$capture_filter = function ( $args ) use ( &$captured_args ) {
+			$captured_args = $args;
+			return $args;
+		};
+		add_filter( 'wc_stripe_create_customer_args', $capture_filter, 10, 1 );
+
+		// Mock Stripe API calls to prevent real requests.
+		$mock_http = function ( $return_value, $parsed_args, $url ) {
+			if ( str_starts_with( $url, 'https://api.stripe.com/v1/customers' ) ) {
+				return [
+					'response' => 200,
+					'headers'  => [ 'Content-Type' => 'application/json' ],
+					'body'     => json_encode( [ 'id' => 'cus_test_fallback' ] ),
+				];
+			}
+			return $return_value;
+		};
+		add_filter( 'pre_http_request', $mock_http, 10, 3 );
+
+		try {
+			$customer->create_customer( [], null, $mock_order );
+
+			$this->assertNotNull( $captured_args, 'Customer args should have been captured' );
+			$this->assertEquals( '123 Main St', $captured_args['address']['line1'], 'line1 should fall back to order billing_address_1' );
+			$this->assertEquals( 'Springfield', $captured_args['address']['city'], 'city should fall back to order billing_city' );
+			$this->assertEquals( '62704', $captured_args['address']['postal_code'], 'postal_code should fall back to order billing_postcode' );
+			$this->assertEquals( 'US', $captured_args['address']['country'], 'country should fall back to order billing_country' );
+		} finally {
+			remove_filter( 'wc_stripe_create_customer_args', $capture_filter, 10 );
+			remove_filter( 'pre_http_request', $mock_http, 10 );
+			wp_delete_user( $user_id );
+		}
+	}
+
+	/**
+	 * Test that generate_customer_request falls back to order data for name when user meta is empty.
+	 *
+	 * Same race condition as address (issue #4697): during auto-account creation,
+	 * user meta for first/last name may not yet be saved.
+	 */
+	public function test_generate_customer_request_falls_back_to_order_for_name_when_user_meta_empty() {
+		// Create a user with no name meta at all.
+		$user_id = $this->factory->user->create( [ 'user_email' => 'test@example.com' ] );
+		wp_set_current_user( $user_id );
+
+		$mock_order = $this->create_mock_order(
+			[
+				'first_name' => 'Jane',
+				'last_name'  => 'Doe',
+			]
+		);
+
+		$customer = new \WC_Stripe_Customer( $user_id );
+
+		$captured_args  = null;
+		$capture_filter = function ( $args ) use ( &$captured_args ) {
+			$captured_args = $args;
+			return $args;
+		};
+		add_filter( 'wc_stripe_create_customer_args', $capture_filter, 10, 1 );
+
+		$mock_http = function ( $return_value, $parsed_args, $url ) {
+			if ( str_starts_with( $url, 'https://api.stripe.com/v1/customers' ) ) {
+				return [
+					'response' => 200,
+					'headers'  => [ 'Content-Type' => 'application/json' ],
+					'body'     => json_encode( [ 'id' => 'cus_test_name_fallback' ] ),
+				];
+			}
+			return $return_value;
+		};
+		add_filter( 'pre_http_request', $mock_http, 10, 3 );
+
+		try {
+			$customer->create_customer( [], null, $mock_order );
+
+			$this->assertNotNull( $captured_args, 'Customer args should have been captured' );
+			$this->assertEquals( 'Jane Doe', $captured_args['name'], 'name should fall back to order billing first/last name' );
+			$this->assertStringContainsString( 'Jane', $captured_args['description'], 'description should contain the fallback first name' );
+		} finally {
+			remove_filter( 'wc_stripe_create_customer_args', $capture_filter, 10 );
+			remove_filter( 'pre_http_request', $mock_http, 10 );
+			wp_delete_user( $user_id );
+		}
+	}
+
+	/**
 	 * Test that order data is excluded from Stripe API requests when passed via $args['order'].
 	 *
 	 * This test verifies the fix for backwards compatibility: when order is passed via $args['order'],


### PR DESCRIPTION
Fixes STRIPE-727
Fixes #4697 

## Changes proposed in this Pull Request:

During guest checkout with auto-account creation, `generate_customer_request()` reads address and name fields exclusively from `get_user_meta()` for logged-in users. However, WooCommerce creates the user account before billing meta is saved, so `get_user_meta()` returns empty strings in this race window — causing Missing required customer field: address->line1 validation failures.

This PR adds a fallback to `get_billing_data_field()` (which checks `$_POST` then the order object) when user meta is empty, matching the pattern already used for email. The fix covers:

* Address fields (line1, city, postal_code, country, state): fall back to $_POST/order when `get_user_meta()` is empty
* Name fields (first_name, last_name): same fallback for symmetry, preventing a potential missing_required_customer_field: name edge case

## Testing instructions

1. Enable guest checkout and "When a guest purchases, create an account for them" in WooCommerce > Settings > Accounts & Privacy
2. Enable Stripe with card payments
3. In a private/incognito window, add a product to cart and proceed to checkout
4. Fill in all billing fields and complete payment as a guest (do not log in)
5. Verify payment succeeds on the first attempt without a "Missing required customer field" error
6. Check the Stripe Dashboard — the created customer should have the correct billing address and name

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Fix - Resolve intermittent "Missing required customer field: address->line1" error during checkout with auto-account creation

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
