### PR TITLE
Reduce noise from bundle size comparison comments

### DIFF
--- a/.github/scripts/compare-bundle-sizes.js
+++ b/.github/scripts/compare-bundle-sizes.js
@@ -76,6 +76,11 @@ for ( const file of allFiles ) {
 	totalBase += base;
 	totalHead += head;
 
+	// Skip files with no change.
+	if ( delta === 0 ) {
+		continue;
+	}
+
 	const icon = statusIcon( file, delta );
 	rows.push(
 		`| ${ icon } \`${ file }\` | ${ toKB( base ) } KB | ${ toKB(
@@ -88,6 +93,12 @@ for ( const file of allFiles ) {
 }
 
 const totalDelta = totalHead - totalBase;
+
+// If no bundles changed, skip the report entirely.
+if ( rows.length === 0 ) {
+	console.log( 'No bundle size changes detected. Skipping report.' );
+	process.exit( 0 );
+}
 
 const lines = [
 	'<!-- bundle-size-report -->',

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -78,11 +78,19 @@ jobs:
             artifacts/head/sizes.json \
             report.md
 
+      - name: Check for report
+        id: check-report
+        run: |
+          if [ -f report.md ]; then
+            echo "has_report=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Write to job summary
+        if: steps.check-report.outputs.has_report == 'true'
         run: cat report.md >> $GITHUB_STEP_SUMMARY
 
       - name: Find existing bundle size comment (pull_request)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.check-report.outputs.has_report == 'true'
         id: find-comment-pr
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         with:
@@ -91,7 +99,7 @@ jobs:
           body-includes: '<!-- bundle-size-report -->'
 
       - name: Post or update PR comment (pull_request)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.check-report.outputs.has_report == 'true'
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ steps.find-comment-pr.outputs.comment-id }}
@@ -100,7 +108,7 @@ jobs:
           edit-mode: replace
 
       - name: Find PR for branch (workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && steps.check-report.outputs.has_report == 'true'
         id: find-pr
         env:
           GH_TOKEN: ${{ github.token }}
@@ -109,7 +117,7 @@ jobs:
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
       - name: Find existing bundle size comment (workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch' && steps.find-pr.outputs.pr_number != ''
+        if: github.event_name == 'workflow_dispatch' && steps.check-report.outputs.has_report == 'true' && steps.find-pr.outputs.pr_number != ''
         id: find-comment-dispatch
         continue-on-error: true
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
@@ -119,7 +127,7 @@ jobs:
           body-includes: '<!-- bundle-size-report -->'
 
       - name: Post or update PR comment (workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch' && steps.find-pr.outputs.pr_number != ''
+        if: github.event_name == 'workflow_dispatch' && steps.check-report.outputs.has_report == 'true' && steps.find-pr.outputs.pr_number != ''
         continue-on-error: true
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

Currently, PRs that don't touch JS bundles still get a comment with every row showing 0.00KB delta. This PR reduces that noise by skipping unchanged files in the bundle size report and suppressing the PR comment entirely when there are no bundle size changes.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. There should not be a "Bundle Size Report" comment (eg: https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5134#issuecomment-4068177811) under this PR. 
2. (Optional) Inspect the bundle size workflow and notice that the report was intentionally skipped https://github.com/woocommerce/woocommerce-gateway-stripe/actions/runs/24102006878/job/70315858743?pr=5233#step:5:11
3. (Optional) Branch off this PR, open a new PR with a JS change and make sure bundle size report is present.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This is an improvement to a GitHub workflow. It does not impact any in-plugin features.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
