### PR TITLE
Keep adaptive pricing amount in sync on block checkout after order total changes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -50,6 +50,7 @@ xxxx-xx-xx - version 10.6.0
 * Fix - Prevent TypeError when processing deferred webhooks using Action Scheduler
 * Fix - Prevent JavaScript error in `elements.update` when using checkout sessions with adaptive pricing
 * Fix - Keep adaptive pricing amount in sync on classic checkout after order total changes
+* Fix - Keep adaptive pricing amount in sync on block checkout after order total changes
 * Fix - Use a single Checkout Session line item priced at the full payable cart total so adaptive pricing sessions match checkout totals
 * Add - Add Ajax endpoint to update line items in a checkout session
 * Tweak - Hide the Adaptive Pricing currency selector from classic checkout when a saved payment method is selected

--- a/client/blocks/checkout-sessions/__tests__/checkout-form.test.js
+++ b/client/blocks/checkout-sessions/__tests__/checkout-form.test.js
@@ -21,6 +21,7 @@ jest.mock( 'wcstripe/blocks/checkout-sessions/hooks', () => ( {
 	usePaymentSetupHandler: jest.fn(),
 	useCheckoutSuccessHandler: jest.fn(),
 	usePaymentFailHandler: jest.fn(),
+	useCheckoutSessionTotalsSync: jest.fn(),
 } ) );
 
 jest.mock(
@@ -31,6 +32,8 @@ jest.mock(
 );
 
 describe( 'CheckoutForm', () => {
+	const api = { checkoutSessionsUpdateSession: jest.fn() };
+
 	const LoadingMask = ( { isLoading, showSpinner, screenReaderLabel } ) => (
 		<div>
 			{ isLoading && showSpinner && <span>{ screenReaderLabel }</span> }
@@ -79,6 +82,7 @@ describe( 'CheckoutForm', () => {
 
 		render(
 			<CheckoutForm
+				api={ api }
 				emitResponse={ emitResponse }
 				eventRegistration={ eventRegistration }
 				LoadingMask={ LoadingMask }
@@ -103,6 +107,7 @@ describe( 'CheckoutForm', () => {
 
 		render(
 			<CheckoutForm
+				api={ api }
 				emitResponse={ emitResponse }
 				eventRegistration={ eventRegistration }
 				LoadingMask={ LoadingMask }
@@ -126,6 +131,7 @@ describe( 'CheckoutForm', () => {
 
 		render(
 			<CheckoutForm
+				api={ api }
 				emitResponse={ emitResponse }
 				eventRegistration={ eventRegistration }
 				LoadingMask={ LoadingMask }

--- a/client/blocks/checkout-sessions/__tests__/hooks.test.js
+++ b/client/blocks/checkout-sessions/__tests__/hooks.test.js
@@ -1,14 +1,21 @@
+import { renderHook, waitFor } from '@testing-library/react';
 import {
 	usePaymentSetupHandler,
 	useCheckoutSuccessHandler,
 	usePaymentFailHandler,
+	useCheckoutSessionTotalsSync,
 } from 'wcstripe/blocks/checkout-sessions/hooks';
 import { useEffect } from '@wordpress/element';
-import { select } from '@wordpress/data';
+import { select, useSelect } from '@wordpress/data';
 
-jest.mock( '@wordpress/element' );
+jest.mock( '@wordpress/element', () => ( {
+	...jest.requireActual( '@wordpress/element' ),
+	useEffect: jest.fn( ( fn ) => fn() ),
+} ) );
+
 jest.mock( '@wordpress/data', () => ( {
 	select: jest.fn(),
+	useSelect: jest.fn( () => '' ),
 } ) );
 
 describe( 'CheckoutSessions hook tests', () => {
@@ -457,6 +464,90 @@ describe( 'CheckoutSessions hook tests', () => {
 				message:
 					'An error occurred during payment processing. Please try again.',
 			} );
+		} );
+	} );
+
+	describe( 'useCheckoutSessionTotalsSync hook', () => {
+		let cartPrice;
+		// const actualElement = jest.requireActual( '@wordpress/element' );
+
+		beforeEach( () => {
+			// useEffect.mockImplementation( actualElement.useEffect );
+			cartPrice = '1000';
+			window.wc = {
+				wcBlocksData: { cartStore: 'wc/store/cart' },
+			};
+			useSelect.mockImplementation( ( mapSelect ) => {
+				const mockSelect = ( storeKey ) =>
+					storeKey === window.wc.wcBlocksData.cartStore
+						? {
+								getCartTotals: () => ( {
+									total_price: cartPrice,
+								} ),
+						  }
+						: {};
+				return mapSelect( mockSelect );
+			} );
+		} );
+
+		afterEach( () => {
+			useEffect.mockImplementation( ( fn ) => fn() );
+		} );
+
+		it( 'does not call update on the first totals snapshot', () => {
+			const api = {
+				checkoutSessionsUpdateSession: jest.fn( () =>
+					Promise.resolve( {} )
+				),
+			};
+			const checkoutState = {
+				type: 'success',
+				checkout: {
+					id: 'cs_test',
+					runServerUpdate: jest.fn( async ( fn ) => {
+						await fn();
+						return { type: 'success' };
+					} ),
+				},
+			};
+
+			renderHook( () =>
+				useCheckoutSessionTotalsSync( api, 'cs_test', checkoutState )
+			);
+
+			expect( api.checkoutSessionsUpdateSession ).not.toHaveBeenCalled();
+		} );
+
+		it( 'calls checkoutSessionsUpdateSession when cart totals change', async () => {
+			const api = {
+				checkoutSessionsUpdateSession: jest.fn( () =>
+					Promise.resolve( {} )
+				),
+			};
+			const checkoutState = {
+				type: 'success',
+				checkout: {
+					id: 'cs_test',
+					runServerUpdate: jest.fn( async ( fn ) => {
+						await fn();
+						return { type: 'success' };
+					} ),
+				},
+			};
+
+			const { rerender } = renderHook( () =>
+				useCheckoutSessionTotalsSync( api, 'cs_test', checkoutState )
+			);
+
+			cartPrice = '2000';
+			rerender();
+
+			await waitFor( () => {
+				expect(
+					api.checkoutSessionsUpdateSession
+				).toHaveBeenCalledWith( 'cs_test' );
+			} );
+			expect( checkoutState.checkout.runServerUpdate ).toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/client/blocks/checkout-sessions/__tests__/hooks.test.js
+++ b/client/blocks/checkout-sessions/__tests__/hooks.test.js
@@ -469,10 +469,8 @@ describe( 'CheckoutSessions hook tests', () => {
 
 	describe( 'useCheckoutSessionTotalsSync hook', () => {
 		let cartPrice;
-		// const actualElement = jest.requireActual( '@wordpress/element' );
 
 		beforeEach( () => {
-			// useEffect.mockImplementation( actualElement.useEffect );
 			cartPrice = '1000';
 			window.wc = {
 				wcBlocksData: { cartStore: 'wc/store/cart' },

--- a/client/blocks/checkout-sessions/checkout-form.js
+++ b/client/blocks/checkout-sessions/checkout-form.js
@@ -11,6 +11,7 @@ import {
 	useCheckoutSuccessHandler,
 	usePaymentFailHandler,
 	usePaymentSetupHandler,
+	useCheckoutSessionTotalsSync,
 } from 'wcstripe/blocks/checkout-sessions/hooks';
 
 /**
@@ -22,6 +23,7 @@ import {
  * Checkout Form component.
  *
  * @param {Object}                 props                             Component props.
+ * @param {Object}                 props.api                         WCStripeAPI instance (checkout session AJAX).
  * @param {EmitResponseProps}      props.emitResponse                Function to emit response back to the parent component.
  * @param {string}                 props.errorMessage                Error message to display if loading the checkout session fails.
  * @param {EventRegistrationProps} props.eventRegistration           Object containing event registration functions for payment setup, checkout success, and checkout failure.
@@ -35,6 +37,7 @@ import {
  * @return {JSX.Element} The Checkout Form component.
  */
 const CheckoutForm = ( {
+	api,
 	emitResponse,
 	errorMessage,
 	eventRegistration: { onPaymentSetup, onCheckoutSuccess, onCheckoutFail },
@@ -71,6 +74,7 @@ const CheckoutForm = ( {
 		shippingData
 	);
 	usePaymentFailHandler( onCheckoutFail, emitResponse );
+	useCheckoutSessionTotalsSync( api, checkoutSessionId, checkoutState );
 
 	const onSelectedPaymentMethodChange = ( { value, complete } ) => {
 		handleDisplayOfPaymentInstructions( value.type, 'blocks' );

--- a/client/blocks/checkout-sessions/hooks.js
+++ b/client/blocks/checkout-sessions/hooks.js
@@ -295,13 +295,13 @@ export const useCheckoutSessionTotalsSync = (
 	checkoutStateRef.current = checkoutState;
 
 	const prevSessionIdRef = useRef( null );
-	const prevTotalsSignatureRef = useRef( null );
+	const prevCartTotalsRef = useRef( null );
 
 	// Update the previous session ID and totals signature when the checkout session ID changes.
 	useEffect( () => {
 		if ( prevSessionIdRef.current !== checkoutSessionId ) {
 			prevSessionIdRef.current = checkoutSessionId;
-			prevTotalsSignatureRef.current = null;
+			prevCartTotalsRef.current = null;
 		}
 	}, [ checkoutSessionId ] );
 
@@ -310,16 +310,16 @@ export const useCheckoutSessionTotalsSync = (
 			return;
 		}
 
-		if ( prevTotalsSignatureRef.current === null ) {
-			prevTotalsSignatureRef.current = cartTotals;
+		if ( prevCartTotalsRef.current === null ) {
+			prevCartTotalsRef.current = cartTotals;
 			return;
 		}
 
-		if ( prevTotalsSignatureRef.current === cartTotals ) {
+		if ( prevCartTotalsRef.current === cartTotals ) {
 			return;
 		}
 
-		prevTotalsSignatureRef.current = cartTotals;
+		prevCartTotalsRef.current = cartTotals;
 
 		const state = checkoutStateRef.current;
 		if ( state?.type !== 'success' ) {

--- a/client/blocks/checkout-sessions/hooks.js
+++ b/client/blocks/checkout-sessions/hooks.js
@@ -276,7 +276,7 @@ export const useCheckoutSessionTotalsSync = (
 	checkoutSessionId,
 	checkoutState
 ) => {
-	const cartTotalsSignature = useSelect( ( selectCart ) => {
+	const cartTotals = useSelect( ( selectCart ) => {
 		const cartStoreKey = window.wc?.wcBlocksData?.cartStore;
 		if ( ! cartStoreKey ) {
 			return '';
@@ -300,20 +300,20 @@ export const useCheckoutSessionTotalsSync = (
 	}, [ checkoutSessionId ] );
 
 	useEffect( () => {
-		if ( ! checkoutSessionId || cartTotalsSignature === '' ) {
+		if ( ! checkoutSessionId || cartTotals === '' ) {
 			return;
 		}
 
 		if ( prevTotalsSignatureRef.current === null ) {
-			prevTotalsSignatureRef.current = cartTotalsSignature;
+			prevTotalsSignatureRef.current = cartTotals;
 			return;
 		}
 
-		if ( prevTotalsSignatureRef.current === cartTotalsSignature ) {
+		if ( prevTotalsSignatureRef.current === cartTotals ) {
 			return;
 		}
 
-		prevTotalsSignatureRef.current = cartTotalsSignature;
+		prevTotalsSignatureRef.current = cartTotals;
 
 		const state = checkoutStateRef.current;
 		if ( state?.type !== 'success' ) {
@@ -349,5 +349,5 @@ export const useCheckoutSessionTotalsSync = (
 		return () => {
 			cancelled = true;
 		};
-	}, [ api, cartTotalsSignature, checkoutSessionId ] );
+	}, [ api, cartTotals, checkoutSessionId ] );
 };

--- a/client/blocks/checkout-sessions/hooks.js
+++ b/client/blocks/checkout-sessions/hooks.js
@@ -1,6 +1,6 @@
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { select } from '@wordpress/data';
+import { select, useSelect } from '@wordpress/data';
 import { isSavePaymentMethodCheckboxChecked } from 'wcstripe/blocks/utils';
 
 /**
@@ -261,4 +261,93 @@ export const usePaymentFailHandler = ( onCheckoutFail, emitResponse ) => {
 			} ),
 		[ onCheckoutFail, emitResponse ]
 	);
+};
+
+/**
+ * Keeps the Stripe Checkout Session in sync with WooCommerce cart totals (price, tax, shipping) on block checkout.
+ * Uses Custom Checkout `runServerUpdate` when available (same pattern as classic checkout).
+ *
+ * @param {Object|null} api               WCStripeAPI instance (with checkoutSessionsUpdateSession).
+ * @param {string|null} checkoutSessionId Stripe Checkout Session id once the session is ready.
+ * @param {Object}      checkoutState     Result of useCheckout() from @stripe/react-stripe-js/checkout.
+ */
+export const useCheckoutSessionTotalsSync = (
+	api,
+	checkoutSessionId,
+	checkoutState
+) => {
+	const cartTotalsSignature = useSelect( ( selectCart ) => {
+		const cartStoreKey = window.wc?.wcBlocksData?.cartStore;
+		if ( ! cartStoreKey ) {
+			return '';
+		}
+		const totals = selectCart( cartStoreKey ).getCartTotals();
+		return totals?.total_price;
+	}, [] );
+
+	const checkoutStateRef = useRef( checkoutState );
+	checkoutStateRef.current = checkoutState;
+
+	const prevSessionIdRef = useRef( null );
+	const prevTotalsSignatureRef = useRef( null );
+
+	// Update the previous session ID and totals signature when the checkout session ID changes.
+	useEffect( () => {
+		if ( prevSessionIdRef.current !== checkoutSessionId ) {
+			prevSessionIdRef.current = checkoutSessionId;
+			prevTotalsSignatureRef.current = null;
+		}
+	}, [ checkoutSessionId ] );
+
+	useEffect( () => {
+		if ( ! checkoutSessionId || cartTotalsSignature === '' ) {
+			return;
+		}
+
+		if ( prevTotalsSignatureRef.current === null ) {
+			prevTotalsSignatureRef.current = cartTotalsSignature;
+			return;
+		}
+
+		if ( prevTotalsSignatureRef.current === cartTotalsSignature ) {
+			return;
+		}
+
+		prevTotalsSignatureRef.current = cartTotalsSignature;
+
+		const state = checkoutStateRef.current;
+		if ( state?.type !== 'success' ) {
+			return;
+		}
+
+		let cancelled = false;
+
+		const run = async () => {
+			try {
+				const { checkout } = state;
+				if ( typeof checkout?.runServerUpdate === 'function' ) {
+					const result = await checkout.runServerUpdate( async () => {
+						await api.checkoutSessionsUpdateSession(
+							checkoutSessionId
+						);
+					} );
+					if ( ! cancelled && result && result.type === 'error' ) {
+						// eslint-disable-next-line no-console
+						console.error( result.error );
+					}
+				}
+			} catch ( error ) {
+				if ( ! cancelled ) {
+					// eslint-disable-next-line no-console
+					console.error( error );
+				}
+			}
+		};
+
+		run();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ api, cartTotalsSignature, checkoutSessionId ] );
 };

--- a/client/blocks/checkout-sessions/hooks.js
+++ b/client/blocks/checkout-sessions/hooks.js
@@ -281,7 +281,13 @@ export const useCheckoutSessionTotalsSync = (
 		if ( ! cartStoreKey ) {
 			return '';
 		}
-		const totals = selectCart( cartStoreKey ).getCartTotals();
+
+		const cartStore = selectCart( cartStoreKey );
+		if ( typeof cartStore?.getCartTotals !== 'function' ) {
+			return '';
+		}
+		const totals = cartStore.getCartTotals();
+
 		return totals?.total_price;
 	}, [] );
 
@@ -325,16 +331,21 @@ export const useCheckoutSessionTotalsSync = (
 		const run = async () => {
 			try {
 				const { checkout } = state;
-				if ( typeof checkout?.runServerUpdate === 'function' ) {
-					const result = await checkout.runServerUpdate( async () => {
-						await api.checkoutSessionsUpdateSession(
-							checkoutSessionId
-						);
-					} );
-					if ( ! cancelled && result && result.type === 'error' ) {
-						// eslint-disable-next-line no-console
-						console.error( result.error );
-					}
+				if (
+					typeof api?.checkoutSessionsUpdateSession !== 'function' ||
+					typeof checkout?.runServerUpdate !== 'function'
+				) {
+					return;
+				}
+
+				const result = await checkout.runServerUpdate( async () => {
+					await api.checkoutSessionsUpdateSession(
+						checkoutSessionId
+					);
+				} );
+				if ( ! cancelled && result && result.type === 'error' ) {
+					// eslint-disable-next-line no-console
+					console.error( result.error );
 				}
 			} catch ( error ) {
 				if ( ! cancelled ) {

--- a/readme.txt
+++ b/readme.txt
@@ -198,6 +198,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Prevent TypeError when processing deferred webhooks using Action Scheduler
 * Fix - Prevent JavaScript error in `elements.update` when using checkout sessions with adaptive pricing
 * Fix - Keep adaptive pricing amount in sync on classic checkout after order total changes
+* Fix - Keep adaptive pricing amount in sync on block checkout after order total changes
 * Fix - Use a single Checkout Session line item priced at the full payable cart total so adaptive pricing sessions match checkout totals
 * Add - Add Ajax endpoint to update line items in a checkout session
 * Tweak - Hide the Adaptive Pricing currency selector from classic checkout when a saved payment method is selected


### PR DESCRIPTION
Towards [STRIPE-1052](https://linear.app/a8c/issue/STRIPE-1052)

## Changes proposed in this Pull Request:
- Introduced `useCheckoutSessionTotalsSync` which detects any changes in the cart total.
- Used `checkout.runServerUpdate` from the `useCheckout`. This ensures that the Payment Element is also updated by Stripe and the currency selector shows the updated amount.


## Testing instructions
- Enable OCS and Adaptive Pricing.
- Create some coupons.
- Create some shipping methods.
- Add some tax rates.
- As a logged in shopper, add a product to your cart and go to the cart page.
- Add a coupon in the cart page.
- Change the shipping method.
- Now go to the block checkout page.
- Verify that the total amount in the order summary table is same as the amount in the currency selector.
- On the checkout page, change the shipping method.
- Remove the coupon and add a different one.
- Verify that, after each action the amount in the currency selector gets updated. ( Note: the update could be a little slow )
- 

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
