### PR TITLE
Fix: Prevent Stripe Link from appearing twice in OCS

### DIFF
--- a/client/blocks/utils.js
+++ b/client/blocks/utils.js
@@ -183,6 +183,13 @@ export const getStripeElementOptions = ( forCheckoutSession = false ) => {
 		},
 	};
 
+	// When Link is shown as an Express Checkout Element button, hide it from inside
+	// the Payment Element to prevent it from appearing twice on the checkout page.
+	const stripeConfig = getBlocksConfiguration();
+	if ( stripeConfig?.isLinkEnabled ) {
+		options.wallets.link = 'never';
+	}
+
 	// Prefill Link customer data if available.
 	if ( isLinkEnabled() && ! forCheckoutSession ) {
 		const userEmail = document.getElementById( 'email' )?.value;

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -288,6 +288,12 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 		},
 	};
 
+	// When Link is shown as an Express Checkout Element button, hide it from inside
+	// the Payment Element to prevent it from appearing twice on the checkout page.
+	if ( stripeServerData?.isLinkEnabled ) {
+		paymentElementOptions.wallets.link = 'never';
+	}
+
 	// Set the layout to accordion if OC is enabled.
 	if ( stripeServerData?.shouldShowOptimizedCheckout ) {
 		const ocsLayout = shouldExpandOptimizedCheckout


### PR DESCRIPTION
## Summary
Fixes STRIPE-732: When OCS is enabled alongside Express Checkout with Link, the Link payment button appeared twice on the checkout page — once as an Express Checkout button and once inside the OCS card form.

## Changes
- Set `wallets.link` to `'never'` on the Payment Element options when Link is already shown via Express Checkout Element (ECE), matching the existing pattern for Apple Pay and Google Pay
- Applied to both blocks checkout (`client/blocks/utils.js`) and classic checkout (`client/classic/upe/payment-processing.js`) paths

## Root Cause
The Payment Element's `wallets` option already disabled Apple Pay and Google Pay (`applePay: 'never'`, `googlePay: 'never'`) since those are handled by ECE. However, Link was not similarly disabled, so when Link was enabled as an ECE button (`isLinkEnabled`), it also appeared inside the Payment Element's built-in wallet integration.

Note: Link cannot be excluded via `excludedPaymentMethodTypes` (it's in `NON_EXCLUDABLE_PAYMENT_METHOD_TYPES`), but it can be hidden from the Payment Element UI via the `wallets.link` option.

## Testing
1. Enable OCS in Stripe settings
2. Enable Google/Apple Pay and Stripe Link in Express Checkout settings
3. Customize to show ECE buttons on checkout page
4. Add item to cart, go to checkout
5. Verify Link appears only once (as ECE button above checkout form)
6. Disable Link in Express Checkout settings
7. Verify Link still appears inside the Payment Element card form when not shown via ECE

## Linear Issue
https://linear.app/a8c/issue/STRIPE-732/stripe-link-shown-in-ocs-twice

---
Part of the [Woo Extensions Bug Blitz](https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz/)