### PR TITLE
Add stripe/stripe-php SDK with WordPress HTTP transport adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,9 @@
     "description": "Take credit card payments on your store using Stripe.",
     "homepage": "https://woocommerce.com/products/woocommerce-gateway-stripe/",
     "license": "GPL-2.0-or-later",
+    "require": {
+        "stripe/stripe-php": "^16.0"
+    },
     "config": {
       "platform": {
         "php": "7.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,68 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c8658b05455b7c8d835065847689fb1",
-    "packages": [],
+    "content-hash": "87df9ac3f7ac82148bd58d6c2d7190b8",
+    "packages": [
+        {
+            "name": "stripe/stripe-php",
+            "version": "v16.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stripe/stripe-php.git",
+                "reference": "d6de0a536f00b5c5c74f36b8f4d0d93b035499ff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/d6de0a536f00b5c5c74f36b8f4d0d93b035499ff",
+                "reference": "d6de0a536f00b5c5c74f36b8f4d0d93b035499ff",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "3.5.0",
+                "phpstan/phpstan": "^1.2",
+                "phpunit/phpunit": "^5.7 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Stripe\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stripe and contributors",
+                    "homepage": "https://github.com/stripe/stripe-php/contributors"
+                }
+            ],
+            "description": "Stripe PHP Library",
+            "homepage": "https://stripe.com/",
+            "keywords": [
+                "api",
+                "payment processing",
+                "stripe"
+            ],
+            "support": {
+                "issues": "https://github.com/stripe/stripe-php/issues",
+                "source": "https://github.com/stripe/stripe-php/tree/v16.6.0"
+            },
+            "time": "2025-02-24T22:35:29+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "composer/ca-bundle",
@@ -7667,5 +7727,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -47,6 +47,16 @@ class WC_Stripe_API {
 	private static $secret_key = '';
 
 	/**
+	 * Cached Stripe SDK client instance.
+	 *
+	 * Reset whenever the secret key changes so callers always get a client
+	 * that matches the currently active key.
+	 *
+	 * @var \Stripe\StripeClient|null
+	 */
+	private static $stripe_client = null;
+
+	/**
 	 * Instance of WC_Stripe_API.
 	 *
 	 * @var WC_Stripe_API
@@ -80,6 +90,9 @@ class WC_Stripe_API {
 	 * @param string $key
 	 */
 	public static function set_secret_key( $secret_key ) {
+		if ( self::$secret_key !== $secret_key ) {
+			self::$stripe_client = null;
+		}
 		self::$secret_key = $secret_key;
 	}
 
@@ -736,5 +749,42 @@ class WC_Stripe_API {
 			return 'secret_key_not_configured';
 		}
 		return substr( $key, 0, 8 ) . '...' . substr( $key, -6 );
+	}
+
+	/**
+	 * Return a configured Stripe PHP SDK client.
+	 *
+	 * The client uses the WordPress HTTP API as its transport (via
+	 * WC_Stripe_WP_HTTP_Client) so that WordPress proxy and SSL settings are
+	 * respected. App info is registered with the SDK so Stripe can identify
+	 * requests from this plugin.
+	 *
+	 * Use this method when you need typed, resource-oriented access to the
+	 * Stripe API (e.g. $client->paymentIntents->retrieve(...)). For lower-level
+	 * requests that must pass through WordPress filters, continue to use the
+	 * static request() / retrieve() methods.
+	 *
+	 * @return \Stripe\StripeClient
+	 */
+	public static function get_stripe_client(): \Stripe\StripeClient {
+		if ( null === self::$stripe_client ) {
+			\Stripe\ApiRequestor::setHttpClient( new WC_Stripe_WP_HTTP_Client() );
+
+			\Stripe\Stripe::setAppInfo(
+				'WooCommerce Stripe Gateway',
+				WC_STRIPE_VERSION,
+				'https://woocommerce.com/products/stripe/',
+				'pp_partner_EYuSt9peR0WTMg'
+			);
+
+			self::$stripe_client = new \Stripe\StripeClient(
+				[
+					'api_key'        => self::get_secret_key(),
+					'stripe_version' => self::STRIPE_API_VERSION,
+				]
+			);
+		}
+
+		return self::$stripe_client;
 	}
 }

--- a/includes/class-wc-stripe-wp-http-client.php
+++ b/includes/class-wc-stripe-wp-http-client.php
@@ -1,0 +1,93 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WordPress HTTP transport adapter for the Stripe PHP SDK.
+ *
+ * Implements \Stripe\HttpClient\ClientInterface so that the Stripe SDK routes
+ * all HTTP traffic through the WordPress HTTP API (wp_safe_remote_request).
+ * This ensures WordPress proxy settings, SSL configuration, and request
+ * filters are respected for every Stripe API call made via the SDK.
+ */
+class WC_Stripe_WP_HTTP_Client implements \Stripe\HttpClient\ClientInterface {
+
+	/**
+	 * Execute an HTTP request on behalf of the Stripe SDK.
+	 *
+	 * @param string   $method    HTTP method (get, post, delete, …).
+	 * @param string   $abs_url   Fully-qualified request URL.
+	 * @param string[] $headers   Headers as "Name: value" strings (Stripe SDK format).
+	 * @param array    $params    Request parameters.
+	 * @param bool     $has_file  Whether the request contains a file upload.
+	 * @param string   $api_mode  API mode ('v1' or 'v2').
+	 *
+	 * @return array{0: string, 1: int, 2: array<string, string>} Tuple of
+	 *                                                             [body, status_code, headers].
+	 * @throws \Stripe\Exception\ApiConnectionException On transport failure or unsupported file upload.
+	 */
+	public function request( $method, $abs_url, $headers, $params, $has_file, $api_mode = 'v1' ) {
+		$method = strtoupper( $method );
+
+		if ( $has_file ) {
+			// Multipart file uploads are handled directly via cURL in
+			// class-wc-stripe-agentic-commerce-files-api-delivery.php and are
+			// never routed through the SDK client, so this path should not be
+			// reached in normal operation.
+			throw new \Stripe\Exception\ApiConnectionException(
+				'Multipart file uploads are not supported through the WordPress HTTP client adapter. Use the dedicated file upload implementation instead.'
+			);
+		}
+
+		$args = [
+			'method'  => $method,
+			'headers' => $this->parse_headers( $headers ),
+			'timeout' => 70,
+		];
+
+		if ( 'GET' === $method ) {
+			if ( ! empty( $params ) ) {
+				$abs_url = add_query_arg( $params, $abs_url );
+			}
+		} else {
+			$args['body'] = $params;
+		}
+
+		$response = wp_safe_remote_request( $abs_url, $args );
+
+		if ( is_wp_error( $response ) ) {
+			throw new \Stripe\Exception\ApiConnectionException(
+				'Error connecting to Stripe API: ' . $response->get_error_message()
+			);
+		}
+
+		$rbody    = wp_remote_retrieve_body( $response );
+		$rcode    = (int) wp_remote_retrieve_response_code( $response );
+		$rheaders = [];
+
+		foreach ( wp_remote_retrieve_headers( $response ) as $key => $value ) {
+			$rheaders[ $key ] = $value;
+		}
+
+		return [ $rbody, $rcode, $rheaders ];
+	}
+
+	/**
+	 * Convert Stripe SDK-style headers ("Name: value" strings) into the
+	 * associative array format expected by the WordPress HTTP API.
+	 *
+	 * @param string[] $headers
+	 * @return array<string, string>
+	 */
+	private function parse_headers( array $headers ): array {
+		$parsed = [];
+		foreach ( $headers as $header ) {
+			$pos = strpos( $header, ': ' );
+			if ( false !== $pos ) {
+				$parsed[ substr( $header, 0, $pos ) ] = substr( $header, $pos + 2 );
+			}
+		}
+		return $parsed;
+	}
+}

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -133,6 +133,7 @@ class WC_Stripe {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-database-cache.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-payment-method-configurations.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-database-cache-prefetch.php';
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-wp-http-client.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-api.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-mode.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/compat/class-wc-stripe-subscriptions-helper.php';

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -31,6 +31,11 @@ define( 'WC_STRIPE_ABSPATH', __DIR__ . '/' );
 define( 'WC_STRIPE_PLUGIN_URL', untrailingslashit( plugin_dir_url( WC_STRIPE_MAIN_FILE ) ) );
 define( 'WC_STRIPE_PLUGIN_PATH', untrailingslashit( plugin_dir_path( WC_STRIPE_MAIN_FILE ) ) );
 
+// Load Composer autoloader for runtime dependencies (e.g. stripe/stripe-php).
+if ( file_exists( WC_STRIPE_ABSPATH . 'vendor/autoload.php' ) ) {
+	require_once WC_STRIPE_ABSPATH . 'vendor/autoload.php';
+}
+
 // phpcs:disable WordPress.Files.FileName
 
 /**


### PR DESCRIPTION
## Summary

- Adds `stripe/stripe-php` v16 as a runtime Composer dependency
- Introduces `WC_Stripe_WP_HTTP_Client`, a new class implementing `\Stripe\HttpClient\ClientInterface` that routes all Stripe SDK HTTP traffic through `wp_safe_remote_request()` — ensuring WordPress proxy settings, SSL configuration, and `http_request_*` hooks are respected
- Adds `WC_Stripe_API::get_stripe_client()`, which returns a cached, fully-configured `\Stripe\StripeClient` (API key, API version, app info, WP HTTP transport); the cache is invalidated whenever `set_secret_key()` is called with a new value so test/live mode switches are handled correctly
- Loads `vendor/autoload.php` on plugin boot (guarded by `file_exists`)

Existing `request()` and `retrieve()` methods are untouched — they retain their WordPress filter hooks, idempotency logic, and structured logging. New code should call `WC_Stripe_API::get_stripe_client()` for typed, resource-oriented SDK access.

## Test plan

- [ ] PHPStan passes (`npm run phpstan`) — verified clean locally
- [ ] PHPCS passes — verified clean via pre-commit hook
- [ ] `composer validate --strict` passes — verified via pre-commit hook
- [ ] Confirm plugin boots without errors with the vendor autoloader present
- [ ] Confirm existing checkout flows (classic, Blocks, ECE) are unaffected
- [ ] Confirm `WC_Stripe_API::get_stripe_client()` returns a `\Stripe\StripeClient` instance with the correct API key in both test and live modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)