### PR TITLE
Fix TypeError when deferred Stripe webhooks run via Action Scheduler

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@
 * Add - Initial implementation of always-expanded Optimized Checkout Suite in shortcode checkout
 * Dev - Collapse PHPUnit tests using data providers to reduce duplication and improve test isolation
 * Dev - Treat misaligned statements as errors in PHPCS ruleset
+* Fix - Prevent TypeError when Action Scheduler runs deferred webhooks by restoring the Stripe notification payload as an object after deserialization
 
 = 10.5.3 - 2026-03-19 =
 * Fix - Restore default layout when Optimized Checkout is disabled

--- a/changelog.txt
+++ b/changelog.txt
@@ -33,7 +33,7 @@
 * Dev - Hide Stripe's testing assistant on checkout page
 * Dev - Treat misaligned statements as errors in PHPCS ruleset
 * Fix - Put subscription on hold when Stripe Radar blocks a renewal payment to prevent WC Subscriptions from scheduling further retry attempts
-* Fix - Prevent TypeError when Action Scheduler runs deferred webhooks by restoring the Stripe notification payload as an object after deserialization
+* Fix - Prevent TypeError when processing deferred webhooks using Action Scheduler
 
 = 10.5.3 - 2026-03-19 =
 * Fix - Restore default layout when Optimized Checkout is disabled

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1312,16 +1312,54 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
+	 * Restores a webhook notification to an object after Action Scheduler deserialization.
+	 *
+	 * Action Scheduler in defer_webhook_processing() serializes job args; stdClass becomes a nested array. process_deferred_webhook() expects Stripe's
+	 * object-shaped payload.
+	 *
+	 * @param array|object $notification Raw notification from the scheduled job.
+	 * @return object      The normalized notification object.
+	 * @throws Exception When the payload cannot be normalized.
+	 */
+	private function normalize_deferred_webhook_notification_to_object( $notification ) {
+		if ( is_array( $notification ) ) {
+			$json = wp_json_encode( $notification );
+			if ( false === $json ) {
+				throw new Exception( 'Failed to encode deferred webhook notification for object restoration.' );
+			}
+
+			$object = json_decode( $json );
+			if ( ! is_object( $object ) ) {
+				throw new Exception( 'Failed to restore deferred webhook notification to an object.' );
+			}
+
+			return $object;
+		}
+
+		if ( is_object( $notification ) ) {
+			return $notification;
+		}
+
+		throw new Exception( 'Deferred webhook notification data is missing or invalid.' );
+	}
+
+	/**
 	 * Processes a deferred webhook event.
 	 *
 	 * Deferred webhooks are scheduled by @see defer_webhook_processing().
 	 *
-	 * @param string $webhook_type    The webhook event name/type.
-	 * @param array  $additional_data Additional data passed to the scheduled job.
-	 * @param stdClass $notification  The webhook notification payload.
+	 * @param string          $webhook_type    The webhook event name/type.
+	 * @param array           $additional_data Additional data passed to the scheduled job.
+	 * @param array|object|null $notification  The webhook notification payload (arrays after AS deserialization).
 	 */
 	public function process_deferred_webhook( $webhook_type, $additional_data, $notification = null ) {
 		try {
+			if ( null === $notification ) {
+				throw new Exception( 'Missing deferred webhook notification.' );
+			}
+
+			$notification = $this->normalize_deferred_webhook_notification_to_object( $notification );
+
 			switch ( $webhook_type ) {
 				case 'payment_intent.succeeded':
 				case 'payment_intent.amount_capturable_updated':

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1322,6 +1322,10 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @throws Exception When the payload cannot be normalized.
 	 */
 	private function normalize_deferred_webhook_notification_to_object( $notification ) {
+		if ( is_object( $notification ) ) {
+			return $notification;
+		}
+
 		if ( is_array( $notification ) ) {
 			$json = wp_json_encode( $notification );
 			if ( false === $json ) {
@@ -1334,10 +1338,6 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			}
 
 			return $object;
-		}
-
-		if ( is_object( $notification ) ) {
-			return $notification;
 		}
 
 		throw new Exception( 'Deferred webhook notification data is missing or invalid.' );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3541,12 +3541,6 @@ parameters:
 			path: includes/class-wc-stripe-webhook-handler.php
 
 		-
-			message: '#^Parameter \#2 \$notification of method WC_Stripe_Webhook_Handler\:\:run_webhook_received_action\(\) expects object, stdClass\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wc-stripe-webhook-handler.php
-
-		-
 			message: '#^Parameter \#2 \$request_body of method WC_Stripe_Webhook_Handler\:\:validate_request\(\) expects array, string\|false given\.$#'
 			identifier: argument.type
 			count: 1
@@ -4691,7 +4685,6 @@ parameters:
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
 
 		-
 			message: '#^Cannot access property \$generated_sepa_debit on string\.$#'

--- a/readme.txt
+++ b/readme.txt
@@ -174,5 +174,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Initial implementation of always-expanded Optimized Checkout Suite in shortcode checkout
 * Dev - Collapse PHPUnit tests using data providers to reduce duplication and improve test isolation
 * Dev - Treat misaligned statements as errors in PHPCS ruleset
+* Fix - Prevent TypeError when Action Scheduler runs deferred webhooks by restoring the Stripe notification payload as an object after deserialization
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -181,6 +181,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Hide Stripe's testing assistant on checkout page
 * Dev - Treat misaligned statements as errors in PHPCS ruleset
 * Fix - Put subscription on hold when Stripe Radar blocks a renewal payment to prevent WC Subscriptions from scheduling further retry attempts
-* Fix - Prevent TypeError when Action Scheduler runs deferred webhooks by restoring the Stripe notification payload as an object after deserialization
+* Fix - Prevent TypeError when processing deferred webhooks using Action Scheduler
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -204,40 +204,43 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 
 		add_action( 'wc_stripe_webhook_received', $listener, 10, 3 );
 
-		$order        = WC_Helper_Order::create_order();
-		$intent_id    = 'pi_mock_1234';
-		$data         = [
-			'order_id'  => $order->get_id(),
-			'intent_id' => $intent_id,
-		];
-		$notification = (object) [
-			'type' => 'payment_intent.succeeded',
-			'data' => (object) [
-				'object' => (object) [
-					'id'                 => $intent_id,
-					'charges'            => (object) [
-						'total_count' => 1,
-						'data'        => [
-							(object) self::MOCK_PAYMENT_INTENT['charges']['data'][0],
+		try {
+
+			$order        = WC_Helper_Order::create_order();
+			$intent_id    = 'pi_mock_1234';
+			$data         = [
+				'order_id'  => $order->get_id(),
+				'intent_id' => $intent_id,
+			];
+			$notification = (object) [
+				'type' => 'payment_intent.succeeded',
+				'data' => (object) [
+					'object' => (object) [
+						'id'                 => $intent_id,
+						'charges'            => (object) [
+							'total_count' => 1,
+							'data'        => [
+								(object) self::MOCK_PAYMENT_INTENT['charges']['data'][0],
+							],
 						],
+						'last_payment_error' => null,
 					],
-					'last_payment_error' => null,
 				],
-			],
-		];
+			];
 
-		$notification_as_arrays = json_decode( wp_json_encode( $notification ), true );
-		$this->assertIsArray( $notification_as_arrays );
+			$notification_as_arrays = json_decode( wp_json_encode( $notification ), true );
+			$this->assertIsArray( $notification_as_arrays );
 
-		$this->mock_webhook_handler->expects( $this->once() )
-			->method( 'handle_deferred_payment_intent_succeeded' );
+			$this->mock_webhook_handler->expects( $this->once() )
+				->method( 'handle_deferred_payment_intent_succeeded' );
 
-		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data, $notification_as_arrays );
+			$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data, $notification_as_arrays );
 
-		$this->assertIsObject( $captured_notification );
-		$this->assertSame( 'payment_intent.succeeded', $captured_notification->type );
-
-		remove_action( 'wc_stripe_webhook_received', $listener, 10 );
+			$this->assertIsObject( $captured_notification );
+			$this->assertSame( 'payment_intent.succeeded', $captured_notification->type );
+		} finally {
+			remove_action( 'wc_stripe_webhook_received', $listener, 10 );
+		}
 	}
 
 	/**

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -190,6 +190,57 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Deferred webhook jobs deserialize notification stdClass to nested arrays; ensure wc_stripe_webhook_received still gets an object.
+	 *
+	 * @return void
+	 */
+	public function test_process_deferred_webhook_normalizes_array_notification_for_wc_stripe_webhook_received() {
+		$captured_notification = null;
+
+		$listener = static function ( $webhook_type, $notification ) use ( &$captured_notification ) {
+			unset( $webhook_type );
+			$captured_notification = $notification;
+		};
+
+		add_action( 'wc_stripe_webhook_received', $listener, 10, 3 );
+
+		$order        = WC_Helper_Order::create_order();
+		$intent_id    = 'pi_mock_1234';
+		$data         = [
+			'order_id'  => $order->get_id(),
+			'intent_id' => $intent_id,
+		];
+		$notification = (object) [
+			'type' => 'payment_intent.succeeded',
+			'data' => (object) [
+				'object' => (object) [
+					'id'                 => $intent_id,
+					'charges'            => (object) [
+						'total_count' => 1,
+						'data'        => [
+							(object) self::MOCK_PAYMENT_INTENT['charges']['data'][0],
+						],
+					],
+					'last_payment_error' => null,
+				],
+			],
+		];
+
+		$notification_as_arrays = json_decode( wp_json_encode( $notification ), true );
+		$this->assertIsArray( $notification_as_arrays );
+
+		$this->mock_webhook_handler->expects( $this->once() )
+			->method( 'handle_deferred_payment_intent_succeeded' );
+
+		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data, $notification_as_arrays );
+
+		$this->assertIsObject( $captured_notification );
+		$this->assertSame( 'payment_intent.succeeded', $captured_notification->type );
+
+		remove_action( 'wc_stripe_webhook_received', $listener, 10 );
+	}
+
+	/**
 	 * Test deferred webhook where the intent is no longer stored on the order.
 	 */
 	public function test_mismatch_intent_id_process_deferred_webhook() {


### PR DESCRIPTION
Fixes STRIPE-1004
Fixes #5184 

Action Scheduler serializes scheduled job arguments. For `wc_stripe_deferred_webhook`, the Stripe webhook stdClass becomes nested arrays on load. `process_deferred_webhook()` then passed that value to `run_webhook_received_action( string $webhook_type, object $notification )`, which triggered a TypeError and failed every deferred job (notably redirect flows such as iDEAL / Klarna).

## Changes proposed in this Pull Request:
- Add `normalize_deferred_webhook_notification_to_object()` method to turn deserialized array payloads back into an object
- Call it at the start of `process_deferred_webhook()` to ensure the data passed to `run_webhook_received_action` is of correct type.

## Testing instructions
- Enable iDEAL or Klarna as a payment method
- Place a test order using iDEAL or Klarna
- Check out to `develop` branch.
- Complete the payment on the bank redirect page
- Go to **WooCommerce > Status > Action Scheduler**
- Search for the `wc_stripe_deferred_webhook` action
- The action should be failed with the TypeError message above
- Check out to this branch and follow the same steps.
-  `wc_stripe_deferred_webhook` actions should be successful now.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
