### PR TITLE
Fix STRIPE-750: Stripe fee and payout not updated after partial capture

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.6.0 - xxxx-xx-xx =
+* Fix - Update Stripe Fee and Stripe Payout values correctly after partial capture by replacing authorization-phase values instead of adding to them
 * Add - Include specific information on converted currency for adaptive pricing in order confirmation emails
 * Fix - Use the order currency instead of the global store currency when creating a payment intent, resolving incorrect charges in multicurrency setups
 * Dev - Rename and move the new Checkout Sessions ajax handler class to be autoloaded

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1141,7 +1141,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 *                                         reflects the captured amount. Default false (add mode
 	 *                                         for refunds and adjustments).
 	 */
-	public function update_fees( $order, $balance_transaction_id, $replace = false ) {
+	public function update_fees( $order, $balance_transaction_id, bool $replace = false ) {
 		$balance_transaction = WC_Stripe_API::retrieve( 'balance/history/' . $balance_transaction_id );
 
 		if ( empty( $balance_transaction->error ) ) {

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1134,27 +1134,35 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 *
 	 * @since 4.0.0
 	 * @version 4.0.6
-	 * @param WC_Order $order The order object
-	 * @param int    $balance_transaction_id
+	 * @param WC_Order $order                  The order object.
+	 * @param string   $balance_transaction_id The balance transaction ID.
+	 * @param bool     $replace                Whether to replace existing fee/net values instead of
+	 *                                         adding to them. Use true for captures where the fee
+	 *                                         reflects the captured amount. Default false (add mode
+	 *                                         for refunds and adjustments).
 	 */
-	public function update_fees( $order, $balance_transaction_id ) {
+	public function update_fees( $order, $balance_transaction_id, $replace = false ) {
 		$balance_transaction = WC_Stripe_API::retrieve( 'balance/history/' . $balance_transaction_id );
 
 		if ( empty( $balance_transaction->error ) ) {
 			if ( isset( $balance_transaction ) && isset( $balance_transaction->fee ) ) {
 				// Fees and Net needs to both come from Stripe to be accurate as the returned
 				// values are in the local currency of the Stripe account, not from WC.
-				$fee_refund = ! empty( $balance_transaction->fee ) ? WC_Stripe_Helper::format_balance_fee( $balance_transaction, 'fee' ) : 0;
-				$net_refund = ! empty( $balance_transaction->net ) ? WC_Stripe_Helper::format_balance_fee( $balance_transaction, 'net' ) : 0;
+				$balance_fee = ! empty( $balance_transaction->fee ) ? WC_Stripe_Helper::format_balance_fee( $balance_transaction, 'fee' ) : 0;
+				$balance_net = ! empty( $balance_transaction->net ) ? WC_Stripe_Helper::format_balance_fee( $balance_transaction, 'net' ) : 0;
 
-				// Current data fee & net.
 				$order_helper = WC_Stripe_Order_Helper::get_instance();
-				$fee_current  = $order_helper->get_stripe_fee( $order );
-				$net_current  = $order_helper->get_stripe_net( $order );
 
-				// Calculation.
-				$fee = (float) $fee_current + (float) $fee_refund;
-				$net = (float) $net_current + (float) $net_refund;
+				if ( $replace ) {
+					$fee = (float) $balance_fee;
+					$net = (float) $balance_net;
+				} else {
+					$fee_current = $order_helper->get_stripe_fee( $order );
+					$net_current = $order_helper->get_stripe_net( $order );
+
+					$fee = (float) $fee_current + (float) $balance_fee;
+					$net = (float) $net_current + (float) $balance_net;
+				}
 
 				$order_helper->update_stripe_fee( $order, $fee );
 				$order_helper->update_stripe_net( $order, $net );

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -377,7 +377,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 					$balance_transaction_id = $this->get_balance_transaction_id_from_charge( $result );
 
 					if ( ! empty( $balance_transaction_id ) ) {
-						$this->update_fees( $order, $balance_transaction_id );
+						$this->update_fees( $order, $balance_transaction_id, true );
 					}
 				}
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -546,7 +546,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				$order->set_transaction_id( $notification->data->object->id );
 
 				if ( isset( $notification->data->object->balance_transaction ) ) {
-					$this->update_fees( $order, $notification->data->object->balance_transaction );
+					$this->update_fees( $order, $notification->data->object->balance_transaction, true );
 				}
 
 				// Check and see if capture is partial.
@@ -626,7 +626,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$order->set_transaction_id( $charge->id );
 
 		if ( isset( $charge->balance_transaction ) ) {
-			$this->update_fees( $order, $charge->balance_transaction );
+			$this->update_fees( $order, $charge->balance_transaction, true );
 		}
 
 		/**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2959,12 +2959,6 @@ parameters:
 			path: includes/class-wc-stripe-order-handler.php
 
 		-
-			message: '#^Parameter \#2 \$balance_transaction_id of method WC_Stripe_Payment_Gateway\:\:update_fees\(\) expects int, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wc-stripe-order-handler.php
-
-		-
 			message: '#^Parameter \#2 \$order of method WC_Stripe_Payment_Gateway\:\:process_response\(\) expects WC_Order, WC_Order\|WC_Order_Refund given\.$#'
 			identifier: argument.type
 			count: 1

--- a/readme.txt
+++ b/readme.txt
@@ -146,6 +146,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.6.0 - xxxx-xx-xx =
+* Fix - Update Stripe Fee and Stripe Payout values correctly after partial capture by replacing authorization-phase values instead of adding to them
 * Add - Include specific information on converted currency for adaptive pricing in order confirmation emails
 * Fix - Use the order currency instead of the global store currency when creating a payment intent, resolving incorrect charges in multicurrency setups
 * Dev - Rename and move the new Checkout Sessions ajax handler class to be autoloaded

--- a/tests/phpunit/class-wc-stripe-payment-gateway-test.php
+++ b/tests/phpunit/class-wc-stripe-payment-gateway-test.php
@@ -1062,14 +1062,14 @@ class WC_Stripe_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			],
 		];
 
-		add_filter(
-			'pre_http_request',
-			function () use ( $mock_response ) {
-				return $mock_response;
-			}
-		);
+		$filter = function () use ( $mock_response ) {
+			return $mock_response;
+		};
+		add_filter( 'pre_http_request', $filter );
 
 		$this->gateway->update_fees( $order, 'txn_test123', $replace );
+
+		remove_filter( 'pre_http_request', $filter );
 
 		$this->assertEquals( $expected_fee, (float) $order_helper->get_stripe_fee( $order ) );
 		$this->assertEquals( $expected_net, (float) $order_helper->get_stripe_net( $order ) );

--- a/tests/phpunit/class-wc-stripe-payment-gateway-test.php
+++ b/tests/phpunit/class-wc-stripe-payment-gateway-test.php
@@ -1031,4 +1031,88 @@ class WC_Stripe_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			],
 		];
 	}
+
+	/**
+	 * @dataProvider provide_update_fees_scenarios
+	 */
+	public function test_update_fees( $existing_fee, $existing_net, $api_fee, $api_net, $replace, $expected_fee, $expected_net ) {
+		$order        = WC_Helper_Order::create_order();
+		$order_helper = WC_Stripe_Order_Helper::get_instance();
+
+		if ( 0 !== $existing_fee ) {
+			$order_helper->update_stripe_fee( $order, $existing_fee );
+		}
+		if ( 0 !== $existing_net ) {
+			$order_helper->update_stripe_net( $order, $existing_net );
+		}
+
+		// Mock the Stripe API balance transaction response.
+		$mock_response = [
+			'headers'  => [],
+			'body'     => wp_json_encode(
+				[
+					'fee'      => $api_fee,
+					'net'      => $api_net,
+					'currency' => 'usd',
+				]
+			),
+			'response' => [
+				'code'    => 200,
+				'message' => 'OK',
+			],
+		];
+
+		add_filter(
+			'pre_http_request',
+			function () use ( $mock_response ) {
+				return $mock_response;
+			}
+		);
+
+		$this->gateway->update_fees( $order, 'txn_test123', $replace );
+
+		$this->assertEquals( $expected_fee, (float) $order_helper->get_stripe_fee( $order ) );
+		$this->assertEquals( $expected_net, (float) $order_helper->get_stripe_net( $order ) );
+	}
+
+	public function provide_update_fees_scenarios() {
+		return [
+			'add mode - refund adjusts existing fees' => [
+				'existing_fee' => 150,
+				'existing_net' => 4850,
+				'api_fee'      => -30,
+				'api_net'      => -970,
+				'replace'      => false,
+				'expected_fee' => 120,
+				'expected_net' => 3880,
+			],
+			'replace mode - capture replaces existing fees' => [
+				'existing_fee' => 150,
+				'existing_net' => 4850,
+				'api_fee'      => 75,
+				'api_net'      => 2425,
+				'replace'      => true,
+				'expected_fee' => 75,
+				'expected_net' => 2425,
+			],
+			'replace mode - works with no existing fees' => [
+				'existing_fee' => 0,
+				'existing_net' => 0,
+				'api_fee'      => 50,
+				'api_net'      => 950,
+				'replace'      => true,
+				'expected_fee' => 50,
+				'expected_net' => 950,
+			],
+			'add mode - first time fee setting' => [
+				'existing_fee' => 0,
+				'existing_net' => 0,
+				'api_fee'      => 100,
+				'api_net'      => 4900,
+				'replace'      => false,
+				'expected_fee' => 100,
+				'expected_net' => 4900,
+			],
+		];
+	}
 }

--- a/tests/phpunit/class-wc-stripe-payment-gateway-test.php
+++ b/tests/phpunit/class-wc-stripe-payment-gateway-test.php
@@ -1076,42 +1076,45 @@ class WC_Stripe_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	public function provide_update_fees_scenarios() {
+		// API fee/net values are in cents (Stripe smallest denomination).
+		// format_balance_fee() converts to dollars (divides by 100 for USD).
+		// Existing and expected values are in dollars (already formatted).
 		return [
-			'add mode - refund adjusts existing fees' => [
-				'existing_fee' => 150,
-				'existing_net' => 4850,
+			'add mode - refund adjusts existing fees'       => [
+				'existing_fee' => 1.50,
+				'existing_net' => 48.50,
 				'api_fee'      => -30,
 				'api_net'      => -970,
 				'replace'      => false,
-				'expected_fee' => 120,
-				'expected_net' => 3880,
+				'expected_fee' => 1.20,
+				'expected_net' => 38.80,
 			],
 			'replace mode - capture replaces existing fees' => [
-				'existing_fee' => 150,
-				'existing_net' => 4850,
+				'existing_fee' => 1.50,
+				'existing_net' => 48.50,
 				'api_fee'      => 75,
 				'api_net'      => 2425,
 				'replace'      => true,
-				'expected_fee' => 75,
-				'expected_net' => 2425,
+				'expected_fee' => 0.75,
+				'expected_net' => 24.25,
 			],
-			'replace mode - works with no existing fees' => [
+			'replace mode - works with no existing fees'    => [
 				'existing_fee' => 0,
 				'existing_net' => 0,
 				'api_fee'      => 50,
 				'api_net'      => 950,
 				'replace'      => true,
-				'expected_fee' => 50,
-				'expected_net' => 950,
+				'expected_fee' => 0.50,
+				'expected_net' => 9.50,
 			],
-			'add mode - first time fee setting' => [
+			'add mode - first time fee setting'             => [
 				'existing_fee' => 0,
 				'existing_net' => 0,
 				'api_fee'      => 100,
 				'api_net'      => 4900,
 				'replace'      => false,
-				'expected_fee' => 100,
-				'expected_net' => 4900,
+				'expected_fee' => 1.00,
+				'expected_net' => 49.00,
 			],
 		];
 	}

--- a/tests/phpunit/class-wc-stripe-payment-gateway-test.php
+++ b/tests/phpunit/class-wc-stripe-payment-gateway-test.php
@@ -1075,6 +1075,45 @@ class WC_Stripe_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		$this->assertEquals( $expected_net, (float) $order_helper->get_stripe_net( $order ) );
 	}
 
+	/**
+	 * Tests that update_fees leaves existing meta intact when the API returns an error.
+	 */
+	public function test_update_fees_with_api_error_leaves_meta_unchanged() {
+		$order        = WC_Helper_Order::create_order();
+		$order_helper = WC_Stripe_Order_Helper::get_instance();
+
+		$order_helper->update_stripe_fee( $order, 1.50 );
+		$order_helper->update_stripe_net( $order, 48.50 );
+
+		$mock_response = [
+			'headers'  => [],
+			'body'     => wp_json_encode(
+				[
+					'error' => [
+						'type'    => 'invalid_request_error',
+						'message' => 'No such balance transaction',
+					],
+				]
+			),
+			'response' => [
+				'code'    => 404,
+				'message' => 'Not Found',
+			],
+		];
+
+		$filter = function () use ( $mock_response ) {
+			return $mock_response;
+		};
+		add_filter( 'pre_http_request', $filter );
+
+		$this->gateway->update_fees( $order, 'txn_invalid', true );
+
+		remove_filter( 'pre_http_request', $filter );
+
+		$this->assertEquals( 1.50, (float) $order_helper->get_stripe_fee( $order ) );
+		$this->assertEquals( 48.50, (float) $order_helper->get_stripe_net( $order ) );
+	}
+
 	public function provide_update_fees_scenarios() {
 		// API fee/net values are in cents (Stripe smallest denomination).
 		// format_balance_fee() converts to dollars (divides by 100 for USD).


### PR DESCRIPTION
## Summary

- Fix `update_fees()` to support replacing fee/net values (not just adding to them) after captures
- Capture call sites now pass `$replace = true` so fees reflect the captured amount, not the authorization-phase values
- Existing refund behavior is unchanged (default `$replace = false`)

## Bug

STRIPE-750: Stripe fee and Stripe Payout line items from order is not updated after a partial capture
https://linear.app/a8c/issue/STRIPE-750/stripe-fee-and-stripe-payout-line-items-from-order-is-not-updated

## Changes

- `includes/abstracts/abstract-wc-stripe-payment-gateway.php`: Added optional `$replace` parameter to `update_fees()`. When `true`, sets fee/net directly from the balance transaction instead of adding to existing values.
- `includes/class-wc-stripe-webhook-handler.php`: Pass `true` for charge.captured (line 549) and charge.succeeded (line 629) webhook handlers.
- `includes/class-wc-stripe-order-handler.php`: Pass `true` for manual capture from admin (line 380).
- `tests/phpunit/class-wc-stripe-payment-gateway-test.php`: Added 4 test scenarios via `@dataProvider` covering both ADD and REPLACE modes.
- `changelog.txt`: Added changelog entry.

**Unchanged call sites** (correctly use default ADD mode):
- Partial capture refund adjustment (webhook-handler.php:557)
- charge.refunded webhook (webhook-handler.php:817)
- charge.refund.updated webhook (webhook-handler.php:881)
- process_response at checkout (abstract-payment-gateway.php:602)

## Testing

- PHP syntax checks pass on all modified files
- 4 new PHPUnit test cases added with data provider covering: refund adjustment (add mode), capture replacing existing fees, capture with no existing fees, first-time fee setting
- The fix is backward-compatible — the new parameter defaults to `false`, preserving all existing behavior

## Notes

This PR was created during the [Woo Bug Blitz](https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz/) via team Ceres' [`/bug-blitz` Claude skill](https://github.com/Automattic/public-resources-squad/blob/trunk/.claude/skills/bug-blitz/skill.md). The fix was authored with Claude Code assistance by a Happiness Engineer who encounters this bug in support tickets.