### PR TITLE
Fix guest checkout with adaptive pricing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -54,6 +54,7 @@ xxxx-xx-xx - version 10.6.0
 * Add - Add Ajax endpoint to update line items in a checkout session
 * Tweak - Hide the Adaptive Pricing currency selector from classic checkout when a saved payment method is selected
 * Add - Allow customers to save payment methods during checkout with adaptive pricing
+* Fix - Restrict Checkout Session saved payment method options to logged-in customers so guest checkout session creation succeeds
 
 2026-03-19 - version 10.5.3
 * Fix - Restore default layout when Optimized Checkout is disabled

--- a/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
+++ b/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
@@ -43,9 +43,6 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler {
 				'adaptive_pricing'              => [
 					'enabled' => 'true',
 				],
-				'saved_payment_method_options'  => [
-					'payment_method_save' => 'enabled',
-				],
 			];
 
 			if ( is_user_logged_in() && WC()->customer instanceof WC_Customer ) {
@@ -56,8 +53,11 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler {
 					throw new Exception( __( 'Unable to create or retrieve Stripe customer.', 'woocommerce-gateway-stripe' ) );
 				}
 
-				$request['customer']                = $stripe_customer->get_id();
-				$request['phone_number_collection'] = [ 'enabled' => true ];
+				$request['customer']                     = $stripe_customer->get_id();
+				$request['phone_number_collection']      = [ 'enabled' => true ];
+				$request['saved_payment_method_options'] = [
+					'payment_method_save' => 'enabled',
+				];
 			}
 
 			$checkout_session = WC_Stripe_API::request( $request, 'checkout/sessions' );

--- a/readme.txt
+++ b/readme.txt
@@ -202,5 +202,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Add Ajax endpoint to update line items in a checkout session
 * Tweak - Hide the Adaptive Pricing currency selector from classic checkout when a saved payment method is selected
 * Add - Allow customers to save payment methods during checkout with adaptive pricing
+* Fix - Restrict Checkout Session saved payment method options to logged-in customers so guest checkout session creation succeeds
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:
Set the Checkout Session `saved_payment_method_options` for logged-in customers only as this param is unsupported for guest users.

Guest checkout is currently broken as session creation fails due to this unsupported param.

## Testing instructions
- Enable OCS and Adaptive Pricing.
- As a guest shopper, add a product to your cart and go to the checkout page.
- In `develop`, notice that the currency selector is absent.
- Check the response of `wc_stripe_create_checkout_session` ajax request in your network tab and find that the session creation failed.
- In this branch, the session creation should be successful and the currency selector should be present on the checkout page.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
