### PR TITLE
Disable stripe developer widget

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@
 * Fix - Improve performance of CSS style lookups
 * Add - Initial implementation of always-expanded Optimized Checkout Suite in shortcode checkout
 * Dev - Collapse PHPUnit tests using data providers to reduce duplication and improve test isolation
+* Dev - Hide Stripe's testing assistant on checkout page
 
 = 10.5.3 - 2026-03-19 =
 * Fix - Restore default layout when Optimized Checkout is disabled

--- a/client/api/__tests__/index.test.js
+++ b/client/api/__tests__/index.test.js
@@ -1,0 +1,31 @@
+const mockStripeConstructor = jest.fn( () => ( {} ) );
+
+global.Stripe = mockStripeConstructor;
+
+import WCStripeAPI from 'wcstripe/api';
+
+describe( 'WCStripeAPI', () => {
+	beforeEach( () => {
+		mockStripeConstructor.mockReturnValue( {} );
+		mockStripeConstructor.mockClear();
+	} );
+
+	it( 'initializes Stripe.js with testing assistant disabled', () => {
+		const api = new WCStripeAPI(
+			{ key: 'pk_test_abc', locale: 'auto' },
+			jest.fn()
+		);
+		api.getStripe();
+		expect( mockStripeConstructor ).toHaveBeenCalledWith(
+			'pk_test_abc',
+			expect.objectContaining( {
+				locale: 'auto',
+				developerTools: {
+					assistant: {
+						enabled: false,
+					},
+				},
+			} )
+		);
+	} );
+} );

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -11,6 +11,7 @@ import { getStripeServerData } from 'wcstripe/stripe-utils';
 import {
 	PAYMENT_INTENT_STATUS_REQUIRES_ACTION,
 	PAYMENT_METHOD_CASHAPP,
+	STRIPE_JS_OPTIONS_DISABLE_TESTING_ASSISTANT,
 } from 'wcstripe/stripe-utils/constants';
 
 /**
@@ -94,6 +95,7 @@ export default class WCStripeAPI {
 	createStripe( key, locale, betas = [] ) {
 		const options = {
 			locale,
+			...STRIPE_JS_OPTIONS_DISABLE_TESTING_ASSISTANT,
 		};
 
 		if ( betas.length ) {

--- a/client/blocks/__tests__/load-stripe.test.js
+++ b/client/blocks/__tests__/load-stripe.test.js
@@ -1,0 +1,33 @@
+const mockLoadStripe = jest.fn( () => Promise.resolve( {} ) );
+
+jest.mock( '@stripe/stripe-js', () => ( {
+	loadStripe: ( ...args ) => mockLoadStripe( ...args ),
+} ) );
+
+jest.mock( 'wcstripe/blocks/utils', () => ( {
+	getApiKey: jest.fn( () => 'pk_test_xxx' ),
+	getBlocksConfiguration: jest.fn( () => ( { stripe_locale: 'en' } ) ),
+} ) );
+
+import { loadStripe } from 'wcstripe/blocks/load-stripe';
+
+describe( 'load-stripe', () => {
+	beforeEach( () => {
+		mockLoadStripe.mockClear();
+	} );
+
+	it( 'passes developerTools.assistant.enabled false to Stripe loadStripe', async () => {
+		await loadStripe();
+		expect( mockLoadStripe ).toHaveBeenCalledWith(
+			'pk_test_xxx',
+			expect.objectContaining( {
+				locale: 'en',
+				developerTools: {
+					assistant: {
+						enabled: false,
+					},
+				},
+			} )
+		);
+	} );
+} );

--- a/client/blocks/load-stripe.js
+++ b/client/blocks/load-stripe.js
@@ -1,5 +1,6 @@
 import { loadStripe } from '@stripe/stripe-js';
 import { getApiKey, getBlocksConfiguration } from './utils';
+import { STRIPE_JS_OPTIONS_DISABLE_TESTING_ASSISTANT } from 'wcstripe/stripe-utils/constants';
 
 const stripePromise = () =>
 	new Promise( ( resolve ) => {
@@ -7,7 +8,12 @@ const stripePromise = () =>
 			// Default to the 'auto' locale so Stripe chooses the browser's locale
 			// if the store's locale is not available.
 			const locale = getBlocksConfiguration()?.stripe_locale ?? 'auto';
-			resolve( loadStripe( getApiKey(), { locale } ) );
+			resolve(
+				loadStripe( getApiKey(), {
+					locale,
+					...STRIPE_JS_OPTIONS_DISABLE_TESTING_ASSISTANT,
+				} )
+			);
 		} catch ( error ) {
 			// In order to avoid showing console error publicly to users,
 			// we resolve instead of rejecting when there is an error.

--- a/client/stripe-utils/constants.js
+++ b/client/stripe-utils/constants.js
@@ -188,3 +188,15 @@ export const PAYMENT_METHOD_UNAVAILABLE_REASONS = {
  * @type {string}
  */
 export const OPTIMIZED_CHECKOUT_DEFAULT_LAYOUT = 'accordion';
+
+/**
+ * Stripe.js options to hide the testing assistant on Clover+ when using Adaptive Pricing
+ * with Checkout Sessions.
+ */
+export const STRIPE_JS_OPTIONS_DISABLE_TESTING_ASSISTANT = {
+	developerTools: {
+		assistant: {
+			enabled: false,
+		},
+	},
+};

--- a/readme.txt
+++ b/readme.txt
@@ -171,5 +171,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Improve performance of CSS style lookups
 * Add - Initial implementation of always-expanded Optimized Checkout Suite in shortcode checkout
 * Dev - Collapse PHPUnit tests using data providers to reduce duplication and improve test isolation
+* Dev - Hide Stripe's testing assistant on checkout page
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Towards STRIPE-1000
Fixes #5167

## Changes proposed in this Pull Request:
In this PR, we are disabling the new Stripe developer widget or testing assistant from the checkout pages. This feature was enabled unintentionally as part of Stripe JS update.
In a follow-up PR, we will make it configurable for test sites only as suggested in the issue.

## Testing instructions
- As an admin, enable OCS and Adaptive Pricing on the Stripe settings page.
- As a shopper, add a product to your cart and go to the checkout page.
- Select Stripe as the payment method.
- In `develop` notice that a developer widget appears on the page as soon as adaptive pricing is available.

<img width="1377" height="636" alt="Screenshot 2026-03-27 at 11 50 43 AM" src="https://github.com/user-attachments/assets/8b207ebe-173f-44e3-bf32-6af549e59b3e" />

- In this branch, confirm that the developer widget is absent.
- Check on both classic and block checkout pages.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
