### PR TITLE
Fix stale banner notices reappearing after tab switch or state change

### DIFF
--- a/client/settings/display-order-customization-notice/__tests__/display-order-customization-notice.js
+++ b/client/settings/display-order-customization-notice/__tests__/display-order-customization-notice.js
@@ -68,4 +68,41 @@ describe( 'DisplayOrderCustomizationNotice', () => {
 
 		expect( container.firstChild ).toBeNull();
 	} );
+
+	it( 'should update wc_stripe_settings_params after dismissal', async () => {
+		render( <DisplayOrderCustomizationNotice isOCEnabled={ false } /> );
+
+		const dismissButton = screen.queryByRole( 'button', {
+			'aria-label': 'Dismiss this notice',
+		} );
+		await act( async () => {
+			await userEvent.click( dismissButton );
+		} );
+
+		expect(
+			global.wc_stripe_settings_params.show_customization_notice
+		).toBe( false );
+	} );
+
+	it( 'should not re-appear after dismissal when remounted', async () => {
+		const { unmount } = render(
+			<DisplayOrderCustomizationNotice isOCEnabled={ false } />
+		);
+
+		const dismissButton = screen.queryByRole( 'button', {
+			'aria-label': 'Dismiss this notice',
+		} );
+		await act( async () => {
+			await userEvent.click( dismissButton );
+		} );
+
+		unmount();
+		render( <DisplayOrderCustomizationNotice isOCEnabled={ false } /> );
+
+		expect(
+			screen.queryByRole( 'button', {
+				'aria-label': 'Dismiss this notice',
+			} )
+		).not.toBeInTheDocument();
+	} );
 } );

--- a/client/settings/display-order-customization-notice/index.js
+++ b/client/settings/display-order-customization-notice/index.js
@@ -30,6 +30,8 @@ const DisplayOrderCustomizationNotice = ( { isOCEnabled } ) => {
 
 	const handleDismissNotice = () => {
 		dismissNotice( 'wc_stripe_show_customization_notice', () => {
+			// eslint-disable-next-line camelcase
+			wc_stripe_settings_params.show_customization_notice = false;
 			setShowNotice( false );
 		} );
 	};

--- a/client/settings/optimized-checkout-notice/__tests__/index.test.js
+++ b/client/settings/optimized-checkout-notice/__tests__/index.test.js
@@ -70,4 +70,41 @@ describe( 'OptimizedCheckoutNotice', () => {
 
 		expect( container.firstChild ).toBeNull();
 	} );
+
+	it( 'should update wc_stripe_settings_params after dismissal', async () => {
+		render( <OptimizedCheckoutNotice isOCEnabled={ true } /> );
+
+		const dismissButton = screen.queryByRole( 'button', {
+			'aria-label': 'Dismiss this notice',
+		} );
+		await act( async () => {
+			await userEvent.click( dismissButton );
+		} );
+
+		expect(
+			global.wc_stripe_settings_params.show_optimized_checkout_notice
+		).toBe( false );
+	} );
+
+	it( 'should not re-appear after dismissal when remounted', async () => {
+		const { unmount } = render(
+			<OptimizedCheckoutNotice isOCEnabled={ true } />
+		);
+
+		const dismissButton = screen.queryByRole( 'button', {
+			'aria-label': 'Dismiss this notice',
+		} );
+		await act( async () => {
+			await userEvent.click( dismissButton );
+		} );
+
+		unmount();
+		render( <OptimizedCheckoutNotice isOCEnabled={ true } /> );
+
+		expect(
+			screen.queryByRole( 'button', {
+				'aria-label': 'Dismiss this notice',
+			} )
+		).not.toBeInTheDocument();
+	} );
 } );

--- a/client/settings/optimized-checkout-notice/index.js
+++ b/client/settings/optimized-checkout-notice/index.js
@@ -33,6 +33,8 @@ const OptimizedCheckoutNotice = ( { isOCEnabled } ) => {
 
 	const handleDismissNotice = () => {
 		dismissNotice( 'wc_stripe_show_optimized_checkout_notice', () => {
+			// eslint-disable-next-line camelcase
+			wc_stripe_settings_params.show_optimized_checkout_notice = false;
 			setShowNotice( false );
 		} );
 	};

--- a/client/settings/payment-settings/promotional-banner/__tests__/index.test.js
+++ b/client/settings/payment-settings/promotional-banner/__tests__/index.test.js
@@ -40,6 +40,7 @@ describe( 'PromotionalBanner', () => {
 	// Keep the original function.
 	const reload = window.location.reload;
 	beforeEach( () => {
+		global.wc_stripe_settings_params = {};
 		Object.defineProperty( window, 'location', {
 			value: { reload: jest.fn() },
 		} );

--- a/client/settings/payment-settings/promotional-banner/__tests__/oc-promotion-banner.test.js
+++ b/client/settings/payment-settings/promotional-banner/__tests__/oc-promotion-banner.test.js
@@ -18,6 +18,7 @@ describe( 'OC promotional banner', () => {
 	const setIsOCEnabled = jest.fn( () => Promise.resolve() );
 
 	beforeEach( () => {
+		global.wc_stripe_settings_params = {};
 		useDispatch.mockImplementation( ( storeName ) => {
 			if ( storeName === 'core/notices' ) {
 				return noticesDispatch;

--- a/client/settings/payment-settings/promotional-banner/__tests__/stripe-tax-banner.test.js
+++ b/client/settings/payment-settings/promotional-banner/__tests__/stripe-tax-banner.test.js
@@ -14,6 +14,7 @@ describe( 'Stripe Tax banner', () => {
 	const setShowPromotionalBanner = jest.fn();
 
 	beforeEach( () => {
+		global.wc_stripe_settings_params = {};
 		apiFetch.mockImplementation(
 			jest.fn( () => Promise.resolve( { data: {} } ) )
 		);

--- a/client/settings/payment-settings/promotional-banner/oc-promotion-banner.js
+++ b/client/settings/payment-settings/promotional-banner/oc-promotion-banner.js
@@ -1,3 +1,4 @@
+/* global wc_stripe_settings_params */
 import { React } from 'react';
 import styled from '@emotion/styled';
 import interpolateComponents from '@automattic/interpolate-components';
@@ -30,6 +31,8 @@ export const OCPromotionBanner = ( {
 
 	const handleBannerDismiss = () => {
 		dismissNotice( 'wc_stripe_show_oc_promotion_banner', () => {
+			// eslint-disable-next-line camelcase
+			wc_stripe_settings_params.show_oc_promotional_banner = false;
 			setShowPromotionalBanner( false );
 		} );
 	};

--- a/client/settings/payment-settings/promotional-banner/stripe-tax-banner.js
+++ b/client/settings/payment-settings/promotional-banner/stripe-tax-banner.js
@@ -1,3 +1,4 @@
+/* global wc_stripe_settings_params */
 import { React } from 'react';
 import interpolateComponents from '@automattic/interpolate-components';
 import styled from '@emotion/styled';
@@ -49,6 +50,8 @@ export const StripeTaxBanner = ( { setShowPromotionalBanner } ) => {
 			method: 'POST',
 			data: { wc_stripe_show_stripe_tax_banner: 'no' },
 		} ).finally( () => {
+			// eslint-disable-next-line camelcase
+			wc_stripe_settings_params.show_stripe_tax_banner = false;
 			setShowPromotionalBanner( false );
 		} );
 	};

--- a/client/settings/settings-manager/__tests__/index.test.js
+++ b/client/settings/settings-manager/__tests__/index.test.js
@@ -1,6 +1,12 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import { getQuery } from '@woocommerce/navigation';
 import SettingsManager from '..';
+import PaymentMethodsPanel from '../../payment-methods';
+import {
+	BNPL_PROMOTION_BANNER,
+	OC_PROMOTION_BANNER,
+} from '../../payment-settings/constants';
 
 jest.mock( '../../payment-settings' );
 
@@ -24,10 +30,12 @@ jest.mock( '@woocommerce/navigation', () => ( {
 	updateQueryString: jest.fn(),
 } ) );
 
+const mockGetPromotionalBannerType = jest.fn().mockReturnValue( null );
 jest.mock(
 	'wcstripe/settings/payment-settings/promotional-banner/get-promotional-banner-type',
 	() => ( {
-		getPromotionalBannerType: jest.fn().mockReturnValue( null ),
+		getPromotionalBannerType: ( ...args ) =>
+			mockGetPromotionalBannerType( ...args ),
 	} )
 );
 
@@ -42,6 +50,16 @@ describe( 'SettingsManager', () => {
 				accountLink: 'https://stripe.com/support',
 			},
 		};
+		mockGetPromotionalBannerType.mockReturnValue( null );
+		getQuery.mockReturnValue( {} );
+		PaymentMethodsPanel.mockImplementation(
+			( { showPromotionalBanner } ) => (
+				<div
+					data-testid="payment-methods-panel"
+					data-show-banner={ String( showPromotionalBanner ) }
+				/>
+			)
+		);
 	} );
 
 	afterEach( () => {
@@ -92,6 +110,55 @@ describe( 'SettingsManager', () => {
 			expect(
 				screen.queryByTestId( 'methods-tab' )
 			).not.toBeInTheDocument();
+		} );
+	} );
+
+	it( 'should show the banner when the promotional banner type is set and params indicate it should show', async () => {
+		global.wc_stripe_settings_params.show_bnpl_promotional_banner = '1';
+		mockGetPromotionalBannerType.mockReturnValue( BNPL_PROMOTION_BANNER );
+
+		render( <SettingsManager /> );
+
+		await waitFor( () => {
+			expect(
+				screen.queryByTestId( 'payment-methods-panel' )
+			).toBeInTheDocument();
+		} );
+		await waitFor( () => {
+			expect(
+				screen.queryByTestId( 'payment-methods-panel' ).dataset
+					.showBanner
+			).toBe( 'true' );
+		} );
+	} );
+
+	it( 'should reset showPromotionalBanner when the promotional banner type changes', async () => {
+		// Start: BNPL banner shown
+		global.wc_stripe_settings_params.show_bnpl_promotional_banner = '1';
+		global.wc_stripe_settings_params.show_oc_promotional_banner = '';
+		mockGetPromotionalBannerType.mockReturnValue( BNPL_PROMOTION_BANNER );
+
+		const { rerender } = render( <SettingsManager /> );
+
+		await waitFor( () => {
+			expect(
+				screen.queryByTestId( 'payment-methods-panel' ).dataset
+					.showBanner
+			).toBe( 'true' );
+		} );
+
+		// Change: switch to OC banner type where OC banner is not set to show
+		mockGetPromotionalBannerType.mockReturnValue( OC_PROMOTION_BANNER );
+
+		await act( async () => {
+			rerender( <SettingsManager /> );
+		} );
+
+		await waitFor( () => {
+			expect(
+				screen.queryByTestId( 'payment-methods-panel' ).dataset
+					.showBanner
+			).toBe( 'false' );
 		} );
 	} );
 } );

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -38,6 +38,23 @@ const TABS_CONTENT = [
 	},
 ];
 
+const getBannerStateFromParams = ( type ) => {
+	// eslint-disable-next-line camelcase
+	if ( type === BNPL_PROMOTION_BANNER ) {
+		// eslint-disable-next-line camelcase
+		return wc_stripe_settings_params?.show_bnpl_promotional_banner === '1';
+	}
+	if ( type === STRIPE_TAX_BANNER ) {
+		// eslint-disable-next-line camelcase
+		return wc_stripe_settings_params?.show_stripe_tax_banner === '1';
+	}
+	if ( type === OC_PROMOTION_BANNER ) {
+		// eslint-disable-next-line camelcase
+		return wc_stripe_settings_params?.show_oc_promotional_banner === '1';
+	}
+	return false;
+};
+
 const SettingsManager = () => {
 	const { settings, isLoading } = useSettings();
 	const [ initialSettings, setInitialSettings ] = useState( settings );
@@ -49,30 +66,15 @@ const SettingsManager = () => {
 		isOCEnabled,
 		enabledPaymentMethodIds
 	);
-	let initialBannerState;
-	if (
-		promotionalBannerType === BNPL_PROMOTION_BANNER &&
-		// eslint-disable-next-line camelcase
-		wc_stripe_settings_params?.show_bnpl_promotional_banner === '1'
-	) {
-		initialBannerState = true;
-	}
-	if (
-		promotionalBannerType === STRIPE_TAX_BANNER &&
-		// eslint-disable-next-line camelcase
-		wc_stripe_settings_params?.show_stripe_tax_banner === '1'
-	) {
-		initialBannerState = true;
-	}
-	if (
-		promotionalBannerType === OC_PROMOTION_BANNER &&
-		// eslint-disable-next-line camelcase
-		wc_stripe_settings_params?.show_oc_promotional_banner === '1'
-	) {
-		initialBannerState = true;
-	}
-	const [ showPromotionalBanner, setShowPromotionalBanner ] =
-		useState( initialBannerState );
+	const [ showPromotionalBanner, setShowPromotionalBanner ] = useState( () =>
+		getBannerStateFromParams( promotionalBannerType )
+	);
+
+	useEffect( () => {
+		setShowPromotionalBanner(
+			getBannerStateFromParams( promotionalBannerType )
+		);
+	}, [ promotionalBannerType ] );
 
 	useEffect( () => {
 		if ( isLoading && ! isEmpty( settings ) ) {


### PR DESCRIPTION
## Summary

- Fixes dismissed notices (`OptimizedCheckoutNotice`, `DisplayOrderCustomizationNotice`) reappearing when the user switches tabs, by writing back the dismissed state into `wc_stripe_settings_params` so remounted components read the correct value instead of the stale page-load data.
- Fixes promotional banners staying stuck in the wrong visibility state when OC is toggled or BNPL methods are enabled/disabled, by replacing the one-time `useState(initialBannerState)` with a `getBannerStateFromParams` helper + `useEffect([promotionalBannerType])` in `SettingsManager`.
- Applies the same `wc_stripe_settings_params` write-back to `OCPromotionBanner` and `StripeTaxBanner` dismiss handlers so mid-session dismissals are correctly reflected when the banner type changes.

Fixes #5079

## Test plan

- [ ] Go to Stripe settings → Payment Methods tab, dismiss the "Customize the display order" or "Optimized Checkout" notice, switch to Settings tab and back — dismissed notice should not reappear.
- [ ] With OC disabled: dismiss the OC promotional banner, then enable OC in Settings — Stripe Tax banner should now appear (previously it was stuck hidden).
- [ ] With OC enabled: dismiss the Stripe Tax banner, then disable OC — OC promotional banner should now appear (previously stuck hidden).
- [ ] `npm run test:js` — all 620 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)