### PR TITLE
Add Stripe Connect agentic_commerce_settings embedded component

### DIFF
--- a/client/settings/agentic-commerce/__tests__/index.test.js
+++ b/client/settings/agentic-commerce/__tests__/index.test.js
@@ -4,6 +4,16 @@ import apiFetch from '@wordpress/api-fetch';
 
 jest.mock( '@wordpress/api-fetch' );
 
+// Stripe Connect packages are not designed for jsdom. Mock them out so tests
+// focus on the product-feed dashboard rather than the embedded component.
+jest.mock( '@stripe/connect-js', () => ( {
+	loadConnectAndInitialize: jest.fn(),
+} ) );
+jest.mock( '@stripe/react-connect-js', () => ( {
+	ConnectComponentsProvider: ( { children } ) => children,
+	useConnectComponents: jest.fn( () => ( { connectInstance: null } ) ),
+} ) );
+
 // Static baseline response. next_sync is intentionally omitted here so
 // individual tests can provide a value that is always relative to real time.
 const LAST_SYNC_SUCCESS = {
@@ -42,8 +52,16 @@ const makeResponse = ( overrides = {} ) => ( {
 const EMPTY_RESPONSE = { last_sync: null, history: [], next_sync: null };
 
 describe( 'AgenticCommercePanel', () => {
+	beforeEach( () => {
+		// Provide the global injected by wp_localize_script. No publishable_key
+		// means AgenticCommerceConnectPanel renders null, keeping tests focused
+		// on the product-feed dashboard.
+		global.wc_stripe_settings_params = {};
+	} );
+
 	afterEach( () => {
 		jest.resetAllMocks();
+		delete global.wc_stripe_settings_params;
 	} );
 
 	// -------------------------------------------------------------------------

--- a/client/settings/agentic-commerce/index.js
+++ b/client/settings/agentic-commerce/index.js
@@ -1,4 +1,9 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { loadConnectAndInitialize } from '@stripe/connect-js';
+import {
+	ConnectComponentsProvider,
+	useConnectComponents,
+} from '@stripe/react-connect-js';
 import styled from '@emotion/styled';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
@@ -167,6 +172,76 @@ const humanTimeDiff = ( timestamp ) => {
 // Minimal sprintf for %d substitution.
 const sprintf = ( fmt, ...args ) => fmt.replace( /%d/g, () => args.shift() );
 
+/* global wc_stripe_settings_params */
+
+/**
+ * Mounts the Stripe Connect agentic-commerce-settings web component.
+ * Uses the imperative API until ConnectAgenticCommerceSettings is
+ * available in the react-connect-js package.
+ */
+const AgenticCommerceSettingsComponent = () => {
+	const containerRef = useRef( null );
+	const { connectInstance } = useConnectComponents();
+
+	useEffect( () => {
+		if ( ! containerRef.current || ! connectInstance ) {
+			return;
+		}
+		// 'agentic-commerce-settings' is not yet in ConnectElementTagName;
+		// cast through unknown until the package ships the type.
+		const tagName = /** @type {unknown} */ ( 'agentic-commerce-settings' );
+		const el = connectInstance.create( tagName );
+		containerRef.current.appendChild( el );
+		const container = containerRef.current;
+		return () => {
+			if ( container.contains( el ) ) {
+				container.removeChild( el );
+			}
+		};
+	}, [ connectInstance ] );
+
+	return <div ref={ containerRef } />;
+};
+
+/**
+ * Initialises a Stripe Connect instance and renders the agentic commerce
+ * settings embedded component. Returns null when no publishable key is set.
+ */
+const AgenticCommerceConnectPanel = () => {
+	// eslint-disable-next-line camelcase
+	const publishableKey = wc_stripe_settings_params?.publishable_key;
+
+	const [ connectInstance ] = useState( () => {
+		if ( ! publishableKey ) {
+			return null;
+		}
+		return loadConnectAndInitialize( {
+			publishableKey,
+			fetchClientSecret: async () => {
+				try {
+					const result = await apiFetch( {
+						path: '/wc/v3/wc_stripe/agentic-commerce/account-session',
+						method: 'POST',
+					} );
+					return result?.client_secret ?? undefined;
+				} catch {
+					return undefined;
+				}
+			},
+		} );
+	} );
+
+	if ( ! connectInstance ) {
+		return null;
+	}
+
+	return (
+		<ConnectComponentsProvider connectInstance={ connectInstance }>
+			<AgenticCommerceSettingsComponent />
+		</ConnectComponentsProvider>
+	);
+};
+
 const AgenticCommercePanel = () => {
 	const [ data, setData ] = useState( null );
 	const [ isLoading, setIsLoading ] = useState( true );
@@ -259,6 +334,8 @@ const AgenticCommercePanel = () => {
 
 	return (
 		<div>
+			<AgenticCommerceConnectPanel />
+
 			<p className="description">
 				{ __(
 					'Monitors the product feed sync status for the Agentic Commerce integration.',

--- a/client/settings/agentic-commerce/index.js
+++ b/client/settings/agentic-commerce/index.js
@@ -175,7 +175,8 @@ const sprintf = ( fmt, ...args ) => fmt.replace( /%d/g, () => args.shift() );
 /* global wc_stripe_settings_params */
 
 /**
- * Mounts the Stripe Connect agentic-commerce-settings web component.
+ * Mounts the Stripe Connect agentic-commerce-settings web component
+ * imperatively. Must be rendered inside ConnectComponentsProvider.
  * Uses the imperative API until ConnectAgenticCommerceSettings is
  * available in the react-connect-js package.
  */
@@ -204,41 +205,94 @@ const AgenticCommerceSettingsComponent = () => {
 };
 
 /**
- * Initialises a Stripe Connect instance and renders the agentic commerce
- * settings embedded component. Returns null when no publishable key is set.
+ * Fetches a Stripe account session, then initialises a Connect instance
+ * and renders the agentic-commerce-settings embedded component.
+ *
+ * Pre-fetching the client_secret before calling loadConnectAndInitialize
+ * prevents the element being mounted without valid authentication, which
+ * would otherwise cause a cascade of Stripe Connect errors in the console.
+ *
+ * Returns null when no publishable key is configured or while loading.
+ * Shows an error notice when the account session endpoint fails.
  */
 const AgenticCommerceConnectPanel = () => {
 	// eslint-disable-next-line camelcase
 	const publishableKey = wc_stripe_settings_params?.publishable_key;
+	const [ connectInstance, setConnectInstance ] = useState( null );
+	const [ sessionError, setSessionError ] = useState( null );
+	const [ isLoading, setIsLoading ] = useState( true );
 
-	const [ connectInstance ] = useState( () => {
+	useEffect( () => {
 		if ( ! publishableKey ) {
-			return null;
+			setIsLoading( false );
+			return;
 		}
-		return loadConnectAndInitialize( {
-			publishableKey,
-			fetchClientSecret: async () => {
-				try {
-					const result = await apiFetch( {
-						path: '/wc/v3/wc_stripe/agentic-commerce/account-session',
-						method: 'POST',
-					} );
-					return result?.client_secret ?? undefined;
-				} catch {
-					return undefined;
+
+		apiFetch( {
+			path: '/wc/v3/wc_stripe/agentic-commerce/account-session',
+			method: 'POST',
+		} )
+			.then( ( result ) => {
+				const secret = result?.client_secret;
+				if ( ! secret ) {
+					throw new Error(
+						__(
+							'No client_secret in account session response.',
+							'woocommerce-gateway-stripe'
+						)
+					);
 				}
-			},
-		} );
-	} );
+				setConnectInstance(
+					loadConnectAndInitialize( {
+						publishableKey,
+						fetchClientSecret: () => Promise.resolve( secret ),
+					} )
+				);
+			} )
+			.catch( ( err ) => {
+				setSessionError(
+					err?.message ??
+						__(
+							'Failed to load agent settings.',
+							'woocommerce-gateway-stripe'
+						)
+				);
+			} )
+			.finally( () => {
+				setIsLoading( false );
+			} );
+	}, [ publishableKey ] );
+
+	if ( ! publishableKey || isLoading ) {
+		return null;
+	}
+
+	if ( sessionError ) {
+		return (
+			<Card>
+				<CardTitle>
+					{ __( 'Agent Settings', 'woocommerce-gateway-stripe' ) }
+				</CardTitle>
+				<Notice status="error" isDismissible={ false }>
+					{ sessionError }
+				</Notice>
+			</Card>
+		);
+	}
 
 	if ( ! connectInstance ) {
 		return null;
 	}
 
 	return (
-		<ConnectComponentsProvider connectInstance={ connectInstance }>
-			<AgenticCommerceSettingsComponent />
-		</ConnectComponentsProvider>
+		<Card>
+			<CardTitle>
+				{ __( 'Agent Settings', 'woocommerce-gateway-stripe' ) }
+			</CardTitle>
+			<ConnectComponentsProvider connectInstance={ connectInstance }>
+				<AgenticCommerceSettingsComponent />
+			</ConnectComponentsProvider>
+		</Card>
 	);
 };
 

--- a/includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
+++ b/includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
@@ -51,6 +51,16 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 				'permission_callback' => [ $this, 'check_permission' ],
 			]
 		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/account-session',
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'create_account_session' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
 	}
 
 	/**
@@ -140,5 +150,76 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 			'import_set_id' => $entry['import_set_id'] ?? null,
 			'error'         => $entry['error'] ?? null,
 		];
+	}
+
+	/**
+	 * Create a Stripe account session for the agentic_commerce_settings embedded component.
+	 *
+	 * @since 10.7.0
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function create_account_session() {
+		$account = WC_Stripe_API::retrieve( 'account' );
+
+		if ( is_wp_error( $account ) || isset( $account->error ) ) {
+			return new WP_Error(
+				'stripe_account_unavailable',
+				__( 'Unable to retrieve Stripe account.', 'woocommerce-gateway-stripe' ),
+				[ 'status' => 503 ]
+			);
+		}
+
+		$account_id = $account->id ?? null;
+
+		if ( ! $account_id ) {
+			return new WP_Error(
+				'stripe_account_id_missing',
+				__( 'Stripe account ID not found.', 'woocommerce-gateway-stripe' ),
+				[ 'status' => 503 ]
+			);
+		}
+
+		// Temporarily add the embedded_connect_beta header required for account sessions.
+		$add_beta_version = function ( array $headers ): array {
+			$headers['Stripe-Version'] .= '; embedded_connect_beta=v2';
+			return $headers;
+		};
+		add_filter( 'wc_stripe_request_headers', $add_beta_version );
+
+		try {
+			$response = WC_Stripe_API::request(
+				[
+					'account'    => $account_id,
+					'components' => [
+						'agentic_commerce_settings' => [
+							'enabled' => 'true',
+						],
+					],
+				],
+				'account_sessions',
+				'POST'
+			);
+		} catch ( WC_Stripe_Exception $e ) {
+			remove_filter( 'wc_stripe_request_headers', $add_beta_version );
+			return new WP_Error(
+				'stripe_account_session_failed',
+				$e->getMessage(),
+				[ 'status' => 503 ]
+			);
+		}
+
+		remove_filter( 'wc_stripe_request_headers', $add_beta_version );
+
+		if ( isset( $response->error ) ) {
+			return new WP_Error(
+				'stripe_account_session_failed',
+				$response->error->message ?? __( 'Failed to create account session.', 'woocommerce-gateway-stripe' ),
+				[ 'status' => 503 ]
+			);
+		}
+
+		$client_secret = is_object( $response ) ? ( $response->client_secret ?? null ) : null;
+
+		return rest_ensure_response( [ 'client_secret' => $client_secret ] );
 	}
 }

--- a/includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
+++ b/includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
@@ -161,7 +161,7 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 	public function create_account_session() {
 		$account = WC_Stripe_API::retrieve( 'account' );
 
-		if ( is_wp_error( $account ) || isset( $account->error ) ) {
+		if ( is_null( $account ) || is_wp_error( $account ) || isset( $account->error ) ) {
 			return new WP_Error(
 				'stripe_account_unavailable',
 				__( 'Unable to retrieve Stripe account.', 'woocommerce-gateway-stripe' ),
@@ -169,7 +169,7 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 			);
 		}
 
-		$account_id = $account->id ?? null;
+		$account_id = is_object( $account ) ? ( $account->id ?? null ) : null;
 
 		if ( ! $account_id ) {
 			return new WP_Error(

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -234,10 +234,17 @@ class WC_Stripe_Settings_Controller {
 			// Show the Stripe Tax banner only if OC is enabled
 			&& $is_oc_enabled;
 
+		$stripe_settings  = WC_Stripe_Helper::get_stripe_settings();
+		$is_test_mode     = $this->get_gateway()->is_in_test_mode();
+		$publishable_key  = $is_test_mode
+			? ( $stripe_settings['test_publishable_key'] ?? '' )
+			: ( $stripe_settings['publishable_key'] ?? '' );
+
 		$params = [
 			'time'                                  => time(),
 			'i18n_out_of_sync'                      => $message,
 			'is_upe_checkout_enabled'               => true,
+			'publishable_key'                       => $publishable_key,
 			'show_customization_notice'             => get_option( 'wc_stripe_show_customization_notice', 'yes' ) === 'yes' ? true : false,
 			'show_optimized_checkout_notice'        => get_option( 'wc_stripe_show_optimized_checkout_notice', 'yes' ) === 'yes' ? true : false,
 			'show_bnpl_promotional_banner'          => $show_bnpl_promotion_banner,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "license": "GPL-3.0",
       "dependencies": {
         "@automattic/interpolate-components": "^1.2.1",
+        "@stripe/connect-js": "3.3.34",
+        "@stripe/react-connect-js": "3.3.33",
         "@stripe/react-stripe-js": "^5.4.1",
         "@stripe/stripe-js": "^8.6.0",
         "@woocommerce/settings": "^1.0.0",
@@ -5423,6 +5425,23 @@
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@stripe/connect-js": {
+      "version": "3.3.34",
+      "resolved": "https://registry.npmjs.org/@stripe/connect-js/-/connect-js-3.3.34.tgz",
+      "integrity": "sha512-yVvlRbAPE1QqIGp+1lJmUtAm4LNlZh7FZPifsYqsuJ6EuDj4kMFkLo12wzEgWNVfNivSUALFSYn5ndEbwc7URg==",
+      "license": "MIT"
+    },
+    "node_modules/@stripe/react-connect-js": {
+      "version": "3.3.33",
+      "resolved": "https://registry.npmjs.org/@stripe/react-connect-js/-/react-connect-js-3.3.33.tgz",
+      "integrity": "sha512-va0ahsZCCBS18F6ro/l+i/BYIFeIm0iQQCYsGO47m0MWcl469a5vaDgLvS0q8woxt9V8DDBu6HfCXognyRq4uA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@stripe/connect-js": ">=3.3.29",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
     },
     "node_modules/@stripe/react-stripe-js": {
       "version": "5.4.1",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,8 @@
   },
   "dependencies": {
     "@automattic/interpolate-components": "^1.2.1",
+    "@stripe/connect-js": "3.3.34",
+    "@stripe/react-connect-js": "3.3.33",
     "@stripe/react-stripe-js": "^5.4.1",
     "@stripe/stripe-js": "^8.6.0",
     "@woocommerce/settings": "^1.0.0",


### PR DESCRIPTION
## Summary

Implements the `ConnectAgenticCommerceSettings` embedded component per the [Stripe docs](https://docs.stripe.com/connect/saas/tasks/enable-in-context-selling-on-ai-agents#enable-agents-for-accounts). The component renders at the top of the **Agentic Commerce** settings tab and lets connected accounts review agent marketplace terms, activate participation on AI chat platforms, and manage their agent settings without leaving the WooCommerce admin.

- **New REST endpoint** `POST /wc/v3/wc_stripe/agentic-commerce/account-session` — creates a Stripe account session with the `agentic_commerce_settings` component enabled; uses the `embedded_connect_beta=v2` API version header required by the beta feature
- **`wc_stripe_settings_params.publishable_key`** — the active (live/test) publishable key is now exposed so the frontend can initialise `loadConnectAndInitialize` without an extra round-trip
- **`AgenticCommerceConnectPanel`** — new React component rendered at the top of the tab; sets up a Stripe Connect instance and mounts the `agentic-commerce-settings` web component via the imperative `connectInstance.create()` API. This approach is used because `ConnectAgenticCommerceSettings` is not yet exported by the current `@stripe/react-connect-js` release (docs note: "for illustrative purposes only and are subject to change"). When the package ships the named export it can be swapped in with a one-line change.
- **New packages**: `@stripe/connect-js`, `@stripe/react-connect-js`
- **Tests**: existing Jest suite updated to mock both Stripe Connect packages and seed `wc_stripe_settings_params`; all 17 tests pass

## Test plan

- [ ] With a valid Stripe account session, the embedded component renders at the top of the Agentic Commerce tab
- [ ] With no publishable key set, `AgenticCommerceConnectPanel` returns `null` and the rest of the tab is unaffected
- [ ] `POST /wc/v3/wc_stripe/agentic-commerce/account-session` returns `{ client_secret }` for an authenticated admin
- [ ] Unauthenticated requests to the new endpoint return 401
- [ ] All 17 Jest tests pass: `npm run test:js`
- [ ] PHPStan passes with no new errors: `npm run phpstan`

🤖 Generated with [Claude Code](https://claude.com/claude-code)