### PR TITLE
Add optimized checkout performance notice with “move Stripe gateways to top” action

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -53,7 +53,7 @@ xxxx-xx-xx - version 10.6.0
 * Add - Add Ajax endpoint to update line items in a checkout session
 * Tweak - Hide the Adaptive Pricing currency selector from classic checkout when a saved payment method is selected
 * Add - Allow customers to save payment methods during checkout with adaptive pricing
-* Add an admin notice and one-click action to move Stripe payment methods to the top of WooCommerce payment gateway order for Optimized Checkout
+* Add - Add an admin notice and one-click action to move Stripe payment methods to the top of WooCommerce payment gateway order for Optimized Checkout
 
 2026-03-19 - version 10.5.3
 * Fix - Restore default layout when Optimized Checkout is disabled

--- a/changelog.txt
+++ b/changelog.txt
@@ -49,6 +49,7 @@ xxxx-xx-xx - version 10.6.0
 * Fix - Prevent JavaScript error in `elements.update` when using checkout sessions with adaptive pricing
 * Tweak - Hide the Adaptive Pricing currency selector from classic checkout when a saved payment method is selected
 * Add - Allow customers to save payment methods during checkout with adaptive pricing
+* Add an admin notice and one-click action to move Stripe payment methods to the top of WooCommerce payment gateway order for Optimized Checkout
 
 2026-03-19 - version 10.5.3
 * Fix - Restore default layout when Optimized Checkout is disabled

--- a/client/settings/advanced-settings-section/__tests__/optimized-checkout-first-method-notice.test.js
+++ b/client/settings/advanced-settings-section/__tests__/optimized-checkout-first-method-notice.test.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import OptimizedCheckoutFirstMethodNotice from 'wcstripe/settings/advanced-settings-section/optimized-checkout-first-method-notice';
+
+jest.mock( '@wordpress/components', () => ( {
+	Notice: ( { children } ) => <div>{ children }</div>,
+} ) );
+
+jest.mock( 'wcstripe/utils', () => ( {
+	dismissNotice: jest.fn(),
+	moveStripeToTop: jest.fn(),
+} ) );
+
+describe( 'OptimizedCheckoutFirstMethodNotice', () => {
+	let prevParams;
+
+	beforeEach( () => {
+		prevParams = global.wc_stripe_settings_params;
+		global.wc_stripe_settings_params = {
+			...prevParams,
+			show_stripe_first_method_notice: true,
+		};
+	} );
+
+	afterEach( () => {
+		global.wc_stripe_settings_params = prevParams;
+	} );
+
+	it.each( [
+		[
+			'OC off',
+			{ isOCEnabled: false, show_stripe_first_method_notice: true },
+		],
+		[
+			'notice suppressed',
+			{ isOCEnabled: true, show_stripe_first_method_notice: false },
+		],
+	] )( 'renders nothing when %s', ( _label, params ) => {
+		global.wc_stripe_settings_params = { ...prevParams, ...params };
+
+		const { container } = render(
+			<OptimizedCheckoutFirstMethodNotice
+				isOCEnabled={ params.isOCEnabled }
+			/>
+		);
+
+		expect( container.firstChild ).toBeNull();
+	} );
+
+	it( 'shows the notice when OC is enabled and the notice is not dismissed', () => {
+		const { container } = render(
+			<OptimizedCheckoutFirstMethodNotice isOCEnabled={ true } />
+		);
+
+		expect( container.firstChild ).toBeDefined();
+	} );
+} );

--- a/client/settings/advanced-settings-section/__tests__/optimized-checkout-first-method-notice.test.js
+++ b/client/settings/advanced-settings-section/__tests__/optimized-checkout-first-method-notice.test.js
@@ -1,9 +1,27 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import OptimizedCheckoutFirstMethodNotice from 'wcstripe/settings/advanced-settings-section/optimized-checkout-first-method-notice';
+import { dismissNotice, moveStripeToTop } from 'wcstripe/utils';
 
 jest.mock( '@wordpress/components', () => ( {
-	Notice: ( { children } ) => <div>{ children }</div>,
+	Notice: ( { children, actions, onRemove } ) => (
+		<div>
+			{ children }
+			{ actions?.map( ( action, index ) => (
+				<button key={ index } type="button" onClick={ action.onClick }>
+					{ action.label }
+				</button>
+			) ) }
+			{ onRemove ? (
+				<button
+					type="button"
+					aria-label="Dismiss the notice"
+					onClick={ onRemove }
+				/>
+			) : null }
+		</div>
+	),
 } ) );
 
 jest.mock( 'wcstripe/utils', () => ( {
@@ -12,6 +30,9 @@ jest.mock( 'wcstripe/utils', () => ( {
 } ) );
 
 describe( 'OptimizedCheckoutFirstMethodNotice', () => {
+	const noticeCopy =
+		'Optimized Checkout works best when Stripe is your first payment method. Move it to the top to start optimizing for conversions.';
+
 	let prevParams;
 
 	beforeEach( () => {
@@ -20,9 +41,13 @@ describe( 'OptimizedCheckoutFirstMethodNotice', () => {
 			...prevParams,
 			show_stripe_first_method_notice: true,
 		};
+		dismissNotice.mockImplementation( ( _key, callback ) => {
+			callback?.();
+		} );
 	} );
 
 	afterEach( () => {
+		jest.clearAllMocks();
 		global.wc_stripe_settings_params = prevParams;
 	} );
 
@@ -48,10 +73,33 @@ describe( 'OptimizedCheckoutFirstMethodNotice', () => {
 	} );
 
 	it( 'shows the notice when OC is enabled and the notice is not dismissed', () => {
-		const { container } = render(
-			<OptimizedCheckoutFirstMethodNotice isOCEnabled={ true } />
+		render( <OptimizedCheckoutFirstMethodNotice isOCEnabled={ true } /> );
+
+		expect( screen.getByText( noticeCopy ) ).toBeInTheDocument();
+	} );
+
+	it( 'calls moveStripeToTop and hides the notice when "Move to top" is clicked', async () => {
+		render( <OptimizedCheckoutFirstMethodNotice isOCEnabled={ true } /> );
+
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'Move to top' } )
 		);
 
-		expect( container.firstChild ).toBeDefined();
+		expect( moveStripeToTop ).toHaveBeenCalled();
+		expect( screen.queryByText( noticeCopy ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'calls dismissNotice and hides the notice when the notice is dismissed', async () => {
+		render( <OptimizedCheckoutFirstMethodNotice isOCEnabled={ true } /> );
+
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'Dismiss the notice' } )
+		);
+
+		expect( dismissNotice ).toHaveBeenCalledWith(
+			'wc_stripe_show_stripe_first_method_notice',
+			expect.any( Function )
+		);
+		expect( screen.queryByText( noticeCopy ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/settings/advanced-settings-section/optimized-checkout-feature.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-feature.js
@@ -7,6 +7,7 @@ import {
 	useIsOCEnabled,
 	useOCLayout,
 } from '../../data';
+import OptimizedCheckoutFirstMethodNotice from './optimized-checkout-first-method-notice';
 import {
 	CheckboxControl,
 	ExternalLink,
@@ -84,6 +85,7 @@ const OptimizedCheckoutFeature = () => {
 				checked={ isOCEnabled }
 				onChange={ setIsOCEnabled }
 			/>
+			<OptimizedCheckoutFirstMethodNotice />
 			{ isOCEnabled && isCheckoutSessionsAvailable && (
 				<AdaptivePricingCheckbox
 					label={ __(

--- a/client/settings/advanced-settings-section/optimized-checkout-feature.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-feature.js
@@ -85,7 +85,7 @@ const OptimizedCheckoutFeature = () => {
 				checked={ isOCEnabled }
 				onChange={ setIsOCEnabled }
 			/>
-			<OptimizedCheckoutFirstMethodNotice />
+			<OptimizedCheckoutFirstMethodNotice isOCEnabled={ isOCEnabled } />
 			{ isOCEnabled && isCheckoutSessionsAvailable && (
 				<AdaptivePricingCheckbox
 					label={ __(

--- a/client/settings/advanced-settings-section/optimized-checkout-first-method-notice.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-first-method-notice.js
@@ -20,10 +20,10 @@ const WarningIcon = () => {
 	);
 };
 
-const OptimizedCheckoutFirstMethodNotice = () => {
+const OptimizedCheckoutFirstMethodNotice = ( { isOCEnabled } ) => {
 	const [ showNotice, setShowNotice ] = useState(
 		// eslint-disable-next-line camelcase
-		wc_stripe_settings_params.show_stripe_first_method_notice
+		wc_stripe_settings_params.show_stripe_first_method_notice && isOCEnabled
 	);
 
 	if ( ! showNotice ) {

--- a/client/settings/advanced-settings-section/optimized-checkout-first-method-notice.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-first-method-notice.js
@@ -23,18 +23,16 @@ const WarningIcon = () => {
 const OptimizedCheckoutFirstMethodNotice = ( { isOCEnabled } ) => {
 	const [ showNotice, setShowNotice ] = useState(
 		// eslint-disable-next-line camelcase
-		wc_stripe_settings_params.show_stripe_first_method_notice && isOCEnabled
+		wc_stripe_settings_params?.show_stripe_first_method_notice
 	);
 
-	if ( ! showNotice ) {
+	if ( ! showNotice || ! isOCEnabled ) {
 		return null;
 	}
 
 	const handleAction = () => {
-		moveStripeToTop( () => {
-			// Hide the notice after moving Stripe to the top.
-			handleRemove();
-		} );
+		moveStripeToTop();
+		setShowNotice( false );
 	};
 
 	const handleRemove = () => {

--- a/client/settings/advanced-settings-section/optimized-checkout-first-method-notice.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-first-method-notice.js
@@ -1,8 +1,9 @@
 /* global wc_stripe_settings_params */
-import React from 'react';
+import React, { useState } from 'react';
 import GridIcon from 'gridicons';
 import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/components';
+import { dismissNotice } from 'wcstripe/utils';
 import './style.scss';
 
 const WarningIcon = () => {
@@ -20,10 +21,12 @@ const WarningIcon = () => {
 };
 
 const OptimizedCheckoutFirstMethodNotice = () => {
-	const showStripeFirstMethodNotice =
-		wc_stripe_settings_params.show_stripe_first_method_notice; // eslint-disable-line camelcase
+	const [ showNotice, setShowNotice ] = useState(
+		// eslint-disable-next-line camelcase
+		wc_stripe_settings_params.show_stripe_first_method_notice
+	);
 
-	if ( ! showStripeFirstMethodNotice ) {
+	if ( ! showNotice ) {
 		return null;
 	}
 
@@ -33,8 +36,9 @@ const OptimizedCheckoutFirstMethodNotice = () => {
 	};
 
 	const handleRemove = () => {
-		// eslint-disable-next-line no-console
-		console.log( 'handleRemove' );
+		dismissNotice( 'wc_stripe_show_stripe_first_method_notice', () => {
+			setShowNotice( false );
+		} );
 	};
 
 	const actions = [

--- a/client/settings/advanced-settings-section/optimized-checkout-first-method-notice.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-first-method-notice.js
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import GridIcon from 'gridicons';
 import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/components';
-import { dismissNotice } from 'wcstripe/utils';
+import { dismissNotice, moveStripeToTop } from 'wcstripe/utils';
 import './style.scss';
 
 const WarningIcon = () => {
@@ -31,8 +31,10 @@ const OptimizedCheckoutFirstMethodNotice = () => {
 	}
 
 	const handleAction = () => {
-		// eslint-disable-next-line no-console
-		console.log( 'handleAction' );
+		moveStripeToTop( () => {
+			// Hide the notice after moving Stripe to the top.
+			handleRemove();
+		} );
 	};
 
 	const handleRemove = () => {

--- a/client/settings/advanced-settings-section/optimized-checkout-first-method-notice.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-first-method-notice.js
@@ -1,0 +1,69 @@
+/* global wc_stripe_settings_params */
+import React from 'react';
+import GridIcon from 'gridicons';
+import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/components';
+import './style.scss';
+
+const WarningIcon = () => {
+	return (
+		<span data-testid="warning-icon">
+			<GridIcon
+				icon="notice-outline"
+				size={ 20 }
+				style={ {
+					fill: '#DFB085',
+				} }
+			/>
+		</span>
+	);
+};
+
+const OptimizedCheckoutFirstMethodNotice = () => {
+	const showStripeFirstMethodNotice =
+		wc_stripe_settings_params.show_stripe_first_method_notice; // eslint-disable-line camelcase
+
+	if ( ! showStripeFirstMethodNotice ) {
+		return null;
+	}
+
+	const handleAction = () => {
+		// eslint-disable-next-line no-console
+		console.log( 'handleAction' );
+	};
+
+	const handleRemove = () => {
+		// eslint-disable-next-line no-console
+		console.log( 'handleRemove' );
+	};
+
+	const actions = [
+		{
+			label: __( 'Move to top', 'woocommerce-gateway-stripe' ),
+			onClick: handleAction,
+			className: 'notice-action',
+		},
+	];
+
+	return (
+		<Notice
+			className="wc-stripe-optimized-checkout-first-method-notice"
+			status="warning"
+			isDismissible={ true }
+			onRemove={ handleRemove }
+			actions={ actions }
+		>
+			<div className="notice-content">
+				<WarningIcon />
+				<div>
+					{ __(
+						'Optimized Checkout works best when Stripe is your first payment method. Move it to the top to start optimizing for conversions.',
+						'woocommerce-gateway-stripe'
+					) }
+				</div>
+			</div>
+		</Notice>
+	);
+};
+
+export default OptimizedCheckoutFirstMethodNotice;

--- a/client/settings/advanced-settings-section/style.scss
+++ b/client/settings/advanced-settings-section/style.scss
@@ -1,0 +1,29 @@
+.wc-stripe-optimized-checkout-first-method-notice {
+    border: 1px solid #DFB085;
+    border-radius: 8px;
+    padding: 12px;
+    background-color: #FFF3E0;
+
+    .notice-content {
+        display: flex;
+        align-items: flex-start;
+        gap: 6px;
+    }
+
+    .components-notice__dismiss {
+        min-width: 18px !important;
+        width: 18px;
+        height: 18px;
+        margin-top: 6px;
+    }
+
+	.components-notice__actions {
+		.components-notice__action {
+			margin-top: 0.5rem;
+            color: #1e1e1e;
+            box-shadow: none;
+            border: 1px solid #898989;
+            border-radius: 2px;
+		}
+	}
+}

--- a/client/utils/index.js
+++ b/client/utils/index.js
@@ -11,6 +11,12 @@ export const getAddToCartVariationParams = ( key ) => {
 	return wcAddToCartVariationParams[ key ];
 };
 
+/**
+ * Dismisses a notice by making an API request to the server.
+ *
+ * @param {string}   noticeKey The key of the notice to dismiss.
+ * @param {Function} callback  The callback to call when the request is complete.
+ */
 export const dismissNotice = ( noticeKey, callback ) => {
 	apiFetch( {
 		path: '/wc/v3/wc_stripe/settings/notice',
@@ -19,6 +25,9 @@ export const dismissNotice = ( noticeKey, callback ) => {
 	} ).finally( callback );
 };
 
+/**
+ * Moves Stripe to the top of the WooCommerce payment gateway order.
+ */
 export const moveStripeToTop = () => {
 	apiFetch( {
 		path: '/wc/v3/wc_stripe/settings/set_stripe_gateways_first',

--- a/client/utils/index.js
+++ b/client/utils/index.js
@@ -19,9 +19,9 @@ export const dismissNotice = ( noticeKey, callback ) => {
 	} ).finally( callback );
 };
 
-export const moveStripeToTop = ( callback ) => {
+export const moveStripeToTop = () => {
 	apiFetch( {
 		path: '/wc/v3/wc_stripe/settings/set_stripe_gateways_first',
 		method: 'POST',
-	} ).finally( callback );
+	} );
 };

--- a/client/utils/index.js
+++ b/client/utils/index.js
@@ -18,3 +18,10 @@ export const dismissNotice = ( noticeKey, callback ) => {
 		data: { [ noticeKey ]: 'no' },
 	} ).finally( callback );
 };
+
+export const moveStripeToTop = ( callback ) => {
+	apiFetch( {
+		path: '/wc/v3/wc_stripe/settings/set_stripe_gateways_first',
+		method: 'POST',
+	} ).finally( callback );
+};

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -208,6 +208,15 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				'permission_callback' => [ $this, 'check_permission' ],
 			]
 		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/set_stripe_gateways_first',
+			[
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'set_stripe_gateways_first' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
 	}
 
 	/**
@@ -695,6 +704,17 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		}
 
 		return new WP_REST_Response( [ 'result' => 'notice dismissed' ], 200 );
+	}
+
+	/**
+	 * Moves Stripe gateways to the first positions in WooCommerce gateway order.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function set_stripe_gateways_first() {
+		WC_Stripe_Helper::move_stripe_gateways_to_top_in_woocommerce_gateway_order();
+
+		return new WP_REST_Response( [ 'result' => 'Stripe moved to first position' ], 200 );
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -699,7 +699,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			update_option( 'wc_stripe_show_oc_promotion_banner', 'no' );
 		}
 
-		if ( null !== $request->get_param( 'wc_stripe_show_stripe_first_method_notice_0' ) ) {
+		if ( null !== $request->get_param( 'wc_stripe_show_stripe_first_method_notice' ) ) {
 			update_option( 'wc_stripe_show_stripe_first_method_notice', 'no' );
 		}
 

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -669,7 +669,8 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		if ( null === $request->get_param( 'wc_stripe_show_customization_notice' )
 			&& null === $request->get_param( 'wc_stripe_show_optimized_checkout_notice' )
 			&& null === $request->get_param( 'wc_stripe_show_bnpl_promotion_banner' )
-			&& null === $request->get_param( 'wc_stripe_show_oc_promotion_banner' ) ) {
+			&& null === $request->get_param( 'wc_stripe_show_oc_promotion_banner' )
+			&& null === $request->get_param( 'wc_stripe_show_stripe_first_method_notice' ) ) {
 			return new WP_REST_Response( [], 200 );
 		}
 
@@ -687,6 +688,10 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 
 		if ( null !== $request->get_param( 'wc_stripe_show_oc_promotion_banner' ) ) {
 			update_option( 'wc_stripe_show_oc_promotion_banner', 'no' );
+		}
+
+		if ( null !== $request->get_param( 'wc_stripe_show_stripe_first_method_notice_0' ) ) {
+			update_option( 'wc_stripe_show_stripe_first_method_notice', 'no' );
 		}
 
 		return new WP_REST_Response( [ 'result' => 'notice dismissed' ], 200 );

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -261,6 +261,7 @@ class WC_Stripe_Settings_Controller {
 			'is_payments_onboarding_task_completed' => $this->is_payments_onboarding_task_completed(),
 			'taxes_based_on_billing'                => wc_tax_enabled() && 'billing' === get_option( 'woocommerce_tax_based_on' ),
 			'is_card_method_enabled'                => in_array( WC_Stripe_Payment_Methods::CARD, $enabled_payment_methods, true ),
+			'show_stripe_first_method_notice'       => true, // TODO: implement this
 		];
 		wp_localize_script(
 			'woocommerce_stripe_admin',

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -261,7 +261,7 @@ class WC_Stripe_Settings_Controller {
 			'is_payments_onboarding_task_completed' => $this->is_payments_onboarding_task_completed(),
 			'taxes_based_on_billing'                => wc_tax_enabled() && 'billing' === get_option( 'woocommerce_tax_based_on' ),
 			'is_card_method_enabled'                => in_array( WC_Stripe_Payment_Methods::CARD, $enabled_payment_methods, true ),
-			'show_stripe_first_method_notice'       => true, // TODO: implement this
+			'show_stripe_first_method_notice'       => ! WC_Stripe_Helper::is_stripe_in_position_one_in_woocommerce_gateway_order(),
 		];
 		wp_localize_script(
 			'woocommerce_stripe_admin',

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -261,7 +261,7 @@ class WC_Stripe_Settings_Controller {
 			'is_payments_onboarding_task_completed' => $this->is_payments_onboarding_task_completed(),
 			'taxes_based_on_billing'                => wc_tax_enabled() && 'billing' === get_option( 'woocommerce_tax_based_on' ),
 			'is_card_method_enabled'                => in_array( WC_Stripe_Payment_Methods::CARD, $enabled_payment_methods, true ),
-			'show_stripe_first_method_notice'       => ! WC_Stripe_Helper::is_stripe_in_position_one_in_woocommerce_gateway_order() && get_option( 'wc_stripe_show_optimized_checkout_first_method_notice', 'yes' ) === 'yes',
+			'show_stripe_first_method_notice'       => WC_Stripe_Helper::should_show_stripe_first_method_notice(),
 		];
 		wp_localize_script(
 			'woocommerce_stripe_admin',

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -261,7 +261,7 @@ class WC_Stripe_Settings_Controller {
 			'is_payments_onboarding_task_completed' => $this->is_payments_onboarding_task_completed(),
 			'taxes_based_on_billing'                => wc_tax_enabled() && 'billing' === get_option( 'woocommerce_tax_based_on' ),
 			'is_card_method_enabled'                => in_array( WC_Stripe_Payment_Methods::CARD, $enabled_payment_methods, true ),
-			'show_stripe_first_method_notice'       => ! WC_Stripe_Helper::is_stripe_in_position_one_in_woocommerce_gateway_order(),
+			'show_stripe_first_method_notice'       => ! WC_Stripe_Helper::is_stripe_in_position_one_in_woocommerce_gateway_order() && get_option( 'wc_stripe_show_optimized_checkout_first_method_notice', 'yes' ) === 'yes',
 		];
 		wp_localize_script(
 			'woocommerce_stripe_admin',

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -835,7 +835,7 @@ class WC_Stripe_Helper {
 			}
 
 			// The first non-internal gateway decides position one.
-			return 'stripe' === $gateway_id || 0 === strpos( $gateway_id, 'stripe_' );
+			return WC_Stripe_UPE_Payment_Gateway::ID === $gateway_id || 0 === strpos( $gateway_id, 'stripe_' );
 		}
 
 		return false;

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -821,8 +821,10 @@ class WC_Stripe_Helper {
 	 */
 	public static function is_stripe_in_position_one_in_woocommerce_gateway_order(): bool {
 		$gateway_order = get_option( 'woocommerce_gateway_order', [] );
+
+		// If the gateway order is empty, assume Stripe is in the first position.
 		if ( empty( $gateway_order ) || ! is_array( $gateway_order ) ) {
-			return false;
+			return true;
 		}
 
 		asort( $gateway_order );

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -821,7 +821,7 @@ class WC_Stripe_Helper {
 			}
 
 			// The first non-internal gateway decides position one.
-			return 'stripe' === $gateway_id;
+			return str_contains( $gateway_id, 'stripe' );
 		}
 
 		return false;

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -803,6 +803,18 @@ class WC_Stripe_Helper {
 	}
 
 	/**
+	 * Checks whether to show the Stripe first method notice.
+	 *
+	 * @return bool
+	 */
+	public static function should_show_stripe_first_method_notice(): bool {
+		if ( get_option( 'wc_stripe_show_stripe_first_method_notice', 'yes' ) === 'no' ) {
+			return false;
+		}
+		return ! WC_Stripe_Helper::is_stripe_in_position_one_in_woocommerce_gateway_order();
+	}
+
+	/**
 	 * Checks whether Stripe is the first gateway in WooCommerce gateway order.
 	 *
 	 * @return bool

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -803,6 +803,23 @@ class WC_Stripe_Helper {
 	}
 
 	/**
+	 * Checks whether Stripe is the first gateway in WooCommerce gateway order.
+	 *
+	 * @return bool
+	 */
+	public static function is_stripe_in_position_one_in_woocommerce_gateway_order(): bool {
+		$gateway_order = get_option( 'woocommerce_gateway_order', [] );
+		if ( empty( $gateway_order ) || ! is_array( $gateway_order ) ) {
+			return false;
+		}
+
+		asort( $gateway_order );
+		$first_gateway_id = array_key_first( $gateway_order );
+
+		return 'stripe' === $first_gateway_id;
+	}
+
+	/**
 	 * Checks if WC version is less than passed in version.
 	 *
 	 * @since 4.1.11

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -835,7 +835,7 @@ class WC_Stripe_Helper {
 			}
 
 			// The first non-internal gateway decides position one.
-			return str_contains( $gateway_id, 'stripe' );
+			return 'stripe' === $gateway_id || 0 === strpos( $gateway_id, 'stripe_' );
 		}
 
 		return false;

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -828,6 +828,44 @@ class WC_Stripe_Helper {
 	}
 
 	/**
+	 * Moves Stripe gateways to the first positions in WooCommerce gateway order.
+	 * Preserves relative order among Stripe gateways and among non-Stripe gateways.
+	 *
+	 * @return void
+	 */
+	public static function move_stripe_gateways_to_top_in_woocommerce_gateway_order(): void {
+		$gateway_order = get_option( 'woocommerce_gateway_order', [] );
+		if ( empty( $gateway_order ) || ! is_array( $gateway_order ) ) {
+			return;
+		}
+
+		asort( $gateway_order );
+		$stripe_gateways     = [];
+		$non_stripe_gateways = [];
+
+		foreach ( array_keys( $gateway_order ) as $gateway_id ) {
+			if ( 'stripe' === $gateway_id || 0 === strpos( $gateway_id, 'stripe_' ) ) {
+				$stripe_gateways[] = $gateway_id;
+			} else {
+				$non_stripe_gateways[] = $gateway_id;
+			}
+		}
+
+		if ( empty( $stripe_gateways ) ) {
+			return;
+		}
+
+		$updated_gateway_order = [];
+		$index                 = 0;
+
+		foreach ( array_merge( $stripe_gateways, $non_stripe_gateways ) as $gateway_id ) {
+			$updated_gateway_order[ $gateway_id ] = (string) $index++;
+		}
+
+		update_option( 'woocommerce_gateway_order', $updated_gateway_order );
+	}
+
+	/**
 	 * Checks if WC version is less than passed in version.
 	 *
 	 * @since 4.1.11

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -814,9 +814,17 @@ class WC_Stripe_Helper {
 		}
 
 		asort( $gateway_order );
-		$first_gateway_id = array_key_first( $gateway_order );
+		foreach ( array_keys( $gateway_order ) as $gateway_id ) {
+			// Skip internal WooCommerce Payments entries.
+			if ( 0 === strpos( $gateway_id, '_wc_pes_' ) ) {
+				continue;
+			}
 
-		return 'stripe' === $first_gateway_id;
+			// The first non-internal gateway decides position one.
+			return 'stripe' === $gateway_id;
+		}
+
+		return false;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -197,5 +197,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Prevent JavaScript error in `elements.update` when using checkout sessions with adaptive pricing
 * Tweak - Hide the Adaptive Pricing currency selector from classic checkout when a saved payment method is selected
 * Add - Allow customers to save payment methods during checkout with adaptive pricing
+* Add an admin notice and one-click action to move Stripe payment methods to the top of WooCommerce payment gateway order for Optimized Checkout
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -201,6 +201,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Add Ajax endpoint to update line items in a checkout session
 * Tweak - Hide the Adaptive Pricing currency selector from classic checkout when a saved payment method is selected
 * Add - Allow customers to save payment methods during checkout with adaptive pricing
-* Add an admin notice and one-click action to move Stripe payment methods to the top of WooCommerce payment gateway order for Optimized Checkout
+* Add - Add an admin notice and one-click action to move Stripe payment methods to the top of WooCommerce payment gateway order for Optimized Checkout
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/admin/class-wc-rest-stripe-settings-controller-test.php
+++ b/tests/phpunit/admin/class-wc-rest-stripe-settings-controller-test.php
@@ -485,6 +485,17 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 					'result' => 'notice dismissed',
 				],
 			],
+			'dismiss stripe first notice'  => [
+				'request params'    => [
+					'wc_stripe_show_stripe_first_method_notice' => 'no',
+				],
+				'expected option'   => [
+					'wc_stripe_show_stripe_first_method_notice' => 'no',
+				],
+				'expected response' => [
+					'result' => 'notice dismissed',
+				],
+			],
 		];
 	}
 

--- a/tests/phpunit/admin/class-wc-rest-stripe-settings-controller-test.php
+++ b/tests/phpunit/admin/class-wc-rest-stripe-settings-controller-test.php
@@ -489,6 +489,44 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 	}
 
 	/**
+	 * Tests for moving Stripe gateways to the top via REST endpoint.
+	 */
+	public function test_set_stripe_gateways_first() {
+		update_option(
+			'woocommerce_gateway_order',
+			[
+				'affirm'      => '0',
+				'woopayments' => '1',
+				'amazon_pay'  => '2',
+				'stripe_sepa' => '3',
+				'stripe'      => '4',
+				'stripe_eps'  => '5',
+				'cod'         => '6',
+				'paypal'      => '7',
+			]
+		);
+
+		$request  = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE . '/set_stripe_gateways_first' );
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( [ 'result' => 'Stripe moved to first position' ], $response->get_data() );
+		$this->assertSame(
+			[
+				'stripe_sepa' => '0',
+				'stripe'      => '1',
+				'stripe_eps'  => '2',
+				'affirm'      => '3',
+				'woopayments' => '4',
+				'amazon_pay'  => '5',
+				'cod'         => '6',
+				'paypal'      => '7',
+			],
+			get_option( 'woocommerce_gateway_order', [] )
+		);
+	}
+
+	/**
 	 * @dataProvider is_payment_request_enabled_provider
 	 */
 	public function test_is_payment_request_enabled( $is_enabled, $enabled_payment_method_ids, $disabled_payment_method_ids ) {

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -778,10 +778,94 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			],
 			'gateway order option missing'                        => [
 				'gateway_order' => null,
-				'expected'      => false,
+				'expected'      => true,
 			],
 			'gateway order option empty'                          => [
 				'gateway_order' => [],
+				'expected'      => true,
+			],
+		];
+	}
+
+	/**
+	 * Test for `should_show_stripe_first_method_notice`.
+	 *
+	 * @param string|null $notice_option Value for `wc_stripe_show_stripe_first_method_notice`, or null to delete (default yes).
+	 * @param array|null  $gateway_order Value for `woocommerce_gateway_order`, or null to delete.
+	 * @param bool        $expected      Expected return value.
+	 * @dataProvider provide_test_should_show_stripe_first_method_notice
+	 */
+	public function test_should_show_stripe_first_method_notice( ?string $notice_option, $gateway_order, bool $expected ): void {
+		if ( null === $notice_option ) {
+			delete_option( 'wc_stripe_show_stripe_first_method_notice' );
+		} else {
+			update_option( 'wc_stripe_show_stripe_first_method_notice', $notice_option );
+		}
+
+		if ( null === $gateway_order ) {
+			delete_option( 'woocommerce_gateway_order' );
+		} else {
+			update_option( 'woocommerce_gateway_order', $gateway_order );
+		}
+
+		$this->assertSame( $expected, WC_Stripe_Helper::should_show_stripe_first_method_notice() );
+	}
+
+	/**
+	 * Data provider for `test_should_show_stripe_first_method_notice`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_should_show_stripe_first_method_notice(): array {
+		return [
+			'notice dismissed'                               => [
+				'notice_option' => 'no',
+				'gateway_order' => [
+					'cod'    => '0',
+					'stripe' => '1',
+				],
+				'expected'      => false,
+			],
+			'notice enabled and stripe is first'             => [
+				'notice_option' => 'yes',
+				'gateway_order' => [
+					'stripe' => '0',
+					'cod'    => '1',
+				],
+				'expected'      => false,
+			],
+			'notice enabled default and stripe is first'     => [
+				'notice_option' => null,
+				'gateway_order' => [
+					'stripe' => '0',
+					'cod'    => '1',
+				],
+				'expected'      => false,
+			],
+			'notice enabled and stripe is not first'         => [
+				'notice_option' => 'yes',
+				'gateway_order' => [
+					'cod'    => '0',
+					'stripe' => '1',
+				],
+				'expected'      => true,
+			],
+			'notice enabled default and stripe is not first' => [
+				'notice_option' => null,
+				'gateway_order' => [
+					'cod'    => '0',
+					'stripe' => '1',
+				],
+				'expected'      => true,
+			],
+			'notice enabled and gateway order empty'         => [
+				'notice_option' => 'yes',
+				'gateway_order' => [],
+				'expected'      => false,
+			],
+			'notice enabled and gateway order missing'       => [
+				'notice_option' => 'yes',
+				'gateway_order' => null,
 				'expected'      => false,
 			],
 		];

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -719,6 +719,67 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
+	 * Test for `is_stripe_in_position_one_in_woocommerce_gateway_order`.
+	 *
+	 * @param array $gateway_order WooCommerce gateway order option value.
+	 * @param bool  $expected      Expected result.
+	 * @dataProvider provide_test_is_stripe_in_position_one_in_woocommerce_gateway_order
+	 */
+	public function test_is_stripe_in_position_one_in_woocommerce_gateway_order( $gateway_order, bool $expected ) {
+		if ( null === $gateway_order ) {
+			delete_option( 'woocommerce_gateway_order' );
+		} else {
+			update_option( 'woocommerce_gateway_order', $gateway_order );
+		}
+
+		$this->assertSame(
+			$expected,
+			WC_Stripe_Helper::is_stripe_in_position_one_in_woocommerce_gateway_order()
+		);
+	}
+
+	/**
+	 * Data provider for `test_is_stripe_in_position_one_in_woocommerce_gateway_order`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_is_stripe_in_position_one_in_woocommerce_gateway_order(): array {
+		return [
+			'stripe is first'                => [
+				'gateway_order' => [
+					'stripe' => '0',
+					'cod'    => '1',
+					'bacs'   => '2',
+				],
+				'expected'      => true,
+			],
+			'stripe exists but is not first' => [
+				'gateway_order' => [
+					'cod'    => '0',
+					'stripe' => '1',
+					'bacs'   => '2',
+				],
+				'expected'      => false,
+			],
+			'stripe missing from order'      => [
+				'gateway_order' => [
+					'cod'  => '0',
+					'bacs' => '1',
+				],
+				'expected'      => false,
+			],
+			'gateway order option missing'   => [
+				'gateway_order' => null,
+				'expected'      => false,
+			],
+			'gateway order option empty'     => [
+				'gateway_order' => [],
+				'expected'      => false,
+			],
+		];
+	}
+
+	/**
 	 * Test for `add_mandate_data`.
 	 *
 	 * @param string $server_variable_key   The key of the server variable to set.

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -745,7 +745,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 */
 	public function provide_test_is_stripe_in_position_one_in_woocommerce_gateway_order(): array {
 		return [
-			'stripe is first'                => [
+			'stripe is first'                                     => [
 				'gateway_order' => [
 					'stripe' => '0',
 					'cod'    => '1',
@@ -753,7 +753,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				],
 				'expected'      => true,
 			],
-			'stripe exists but is not first' => [
+			'stripe exists but is not first'                      => [
 				'gateway_order' => [
 					'cod'    => '0',
 					'stripe' => '1',
@@ -761,18 +761,26 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				],
 				'expected'      => false,
 			],
-			'stripe missing from order'      => [
+			'stripe is first real gateway after internal entries' => [
+				'gateway_order' => [
+					'_wc_pes_wc_payments' => '0',
+					'stripe'              => '1',
+					'cod'                 => '2',
+				],
+				'expected'      => true,
+			],
+			'stripe missing from order'                           => [
 				'gateway_order' => [
 					'cod'  => '0',
 					'bacs' => '1',
 				],
 				'expected'      => false,
 			],
-			'gateway order option missing'   => [
+			'gateway order option missing'                        => [
 				'gateway_order' => null,
 				'expected'      => false,
 			],
-			'gateway order option empty'     => [
+			'gateway order option empty'                          => [
 				'gateway_order' => [],
 				'expected'      => false,
 			],

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -788,6 +788,44 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
+	 * Test for `move_stripe_gateways_to_top_in_woocommerce_gateway_order`.
+	 */
+	public function test_move_stripe_gateways_to_top_in_woocommerce_gateway_order() {
+		update_option(
+			'woocommerce_gateway_order',
+			[
+				'affirm'       => '0',
+				'woopayments'  => '1',
+				'amazon_pay'   => '2',
+				'stripe_sepa'  => '3',
+				'stripe_ideal' => '4',
+				'stripe'       => '5',
+				'stripe_eps'   => '6',
+				'cod'          => '7',
+				'paypal'       => '8',
+			]
+		);
+
+		WC_Stripe_Helper::move_stripe_gateways_to_top_in_woocommerce_gateway_order();
+		$gateway_order = get_option( 'woocommerce_gateway_order', [] );
+
+		$this->assertSame(
+			[
+				'stripe_sepa'  => '0',
+				'stripe_ideal' => '1',
+				'stripe'       => '2',
+				'stripe_eps'   => '3',
+				'affirm'       => '4',
+				'woopayments'  => '5',
+				'amazon_pay'   => '6',
+				'cod'          => '7',
+				'paypal'       => '8',
+			],
+			$gateway_order
+		);
+	}
+
+	/**
 	 * Test for `add_mandate_data`.
 	 *
 	 * @param string $server_variable_key   The key of the server variable to set.

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -725,7 +725,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 * @param bool  $expected      Expected result.
 	 * @dataProvider provide_test_is_stripe_in_position_one_in_woocommerce_gateway_order
 	 */
-	public function test_is_stripe_in_position_one_in_woocommerce_gateway_order( $gateway_order, bool $expected ) {
+	public function test_is_stripe_in_position_one_in_woocommerce_gateway_order( ?array $gateway_order, bool $expected ) {
 		if ( null === $gateway_order ) {
 			delete_option( 'woocommerce_gateway_order' );
 		} else {
@@ -795,7 +795,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 * @param bool        $expected      Expected return value.
 	 * @dataProvider provide_test_should_show_stripe_first_method_notice
 	 */
-	public function test_should_show_stripe_first_method_notice( ?string $notice_option, $gateway_order, bool $expected ): void {
+	public function test_should_show_stripe_first_method_notice( ?string $notice_option, ?array $gateway_order, bool $expected ): void {
 		if ( null === $notice_option ) {
 			delete_option( 'wc_stripe_show_stripe_first_method_notice' );
 		} else {


### PR DESCRIPTION
Towards STRIPE-1030

## Changes proposed in this Pull Request:
- Added `OptimizedCheckoutFirstMethodNotice` component to show the notice
- Added a new REST endpoint in `WC_REST_Stripe_Settings_Controller` to move Stripe gateways to the top of `woocommerce_gateway_order`.
- Added helper methods in `WC_Stripe_Helper` to:
    - Detect whether Stripe is first among real gateways (ignoring _wc_pes_* entries).
    - Move Stripe gateways (stripe + stripe_*) to the top while preserving internal relative order.

<img width="1198" height="564" alt="Screenshot 2026-04-09 at 2 34 50 AM" src="https://github.com/user-attachments/assets/efbbeef0-7849-4d03-b18f-f8c413ac56ff" />


## Testing instructions
- Go to **WooCommerce > Settings > Payments** page
- Enable COD, Cheque, PayPal etc., a few non-Stripe gateways.
- Move Stripe to 1st position among the gateways
- Go to the Stripe settings page and scroll down to the advanced settings section.
- Enable Optimized checkout
- There should be no notices below the OCS checkbox
- Now move Stripe to the 3rd/4th position in **WooCommerce > Settings > Payments** page
- Refresh the Stripe settings page
- You should see a notice below the OCS checkbox.
- Click the `Move to top` button.
- Refresh the **WooCommerce > Settings > Payments** page and verify that Stripe is moved to the first position
- The relative order of the other payment gateways should be unchanged.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
