### PR TITLE
Fix: Stripe Link in Payment Element respects checkout placement

### DIFF
--- a/client/blocks/__tests__/utils.test.js
+++ b/client/blocks/__tests__/utils.test.js
@@ -84,6 +84,16 @@ describe( 'Blocks Utils', () => {
 				} );
 			} );
 
+			it( 'sets wallets.link to never when Link is enabled', () => {
+				isLinkEnabled.mockReturnValue( true );
+				const options = getStripeElementOptions();
+				expect( options.wallets ).toStrictEqual( {
+					applePay: 'never',
+					googlePay: 'never',
+					link: 'never',
+				} );
+			} );
+
 			it( 'preserves billing details fields', () => {
 				const options = getStripeElementOptions();
 				expect( options.fields.billingDetails.name ).toBe( 'never' );

--- a/client/blocks/utils.js
+++ b/client/blocks/utils.js
@@ -183,6 +183,14 @@ export const getStripeElementOptions = ( forCheckoutSession = false ) => {
 		},
 	};
 
+	// When Link is enabled as a payment method, hide it from the Payment Element
+	// so it only appears via the Express Checkout Element where placement settings
+	// (product, cart, checkout) are respected. This prevents Link from showing
+	// inside the OCS card form when the merchant has not enabled ECE on checkout.
+	if ( isLinkEnabled() ) {
+		options.wallets.link = 'never';
+	}
+
 	// Prefill Link customer data if available.
 	if ( isLinkEnabled() && ! forCheckoutSession ) {
 		const userEmail = document.getElementById( 'email' )?.value;

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -288,6 +288,14 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 		},
 	};
 
+	// When Link is enabled as a payment method, hide it from the Payment Element
+	// so it only appears via the Express Checkout Element where placement settings
+	// (product, cart, checkout) are respected. This prevents Link from showing
+	// inside the OCS card form when the merchant has not enabled ECE on checkout.
+	if ( isLinkEnabled() ) {
+		paymentElementOptions.wallets.link = 'never';
+	}
+
 	// Set the layout to accordion if OC is enabled.
 	if ( stripeServerData?.shouldShowOptimizedCheckout ) {
 		const ocsLayout = shouldExpandOptimizedCheckout


### PR DESCRIPTION
## Summary
Fixes STRIPE-731: When Express Checkout is configured to show only on products/cart (not checkout), Link was still appearing inside the OCS Payment Element on the checkout page.

## Changes
- When Link is enabled as a payment method, set `wallets.link = 'never'` in the Payment Element options in both blocks (`client/blocks/utils.js`) and classic (`client/classic/upe/payment-processing.js`) flows
- This ensures Link only appears via the Express Checkout Element, where placement settings (product, cart, checkout) are properly respected
- Added test coverage for the new behavior

## How it works
The `isLinkEnabled()` utility checks if Link is configured in `paymentMethodsConfig`. When it is, we hide Link from the Payment Element's built-in wallet UI. Link will only show through the Express Checkout Element, which already respects the merchant's ECE location settings via `is_enabled_for_current_context()` on the PHP side.

This also complements STRIPE-732 (PR #5201): that fix hides Link from the Payment Element when Link ECE *is* showing (to prevent duplication); this fix hides it when Link ECE is *not* showing on checkout (to respect placement). Together, they mean Link in the Payment Element is always suppressed when Link is an enabled payment method, deferring to the ECE for display decisions.

## Testing
1. Enable OCS in Stripe settings
2. Enable Google/Apple Pay and Stripe Link
3. Set ECE to show only on product and cart pages (NOT checkout)
4. Add item to cart, go to checkout
5. Verify Link does NOT appear inside the OCS card form

## Linear Issue
https://linear.app/a8c/issue/STRIPE-731/stripe-link-shown-in-ocs-even-if-disabled-on-checkout

---
Part of the [Woo Extensions Bug Blitz](https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)