### PR TITLE
Fix console error when toggling save payment method with Adaptive Pricing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -31,6 +31,7 @@
 * Dev - Hide Stripe's testing assistant on checkout page
 * Dev - Treat misaligned statements as errors in PHPCS ruleset
 * Fix - Put subscription on hold when Stripe Radar blocks a renewal payment to prevent WC Subscriptions from scheduling further retry attempts
+* Fix - Prevent JavaScript error in `elements.update` when using checkout sessions with adaptive pricing
 
 = 10.5.3 - 2026-03-19 =
 * Fix - Restore default layout when Optimized Checkout is disabled

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
@@ -289,13 +289,20 @@ const PaymentProcessor = ( {
 			savingPaymentMethodCheckbox?.addEventListener(
 				'change',
 				function () {
-					elements.update( {
-						setupFutureUsage:
-							stripeServerData?.cartContainsSubscription ||
-							savingPaymentMethodCheckbox?.checked
-								? 'off_session'
-								: null,
-					} );
+					// `stripe.elements()` exposes `update()`; Adaptive Pricing uses `initCheckout()`, which
+					// returns a Checkout object without that API — toggling save-for-later there requires handling the change in the server.
+					// not a client-side Elements update.
+					// We check for the existence of the `update` function here instead of the 'isAdaptivePricingEnabled' flag
+					// because we might be using the payment element as a fallback though the flag is set to true.
+					if ( typeof elements.update === 'function' ) {
+						elements.update( {
+							setupFutureUsage:
+								stripeServerData?.cartContainsSubscription ||
+								savingPaymentMethodCheckbox?.checked
+									? 'off_session'
+									: null,
+						} );
+					}
 				}
 			);
 		}

--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -190,13 +190,19 @@ jQuery( function ( $ ) {
 				const cartContainsSubscription =
 					stripeServerData?.cartContainsSubscription;
 
-				// Update only the setupFutureUsage on the Elements object and preserve user input.
-				component.elements.update( {
-					setupFutureUsage:
-						cartContainsSubscription || isChecked
-							? 'off_session'
-							: null,
-				} );
+				// `stripe.elements()` exposes `update()`; Adaptive Pricing uses `initCheckout()`, which
+				// returns a Checkout object without that API — toggling save-for-later there requires handling the change in the server.
+				// not a client-side Elements update.
+				// We check for the existence of the `update` function here instead of the 'isAdaptivePricingEnabled' flag
+				// because we might be using the paaymente element as a fallback though the flag is set to true.
+				if ( typeof component.elements.update === 'function' ) {
+					component.elements.update( {
+						setupFutureUsage:
+							cartContainsSubscription || isChecked
+								? 'off_session'
+								: null,
+					} );
+				}
 			}
 		} );
 	}

--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -194,7 +194,7 @@ jQuery( function ( $ ) {
 				// returns a Checkout object without that API — toggling save-for-later there requires handling the change in the server.
 				// not a client-side Elements update.
 				// We check for the existence of the `update` function here instead of the 'isAdaptivePricingEnabled' flag
-				// because we might be using the paaymente element as a fallback though the flag is set to true.
+				// because we might be using the payment element as a fallback though the flag is set to true.
 				if ( typeof component.elements.update === 'function' ) {
 					component.elements.update( {
 						setupFutureUsage:

--- a/readme.txt
+++ b/readme.txt
@@ -179,5 +179,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Hide Stripe's testing assistant on checkout page
 * Dev - Treat misaligned statements as errors in PHPCS ruleset
 * Fix - Put subscription on hold when Stripe Radar blocks a renewal payment to prevent WC Subscriptions from scheduling further retry attempts
+* Fix - Prevent JavaScript error in `elements.update` when using checkout sessions with adaptive pricing
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-998

On classic checkout with Optimized Checkout, changing the “save payment information” checkbox runs code that calls `elements.update`. When Adaptive Pricing is active, the Payment Element is created via `stripe.initCheckout()`, which returns a Checkout instance that does not expose `elements.update`, causing an uncaught TypeError in the console.

## Changes proposed in this Pull Request:
Call `elements.update` only when the function is defined.

Added this function check instead of `isAdaptivePricingEnabled` flag check (which is sent from the server side) because the integration can still use the standard `stripe.elements()` path as a fallback when AP session creation fails, and that path does support update.

## Testing instructions
- Enable adaptive pricing flag by adding this code snippet `add_filter('wc_stripe_is_checkout_sessions_available', '__return_true');`
- Enable optimized checkout and adaptive pricing from the settings page.
- As a shopper, add a product to your cart and go to the classic checkout page.
- Select Stripe for payment.
- Open the developer console of your browser.
- When the adaptive pricing element is loaded, click the save payment method checkbox.
- In `develop` branch, you'll see the following console error

```
Uncaught TypeError: component.elements.update is not a function
```
- In this branch, there should be no console errors.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
