### PR TITLE
Add Ajax endpoint to update checkout session

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -36,6 +36,7 @@
 * Fix - Put subscription on hold when Stripe Radar blocks a renewal payment to prevent WC Subscriptions from scheduling further retry attempts
 * Fix - Prevent TypeError when processing deferred webhooks using Action Scheduler
 * Fix - Prevent JavaScript error in `elements.update` when using checkout sessions with adaptive pricing
+* Fix - Keep adaptive pricing amount in sync on classic checkout after order total changes
 * Fix - Use a single Checkout Session line item priced at the full payable cart total so adaptive pricing sessions match checkout totals
 * Add - Add Ajax endpoint to update line items in a checkout session
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -37,6 +37,7 @@
 * Fix - Prevent TypeError when processing deferred webhooks using Action Scheduler
 * Fix - Prevent JavaScript error in `elements.update` when using checkout sessions with adaptive pricing
 * Fix - Use a single Checkout Session line item priced at the full payable cart total so adaptive pricing sessions match checkout totals
+* Add - Add Ajax endpoint to update line items in a checkout session
 
 = 10.5.3 - 2026-03-19 =
 * Fix - Restore default layout when Optimized Checkout is disabled

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -687,4 +687,17 @@ export default class WCStripeAPI {
 			security: this.options?.createCheckoutSessionNonce,
 		} );
 	}
+
+	/**
+	 * Update a Stripe Checkout Session.
+	 *
+	 * @param {string} sessionId The ID of the checkout session to update.
+	 * @return {Promise} Promise for the request to the server.
+	 */
+	checkoutSessionsUpdateSession( sessionId ) {
+		return this.request( this.getAjaxUrl( 'update_checkout_session' ), {
+			security: this.options?.updateCheckoutSessionNonce,
+			checkout_session_id: sessionId,
+		} );
+	}
 }

--- a/client/classic/upe/__tests__/payment-processing.test.js
+++ b/client/classic/upe/__tests__/payment-processing.test.js
@@ -84,13 +84,33 @@ const createMockPaymentElement = () => ( {
 	update: jest.fn(),
 } );
 
-const createMockElements = () => ( {
-	create: jest.fn( () => createMockPaymentElement() ),
-	submit: jest.fn( () => Promise.resolve( {} ) ),
-	loadActions: jest.fn( () => Promise.resolve( { type: 'success' } ) ),
-	createPaymentElement: jest.fn( () => createMockPaymentElement() ),
-	createCurrencySelectorElement: jest.fn( () => ( { mount: jest.fn() } ) ),
-} );
+const MOCK_AP_CHECKOUT_CLIENT_SECRET = 'cs_test_ap_client_secret';
+const MOCK_AP_CHECKOUT_SESSION_ID = 'cs_test_abc';
+
+const createMockElements = () => {
+	const checkoutActions = {
+		runServerUpdate: jest.fn( async ( userFunction ) => {
+			await userFunction();
+			return {
+				type: 'success',
+				session: { id: MOCK_AP_CHECKOUT_SESSION_ID },
+			};
+		} ),
+		confirm: jest.fn( () => Promise.resolve( {} ) ),
+	};
+	return {
+		create: jest.fn( () => createMockPaymentElement() ),
+		submit: jest.fn( () => Promise.resolve( {} ) ),
+		loadActions: jest.fn( () =>
+			Promise.resolve( { type: 'success', actions: checkoutActions } )
+		),
+		checkoutActions,
+		createPaymentElement: jest.fn( () => createMockPaymentElement() ),
+		createCurrencySelectorElement: jest.fn( () => ( {
+			mount: jest.fn(),
+		} ) ),
+	};
+};
 
 const createMockApi = ( checkoutElements ) => {
 	const standardElements = createMockElements();
@@ -104,7 +124,15 @@ const createMockApi = ( checkoutElements ) => {
 	return {
 		getStripe: jest.fn( () => stripe ),
 		checkoutSessionsCreateSession: jest.fn( () =>
-			Promise.resolve( { data: { client_secret: 'cs_test_abc' } } )
+			Promise.resolve( {
+				data: {
+					client_secret: MOCK_AP_CHECKOUT_CLIENT_SECRET,
+					session_id: MOCK_AP_CHECKOUT_SESSION_ID,
+				},
+			} )
+		),
+		checkoutSessionsUpdateSession: jest.fn( () =>
+			Promise.resolve( { success: true } )
 		),
 		createIntent: jest.fn(),
 		initSetupIntent: jest.fn(),
@@ -255,7 +283,9 @@ describe( 'payment-processing', () => {
 
 				expect( api.checkoutSessionsCreateSession ).toHaveBeenCalled();
 				expect( api._stripe.initCheckout ).toHaveBeenCalledWith(
-					expect.objectContaining( { clientSecret: 'cs_test_abc' } )
+					expect.objectContaining( {
+						clientSecret: MOCK_AP_CHECKOUT_CLIENT_SECRET,
+					} )
 				);
 				expect( api._stripe.elements ).not.toHaveBeenCalled();
 			} );
@@ -292,7 +322,7 @@ describe( 'payment-processing', () => {
 				expect( api._stripe.initCheckout ).not.toHaveBeenCalled();
 			} );
 
-			it( 'falls back to standard elements when client_secret is absent', async () => {
+			it( 'falls back to standard elements when client_secret or session_id is absent', async () => {
 				const checkoutElements = createMockElements();
 				const api = createMockApi( checkoutElements );
 				api.checkoutSessionsCreateSession.mockResolvedValue( {
@@ -305,6 +335,57 @@ describe( 'payment-processing', () => {
 
 				expect( api._stripe.elements ).toHaveBeenCalled();
 				expect( api._stripe.initCheckout ).not.toHaveBeenCalled();
+			} );
+
+			it( 'falls back to standard elements when session_id is absent', async () => {
+				const checkoutElements = createMockElements();
+				const api = createMockApi( checkoutElements );
+				api.checkoutSessionsCreateSession.mockResolvedValue( {
+					data: { client_secret: MOCK_AP_CHECKOUT_CLIENT_SECRET },
+				} );
+				const dom = document.createElement( 'div' );
+				dom.dataset.paymentMethodType = 'card';
+
+				await paymentProcessing.mountStripePaymentElement( api, dom );
+
+				expect( api._stripe.elements ).toHaveBeenCalled();
+				expect( api._stripe.initCheckout ).not.toHaveBeenCalled();
+			} );
+
+			it( 'uses runServerUpdate to call checkoutSessionsUpdateSession after maybeUpdateAdaptivePricingCheckoutSession', async () => {
+				const checkoutElements = createMockElements();
+				const api = createMockApi( checkoutElements );
+				const dom = document.createElement( 'div' );
+				dom.dataset.paymentMethodType = 'card';
+
+				await paymentProcessing.mountStripePaymentElement( api, dom );
+				await paymentProcessing.maybeUpdateAdaptivePricingCheckoutSession(
+					api
+				);
+
+				expect(
+					checkoutElements.checkoutActions.runServerUpdate
+				).toHaveBeenCalled();
+				expect(
+					api.checkoutSessionsUpdateSession
+				).toHaveBeenCalledWith( MOCK_AP_CHECKOUT_SESSION_ID );
+			} );
+
+			it( 'does not call checkoutSessionsUpdateSession when adaptive pricing is disabled', async () => {
+				stripeUtils.getStripeServerData.mockReturnValue( {
+					...BASE_SERVER_DATA,
+					isAdaptivePricingEnabled: false,
+				} );
+				paymentProcessing.initializeUPEComponents();
+				const api = createMockApi( createMockElements() );
+
+				await paymentProcessing.maybeUpdateAdaptivePricingCheckoutSession(
+					api
+				);
+
+				expect(
+					api.checkoutSessionsUpdateSession
+				).not.toHaveBeenCalled();
 			} );
 		} );
 

--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -16,6 +16,7 @@ import {
 	createAndConfirmSetupIntent,
 	getMountedUPEComponent,
 	initializeUPEComponents,
+	maybeUpdateAdaptivePricingCheckoutSession,
 	mountStripePaymentElement,
 	processPayment,
 } from './payment-processing';
@@ -85,7 +86,10 @@ jQuery( function ( $ ) {
 	// Only attempt to mount the card element once that section of the page has loaded.
 	// We can use the updated_checkout event for this.
 	$( document.body ).on( 'updated_checkout', () => {
-		maybeMountStripePaymentElement();
+		void ( async () => {
+			await maybeUpdateAdaptivePricingCheckoutSession( api );
+			await maybeMountStripePaymentElement();
+		} )();
 	} );
 
 	function processPaymentIfNotUsingSavedMethod( $form ) {

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -36,6 +36,7 @@ import { handleDisplayOfSavingCheckbox } from 'wcstripe/optimized-checkout/handl
 /**
  * @typedef {Object} UPEComponent
  * @property {string|null}          intentId          The ID of the intent.
+ * @property {string|null}          checkoutSessionId Stripe Checkout Session id (cs_…) from create session; same value passed to initCheckout as clientSecret.
  * @property {Object|null}          elements          The Stripe elements object.
  * @property {Object|null}          upeElement        The Stripe payment element.
  * @property {boolean}              hasLoadError      Whether the payment element has a load error.
@@ -57,6 +58,7 @@ export function initializeUPEComponents() {
 	for ( const paymentMethodType in paymentMethodsConfig ) {
 		gatewayUPEComponents[ paymentMethodType ] = {
 			intentId: null,
+			checkoutSessionId: null,
 			elements: null,
 			upeElement: null,
 			hasLoadError: false,
@@ -65,6 +67,73 @@ export function initializeUPEComponents() {
 	}
 	// Reset so processPayment runs fully when called again (e.g. after re-init or in tests).
 	hasCheckoutCompleted = false;
+}
+
+/**
+ * After classic checkout AJAX refresh (e.g. shipping or coupon), sync line items on the Stripe Checkout Session
+ * so the Payment Element amount matches the cart. Uses checkoutSessionId from the create-session response.
+ *
+ * Wraps the server request in Stripe Custom Checkout {@link https://docs.stripe.com/js/custom_checkout/run_server_update runServerUpdate}
+ * when available so the embedded session state stays consistent after the update.
+ *
+ * @param {Object} api WCStripeAPI instance.
+ * @return {Promise<void>}
+ */
+export async function maybeUpdateAdaptivePricingCheckoutSession( api ) {
+	if ( ! getStripeServerData()?.isAdaptivePricingEnabled ) {
+		return;
+	}
+
+	const seen = new Set();
+	for ( const paymentMethodType of Object.keys( gatewayUPEComponents ) ) {
+		const component = gatewayUPEComponents[ paymentMethodType ];
+		const sessionId = component?.checkoutSessionId;
+		if ( ! sessionId || seen.has( sessionId ) ) {
+			continue;
+		}
+		seen.add( sessionId );
+
+		const checkout = component?.elements;
+
+		if ( checkout && typeof checkout.loadActions === 'function' ) {
+			try {
+				const loadResult = await checkout.loadActions();
+				if (
+					loadResult.type === 'success' &&
+					typeof loadResult.actions?.runServerUpdate === 'function'
+				) {
+					try {
+						const updateResult =
+							await loadResult.actions.runServerUpdate(
+								async () => {
+									await api.checkoutSessionsUpdateSession(
+										sessionId
+									);
+								}
+							);
+						if ( updateResult.type === 'error' ) {
+							// eslint-disable-next-line no-console
+							console.error( updateResult.error );
+						}
+					} catch ( error ) {
+						// eslint-disable-next-line no-console
+						console.error( error );
+					}
+					continue;
+				}
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.error( error );
+			}
+		}
+
+		try {
+			await api.checkoutSessionsUpdateSession( sessionId );
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( error );
+		}
+	}
 }
 
 /**
@@ -234,15 +303,19 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 		try {
 			const response = await api.checkoutSessionsCreateSession();
 			const clientSecret = response?.data?.client_secret;
+			const sessionId = response?.data?.session_id;
 
-			if ( ! clientSecret ) {
+			if ( ! clientSecret || ! sessionId ) {
 				throw new Error(
 					__(
-						'Failed to load payment method due to missing client secret.',
+						'Failed to load payment method due to missing client secret or session id.',
 						'woocommerce-gateway-stripe'
 					)
 				);
 			}
+
+			gatewayUPEComponents[ paymentMethodType ].checkoutSessionId =
+				sessionId;
 
 			elements = await api.getStripe().initCheckout( {
 				clientSecret,
@@ -258,6 +331,7 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 
 			shouldLoadStripeElements = false;
 		} catch ( error ) {
+			gatewayUPEComponents[ paymentMethodType ].checkoutSessionId = null;
 			// eslint-disable-next-line no-console
 			console.error( error );
 			shouldLoadStripeElements = true;
@@ -267,6 +341,7 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 	// If Adaptive Pricing is not enabled, or if there was an error loading the AP elements,
 	// load the Stripe elements as fallback.
 	if ( shouldLoadStripeElements ) {
+		gatewayUPEComponents[ paymentMethodType ].checkoutSessionId = null;
 		elements = api.getStripe().elements( options );
 	}
 

--- a/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
+++ b/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
@@ -140,8 +140,10 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler {
 				throw new Exception( __( "We're not able to process this request. Please refresh the page and try again.", 'woocommerce-gateway-stripe' ) );
 			}
 
-			$session_id = wc_clean( wp_unslash( $_POST['checkout_session_id'] ?? '' ) );
-			if ( ! $session_id ) {
+			$session_id = isset( $_POST['checkout_session_id'] )
+				? wc_clean( wp_unslash( $_POST['checkout_session_id'] ) )
+				: '';
+			if ( ! is_string( $session_id ) || '' === $session_id ) {
 				throw new Exception( __( 'Checkout session ID is required.', 'woocommerce-gateway-stripe' ) );
 			}
 
@@ -149,7 +151,7 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler {
 			WC()->cart->calculate_totals();
 
 			$currency   = get_woocommerce_currency();
-			$cart_total = WC_Stripe_Helper::get_stripe_amount( WC()->cart->get_total( 'edit' ), $currency );
+			$cart_total = WC_Stripe_Helper::get_stripe_amount( (float) WC()->cart->get_total( 'edit' ), $currency );
 			$request    = [
 				'line_items' => [
 					[

--- a/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
+++ b/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
@@ -121,7 +121,12 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler {
 				throw new Exception( __( 'Unable to create Stripe Checkout Session.', 'woocommerce-gateway-stripe' ) );
 			}
 
-			wp_send_json_success( [ 'client_secret' => $checkout_session->client_secret ] );
+			wp_send_json_success(
+				[
+					'client_secret' => $checkout_session->client_secret,
+					'session_id'    => $checkout_session->id,
+				]
+			);
 		} catch ( Exception $e ) {
 			WC_Stripe_Logger::error( 'Create checkout session error.', [ 'error_message' => $e->getMessage() ] );
 			wp_send_json_error( [ 'message' => $e->getMessage() ] );

--- a/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
+++ b/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
@@ -15,6 +15,7 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler {
 	 */
 	public function init_hooks(): void {
 		add_action( 'wc_ajax_wc_stripe_create_checkout_session', [ $this, 'create_checkout_session' ] );
+		add_action( 'wc_ajax_wc_stripe_update_checkout_session', [ $this, 'update_checkout_session' ] );
 	}
 
 	/**
@@ -123,6 +124,58 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler {
 			wp_send_json_success( [ 'client_secret' => $checkout_session->client_secret ] );
 		} catch ( Exception $e ) {
 			WC_Stripe_Logger::error( 'Create checkout session error.', [ 'error_message' => $e->getMessage() ] );
+			wp_send_json_error( [ 'message' => $e->getMessage() ] );
+		}
+	}
+
+	/**
+	 * Update a Stripe Checkout Session. Currently only used to update the line items.
+	 *
+	 * @return void
+	 */
+	public function update_checkout_session(): void {
+		try {
+			$is_nonce_valid = check_ajax_referer( 'wc_stripe_update_checkout_session_nonce', 'security', false );
+			if ( ! $is_nonce_valid ) {
+				throw new Exception( __( "We're not able to process this request. Please refresh the page and try again.", 'woocommerce-gateway-stripe' ) );
+			}
+
+			$session_id = wc_clean( wp_unslash( $_POST['checkout_session_id'] ?? '' ) );
+			if ( ! $session_id ) {
+				throw new Exception( __( 'Checkout session ID is required.', 'woocommerce-gateway-stripe' ) );
+			}
+
+			// Recalculate totals.
+			WC()->cart->calculate_totals();
+
+			$currency   = get_woocommerce_currency();
+			$cart_total = WC_Stripe_Helper::get_stripe_amount( WC()->cart->get_total( 'edit' ), $currency );
+			$request    = [
+				'line_items' => [
+					[
+						'price_data' => [
+							'currency'     => strtolower( $currency ),
+							'product_data' => [
+								'name' => __( 'Cart total', 'woocommerce-gateway-stripe' ),
+							],
+							'unit_amount'  => $cart_total,
+						],
+						'quantity'   => 1,
+					],
+				],
+			];
+
+			$checkout_session = WC_Stripe_API::request( $request, "checkout/sessions/$session_id" );
+
+			if ( ! empty( $checkout_session->error ) ) {
+				$message = empty( $checkout_session->error->message ) ? __( 'Checkout Sessions update API returned an error', 'woocommerce-gateway-stripe' ) : $checkout_session->error->message;
+				throw new Exception( $message );
+			}
+
+			wp_send_json_success( [ 'result' => 'success' ] );
+
+		} catch ( Exception $e ) {
+			WC_Stripe_Logger::error( 'Update checkout session error.', [ 'error_message' => $e->getMessage() ] );
 			wp_send_json_error( [ 'message' => $e->getMessage() ] );
 		}
 	}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -549,6 +549,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		$stripe_params['createAndConfirmSetupIntentNonce']  = wp_create_nonce( 'wc_stripe_create_and_confirm_setup_intent_nonce' );
 		$stripe_params['updateFailedOrderNonce']            = wp_create_nonce( 'wc_stripe_update_failed_order_nonce' );
 		$stripe_params['createCheckoutSessionNonce']        = wp_create_nonce( 'wc_stripe_create_checkout_session_nonce' );
+		$stripe_params['updateCheckoutSessionNonce']        = wp_create_nonce( 'wc_stripe_update_checkout_session_nonce' );
 		$stripe_params['paymentMethodsConfig']              = $this->get_enabled_payment_method_config();
 		$stripe_params['genericErrorMessage']               = __( 'There was a problem processing the payment. Please check your email inbox and refresh the page to try again.', 'woocommerce-gateway-stripe' );
 		$stripe_params['accountDescriptor']                 = $this->statement_descriptor;

--- a/readme.txt
+++ b/readme.txt
@@ -184,6 +184,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Put subscription on hold when Stripe Radar blocks a renewal payment to prevent WC Subscriptions from scheduling further retry attempts
 * Fix - Prevent TypeError when processing deferred webhooks using Action Scheduler
 * Fix - Prevent JavaScript error in `elements.update` when using checkout sessions with adaptive pricing
+* Fix - Keep adaptive pricing amount in sync on classic checkout after order total changes
 * Fix - Use a single Checkout Session line item priced at the full payable cart total so adaptive pricing sessions match checkout totals
 * Add - Add Ajax endpoint to update line items in a checkout session
 

--- a/readme.txt
+++ b/readme.txt
@@ -185,5 +185,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Prevent TypeError when processing deferred webhooks using Action Scheduler
 * Fix - Prevent JavaScript error in `elements.update` when using checkout sessions with adaptive pricing
 * Fix - Use a single Checkout Session line item priced at the full payable cart total so adaptive pricing sessions match checkout totals
+* Add - Add Ajax endpoint to update line items in a checkout session
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-checkout-sessions-ajax-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-checkout-sessions-ajax-handler-test.php
@@ -369,7 +369,8 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler_Test extends WP_UnitTestCase {
 
 		$mocked_error_message = 'Simulated error for testing.';
 
-		$mocked_secret = 'cs_test_1234567890abcdef';
+		$mocked_secret     = 'cs_test_1234567890abcdef';
+		$mocked_session_id = 'cs_test_session_id';
 
 		$checkout_session_error = (object) [
 			'error' => (object) [
@@ -381,6 +382,7 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler_Test extends WP_UnitTestCase {
 
 		$checkout_session_success = (object) [
 			'client_secret' => $mocked_secret,
+			'id'            => $mocked_session_id,
 		];
 
 		return [
@@ -453,6 +455,7 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler_Test extends WP_UnitTestCase {
 					'success' => true,
 					'data'    => (object) [
 						'client_secret' => $mocked_secret,
+						'session_id'    => $mocked_session_id,
 					],
 				],
 			],

--- a/tests/phpunit/class-wc-stripe-checkout-sessions-ajax-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-checkout-sessions-ajax-handler-test.php
@@ -17,6 +17,12 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler_Test extends WP_UnitTestCase {
 				[ $ajax_handler, 'create_checkout_session' ]
 			)
 		);
+		$this->assertTrue(
+			(bool) has_action(
+				'wc_ajax_wc_stripe_update_checkout_session',
+				[ $ajax_handler, 'update_checkout_session' ]
+			)
+		);
 	}
 
 	/**
@@ -187,6 +193,162 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler_Test extends WP_UnitTestCase {
 		$this->assertSame( __( 'Cart total', 'woocommerce-gateway-stripe' ), $line_item['price_data']['product_data']['name'] );
 		$this->assertSame( $expected_amount, $line_item['price_data']['unit_amount'] );
 		$this->assertSame( 1, $line_item['quantity'] );
+	}
+
+	/**
+	 * Tests for the `update_checkout_session` method.
+	 *
+	 * @param bool        $is_valid_nonce             Whether the AJAX nonce is valid.
+	 * @param bool        $set_checkout_session_id    Whether `checkout_session_id` is present in $_POST.
+	 * @param string      $checkout_session_id        Value for `checkout_session_id` when set.
+	 * @param object|null $checkout_session_response  Mocked Stripe API response body, or null when the API should not be called.
+	 * @param object      $expected_response          Expected JSON-decoded AJAX response.
+	 * @return void
+	 * @dataProvider provide_test_update_checkout_session
+	 */
+	public function test_update_checkout_session(
+		bool $is_valid_nonce,
+		bool $set_checkout_session_id,
+		string $checkout_session_id,
+		?object $checkout_session_response,
+		object $expected_response
+	): void {
+		Ajax_Test_Helper::init_hooks();
+
+		$post_before = $_POST;
+
+		WC()->session->init();
+		WC()->cart->empty_cart();
+		$product = WC_Helper_Product::create_simple_product( true, [ 'regular_price' => 10 ] );
+		$product->save();
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		$test_request = null;
+		if ( null !== $checkout_session_response ) {
+			$test_request = function ( $return_value, $parsed_args, $url ) use ( $checkout_session_id, $checkout_session_response ) {
+				$expected_path = 'checkout/sessions/' . $checkout_session_id;
+				if ( is_string( $url ) && strpos( $url, $expected_path ) !== false ) {
+					return [
+						'response' => 200,
+						'headers'  => [ 'Content-Type' => 'application/json' ],
+						'body'     => wp_json_encode( $checkout_session_response ),
+					];
+				}
+
+				return $return_value;
+			};
+			add_filter( 'pre_http_request', $test_request, 10, 3 );
+		}
+
+		$_REQUEST['_ajax_nonce'] = $is_valid_nonce ? wp_create_nonce( 'wc_stripe_update_checkout_session_nonce' ) : 'invalid_nonce_value';
+
+		if ( $set_checkout_session_id ) {
+			$_POST['checkout_session_id'] = $checkout_session_id;
+		} else {
+			unset( $_POST['checkout_session_id'] );
+		}
+
+		$ajax_handler = new WC_Stripe_Checkout_Sessions_Ajax_Handler();
+
+		try {
+			ob_start();
+			$ajax_handler->update_checkout_session();
+			$output = ob_get_clean();
+		} catch ( \Exception $e ) {
+			ob_end_clean();
+			throw $e;
+		} finally {
+			$_POST = $post_before;
+			if ( null !== $test_request ) {
+				remove_filter( 'pre_http_request', $test_request, 10, 3 );
+			}
+			Ajax_Test_Helper::remove_hooks();
+		}
+
+		$response = json_decode( $output );
+		$this->assertEquals( (object) $expected_response, $response );
+	}
+
+	/**
+	 * Data provider for `test_update_checkout_session`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_update_checkout_session(): array {
+		$mocked_error_message = 'Simulated update error for testing.';
+
+		$checkout_session_error = (object) [
+			'error' => (object) [
+				'message' => $mocked_error_message,
+			],
+		];
+
+		$checkout_session_success = (object) [
+			'id' => 'cs_test_updated',
+		];
+
+		return [
+			'invalid nonce'                => [
+				'is valid nonce'            => false,
+				'set checkout session id'   => true,
+				'checkout session id'       => 'cs_test_123',
+				'checkout session response' => null,
+				'expected response'         => (object) [
+					'success' => false,
+					'data'    => (object) [
+						'message' => "We're not able to process this request. Please refresh the page and try again.",
+					],
+				],
+			],
+			'checkout session ID not sent' => [
+				'is valid nonce'            => true,
+				'set checkout session id'   => false,
+				'checkout session id'       => '',
+				'checkout session response' => null,
+				'expected response'         => (object) [
+					'success' => false,
+					'data'    => (object) [
+						'message' => 'Checkout session ID is required.',
+					],
+				],
+			],
+			'checkout session ID empty'    => [
+				'is valid nonce'            => true,
+				'set checkout session id'   => true,
+				'checkout session id'       => '',
+				'checkout session response' => null,
+				'expected response'         => (object) [
+					'success' => false,
+					'data'    => (object) [
+						'message' => 'Checkout session ID is required.',
+					],
+				],
+			],
+			'error updating session'       => [
+				'is valid nonce'            => true,
+				'set checkout session id'   => true,
+				'checkout session id'       => 'cs_test_123',
+				'checkout session response' => $checkout_session_error,
+				'expected response'         => (object) [
+					'success' => false,
+					'data'    => (object) [
+						'message' => $mocked_error_message,
+					],
+				],
+			],
+			'successful update'            => [
+				'is valid nonce'            => true,
+				'set checkout session id'   => true,
+				'checkout session id'       => 'cs_test_123',
+				'checkout session response' => $checkout_session_success,
+				'expected response'         => (object) [
+					'success' => true,
+					'data'    => (object) [
+						'result' => 'success',
+					],
+				],
+			],
+		];
 	}
 
 	/**


### PR DESCRIPTION
Towards [STRIPE-1052](https://linear.app/a8c/issue/STRIPE-1052)

## Changes proposed in this Pull Request:
Added an Ajax endpoint to update a checkout session in Stripe. Currently, this is being used to update the line items only. This will be used to update the amount in a checkout session when the order total is updated on the checkout page (via shipping method change or coupon usage or tax amount change etc.)

## Testing instructions
- Code review is sufficient.
- Functional test can be done with the follow up PR later.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
