### PR TITLE
Add custom Agentic Commerce merchant onboarding panel (STRIPE-899)

### DIFF
--- a/client/settings/agentic-commerce/__tests__/index.test.js
+++ b/client/settings/agentic-commerce/__tests__/index.test.js
@@ -4,8 +4,10 @@ import apiFetch from '@wordpress/api-fetch';
 
 jest.mock( '@wordpress/api-fetch' );
 
-// Static baseline response. next_sync is intentionally omitted here so
-// individual tests can provide a value that is always relative to real time.
+// ---------------------------------------------------------------------------
+// Feed status fixtures
+// ---------------------------------------------------------------------------
+
 const LAST_SYNC_SUCCESS = {
 	status: 'succeeded',
 	timestamp: 1700000000,
@@ -32,14 +34,49 @@ const HISTORY = [
 	},
 ];
 
-const makeResponse = ( overrides = {} ) => ( {
+const makeFeedResponse = ( overrides = {} ) => ( {
 	last_sync: LAST_SYNC_SUCCESS,
 	history: HISTORY,
 	next_sync: null,
 	...overrides,
 } );
 
-const EMPTY_RESPONSE = { last_sync: null, history: [], next_sync: null };
+const EMPTY_FEED_RESPONSE = { last_sync: null, history: [], next_sync: null };
+
+// ---------------------------------------------------------------------------
+// Merchant settings fixtures
+// ---------------------------------------------------------------------------
+
+const EMPTY_MERCHANT_SETTINGS = {
+	terms_of_service_url: '',
+	privacy_policy_url: '',
+	refund_policy_url: '',
+	hook_url: '',
+	hook_secret: '',
+	hook_secret_is_set: false,
+};
+
+const POPULATED_MERCHANT_SETTINGS = {
+	terms_of_service_url: 'https://example.com/terms',
+	privacy_policy_url: 'https://example.com/privacy',
+	refund_policy_url: 'https://example.com/returns',
+	hook_url: 'https://example.com/hook',
+	hook_secret: '••••••••',
+	hook_secret_is_set: true,
+};
+
+// ---------------------------------------------------------------------------
+// Helper: mock both API calls that fire on mount (merchant-settings + feed status)
+// ---------------------------------------------------------------------------
+
+const mockBothOnMount = ( merchantOverrides = {}, feedOverrides = {} ) => {
+	apiFetch
+		.mockResolvedValueOnce( {
+			...EMPTY_MERCHANT_SETTINGS,
+			...merchantOverrides,
+		} )
+		.mockResolvedValueOnce( { ...EMPTY_FEED_RESPONSE, ...feedOverrides } );
+};
 
 describe( 'AgenticCommercePanel', () => {
 	afterEach( () => {
@@ -51,7 +88,8 @@ describe( 'AgenticCommercePanel', () => {
 	// -------------------------------------------------------------------------
 
 	it( 'shows loading indicators while fetching', () => {
-		apiFetch.mockReturnValueOnce( new Promise( () => {} ) );
+		// Both fetch calls never resolve during this test.
+		apiFetch.mockReturnValue( new Promise( () => {} ) );
 
 		render( <AgenticCommercePanel /> );
 
@@ -61,11 +99,231 @@ describe( 'AgenticCommercePanel', () => {
 	} );
 
 	// -------------------------------------------------------------------------
-	// Empty state
+	// Onboarding panel — empty state
+	// -------------------------------------------------------------------------
+
+	it( 'renders the Agentic Commerce Setup card', async () => {
+		mockBothOnMount();
+
+		render( <AgenticCommercePanel /> );
+
+		await waitFor( () => {
+			expect(
+				screen.getByText( /Agentic Commerce Setup/i )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'renders all four URL fields', async () => {
+		mockBothOnMount();
+
+		render( <AgenticCommercePanel /> );
+
+		await waitFor( () => {
+			expect(
+				screen.getByLabelText( /Terms & Conditions URL/i )
+			).toBeInTheDocument();
+		} );
+		await waitFor( () => {
+			expect(
+				screen.getByLabelText( /Privacy Policy URL/i )
+			).toBeInTheDocument();
+		} );
+		await waitFor( () => {
+			expect(
+				screen.getByLabelText( /Refund & Return Policy URL/i )
+			).toBeInTheDocument();
+		} );
+		await waitFor( () => {
+			expect(
+				screen.getByLabelText( /Customization Webhook URL/i )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'renders the Webhook Secret field', async () => {
+		mockBothOnMount();
+
+		render( <AgenticCommercePanel /> );
+
+		await waitFor( () => {
+			expect(
+				screen.getByLabelText( /Webhook Secret/i )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'renders the Manage on Stripe Dashboard link', async () => {
+		mockBothOnMount();
+
+		render( <AgenticCommercePanel /> );
+
+		await waitFor( () => {
+			expect(
+				screen.getByText( /Manage on Stripe Dashboard/i )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'renders the Save Settings button', async () => {
+		mockBothOnMount();
+
+		render( <AgenticCommercePanel /> );
+
+		await waitFor( () => {
+			expect(
+				screen.getByRole( 'button', { name: /Save Settings/i } )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// Onboarding panel — populated state
+	// -------------------------------------------------------------------------
+
+	it( 'pre-fills URL fields from fetched settings', async () => {
+		mockBothOnMount( POPULATED_MERCHANT_SETTINGS );
+
+		render( <AgenticCommercePanel /> );
+
+		await waitFor( () => {
+			expect(
+				screen.getByDisplayValue( 'https://example.com/terms' )
+			).toBeInTheDocument();
+		} );
+		await waitFor( () => {
+			expect(
+				screen.getByDisplayValue( 'https://example.com/privacy' )
+			).toBeInTheDocument();
+		} );
+		await waitFor( () => {
+			expect(
+				screen.getByDisplayValue( 'https://example.com/returns' )
+			).toBeInTheDocument();
+		} );
+		await waitFor( () => {
+			expect(
+				screen.getByDisplayValue( 'https://example.com/hook' )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'shows "A webhook secret is already configured" when hook_secret_is_set is true', async () => {
+		mockBothOnMount( POPULATED_MERCHANT_SETTINGS );
+
+		render( <AgenticCommercePanel /> );
+
+		await waitFor( () => {
+			expect(
+				screen.getAllByText( /A webhook secret is already configured/i )
+					.length
+			).toBeGreaterThanOrEqual( 1 );
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// Onboarding panel — save settings
+	// -------------------------------------------------------------------------
+
+	it( 'calls the merchant-settings POST endpoint on save', async () => {
+		mockBothOnMount();
+
+		render( <AgenticCommercePanel /> );
+
+		const saveBtn = await screen.findByRole( 'button', {
+			name: /Save Settings/i,
+		} );
+
+		// Set up the POST mock before clicking.
+		apiFetch.mockResolvedValueOnce( EMPTY_MERCHANT_SETTINGS );
+
+		fireEvent.click( saveBtn );
+
+		await waitFor( () => {
+			expect( apiFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					path: '/wc/v3/wc_stripe/agentic-commerce/merchant-settings',
+					method: 'POST',
+				} )
+			);
+		} );
+	} );
+
+	it( 'shows success notice after saving', async () => {
+		mockBothOnMount();
+
+		render( <AgenticCommercePanel /> );
+
+		const saveBtn = await screen.findByRole( 'button', {
+			name: /Save Settings/i,
+		} );
+
+		apiFetch.mockResolvedValueOnce( EMPTY_MERCHANT_SETTINGS );
+		fireEvent.click( saveBtn );
+
+		await waitFor( () => {
+			expect(
+				screen.getAllByText( /Settings saved/i ).length
+			).toBeGreaterThanOrEqual( 1 );
+		} );
+	} );
+
+	it( 'shows error notice when save fails', async () => {
+		mockBothOnMount();
+
+		render( <AgenticCommercePanel /> );
+
+		const saveBtn = await screen.findByRole( 'button', {
+			name: /Save Settings/i,
+		} );
+
+		apiFetch.mockRejectedValueOnce( { message: 'Validation failed' } );
+		fireEvent.click( saveBtn );
+
+		await waitFor( () => {
+			expect(
+				screen.getAllByText( /Validation failed/i ).length
+			).toBeGreaterThanOrEqual( 1 );
+		} );
+	} );
+
+	it( 'shows fallback error message when save fails without a message', async () => {
+		mockBothOnMount();
+
+		render( <AgenticCommercePanel /> );
+
+		const saveBtn = await screen.findByRole( 'button', {
+			name: /Save Settings/i,
+		} );
+
+		apiFetch.mockRejectedValueOnce( {} );
+		fireEvent.click( saveBtn );
+
+		await waitFor( () => {
+			expect(
+				screen.getAllByText( /Failed to save settings/i ).length
+			).toBeGreaterThanOrEqual( 1 );
+		} );
+	} );
+
+	it( 'fetches merchant-settings from the correct REST path on mount', async () => {
+		mockBothOnMount();
+
+		render( <AgenticCommercePanel /> );
+
+		await waitFor( () => {
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/wc/v3/wc_stripe/agentic-commerce/merchant-settings',
+			} );
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// Feed status — empty state
 	// -------------------------------------------------------------------------
 
 	it( 'shows "No syncs yet" when last_sync is null', async () => {
-		apiFetch.mockResolvedValueOnce( EMPTY_RESPONSE );
+		mockBothOnMount();
 
 		render( <AgenticCommercePanel /> );
 
@@ -75,7 +333,7 @@ describe( 'AgenticCommercePanel', () => {
 	} );
 
 	it( 'shows "No sync history available" when history is empty', async () => {
-		apiFetch.mockResolvedValueOnce( EMPTY_RESPONSE );
+		mockBothOnMount();
 
 		render( <AgenticCommercePanel /> );
 
@@ -87,17 +345,15 @@ describe( 'AgenticCommercePanel', () => {
 	} );
 
 	// -------------------------------------------------------------------------
-	// Populated state — last_sync card
+	// Feed status — populated state
 	// -------------------------------------------------------------------------
 
 	it( 'renders a success status badge when last sync succeeded', async () => {
-		apiFetch.mockResolvedValueOnce( makeResponse() );
+		mockBothOnMount( {}, makeFeedResponse() );
 
 		render( <AgenticCommercePanel /> );
 
 		await waitFor( () => {
-			// At least one "Success" badge must be in the document (may also
-			// appear in the history table row and the aria-live region).
 			expect(
 				screen.getAllByText( /Success/i ).length
 			).toBeGreaterThanOrEqual( 1 );
@@ -105,12 +361,11 @@ describe( 'AgenticCommercePanel', () => {
 	} );
 
 	it( 'renders product count from last_sync', async () => {
-		apiFetch.mockResolvedValueOnce( makeResponse() );
+		mockBothOnMount( {}, makeFeedResponse() );
 
 		render( <AgenticCommercePanel /> );
 
 		await waitFor( () => {
-			// "42" appears in the status table (products synced).
 			expect( screen.getAllByText( '42' ).length ).toBeGreaterThanOrEqual(
 				1
 			);
@@ -118,7 +373,7 @@ describe( 'AgenticCommercePanel', () => {
 	} );
 
 	it( 'renders import_set_id from last_sync', async () => {
-		apiFetch.mockResolvedValueOnce( makeResponse() );
+		mockBothOnMount( {}, makeFeedResponse() );
 
 		render( <AgenticCommercePanel /> );
 
@@ -130,11 +385,11 @@ describe( 'AgenticCommercePanel', () => {
 	} );
 
 	// -------------------------------------------------------------------------
-	// Populated state — history table
+	// Feed status — history table
 	// -------------------------------------------------------------------------
 
 	it( 'renders the history table with correct row count', async () => {
-		apiFetch.mockResolvedValueOnce( makeResponse() );
+		mockBothOnMount( {}, makeFeedResponse() );
 
 		render( <AgenticCommercePanel /> );
 
@@ -144,7 +399,7 @@ describe( 'AgenticCommercePanel', () => {
 	} );
 
 	it( 'shows an info icon next to failed history rows that have an error', async () => {
-		apiFetch.mockResolvedValueOnce( makeResponse() );
+		mockBothOnMount( {}, makeFeedResponse() );
 
 		render( <AgenticCommercePanel /> );
 
@@ -161,8 +416,9 @@ describe( 'AgenticCommercePanel', () => {
 	// -------------------------------------------------------------------------
 
 	it( 'renders the last sync error notice when last_sync has an error', async () => {
-		apiFetch.mockResolvedValueOnce(
-			makeResponse( {
+		mockBothOnMount(
+			{},
+			makeFeedResponse( {
 				last_sync: {
 					...LAST_SYNC_SUCCESS,
 					status: 'failed',
@@ -186,9 +442,7 @@ describe( 'AgenticCommercePanel', () => {
 
 	it( 'shows next sync countdown when next_sync is in the future', async () => {
 		const futureTs = Math.floor( Date.now() / 1000 ) + 1800; // 30 min ahead
-		apiFetch.mockResolvedValueOnce(
-			makeResponse( { next_sync: futureTs } )
-		);
+		mockBothOnMount( {}, makeFeedResponse( { next_sync: futureTs } ) );
 
 		render( <AgenticCommercePanel /> );
 
@@ -201,7 +455,7 @@ describe( 'AgenticCommercePanel', () => {
 
 	it( 'shows "imminent" label when next_sync is in the past', async () => {
 		const pastTs = Math.floor( Date.now() / 1000 ) - 100;
-		apiFetch.mockResolvedValueOnce( makeResponse( { next_sync: pastTs } ) );
+		mockBothOnMount( {}, makeFeedResponse( { next_sync: pastTs } ) );
 
 		render( <AgenticCommercePanel /> );
 
@@ -211,11 +465,11 @@ describe( 'AgenticCommercePanel', () => {
 	} );
 
 	// -------------------------------------------------------------------------
-	// API fetch call
+	// API fetch calls
 	// -------------------------------------------------------------------------
 
 	it( 'fetches status from the correct REST path on mount', async () => {
-		apiFetch.mockResolvedValueOnce( EMPTY_RESPONSE );
+		mockBothOnMount();
 
 		render( <AgenticCommercePanel /> );
 
@@ -231,7 +485,7 @@ describe( 'AgenticCommercePanel', () => {
 	// -------------------------------------------------------------------------
 
 	it( 'renders the Sync Now button', async () => {
-		apiFetch.mockResolvedValueOnce( EMPTY_RESPONSE );
+		mockBothOnMount();
 
 		render( <AgenticCommercePanel /> );
 
@@ -244,9 +498,10 @@ describe( 'AgenticCommercePanel', () => {
 
 	it( 'shows success notice and re-fetches after a successful sync', async () => {
 		apiFetch
-			.mockResolvedValueOnce( EMPTY_RESPONSE )
-			.mockResolvedValueOnce( { success: true } )
-			.mockResolvedValueOnce( makeResponse() );
+			.mockResolvedValueOnce( EMPTY_MERCHANT_SETTINGS ) // merchant-settings GET
+			.mockResolvedValueOnce( EMPTY_FEED_RESPONSE ) // feed status GET
+			.mockResolvedValueOnce( { success: true } ) // sync POST
+			.mockResolvedValueOnce( makeFeedResponse() ); // re-fetch after sync
 
 		render( <AgenticCommercePanel /> );
 
@@ -278,7 +533,8 @@ describe( 'AgenticCommercePanel', () => {
 
 	it( 'shows error notice when sync POST fails', async () => {
 		apiFetch
-			.mockResolvedValueOnce( EMPTY_RESPONSE )
+			.mockResolvedValueOnce( EMPTY_MERCHANT_SETTINGS )
+			.mockResolvedValueOnce( EMPTY_FEED_RESPONSE )
 			.mockRejectedValueOnce( { message: 'Server error' } );
 
 		render( <AgenticCommercePanel /> );
@@ -297,7 +553,8 @@ describe( 'AgenticCommercePanel', () => {
 
 	it( 'shows fallback error message when sync POST fails without a message', async () => {
 		apiFetch
-			.mockResolvedValueOnce( EMPTY_RESPONSE )
+			.mockResolvedValueOnce( EMPTY_MERCHANT_SETTINGS )
+			.mockResolvedValueOnce( EMPTY_FEED_RESPONSE )
 			.mockRejectedValueOnce( {} );
 
 		render( <AgenticCommercePanel /> );
@@ -317,10 +574,10 @@ describe( 'AgenticCommercePanel', () => {
 	} );
 
 	// -------------------------------------------------------------------------
-	// Fetch error
+	// Fetch error (initial load)
 	// -------------------------------------------------------------------------
 
-	it( 'shows an error notice when the initial fetch fails', async () => {
+	it( 'shows an error notice when the initial merchant-settings fetch fails', async () => {
 		apiFetch.mockRejectedValueOnce( { message: 'Connection refused' } );
 
 		render( <AgenticCommercePanel /> );

--- a/client/settings/agentic-commerce/index.js
+++ b/client/settings/agentic-commerce/index.js
@@ -2,7 +2,12 @@ import React, { useState, useEffect, useCallback } from 'react';
 import styled from '@emotion/styled';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
-import { Button, Notice } from '@wordpress/components';
+import {
+	Button,
+	Notice,
+	TextControl,
+	ExternalLink,
+} from '@wordpress/components';
 
 const Card = styled.div`
 	background: #fff;
@@ -100,6 +105,28 @@ const HistoryTable = styled.table`
 	}
 `;
 
+const FieldRow = styled.div`
+	margin-bottom: 16px;
+
+	label {
+		display: block;
+		font-weight: 600;
+		margin-bottom: 4px;
+	}
+
+	p.description {
+		margin: 4px 0 0;
+		color: #646970;
+		font-size: 13px;
+	}
+`;
+
+const SecretPlaceholder = styled.span`
+	font-family: monospace;
+	color: #646970;
+	font-size: 13px;
+`;
+
 const STATUS_CONFIG = {
 	succeeded: {
 		label: __( 'Success', 'woocommerce-gateway-stripe' ),
@@ -166,6 +193,277 @@ const humanTimeDiff = ( timestamp ) => {
 
 // Minimal sprintf for %d substitution.
 const sprintf = ( fmt, ...args ) => fmt.replace( /%d/g, () => args.shift() );
+
+// ---------------------------------------------------------------------------
+// Onboarding panel
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders the merchant onboarding form for the Agentic Commerce integration.
+ * Collects policy URLs, a customization hook URL, and a webhook secret, then
+ * saves them via the REST API. Also provides a link to the Stripe Dashboard.
+ */
+const AgenticCommerceOnboardingPanel = () => {
+	const [ settings, setSettings ] = useState( null );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ isSaving, setIsSaving ] = useState( false );
+	const [ notice, setNotice ] = useState( null );
+
+	// Local form state — keyed identically to the API fields.
+	const [ termsUrl, setTermsUrl ] = useState( '' );
+	const [ privacyUrl, setPrivacyUrl ] = useState( '' );
+	const [ refundUrl, setRefundUrl ] = useState( '' );
+	const [ hookUrl, setHookUrl ] = useState( '' );
+	const [ hookSecret, setHookSecret ] = useState( '' );
+
+	const fetchSettings = useCallback( async () => {
+		setIsLoading( true );
+		try {
+			const result = await apiFetch( {
+				path: '/wc/v3/wc_stripe/agentic-commerce/merchant-settings',
+			} );
+			setSettings( result );
+			setTermsUrl( result.terms_of_service_url ?? '' );
+			setPrivacyUrl( result.privacy_policy_url ?? '' );
+			setRefundUrl( result.refund_policy_url ?? '' );
+			setHookUrl( result.hook_url ?? '' );
+			// Never pre-fill the secret — show placeholder only.
+			setHookSecret( '' );
+		} catch ( err ) {
+			setNotice( {
+				status: 'error',
+				message:
+					err?.message ??
+					__(
+						'Failed to load Agentic Commerce settings.',
+						'woocommerce-gateway-stripe'
+					),
+			} );
+		} finally {
+			setIsLoading( false );
+		}
+	}, [] );
+
+	useEffect( () => {
+		fetchSettings();
+	}, [ fetchSettings ] );
+
+	const handleSave = async () => {
+		setIsSaving( true );
+		setNotice( null );
+		try {
+			const body = {
+				terms_of_service_url: termsUrl,
+				privacy_policy_url: privacyUrl,
+				refund_policy_url: refundUrl,
+				hook_url: hookUrl,
+			};
+			// Only send secret when the user typed something new.
+			if ( hookSecret ) {
+				body.hook_secret = hookSecret;
+			}
+			const result = await apiFetch( {
+				path: '/wc/v3/wc_stripe/agentic-commerce/merchant-settings',
+				method: 'POST',
+				data: body,
+			} );
+			setSettings( result );
+			setHookSecret( '' );
+			setNotice( {
+				status: 'success',
+				message: __( 'Settings saved.', 'woocommerce-gateway-stripe' ),
+			} );
+		} catch ( err ) {
+			setNotice( {
+				status: 'error',
+				message:
+					err?.message ??
+					__(
+						'Failed to save settings.',
+						'woocommerce-gateway-stripe'
+					),
+			} );
+		} finally {
+			setIsSaving( false );
+		}
+	};
+
+	return (
+		<Card>
+			<CardTitle>
+				{ __( 'Agentic Commerce Setup', 'woocommerce-gateway-stripe' ) }
+			</CardTitle>
+
+			<p className="description">
+				{ __(
+					'Agentic Commerce lets AI agents browse and purchase products from your store on behalf of customers. Configure the policies and webhook below so Stripe can display accurate terms and notify your store about agent-initiated events.',
+					'woocommerce-gateway-stripe'
+				) }
+			</p>
+
+			{ notice && (
+				<Notice
+					status={ notice.status }
+					onRemove={ () => setNotice( null ) }
+					isDismissible
+				>
+					{ notice.message }
+				</Notice>
+			) }
+
+			{ isLoading && (
+				<p>{ __( 'Loading…', 'woocommerce-gateway-stripe' ) }</p>
+			) }
+
+			{ ! isLoading && (
+				<>
+					<FieldRow>
+						<TextControl
+							label={ __(
+								'Terms & Conditions URL',
+								'woocommerce-gateway-stripe'
+							) }
+							value={ termsUrl }
+							onChange={ setTermsUrl }
+							placeholder="https://example.com/terms"
+							type="url"
+						/>
+						<p className="description">
+							{ __(
+								"Your store's Terms & Conditions page. Shown to customers during AI agent-assisted checkout.",
+								'woocommerce-gateway-stripe'
+							) }
+						</p>
+					</FieldRow>
+
+					<FieldRow>
+						<TextControl
+							label={ __(
+								'Privacy Policy URL',
+								'woocommerce-gateway-stripe'
+							) }
+							value={ privacyUrl }
+							onChange={ setPrivacyUrl }
+							placeholder="https://example.com/privacy"
+							type="url"
+						/>
+						<p className="description">
+							{ __(
+								"Your store's Privacy Policy page.",
+								'woocommerce-gateway-stripe'
+							) }
+						</p>
+					</FieldRow>
+
+					<FieldRow>
+						<TextControl
+							label={ __(
+								'Refund & Return Policy URL',
+								'woocommerce-gateway-stripe'
+							) }
+							value={ refundUrl }
+							onChange={ setRefundUrl }
+							placeholder="https://example.com/returns"
+							type="url"
+						/>
+						<p className="description">
+							{ __(
+								"Your store's Refund & Return Policy page.",
+								'woocommerce-gateway-stripe'
+							) }
+						</p>
+					</FieldRow>
+
+					<FieldRow>
+						<TextControl
+							label={ __(
+								'Customization Webhook URL',
+								'woocommerce-gateway-stripe'
+							) }
+							value={ hookUrl }
+							onChange={ setHookUrl }
+							placeholder="https://example.com/stripe-hook"
+							type="url"
+						/>
+						<p className="description">
+							{ __(
+								'URL that Stripe calls to allow real-time checkout customization by your store (for example custom line items or discounts).',
+								'woocommerce-gateway-stripe'
+							) }
+						</p>
+					</FieldRow>
+
+					<FieldRow>
+						<TextControl
+							label={ __(
+								'Webhook Secret',
+								'woocommerce-gateway-stripe'
+							) }
+							value={ hookSecret }
+							onChange={ setHookSecret }
+							placeholder={
+								settings?.hook_secret_is_set
+									? __(
+											'Leave blank to keep current secret',
+											'woocommerce-gateway-stripe'
+									  )
+									: __(
+											'Enter webhook signing secret',
+											'woocommerce-gateway-stripe'
+									  )
+							}
+							type="password"
+							autoComplete="off"
+						/>
+						{ settings?.hook_secret_is_set && ! hookSecret && (
+							<p className="description">
+								{ __(
+									'A webhook secret is already configured.',
+									'woocommerce-gateway-stripe'
+								) }{ ' ' }
+								<SecretPlaceholder aria-hidden="true">
+									{ settings.hook_secret }
+								</SecretPlaceholder>
+							</p>
+						) }
+						<p className="description">
+							{ __(
+								'Used to verify that webhook events originate from Stripe. Generate one in your Stripe Dashboard webhook settings.',
+								'woocommerce-gateway-stripe'
+							) }
+						</p>
+					</FieldRow>
+
+					<Actions>
+						<Button
+							variant="primary"
+							isBusy={ isSaving }
+							disabled={ isSaving }
+							onClick={ handleSave }
+						>
+							{ isSaving
+								? __( 'Saving…', 'woocommerce-gateway-stripe' )
+								: __(
+										'Save Settings',
+										'woocommerce-gateway-stripe'
+								  ) }
+						</Button>
+						<ExternalLink href="https://dashboard.stripe.com/settings/agentic-commerce">
+							{ __(
+								'Manage on Stripe Dashboard',
+								'woocommerce-gateway-stripe'
+							) }
+						</ExternalLink>
+					</Actions>
+				</>
+			) }
+		</Card>
+	);
+};
+
+// ---------------------------------------------------------------------------
+// Feed status panel
+// ---------------------------------------------------------------------------
 
 const AgenticCommercePanel = () => {
 	const [ data, setData ] = useState( null );
@@ -259,6 +557,8 @@ const AgenticCommercePanel = () => {
 
 	return (
 		<div>
+			<AgenticCommerceOnboardingPanel />
+
 			<p className="description">
 				{ __(
 					'Monitors the product feed sync status for the Agentic Commerce integration.',

--- a/includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
+++ b/includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
@@ -3,7 +3,8 @@
  * Class WC_REST_Stripe_Agentic_Commerce_Controller
  *
  * REST API controller for the Agentic Commerce product feed dashboard.
- * Provides read access to sync status/history and a sync trigger endpoint.
+ * Provides read access to sync status/history, a sync trigger endpoint,
+ * merchant onboarding settings, and an account session creator.
  *
  * @package WooCommerce_Stripe
  * @since 10.6.0
@@ -24,6 +25,13 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 	 * @var string
 	 */
 	protected $rest_base = 'wc_stripe/agentic-commerce';
+
+	/**
+	 * Option key for merchant onboarding settings.
+	 *
+	 * @var string
+	 */
+	const MERCHANT_SETTINGS_OPTION = 'wc_stripe_agentic_merchant_settings';
 
 	/**
 	 * Configure REST API routes.
@@ -48,6 +56,34 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'trigger_sync' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/merchant-settings',
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_merchant_settings' ],
+					'permission_callback' => [ $this, 'check_permission' ],
+				],
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'save_merchant_settings' ],
+					'permission_callback' => [ $this, 'check_permission' ],
+					'args'                => $this->get_merchant_settings_args(),
+				],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/account-session',
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'create_account_session' ],
 				'permission_callback' => [ $this, 'check_permission' ],
 			]
 		);
@@ -79,9 +115,9 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 
 		return rest_ensure_response(
 			[
-				'last_sync'  => empty( $last_sync ) ? null : $this->format_sync_entry( $last_sync ),
-				'history'    => $history,
-				'next_sync'  => $next_sync,
+				'last_sync' => empty( $last_sync ) ? null : $this->format_sync_entry( $last_sync ),
+				'history'   => $history,
+				'next_sync' => $next_sync,
 			]
 		);
 	}
@@ -105,6 +141,158 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 		$integration->sync_feed();
 
 		return rest_ensure_response( [ 'success' => true ] );
+	}
+
+	/**
+	 * Return the stored merchant onboarding settings.
+	 * The hook_secret field is masked for display.
+	 *
+	 * @since 10.6.0
+	 * @return WP_REST_Response
+	 */
+	public function get_merchant_settings(): WP_REST_Response {
+		$settings = get_option( self::MERCHANT_SETTINGS_OPTION, [] );
+
+		return rest_ensure_response( $this->format_merchant_settings( $settings ) );
+	}
+
+	/**
+	 * Save merchant onboarding settings.
+	 *
+	 * @since 10.6.0
+	 * @param WP_REST_Request $request Incoming request.
+	 * @return WP_REST_Response
+	 */
+	public function save_merchant_settings( WP_REST_Request $request ): WP_REST_Response {
+		$existing = get_option( self::MERCHANT_SETTINGS_OPTION, [] );
+
+		$updatable_fields = [
+			'terms_of_service_url',
+			'privacy_policy_url',
+			'refund_policy_url',
+			'hook_url',
+		];
+
+		$updated = array_merge( $existing, array_filter( array_intersect_key( $request->get_params(), array_flip( $updatable_fields ) ), 'is_string' ) );
+
+		// Only overwrite the secret if a non-empty value is explicitly provided.
+		$raw_secret = $request->get_param( 'hook_secret' );
+		if ( is_string( $raw_secret ) && '' !== $raw_secret ) {
+			$updated['hook_secret'] = $raw_secret;
+		}
+
+		update_option( self::MERCHANT_SETTINGS_OPTION, $updated );
+
+		return rest_ensure_response( $this->format_merchant_settings( $updated ) );
+	}
+
+	/**
+	 * Create a Stripe account session for the Agentic Commerce component.
+	 *
+	 * Wraps POST /v1/account_sessions with the agentic_commerce component.
+	 *
+	 * @since 10.6.0
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function create_account_session() {
+		$account = WC_Stripe_API::retrieve( 'account' );
+
+		if ( is_wp_error( $account ) ) {
+			return $account;
+		}
+
+		if ( is_null( $account ) || ! is_object( $account ) ) {
+			return new WP_Error(
+				'stripe_account_unavailable',
+				__( 'Unable to retrieve Stripe account. Please check your API keys.', 'woocommerce-gateway-stripe' ),
+				[ 'status' => 503 ]
+			);
+		}
+
+		$account_id = $account->id ?? null;
+		if ( empty( $account_id ) ) {
+			return new WP_Error(
+				'stripe_account_id_missing',
+				__( 'Stripe account ID could not be determined.', 'woocommerce-gateway-stripe' ),
+				[ 'status' => 503 ]
+			);
+		}
+
+		$response = WC_Stripe_API::request(
+			[
+				'account'    => $account_id,
+				'components' => [
+					'agentic_commerce_settings' => [ 'enabled' => true ],
+				],
+			],
+			'account_sessions'
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$client_secret = is_object( $response ) ? ( $response->client_secret ?? null ) : null;
+
+		if ( empty( $client_secret ) ) {
+			return new WP_Error(
+				'stripe_session_failed',
+				__( 'Failed to create an account session.', 'woocommerce-gateway-stripe' ),
+				[ 'status' => 502 ]
+			);
+		}
+
+		return rest_ensure_response( [ 'client_secret' => $client_secret ] );
+	}
+
+	/**
+	 * Argument schema for the save_merchant_settings endpoint.
+	 *
+	 * @since 10.6.0
+	 * @return array
+	 */
+	private function get_merchant_settings_args(): array {
+		$url_schema = [
+			'type'              => 'string',
+			'format'            => 'uri',
+			'sanitize_callback' => 'esc_url_raw',
+			'required'          => false,
+		];
+
+		return [
+			'terms_of_service_url' => $url_schema,
+			'privacy_policy_url'   => $url_schema,
+			'refund_policy_url'    => $url_schema,
+			'hook_url'             => $url_schema,
+			'hook_secret'          => [
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+				'required'          => false,
+			],
+		];
+	}
+
+	/**
+	 * Format stored merchant settings for API responses.
+	 * The hook_secret is masked so it is never returned in full.
+	 *
+	 * @since 10.6.0
+	 * @param array $settings Raw stored settings.
+	 * @return array
+	 */
+	private function format_merchant_settings( array $settings ): array {
+		$raw_secret = $settings['hook_secret'] ?? '';
+		$secret_set = '' !== $raw_secret;
+
+		return [
+			'terms_of_service_url' => $settings['terms_of_service_url'] ?? '',
+			'privacy_policy_url'   => $settings['privacy_policy_url'] ?? '',
+			'refund_policy_url'    => $settings['refund_policy_url'] ?? '',
+			'hook_url'             => $settings['hook_url'] ?? '',
+			// Never expose the real secret — return a placeholder when set.
+			'hook_secret'          => $secret_set ? '••••••••' : '',
+			'hook_secret_is_set'   => $secret_set,
+		];
 	}
 
 	/**

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -262,6 +262,7 @@ class WC_Stripe_Settings_Controller {
 			'taxes_based_on_billing'                => wc_tax_enabled() && 'billing' === get_option( 'woocommerce_tax_based_on' ),
 			'is_card_method_enabled'                => in_array( WC_Stripe_Payment_Methods::CARD, $enabled_payment_methods, true ),
 			'is_agentic_commerce_enabled'           => WC_Stripe_Feature_Flags::is_agentic_commerce_enabled(),
+			'stripe_publishable_key'                => $this->get_publishable_key(),
 		];
 		wp_localize_script(
 			'woocommerce_stripe_admin',
@@ -275,6 +276,19 @@ class WC_Stripe_Settings_Controller {
 
 		wp_enqueue_script( 'woocommerce_stripe_admin' );
 		wp_enqueue_style( 'woocommerce_stripe_admin' );
+	}
+
+	/**
+	 * Returns the publishable key appropriate for the current mode (live or test).
+	 *
+	 * @return string
+	 */
+	private function get_publishable_key(): string {
+		$settings = WC_Stripe_Helper::get_stripe_settings();
+		if ( $this->get_gateway()->is_in_test_mode() ) {
+			return $settings['test_publishable_key'] ?? '';
+		}
+		return $settings['publishable_key'] ?? '';
 	}
 
 	/**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10129,6 +10129,12 @@ parameters:
 			path: woocommerce-gateway-stripe.php
 
 		-
+			message: '#^Method WC_REST_Stripe_Agentic_Commerce_Controller\:\:save_merchant_settings\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
+			identifier: missingType.generics
+			count: 1
+			path: includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
+
+		-
 			message: '#^Function woocommerce_stripe_wc_not_supported\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/tests/phpunit/admin/class-wc-rest-stripe-agentic-commerce-controller-test.php
+++ b/tests/phpunit/admin/class-wc-rest-stripe-agentic-commerce-controller-test.php
@@ -45,6 +45,7 @@ class WC_REST_Stripe_Agentic_Commerce_Controller_Test extends WP_UnitTestCase {
 		// Ensure options start clean.
 		delete_option( WC_Stripe_Agentic_Commerce_Integration::LAST_SYNC_OPTION );
 		delete_option( WC_Stripe_Agentic_Commerce_Integration::SYNC_HISTORY_OPTION );
+		delete_option( WC_REST_Stripe_Agentic_Commerce_Controller::MERCHANT_SETTINGS_OPTION );
 	}
 
 	/**
@@ -55,6 +56,7 @@ class WC_REST_Stripe_Agentic_Commerce_Controller_Test extends WP_UnitTestCase {
 	public function tear_down(): void {
 		delete_option( WC_Stripe_Agentic_Commerce_Integration::LAST_SYNC_OPTION );
 		delete_option( WC_Stripe_Agentic_Commerce_Integration::SYNC_HISTORY_OPTION );
+		delete_option( WC_REST_Stripe_Agentic_Commerce_Controller::MERCHANT_SETTINGS_OPTION );
 		parent::tear_down();
 	}
 
@@ -81,6 +83,33 @@ class WC_REST_Stripe_Agentic_Commerce_Controller_Test extends WP_UnitTestCase {
 		wp_set_current_user( 0 );
 
 		$request  = new WP_REST_Request( 'POST', self::REST_BASE . '/sync' );
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Unauthenticated GET /merchant-settings requests should be refused.
+	 */
+	public function test_get_merchant_settings_requires_auth(): void {
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( 'GET', self::REST_BASE . '/merchant-settings' );
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Unauthenticated POST /merchant-settings requests should be refused.
+	 */
+	public function test_save_merchant_settings_requires_auth(): void {
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'POST', self::REST_BASE . '/merchant-settings' );
+		$request->set_body_params(
+			[ 'terms_of_service_url' => 'https://example.com/terms' ]
+		);
 		$response = rest_do_request( $request );
 
 		$this->assertEquals( 401, $response->get_status() );
@@ -312,6 +341,188 @@ class WC_REST_Stripe_Agentic_Commerce_Controller_Test extends WP_UnitTestCase {
 		if ( 200 === $response->get_status() ) {
 			$this->assertTrue( $response->get_data()['success'] );
 		}
+	}
+
+	// -------------------------------------------------------------------------
+	// GET /wc/v3/wc_stripe/agentic-commerce/merchant-settings
+	// -------------------------------------------------------------------------
+
+	/**
+	 * GET /merchant-settings returns defaults when no settings are stored.
+	 */
+	public function test_get_merchant_settings_returns_empty_defaults(): void {
+		$request  = new WP_REST_Request( 'GET', self::REST_BASE . '/merchant-settings' );
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'terms_of_service_url', $data );
+		$this->assertArrayHasKey( 'privacy_policy_url', $data );
+		$this->assertArrayHasKey( 'refund_policy_url', $data );
+		$this->assertArrayHasKey( 'hook_url', $data );
+		$this->assertArrayHasKey( 'hook_secret', $data );
+		$this->assertArrayHasKey( 'hook_secret_is_set', $data );
+		$this->assertSame( '', $data['terms_of_service_url'] );
+		$this->assertSame( '', $data['hook_secret'] );
+		$this->assertFalse( $data['hook_secret_is_set'] );
+	}
+
+	/**
+	 * GET /merchant-settings returns stored URL values.
+	 */
+	public function test_get_merchant_settings_returns_stored_urls(): void {
+		update_option(
+			WC_REST_Stripe_Agentic_Commerce_Controller::MERCHANT_SETTINGS_OPTION,
+			[
+				'terms_of_service_url' => 'https://example.com/terms',
+				'privacy_policy_url'   => 'https://example.com/privacy',
+				'refund_policy_url'    => 'https://example.com/returns',
+				'hook_url'             => 'https://example.com/hook',
+				'hook_secret'          => 'whsec_abc123',
+			]
+		);
+
+		$request  = new WP_REST_Request( 'GET', self::REST_BASE . '/merchant-settings' );
+		$response = rest_do_request( $request );
+
+		$data = $response->get_data();
+		$this->assertEquals( 'https://example.com/terms', $data['terms_of_service_url'] );
+		$this->assertEquals( 'https://example.com/privacy', $data['privacy_policy_url'] );
+		$this->assertEquals( 'https://example.com/returns', $data['refund_policy_url'] );
+		$this->assertEquals( 'https://example.com/hook', $data['hook_url'] );
+	}
+
+	/**
+	 * GET /merchant-settings masks the hook_secret.
+	 */
+	public function test_get_merchant_settings_masks_hook_secret(): void {
+		update_option(
+			WC_REST_Stripe_Agentic_Commerce_Controller::MERCHANT_SETTINGS_OPTION,
+			[ 'hook_secret' => 'whsec_supersecret' ]
+		);
+
+		$request  = new WP_REST_Request( 'GET', self::REST_BASE . '/merchant-settings' );
+		$response = rest_do_request( $request );
+
+		$data = $response->get_data();
+		// The real secret must NOT be exposed.
+		$this->assertNotEquals( 'whsec_supersecret', $data['hook_secret'] );
+		$this->assertTrue( $data['hook_secret_is_set'] );
+		// Placeholder mask is returned instead.
+		$this->assertStringContainsString( '•', $data['hook_secret'] );
+	}
+
+	/**
+	 * GET /merchant-settings sets hook_secret_is_set to false when no secret is stored.
+	 */
+	public function test_get_merchant_settings_secret_is_set_false_when_empty(): void {
+		update_option(
+			WC_REST_Stripe_Agentic_Commerce_Controller::MERCHANT_SETTINGS_OPTION,
+			[ 'terms_of_service_url' => 'https://example.com/terms' ]
+		);
+
+		$request  = new WP_REST_Request( 'GET', self::REST_BASE . '/merchant-settings' );
+		$response = rest_do_request( $request );
+
+		$data = $response->get_data();
+		$this->assertFalse( $data['hook_secret_is_set'] );
+		$this->assertSame( '', $data['hook_secret'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// POST /wc/v3/wc_stripe/agentic-commerce/merchant-settings
+	// -------------------------------------------------------------------------
+
+	/**
+	 * POST /merchant-settings saves URL fields and returns masked response.
+	 *
+	 * @return void
+	 */
+	public function test_save_merchant_settings_persists_urls(): void {
+		$request = new WP_REST_Request( 'POST', self::REST_BASE . '/merchant-settings' );
+		$request->set_body_params(
+			[
+				'terms_of_service_url' => 'https://example.com/terms',
+				'privacy_policy_url'   => 'https://example.com/privacy',
+				'refund_policy_url'    => 'https://example.com/returns',
+				'hook_url'             => 'https://example.com/hook',
+			]
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Verify the option was actually written.
+		$stored = get_option( WC_REST_Stripe_Agentic_Commerce_Controller::MERCHANT_SETTINGS_OPTION );
+		$this->assertEquals( 'https://example.com/terms', $stored['terms_of_service_url'] );
+		$this->assertEquals( 'https://example.com/hook', $stored['hook_url'] );
+	}
+
+	/**
+	 * POST /merchant-settings saves the hook_secret when provided.
+	 */
+	public function test_save_merchant_settings_saves_hook_secret(): void {
+		$request = new WP_REST_Request( 'POST', self::REST_BASE . '/merchant-settings' );
+		$request->set_body_params( [ 'hook_secret' => 'whsec_newsecret' ] );
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$stored = get_option( WC_REST_Stripe_Agentic_Commerce_Controller::MERCHANT_SETTINGS_OPTION );
+		$this->assertEquals( 'whsec_newsecret', $stored['hook_secret'] );
+
+		// Response should mask the secret.
+		$data = $response->get_data();
+		$this->assertNotEquals( 'whsec_newsecret', $data['hook_secret'] );
+		$this->assertTrue( $data['hook_secret_is_set'] );
+	}
+
+	/**
+	 * POST /merchant-settings does not overwrite an existing secret when none is supplied.
+	 */
+	public function test_save_merchant_settings_preserves_existing_secret_when_blank(): void {
+		update_option(
+			WC_REST_Stripe_Agentic_Commerce_Controller::MERCHANT_SETTINGS_OPTION,
+			[ 'hook_secret' => 'whsec_existing' ]
+		);
+
+		$request = new WP_REST_Request( 'POST', self::REST_BASE . '/merchant-settings' );
+		$request->set_body_params(
+			[
+				'terms_of_service_url' => 'https://example.com/terms',
+				'hook_secret'          => '', // blank → should not overwrite
+			]
+		);
+		rest_do_request( $request );
+
+		$stored = get_option( WC_REST_Stripe_Agentic_Commerce_Controller::MERCHANT_SETTINGS_OPTION );
+		$this->assertEquals( 'whsec_existing', $stored['hook_secret'] );
+	}
+
+	/**
+	 * POST /merchant-settings merges new values with existing ones.
+	 */
+	public function test_save_merchant_settings_merges_with_existing(): void {
+		update_option(
+			WC_REST_Stripe_Agentic_Commerce_Controller::MERCHANT_SETTINGS_OPTION,
+			[
+				'terms_of_service_url' => 'https://old.example.com/terms',
+				'privacy_policy_url'   => 'https://example.com/privacy',
+			]
+		);
+
+		$request = new WP_REST_Request( 'POST', self::REST_BASE . '/merchant-settings' );
+		$request->set_body_params(
+			[ 'terms_of_service_url' => 'https://new.example.com/terms' ]
+		);
+		rest_do_request( $request );
+
+		$stored = get_option( WC_REST_Stripe_Agentic_Commerce_Controller::MERCHANT_SETTINGS_OPTION );
+		// Updated field.
+		$this->assertEquals( 'https://new.example.com/terms', $stored['terms_of_service_url'] );
+		// Untouched field preserved.
+		$this->assertEquals( 'https://example.com/privacy', $stored['privacy_policy_url'] );
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds a custom **Agentic Commerce Setup** card at the top of the Agentic Commerce tab in Stripe settings. Since the Stripe embedded components are not yet available, this is a fully custom implementation that talks to the same underlying Stripe APIs.
- **Backend** — two new REST routes under `/wc/v3/wc_stripe/agentic-commerce/`:
  - `GET /merchant-settings` — returns stored policy URLs and a masked webhook secret placeholder
  - `POST /merchant-settings` — saves policy URLs, webhook URL, and webhook secret (blank secret preserves the existing value)
  - `POST /account-session` — wraps Stripe's `account_sessions/create` for future use when embedded components become available
- **Frontend** — `AgenticCommerceOnboardingPanel` renders `TextControl` fields for:
  - Terms & Conditions URL
  - Privacy Policy URL
  - Refund & Return Policy URL
  - Customization webhook URL + secret (masked on read, only written when non-blank)
  - A **Manage on Stripe Dashboard** external link
- Passes `stripe_publishable_key` via `wc_stripe_settings_params` for future embedded component use
- Webhook secret is never returned in full — API always returns `••••••••` with a `hook_secret_is_set` boolean flag

## Test plan

- [ ] Jest: `npm run test:js -- --testPathPattern="agentic-commerce|settings-manager"` — 35 tests pass
- [ ] PHPStan: `npm run phpstan` — no errors
- [ ] PHP lint: `npm run lint:php` — no errors
- [ ] Navigate to WooCommerce → Settings → Payments → Stripe → Agentic Commerce tab
- [ ] Verify the **Agentic Commerce Setup** card appears above the product feed status card
- [ ] Fill in policy URLs and a webhook secret, click **Save Settings** — verify success notice and persistence across page reload
- [ ] Verify that the saved secret is shown as `••••••••` (never the raw value) after reload
- [ ] Verify **Manage on Stripe Dashboard** link opens in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)