### PR TITLE
Fix: prevent "Credit/Debit Card" title flash on classic checkout with Optimized Checkout enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.6.0 - xxxx-xx-xx =
+* Fix - Prevent brief display of wrong title on classic checkout when Optimized Checkout is enabled
 * Fix - Update Stripe Fee and Stripe Payout values correctly after partial capture by replacing authorization-phase values instead of adding to them
 * Fix - Add defensive checks before running renewal meta cleanup when renewal/subscription objects are missing or invalid
 * Dev - Add metadata accessor methods for subscription objects to WC_Stripe_Order_Helper, centralizing subscription-specific metadata handling

--- a/client/classic/upe/index.js
+++ b/client/classic/upe/index.js
@@ -312,15 +312,6 @@ jQuery( function ( $ ) {
 				removeCashAppLimitNotice();
 			}
 
-			// Change the payment method container title when the Optimized Checkout is enabled
-			const stripeServerData = getStripeServerData();
-			if (
-				stripeServerData?.shouldShowOptimizedCheckout &&
-				$( 'input#payment_method_stripe' ).is( ':checked' )
-			) {
-				$( 'label[for=payment_method_stripe]' ).text( 'Stripe' );
-			}
-
 			maybeClearBlikCodeValidation();
 		} );
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -781,6 +781,20 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
+	 * Returns the payment method title.
+	 *
+	 * When Optimized Checkout is enabled, returns the title from the OC payment method class.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		if ( $this->oc_enabled && $this->is_valid_optimized_checkout_page() ) {
+			return ( new WC_Stripe_UPE_Payment_Method_OC() )->get_title();
+		}
+		return parent::get_title();
+	}
+
+	/**
 	 * Gets payment method settings to pass to client scripts
 	 *
 	 * @return array

--- a/readme.txt
+++ b/readme.txt
@@ -146,6 +146,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.6.0 - xxxx-xx-xx =
+* Fix - Prevent brief display of wrong title on classic checkout when Optimized Checkout is enabled
 * Fix - Update Stripe Fee and Stripe Payout values correctly after partial capture by replacing authorization-phase values instead of adding to them
 * Fix - Add defensive checks before running renewal meta cleanup when renewal/subscription objects are missing or invalid
 * Dev - Add metadata accessor methods for subscription objects to WC_Stripe_Order_Helper, centralizing subscription-specific metadata handling


### PR DESCRIPTION
Fixes STRIPE-1029

## Changes proposed in this Pull Request:
- Overrides `get_title()` on `WC_Stripe_UPE_Payment_Gateway` to return the OC payment method's title when Optimized Checkout is active.                                                                                                                                                                                               
- Previously, PHP rendered "Credit/Debit Card" (the card method's title) in the checkout HTML, and JavaScript would replace it after the DOM was ready, causing a visible flash      
- Removed the now-redundant JS label override in `client/classic/upe/index.js`                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                               
## Testing instructions
- Enable Optimized Checkout in Stripe settings        
- Classic checkout: 
    - As a shopper, add a product to your cart and go to the classic checkout page. 
    - In `develop`, notice that the title is "Credit/Debit card" initially and after a short time it changes to "Stripe".
    - In this branch, verify the payment method label renders correctly on first paint with no flash of "Credit/Debit Card"                      
- Blocks checkout and pay-for-order: verify no regression in title display                                                                                                                               
 
### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
