### PR TITLE
Fix Dependabot #189: remove locutus (CVE-2026-32304) via @woocommerce/currency

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,6 +81,7 @@ module.exports = {
 		'import/core-modules': [
 			'@woocommerce/blocks-checkout',
 			'@woocommerce/blocks-registry',
+			'@woocommerce/currency',
 			'@woocommerce/settings',
 			'@wordpress/i18n',
 			'@wordpress/is-shallow-equal',

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@
 * Fix - Improve performance of CSS style lookups
 * Add - Initial implementation of always-expanded Optimized Checkout Suite in shortcode checkout
 * Dev - Collapse PHPUnit tests using data providers to reduce duplication and improve test isolation
+* Dev - Remove @woocommerce/currency dev dependency to resolve locutus CVE-2026-32304 (GHSA-vh9h-29pq-r5m8)
 
 = 10.5.3 - 2026-03-19 =
 * Fix - Restore default layout when Optimized Checkout is disabled

--- a/client/settings/payments-and-transactions-section/statement-preview/index.js
+++ b/client/settings/payments-and-transactions-section/statement-preview/index.js
@@ -1,5 +1,5 @@
-import React from 'react';
 import CurrencyFactory from '@woocommerce/currency';
+import React from 'react';
 import { CreditCardIcon } from './icons/creditCard';
 import { CashAppIcon } from './icons/cashApp.js';
 import { BankIcon } from './icons/bank.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "@types/react-dom": "^18.3.7",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
-        "@woocommerce/currency": "^3.2.0",
         "@woocommerce/dependency-extraction-webpack-plugin": "^3.1.0",
         "@woocommerce/eslint-plugin": "^2.2.0",
         "@woocommerce/navigation": "^8.2.0",
@@ -7432,45 +7431,6 @@
         }
       }
     },
-    "node_modules/@woocommerce/currency": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@woocommerce/currency/-/currency-3.2.0.tgz",
-      "integrity": "sha512-u+j58p+FLAM3d3BJtkpfFOb5x30QSBfsisrmfQSgr23QCo0N8mkkkceA+vLREK6USPnD12bWcb6klG97fMTEIw==",
-      "dev": true,
-      "dependencies": {
-        "@woocommerce/number": "^2.2.0",
-        "@wordpress/deprecated": "^2.9.0",
-        "@wordpress/element": "2.19.0",
-        "@wordpress/html-entities": "2.10.0",
-        "@wordpress/i18n": "3.17.0"
-      }
-    },
-    "node_modules/@woocommerce/currency/node_modules/@wordpress/html-entities": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.10.0.tgz",
-      "integrity": "sha512-D6lWrDOOiI/a/uYZpXMqL9ErT1Q4cauLWRZK/E4kaNOkhRxEUtWFiDD+00HdIkrT5QYPIuWos4h4Vw/HHM8Cgg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      }
-    },
-    "node_modules/@woocommerce/currency/node_modules/@wordpress/i18n": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.17.0.tgz",
-      "integrity": "sha512-CTZ0oezI6BT5GlmiE4X0fzRY6i7bNsX6hxiROkGlpREY6q4s1pnwhM8ggLIaP18Bvkb/HDkUEENDrv3iwM/LIQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "gettext-parser": "^1.3.1",
-        "lodash": "^4.17.19",
-        "memize": "^1.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      }
-    },
     "node_modules/@woocommerce/dependency-extraction-webpack-plugin": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@woocommerce/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-3.1.0.tgz",
@@ -7856,16 +7816,6 @@
       },
       "peerDependencies": {
         "lodash": "^4.17.0"
-      }
-    },
-    "node_modules/@woocommerce/number": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@woocommerce/number/-/number-2.4.0.tgz",
-      "integrity": "sha512-SmEgad2zZ9fGZtpujrdk0/toSXjNuDOUxDKQutJ++ASID17bGKZtLxXcu/E7mvF1tTgszpiToPvqZlyC+vjOlg==",
-      "dev": true,
-      "license": "GPL-3.0-or-later",
-      "dependencies": {
-        "locutus": "^2.0.16"
       }
     },
     "node_modules/@woocommerce/settings": {
@@ -20514,17 +20464,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/locutus": {
-      "version": "2.0.39",
-      "resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.39.tgz",
-      "integrity": "sha512-v2iub44UtGpbIv+pFkkYhZ+JsbIM0bJsQcQ1+VayUNGVA/YhM8+CkBiRACcpuuE9Q0xI1pgNzGNwzZDCp1MCww==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10",
-        "yarn": ">= 1"
       }
     },
     "node_modules/lodash": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@types/react-dom": "^18.3.7",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
-    "@woocommerce/currency": "^3.2.0",
     "@woocommerce/dependency-extraction-webpack-plugin": "^3.1.0",
     "@woocommerce/eslint-plugin": "^2.2.0",
     "@woocommerce/navigation": "^8.2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -163,6 +163,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Allow additional font domains to be included in Stripe fonts
 * Dev - Skip registering Stripe email classes when WooCommerce email class is not loaded
 * Fix - Add order and payment method validation to prevent errors
+* Dev - Remove @woocommerce/currency dev dependency to resolve locutus CVE-2026-32304 (GHSA-vh9h-29pq-r5m8)
 * Tweak - Hide pay and cancel actions for pending orders processed via Checkout Session in order received page and My Account orders list
 * Fix - Improve default layout when Optimized Checkout is disabled
 * Fix - Ensure that we enqueue all needed scripts on payment pages

--- a/tests/js/__mocks__/woocommerce-currency.js
+++ b/tests/js/__mocks__/woocommerce-currency.js
@@ -1,0 +1,17 @@
+// Mock for @woocommerce/currency, which is a webpack external (loaded from
+// WooCommerce globals at runtime) and no longer installed as a devDependency.
+const CurrencyFactory = jest.fn( () => ( {
+	formatAmount: jest.fn(
+		( amount ) => `$${ Number( amount ).toFixed( 2 ) }`
+	),
+	formatCurrency: jest.fn(
+		( amount ) => `$${ Number( amount ).toFixed( 2 ) }`
+	),
+	formatDecimal: jest.fn( ( amount ) => Number( amount ) ),
+	formatDecimalString: jest.fn( ( amount ) => Number( amount ).toFixed( 2 ) ),
+	getPriceFormat: jest.fn( () => '%1$s%2$s' ),
+	render: jest.fn( ( amount ) => `$${ Number( amount ).toFixed( 2 ) }` ),
+} ) );
+
+module.exports = CurrencyFactory;
+module.exports.default = CurrencyFactory;

--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -19,6 +19,11 @@ module.exports = {
 		// Global mock for wordpress/data but individual tests can override if necessary
 		'^@wordpress/data$': '<rootDir>/tests/js/__mocks__/wordpress-data.js',
 
+		// @woocommerce/currency is a webpack external (loaded from WooCommerce globals
+		// at runtime) and is not installed as a devDependency.
+		'^@woocommerce/currency$':
+			'<rootDir>/tests/js/__mocks__/woocommerce-currency.js',
+
 		// Asset/file mocks
 		'\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
 			'<rootDir>/tests/js/jest-file-mock.js',


### PR DESCRIPTION
## Summary

- Removes `@woocommerce/currency` from `devDependencies`, eliminating the `locutus` transitive dependency that carries CVE-2026-32304 (CVSS 9.8, RCE via `create_function()`).
- Adds a Jest mock for `@woocommerce/currency` so tests that transitively import `statement-preview/index.js` continue to pass.

## Context

**Vulnerability:** [GHSA-vh9h-29pq-r5m8](https://github.com/advisories/GHSA-vh9h-29pq-r5m8) / CVE-2026-32304 — `locutus <= 3.0.13` allows RCE via unsanitized input in `create_function()`. Fixed in `locutus@3.0.14`.

**Why not just bump locutus?** The patched version (`locutus@3.0.14`) requires Node >= 22, but this project is pinned to Node 20 with `engine-strict=true` in `.npmrc`. A version override is therefore not installable.

**Why is removing `@woocommerce/currency` safe?**
- It is [externalized by `@woocommerce/dependency-extraction-webpack-plugin`](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/webpack.config.js) — the package is never bundled into the plugin; at runtime it loads from WooCommerce's global `wc.currency`.
- No existing Jest tests directly import or exercise `@woocommerce/currency` or `@woocommerce/number`.
- All 98 Jest test suites pass after the change.

## Test plan

- [x] `npm run test:js` — 98 suites, 612 tests, all passing
- [x] `npm run phpstan` — no errors (run by the push hook)
- [ ] Manual: verify statement preview still renders correctly in the admin UI (it loads `@woocommerce/currency` from the WooCommerce global as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)