### PR TITLE
Keep adaptive pricing amount in sync on classic checkout after order total changes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -36,7 +36,7 @@
 * Fix - Put subscription on hold when Stripe Radar blocks a renewal payment to prevent WC Subscriptions from scheduling further retry attempts
 * Fix - Prevent TypeError when processing deferred webhooks using Action Scheduler
 * Fix - Prevent JavaScript error in `elements.update` when using checkout sessions with adaptive pricing
-* Fix - Use a single Checkout Session line item priced at the full payable cart total so adaptive pricing sessions match checkout totals
+* Fix - Keep adaptive pricing amount in sync on classic checkout after order total changes
 
 = 10.5.3 - 2026-03-19 =
 * Fix - Restore default layout when Optimized Checkout is disabled

--- a/client/classic/upe/__tests__/payment-processing.test.js
+++ b/client/classic/upe/__tests__/payment-processing.test.js
@@ -84,13 +84,33 @@ const createMockPaymentElement = () => ( {
 	update: jest.fn(),
 } );
 
-const createMockElements = () => ( {
-	create: jest.fn( () => createMockPaymentElement() ),
-	submit: jest.fn( () => Promise.resolve( {} ) ),
-	loadActions: jest.fn( () => Promise.resolve( { type: 'success' } ) ),
-	createPaymentElement: jest.fn( () => createMockPaymentElement() ),
-	createCurrencySelectorElement: jest.fn( () => ( { mount: jest.fn() } ) ),
-} );
+const MOCK_AP_CHECKOUT_CLIENT_SECRET = 'cs_test_ap_client_secret';
+const MOCK_AP_CHECKOUT_SESSION_ID = 'cs_test_abc';
+
+const createMockElements = () => {
+	const checkoutActions = {
+		runServerUpdate: jest.fn( async ( userFunction ) => {
+			await userFunction();
+			return {
+				type: 'success',
+				session: { id: MOCK_AP_CHECKOUT_SESSION_ID },
+			};
+		} ),
+		confirm: jest.fn( () => Promise.resolve( {} ) ),
+	};
+	return {
+		create: jest.fn( () => createMockPaymentElement() ),
+		submit: jest.fn( () => Promise.resolve( {} ) ),
+		loadActions: jest.fn( () =>
+			Promise.resolve( { type: 'success', actions: checkoutActions } )
+		),
+		checkoutActions,
+		createPaymentElement: jest.fn( () => createMockPaymentElement() ),
+		createCurrencySelectorElement: jest.fn( () => ( {
+			mount: jest.fn(),
+		} ) ),
+	};
+};
 
 const createMockApi = ( checkoutElements ) => {
 	const standardElements = createMockElements();
@@ -104,7 +124,15 @@ const createMockApi = ( checkoutElements ) => {
 	return {
 		getStripe: jest.fn( () => stripe ),
 		checkoutSessionsCreateSession: jest.fn( () =>
-			Promise.resolve( { data: { client_secret: 'cs_test_abc' } } )
+			Promise.resolve( {
+				data: {
+					client_secret: MOCK_AP_CHECKOUT_CLIENT_SECRET,
+					session_id: MOCK_AP_CHECKOUT_SESSION_ID,
+				},
+			} )
+		),
+		checkoutSessionsUpdateSession: jest.fn( () =>
+			Promise.resolve( { success: true } )
 		),
 		createIntent: jest.fn(),
 		initSetupIntent: jest.fn(),
@@ -255,7 +283,9 @@ describe( 'payment-processing', () => {
 
 				expect( api.checkoutSessionsCreateSession ).toHaveBeenCalled();
 				expect( api._stripe.initCheckout ).toHaveBeenCalledWith(
-					expect.objectContaining( { clientSecret: 'cs_test_abc' } )
+					expect.objectContaining( {
+						clientSecret: MOCK_AP_CHECKOUT_CLIENT_SECRET,
+					} )
 				);
 				expect( api._stripe.elements ).not.toHaveBeenCalled();
 			} );
@@ -292,7 +322,7 @@ describe( 'payment-processing', () => {
 				expect( api._stripe.initCheckout ).not.toHaveBeenCalled();
 			} );
 
-			it( 'falls back to standard elements when client_secret is absent', async () => {
+			it( 'falls back to standard elements when client_secret or session_id is absent', async () => {
 				const checkoutElements = createMockElements();
 				const api = createMockApi( checkoutElements );
 				api.checkoutSessionsCreateSession.mockResolvedValue( {
@@ -305,6 +335,57 @@ describe( 'payment-processing', () => {
 
 				expect( api._stripe.elements ).toHaveBeenCalled();
 				expect( api._stripe.initCheckout ).not.toHaveBeenCalled();
+			} );
+
+			it( 'falls back to standard elements when session_id is absent', async () => {
+				const checkoutElements = createMockElements();
+				const api = createMockApi( checkoutElements );
+				api.checkoutSessionsCreateSession.mockResolvedValue( {
+					data: { client_secret: MOCK_AP_CHECKOUT_CLIENT_SECRET },
+				} );
+				const dom = document.createElement( 'div' );
+				dom.dataset.paymentMethodType = 'card';
+
+				await paymentProcessing.mountStripePaymentElement( api, dom );
+
+				expect( api._stripe.elements ).toHaveBeenCalled();
+				expect( api._stripe.initCheckout ).not.toHaveBeenCalled();
+			} );
+
+			it( 'uses runServerUpdate to call checkoutSessionsUpdateSession after maybeUpdateAdaptivePricingCheckoutSession', async () => {
+				const checkoutElements = createMockElements();
+				const api = createMockApi( checkoutElements );
+				const dom = document.createElement( 'div' );
+				dom.dataset.paymentMethodType = 'card';
+
+				await paymentProcessing.mountStripePaymentElement( api, dom );
+				await paymentProcessing.maybeUpdateAdaptivePricingCheckoutSession(
+					api
+				);
+
+				expect(
+					checkoutElements.checkoutActions.runServerUpdate
+				).toHaveBeenCalled();
+				expect(
+					api.checkoutSessionsUpdateSession
+				).toHaveBeenCalledWith( MOCK_AP_CHECKOUT_SESSION_ID );
+			} );
+
+			it( 'does not call checkoutSessionsUpdateSession when adaptive pricing is disabled', async () => {
+				stripeUtils.getStripeServerData.mockReturnValue( {
+					...BASE_SERVER_DATA,
+					isAdaptivePricingEnabled: false,
+				} );
+				paymentProcessing.initializeUPEComponents();
+				const api = createMockApi( createMockElements() );
+
+				await paymentProcessing.maybeUpdateAdaptivePricingCheckoutSession(
+					api
+				);
+
+				expect(
+					api.checkoutSessionsUpdateSession
+				).not.toHaveBeenCalled();
 			} );
 		} );
 

--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -16,6 +16,7 @@ import {
 	createAndConfirmSetupIntent,
 	getMountedUPEComponent,
 	initializeUPEComponents,
+	maybeUpdateAdaptivePricingCheckoutSession,
 	mountStripePaymentElement,
 	processPayment,
 } from './payment-processing';
@@ -85,7 +86,10 @@ jQuery( function ( $ ) {
 	// Only attempt to mount the card element once that section of the page has loaded.
 	// We can use the updated_checkout event for this.
 	$( document.body ).on( 'updated_checkout', () => {
-		maybeMountStripePaymentElement();
+		void ( async () => {
+			await maybeUpdateAdaptivePricingCheckoutSession( api );
+			await maybeMountStripePaymentElement();
+		} )();
 	} );
 
 	function processPaymentIfNotUsingSavedMethod( $form ) {

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -71,7 +71,10 @@ export function initializeUPEComponents() {
 
 /**
  * After classic checkout AJAX refresh (e.g. shipping or coupon), sync line items on the Stripe Checkout Session
- * so the Payment Element amount matches the cart. Uses checkoutSessionId from create session (same value as clientSecret).
+ * so the Payment Element amount matches the cart. Uses checkoutSessionId from the create-session response.
+ *
+ * Wraps the server request in Stripe Custom Checkout {@link https://docs.stripe.com/js/custom_checkout/run_server_update runServerUpdate}
+ * when available so the embedded session state stays consistent after the update.
  *
  * @param {Object} api WCStripeAPI instance.
  * @return {Promise<void>}
@@ -83,12 +86,47 @@ export async function maybeUpdateAdaptivePricingCheckoutSession( api ) {
 
 	const seen = new Set();
 	for ( const paymentMethodType of Object.keys( gatewayUPEComponents ) ) {
-		const sessionId =
-			gatewayUPEComponents[ paymentMethodType ]?.checkoutSessionId;
+		const component = gatewayUPEComponents[ paymentMethodType ];
+		const sessionId = component?.checkoutSessionId;
 		if ( ! sessionId || seen.has( sessionId ) ) {
 			continue;
 		}
 		seen.add( sessionId );
+
+		const checkout = component?.elements;
+
+		if ( checkout && typeof checkout.loadActions === 'function' ) {
+			try {
+				const loadResult = await checkout.loadActions();
+				if (
+					loadResult.type === 'success' &&
+					typeof loadResult.actions?.runServerUpdate === 'function'
+				) {
+					try {
+						const updateResult =
+							await loadResult.actions.runServerUpdate(
+								async () => {
+									await api.checkoutSessionsUpdateSession(
+										sessionId
+									);
+								}
+							);
+						if ( updateResult.type === 'error' ) {
+							// eslint-disable-next-line no-console
+							console.error( updateResult.error );
+						}
+					} catch ( error ) {
+						// eslint-disable-next-line no-console
+						console.error( error );
+					}
+					continue;
+				}
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.error( error );
+			}
+		}
+
 		try {
 			await api.checkoutSessionsUpdateSession( sessionId );
 		} catch ( error ) {

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -36,6 +36,7 @@ import { handleDisplayOfSavingCheckbox } from 'wcstripe/optimized-checkout/handl
 /**
  * @typedef {Object} UPEComponent
  * @property {string|null}          intentId          The ID of the intent.
+ * @property {string|null}          checkoutSessionId Stripe Checkout Session id (cs_…) from create session; same value passed to initCheckout as clientSecret.
  * @property {Object|null}          elements          The Stripe elements object.
  * @property {Object|null}          upeElement        The Stripe payment element.
  * @property {boolean}              hasLoadError      Whether the payment element has a load error.
@@ -57,6 +58,7 @@ export function initializeUPEComponents() {
 	for ( const paymentMethodType in paymentMethodsConfig ) {
 		gatewayUPEComponents[ paymentMethodType ] = {
 			intentId: null,
+			checkoutSessionId: null,
 			elements: null,
 			upeElement: null,
 			hasLoadError: false,
@@ -65,6 +67,35 @@ export function initializeUPEComponents() {
 	}
 	// Reset so processPayment runs fully when called again (e.g. after re-init or in tests).
 	hasCheckoutCompleted = false;
+}
+
+/**
+ * After classic checkout AJAX refresh (e.g. shipping or coupon), sync line items on the Stripe Checkout Session
+ * so the Payment Element amount matches the cart. Uses checkoutSessionId from create session (same value as clientSecret).
+ *
+ * @param {Object} api WCStripeAPI instance.
+ * @return {Promise<void>}
+ */
+export async function maybeUpdateAdaptivePricingCheckoutSession( api ) {
+	if ( ! getStripeServerData()?.isAdaptivePricingEnabled ) {
+		return;
+	}
+
+	const seen = new Set();
+	for ( const paymentMethodType of Object.keys( gatewayUPEComponents ) ) {
+		const sessionId =
+			gatewayUPEComponents[ paymentMethodType ]?.checkoutSessionId;
+		if ( ! sessionId || seen.has( sessionId ) ) {
+			continue;
+		}
+		seen.add( sessionId );
+		try {
+			await api.checkoutSessionsUpdateSession( sessionId );
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( error );
+		}
+	}
 }
 
 /**
@@ -234,15 +265,19 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 		try {
 			const response = await api.checkoutSessionsCreateSession();
 			const clientSecret = response?.data?.client_secret;
+			const sessionId = response?.data?.session_id;
 
-			if ( ! clientSecret ) {
+			if ( ! clientSecret || ! sessionId ) {
 				throw new Error(
 					__(
-						'Failed to load payment method due to missing client secret.',
+						'Failed to load payment method due to missing client secret or session id.',
 						'woocommerce-gateway-stripe'
 					)
 				);
 			}
+
+			gatewayUPEComponents[ paymentMethodType ].checkoutSessionId =
+				sessionId;
 
 			elements = await api.getStripe().initCheckout( {
 				clientSecret,
@@ -258,6 +293,7 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 
 			shouldLoadStripeElements = false;
 		} catch ( error ) {
+			gatewayUPEComponents[ paymentMethodType ].checkoutSessionId = null;
 			// eslint-disable-next-line no-console
 			console.error( error );
 			shouldLoadStripeElements = true;
@@ -267,6 +303,7 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 	// If Adaptive Pricing is not enabled, or if there was an error loading the AP elements,
 	// load the Stripe elements as fallback.
 	if ( shouldLoadStripeElements ) {
+		gatewayUPEComponents[ paymentMethodType ].checkoutSessionId = null;
 		elements = api.getStripe().elements( options );
 	}
 

--- a/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
+++ b/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
@@ -121,7 +121,12 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler {
 				throw new Exception( __( 'Unable to create Stripe Checkout Session.', 'woocommerce-gateway-stripe' ) );
 			}
 
-			wp_send_json_success( [ 'client_secret' => $checkout_session->client_secret ] );
+			wp_send_json_success(
+				[
+					'client_secret' => $checkout_session->client_secret,
+					'session_id'    => $checkout_session->id,
+				]
+			);
 		} catch ( Exception $e ) {
 			WC_Stripe_Logger::error( 'Create checkout session error.', [ 'error_message' => $e->getMessage() ] );
 			wp_send_json_error( [ 'message' => $e->getMessage() ] );

--- a/readme.txt
+++ b/readme.txt
@@ -185,5 +185,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Prevent TypeError when processing deferred webhooks using Action Scheduler
 * Fix - Prevent JavaScript error in `elements.update` when using checkout sessions with adaptive pricing
 * Fix - Use a single Checkout Session line item priced at the full payable cart total so adaptive pricing sessions match checkout totals
+* Fix - Keep adaptive pricing amount in sync on classic checkout after order total changes
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-checkout-sessions-ajax-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-checkout-sessions-ajax-handler-test.php
@@ -207,7 +207,8 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler_Test extends WP_UnitTestCase {
 
 		$mocked_error_message = 'Simulated error for testing.';
 
-		$mocked_secret = 'cs_test_1234567890abcdef';
+		$mocked_secret     = 'cs_test_1234567890abcdef';
+		$mocked_session_id = 'cs_test_session_id';
 
 		$checkout_session_error = (object) [
 			'error' => (object) [
@@ -219,6 +220,7 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler_Test extends WP_UnitTestCase {
 
 		$checkout_session_success = (object) [
 			'client_secret' => $mocked_secret,
+			'id'            => $mocked_session_id,
 		];
 
 		return [
@@ -291,6 +293,7 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler_Test extends WP_UnitTestCase {
 					'success' => true,
 					'data'    => (object) [
 						'client_secret' => $mocked_secret,
+						'session_id'    => $mocked_session_id,
 					],
 				],
 			],


### PR DESCRIPTION
Towards [STRIPE-1052](https://linear.app/a8c/issue/STRIPE-1052)

## Changes proposed in this Pull Request:
- Add `session_id` in the create-session response to use it later in the update-session request.
- On WooCommerce’s checkout refresh (`updated_checkout`), the client calls the "update checkout session" endpoint. 
- The server update is performed inside Stripe’s `actions.runServerUpdate()` (after loadActions()). This ensures that the Payment Element is also updated by Stripe and the currency selector shows the updated amount.

## Testing instructions
- Enable OCS and Adaptive Pricing.
- Create some coupons.
- Create some shipping methods.
- Add some tax rates.
- As a logged in shopper, add a product to your cart and go to the cart page.
- Add a coupon in the cart page.
- Change the shipping method.
- Now go to the classic checkout page.
- Verify that the total amount in the order summary table is same as the amount in the currency selector.
- On the checkout page, change the shipping method.
- Remove the coupon and add a different one.
- Verify that, after each action the amount in the currency selector gets updated. ( Note: the update could be a little slow )

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
