### PR TITLE
Add checkout session webhook handlers for failed events

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@
 * Fix - Improve performance of CSS style lookups
 * Add - Initial implementation of always-expanded Optimized Checkout Suite in shortcode checkout
 * Dev - Collapse PHPUnit tests using data providers to reduce duplication and improve test isolation
+* Add - Handle Checkout Session failure webhook events for expired and async failed payments
 
 = 10.5.3 - 2026-03-19 =
 * Fix - Restore default layout when Optimized Checkout is disabled

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1646,9 +1646,9 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$status_update['to']   = OrderStatus::FAILED;
 		$order->update_status( OrderStatus::FAILED, $message );
 
-		$this->send_failed_order_email( $order->get_id(), $status_update );
-
 		do_action( 'wc_gateway_stripe_process_webhook_payment_error', $order, $notification );
+
+		$this->send_failed_order_email( $order->get_id(), $status_update );
 	}
 
 	/**

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1636,13 +1636,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			$status_update['from'] = $order->get_status();
 			$status_update['to']   = OrderStatus::FAILED;
 			$order->update_status( OrderStatus::FAILED, $message );
+
+			$this->send_failed_order_email( $order->get_id(), $status_update );
 		} else {
 			$order->add_order_note( $message );
 		}
 
 		do_action( 'wc_gateway_stripe_process_webhook_payment_error', $order, $notification );
-
-		$this->send_failed_order_email( $order->get_id(), $status_update );
 	}
 
 	/**

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1614,6 +1614,12 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_checkout_session_failure( object $notification ): void {
 		$checkout_session = $notification->data->object;
+
+		if ( ! isset( $checkout_session->id ) ) {
+			WC_Stripe_Logger::debug( 'Checkout session ID is missing from the event data.' );
+			return;
+		}
+
 		$order            = WC_Stripe_Helper::get_order_by_checkout_session_id( $checkout_session->id );
 
 		if ( ! $order instanceof \WC_Order ) {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1604,6 +1604,48 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
+	 * Processes checkout session failure events.
+	 * This includes:
+	 * - checkout.session.expired event; Fires when a Stripe Checkout session expires before the customer completes payment.
+	 * - checkout.session.async_payment_failed event; Fires when an asynchronous payment method on a Stripe Checkout session fails.
+	 * Marks the associated WooCommerce order as failed.
+	 *
+	 * @param object $notification The Stripe notification containing the checkout session data.
+	 */
+	public function process_checkout_session_failure( object $notification ): void {
+		$checkout_session = $notification->data->object;
+		$order            = WC_Stripe_Helper::get_order_by_checkout_session_id( $checkout_session->id );
+
+		if ( ! $order instanceof \WC_Order ) {
+			WC_Stripe_Logger::debug( 'Could not find order via checkout session ID: ' . $checkout_session->id );
+			return;
+		}
+
+		$this->resolved_order = $order;
+
+		$order_helper = WC_Stripe_Order_Helper::get_instance();
+
+		if ( $order_helper->is_stripe_status_final( $order ) ) {
+			return;
+		}
+
+		$message = 'checkout.session.expired' === $notification->type ? __( 'The checkout session has expired.', 'woocommerce-gateway-stripe' ) : __( 'The async payment for this checkout session has failed.', 'woocommerce-gateway-stripe' );
+
+		$status_update = [];
+		if ( ! $order->has_status( [ OrderStatus::PROCESSING, OrderStatus::COMPLETED, OrderStatus::FAILED ] ) ) {
+			$status_update['from'] = $order->get_status();
+			$status_update['to']   = OrderStatus::FAILED;
+			$order->update_status( OrderStatus::FAILED, $message );
+		} else {
+			$order->add_order_note( $message );
+		}
+
+		do_action( 'wc_gateway_stripe_process_webhook_payment_error', $order, $notification );
+
+		$this->send_failed_order_email( $order->get_id(), $status_update );
+	}
+
+	/**
 	 * Processes the incoming webhook.
 	 *
 	 * @since 4.0.0
@@ -1679,7 +1721,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				break;
 			case 'checkout.session.completed':
 				$this->process_checkout_session( $notification );
-
+				break;
+			case 'checkout.session.expired':
+			case 'checkout.session.async_payment_failed':
+				$this->process_checkout_session_failure( $notification );
+				break;
 		}
 
 		// These events might be processed async. Skip the action trigger for them here. The trigger will be called inside the specific methods.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1620,7 +1620,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$order            = WC_Stripe_Helper::get_order_by_checkout_session_id( $checkout_session->id );
+		$order = WC_Stripe_Helper::get_order_by_checkout_session_id( $checkout_session->id );
 
 		if ( ! $order instanceof \WC_Order ) {
 			WC_Stripe_Logger::debug( 'Could not find order via checkout session ID: ' . $checkout_session->id );

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1629,18 +1629,18 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
+		if ( $order->has_status( [ OrderStatus::PROCESSING, OrderStatus::COMPLETED, OrderStatus::FAILED ] ) ) {
+			return;
+		}
+
 		$message = 'checkout.session.expired' === $notification->type ? __( 'The checkout session has expired.', 'woocommerce-gateway-stripe' ) : __( 'The async payment for this checkout session has failed.', 'woocommerce-gateway-stripe' );
 
-		$status_update = [];
-		if ( ! $order->has_status( [ OrderStatus::PROCESSING, OrderStatus::COMPLETED, OrderStatus::FAILED ] ) ) {
-			$status_update['from'] = $order->get_status();
-			$status_update['to']   = OrderStatus::FAILED;
-			$order->update_status( OrderStatus::FAILED, $message );
+		$status_update         = [];
+		$status_update['from'] = $order->get_status();
+		$status_update['to']   = OrderStatus::FAILED;
+		$order->update_status( OrderStatus::FAILED, $message );
 
-			$this->send_failed_order_email( $order->get_id(), $status_update );
-		} else {
-			$order->add_order_note( $message );
-		}
+		$this->send_failed_order_email( $order->get_id(), $status_update );
 
 		do_action( 'wc_gateway_stripe_process_webhook_payment_error', $order, $notification );
 	}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3201,7 +3201,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property object\:\:\$data\.$#'
 			identifier: property.notFound
-			count: 42
+			count: 43
 			path: includes/class-wc-stripe-webhook-handler.php
 
 		-
@@ -3225,7 +3225,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property object\:\:\$type\.$#'
 			identifier: property.notFound
-			count: 1
+			count: 2
 			path: includes/class-wc-stripe-webhook-handler.php
 
 		-

--- a/readme.txt
+++ b/readme.txt
@@ -170,5 +170,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Improve performance of CSS style lookups
 * Add - Initial implementation of always-expanded Optimized Checkout Suite in shortcode checkout
 * Dev - Collapse PHPUnit tests using data providers to reduce duplication and improve test isolation
+* Add - Handle Checkout Session failure webhook events for expired and async failed payments
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -850,6 +850,123 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that checkout session failure returns early when no order is found.
+	 *
+	 * @return void
+	 */
+	public function test_process_checkout_session_failure_returns_when_order_is_not_found(): void {
+		$notification = (object) [
+			'type' => 'checkout.session.expired',
+			'data' => (object) [
+				'object' => (object) [
+					'id' => 'cs_missing_order',
+				],
+			],
+		];
+
+		$hook_calls = 0;
+		$hook       = function () use ( &$hook_calls ) {
+			++$hook_calls;
+		};
+		add_action( 'wc_gateway_stripe_process_webhook_payment_error', $hook, 10, 2 );
+
+		$this->mock_webhook_handler->process_checkout_session_failure( $notification );
+		remove_action( 'wc_gateway_stripe_process_webhook_payment_error', $hook, 10 );
+
+		$resolved_order_property = new ReflectionProperty( WC_Stripe_Webhook_Handler::class, 'resolved_order' );
+		$resolved_order_property->setAccessible( true );
+
+		$this->assertNull( $resolved_order_property->getValue( $this->mock_webhook_handler ) );
+		$this->assertSame( 0, $hook_calls );
+	}
+
+	/**
+	 * Test that checkout session failure marks pending orders as failed.
+	 *
+	 * @return void
+	 */
+	public function test_process_checkout_session_failure_marks_order_as_failed(): void {
+		$checkout_session_id = 'cs_test_failed';
+		$order               = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::PENDING );
+		$order->save();
+		WC_Stripe_Order_Helper::get_instance()->update_stripe_checkout_session_id( $order, $checkout_session_id );
+		$order->save_meta_data();
+
+		$order_helper = $this->createPartialMock( WC_Stripe_Order_Helper::class, [ 'is_stripe_status_final' ] );
+		$order_helper->expects( $this->once() )
+			->method( 'is_stripe_status_final' )
+			->willReturn( false );
+		WC_Stripe_Order_Helper::set_instance( $order_helper );
+
+		$notification = (object) [
+			'type' => 'checkout.session.expired',
+			'data' => (object) [
+				'object' => (object) [
+					'id' => $checkout_session_id,
+				],
+			],
+		];
+
+		$hook_calls = 0;
+		$hook       = function ( $hook_order, $hook_notification ) use ( $order, $notification, &$hook_calls ) {
+			++$hook_calls;
+			$this->assertSame( $order->get_id(), $hook_order->get_id() );
+			$this->assertSame( $notification, $hook_notification );
+		};
+		add_action( 'wc_gateway_stripe_process_webhook_payment_error', $hook, 10, 2 );
+
+		$this->mock_webhook_handler->process_checkout_session_failure( $notification );
+		remove_action( 'wc_gateway_stripe_process_webhook_payment_error', $hook, 10 );
+
+		$order = wc_get_order( $order->get_id() );
+		$this->assertSame( OrderStatus::FAILED, $order->get_status() );
+		$this->assertSame( 1, $hook_calls );
+	}
+
+	/**
+	 * Test that checkout session failure does not change status for final Stripe orders.
+	 *
+	 * @return void
+	 */
+	public function test_process_checkout_session_failure_returns_for_final_stripe_status(): void {
+		$checkout_session_id = 'cs_test_final_status';
+		$order               = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::PROCESSING );
+		$order->save();
+		WC_Stripe_Order_Helper::get_instance()->update_stripe_checkout_session_id( $order, $checkout_session_id );
+		$order->save_meta_data();
+
+		$order_helper = $this->createPartialMock( WC_Stripe_Order_Helper::class, [ 'is_stripe_status_final' ] );
+		$order_helper->expects( $this->once() )
+			->method( 'is_stripe_status_final' )
+			->willReturn( true );
+		WC_Stripe_Order_Helper::set_instance( $order_helper );
+
+		$notification = (object) [
+			'type' => 'checkout.session.async_payment_failed',
+			'data' => (object) [
+				'object' => (object) [
+					'id' => $checkout_session_id,
+				],
+			],
+		];
+
+		$hook_calls = 0;
+		$hook       = function () use ( &$hook_calls ) {
+			++$hook_calls;
+		};
+		add_action( 'wc_gateway_stripe_process_webhook_payment_error', $hook, 10, 2 );
+
+		$this->mock_webhook_handler->process_checkout_session_failure( $notification );
+		remove_action( 'wc_gateway_stripe_process_webhook_payment_error', $hook, 10 );
+
+		$order = wc_get_order( $order->get_id() );
+		$this->assertSame( OrderStatus::PROCESSING, $order->get_status() );
+		$this->assertSame( 0, $hook_calls );
+	}
+
+	/**
 	 * Provider for `test_process_webhook_refund_updated`.
 	 *
 	 * @return array

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -881,11 +881,33 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that checkout session failure marks pending orders as failed.
+	 * Provider for checkout session failure event types.
 	 *
+	 * @return array
+	 */
+	public function provide_checkout_session_failure_event_types(): array {
+		return [
+			'checkout.session.expired'              => [
+				'event_type'    => 'checkout.session.expired',
+				'expected_note' => 'The checkout session has expired.',
+			],
+			'checkout.session.async_payment_failed' => [
+				'event_type'    => 'checkout.session.async_payment_failed',
+				'expected_note' => 'The async payment for this checkout session has failed.',
+			],
+		];
+	}
+
+	/**
+	 * Test that checkout session failure marks pending orders as failed for both event types.
+	 *
+	 * @dataProvider provide_checkout_session_failure_event_types
+	 *
+	 * @param string $event_type Event type.
+	 * @param string $expected_note Expected note content.
 	 * @return void
 	 */
-	public function test_process_checkout_session_failure_marks_order_as_failed(): void {
+	public function test_process_checkout_session_failure_marks_order_as_failed_for_event_type( string $event_type, string $expected_note ): void {
 		$checkout_session_id = 'cs_test_failed';
 		$order               = WC_Helper_Order::create_order();
 		$order->set_status( OrderStatus::PENDING );
@@ -900,7 +922,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		WC_Stripe_Order_Helper::set_instance( $order_helper );
 
 		$notification = (object) [
-			'type' => 'checkout.session.expired',
+			'type' => $event_type,
 			'data' => (object) [
 				'object' => (object) [
 					'id' => $checkout_session_id,
@@ -922,6 +944,15 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$order = wc_get_order( $order->get_id() );
 		$this->assertSame( OrderStatus::FAILED, $order->get_status() );
 		$this->assertSame( 1, $hook_calls );
+
+		$notes = wc_get_order_notes(
+			[
+				'order_id' => $order->get_id(),
+				'limit'    => 1,
+			]
+		);
+		$this->assertNotEmpty( $notes );
+		$this->assertStringContainsString( $expected_note, $notes[0]->content );
 	}
 
 	/**
@@ -964,6 +995,74 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$order = wc_get_order( $order->get_id() );
 		$this->assertSame( OrderStatus::PROCESSING, $order->get_status() );
 		$this->assertSame( 0, $hook_calls );
+	}
+
+	/**
+	 * Test that duplicate checkout session failure webhooks return early when the order is already failed.
+	 *
+	 * @dataProvider provide_checkout_session_failure_event_types
+	 *
+	 * @param string $event_type Event type.
+	 * @param string $unused_note Unused; provider shares rows with other tests.
+	 * @return void
+	 */
+	public function test_process_checkout_session_failure_returns_early_when_order_already_failed( string $event_type, string $unused_note ): void {
+		$checkout_session_id = 'cs_test_duplicate';
+		$order               = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::FAILED );
+		$order->save();
+		WC_Stripe_Order_Helper::get_instance()->update_stripe_checkout_session_id( $order, $checkout_session_id );
+		$order->save_meta_data();
+
+		$notes_before = wc_get_order_notes(
+			[
+				'order_id' => $order->get_id(),
+				'limit'    => 100,
+			]
+		);
+
+		$order_helper = $this->createPartialMock( WC_Stripe_Order_Helper::class, [ 'is_stripe_status_final' ] );
+		$order_helper->expects( $this->once() )
+			->method( 'is_stripe_status_final' )
+			->willReturn( false );
+		WC_Stripe_Order_Helper::set_instance( $order_helper );
+
+		$webhook_handler = $this->getMockBuilder( WC_Stripe_Webhook_Handler::class )
+			->setMethods( [ 'send_failed_order_email' ] )
+			->getMock();
+
+		$webhook_handler->expects( $this->never() )->method( 'send_failed_order_email' );
+
+		$notification = (object) [
+			'type' => $event_type,
+			'data' => (object) [
+				'object' => (object) [
+					'id' => $checkout_session_id,
+				],
+			],
+		];
+
+		$hook_calls = 0;
+		$hook       = function () use ( &$hook_calls ) {
+			++$hook_calls;
+		};
+		add_action( 'wc_gateway_stripe_process_webhook_payment_error', $hook, 10, 2 );
+
+		$webhook_handler->process_checkout_session_failure( $notification );
+
+		remove_action( 'wc_gateway_stripe_process_webhook_payment_error', $hook, 10 );
+
+		$order = wc_get_order( $order->get_id() );
+		$this->assertSame( OrderStatus::FAILED, $order->get_status() );
+		$this->assertSame( 0, $hook_calls );
+
+		$notes_after = wc_get_order_notes(
+			[
+				'order_id' => $order->get_id(),
+				'limit'    => 100,
+			]
+		);
+		$this->assertCount( count( $notes_before ), $notes_after );
 	}
 
 	/**


### PR DESCRIPTION
Towards [STRIPE-921](https://linear.app/a8c/issue/STRIPE-921)

## Changes proposed in this Pull Request:
Added webhook handlers for the remaining checkout session related events.
- 'checkout.session.expired'
- 'checkout.session.async_payment_failed'

## Testing instructions
- Add the following code in [process_payment_with_checkout_session](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L1212) right before the return statement, to simulate an expired checkout session

```
try {
			$expired_session = WC_Stripe_API::request( [], 'checkout/sessions/' . $checkout_session_id . '/expire', 'POST' );
			WC_Stripe_Logger::debug( 'Expired checkout session.', [ 'session_id' => $checkout_session_id ] );
			WC_Stripe_Logger::debug( 'Expired session response.', [ 'response' => wp_json_encode( $expired_session ) ] );
		} catch ( Exception $e ) {
			WC_Stripe_Logger::error( 'Expire checkout session error.', [ 'error_message' => $e->getMessage() ] );
		}
```
- As an admin, enable OCS and adaptive pricing in your Stripe settings page.
- As a shopper, add a product to your cart and go to the block checkout page.
- Verify that adaptive pricing is displayed.
- Choose your local currency to pay and complete checkout (The checkout might fail because of how we are hacking the expired session to receive the event)
- In your logs, verify that you received the 'checkout.session.expired' event.
- As an admin, check the order. The order should be in failed status and the order note should be present.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
