### PR TITLE
Autoload all Agentic Commerce classes via Composer classmap

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ xxxx-xx-xx - version 10.6.0
 * Add - Include specific information on converted currency for adaptive pricing in order confirmation emails
 * Fix - Use the order currency instead of the global store currency when creating a payment intent, resolving incorrect charges in multicurrency setups
 * Dev - Rename and move the new Checkout Sessions ajax handler class to be autoloaded
+* Dev - Autoload all Agentic Commerce classes via Composer classmap, removing manual require_once calls
 * Add - Process payment with adaptive pricing in the classic checkout
 * Dev - Add WC_Stripe_Country_Code constants class and replace hardcoded country code strings
 * Fix - Resolve intermittent "Missing required customer field: address->line1" error during checkout with auto-account creation

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     },
     "autoload": {
       "classmap": [
-        "includes/ajax-handlers/"
+        "includes/ajax-handlers/",
+        "includes/agentic-commerce/"
       ]
     },
     "autoload-dev": {

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -216,42 +216,6 @@ class WC_Stripe {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/class-migrate-payment-request-data-to-express-checkout-data.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-account.php';
 
-		require_once WC_STRIPE_PLUGIN_PATH . '/includes/agentic-commerce/class-wc-stripe-agentic-commerce-product-resolver.php';
-
-		// Load Agentic Commerce classes.
-		// Requires WooCommerce 10.5.0+ with FeedInterface.
-		if ( interface_exists( 'Automattic\WooCommerce\Internal\ProductFeed\Feed\FeedInterface' ) ) {
-			require_once WC_STRIPE_PLUGIN_PATH . '/includes/agentic-commerce/class-wc-stripe-agentic-commerce-csv-feed.php';
-			require_once WC_STRIPE_PLUGIN_PATH . '/includes/agentic-commerce/class-wc-stripe-agentic-commerce-feed-schema.php';
-
-			// Load delivery method and integration.
-			require_once WC_STRIPE_PLUGIN_PATH . '/includes/agentic-commerce/class-wc-stripe-agentic-commerce-files-api-delivery.php';
-			require_once WC_STRIPE_PLUGIN_PATH . '/includes/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper.php';
-			require_once WC_STRIPE_PLUGIN_PATH . '/includes/agentic-commerce/class-wc-stripe-agentic-commerce-feed-validator.php';
-
-			require_once WC_STRIPE_PLUGIN_PATH . '/includes/agentic-commerce/class-wc-stripe-agentic-commerce-integration.php';
-			require_once WC_STRIPE_PLUGIN_PATH . '/includes/agentic-commerce/class-wc-stripe-agentic-commerce-inventory-tracker.php';
-
-			if ( defined( 'WP_CLI' ) && WP_CLI ) {
-				require_once WC_STRIPE_PLUGIN_PATH . '/includes/agentic-commerce/class-wc-stripe-agentic-commerce-cli.php';
-			}
-		}
-
-		// Load Agentic Commerce classes that do not depend on FeedInterface/core.
-		require_once WC_STRIPE_PLUGIN_PATH . '/includes/agentic-commerce/class-wc-stripe-api-address.php';
-		require_once WC_STRIPE_PLUGIN_PATH . '/includes/agentic-commerce/class-wc-stripe-agentic-line-item.php';
-		require_once WC_STRIPE_PLUGIN_PATH . '/includes/agentic-commerce/class-wc-stripe-agentic-checkout-session.php';
-		require_once WC_STRIPE_PLUGIN_PATH . '/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php';
-
-		// Customize checkout (tax calculation) hook — used by the webhook handler.
-		require_once WC_STRIPE_PLUGIN_PATH . '/includes/agentic-commerce/class-wc-stripe-agentic-customize-checkout-line-item.php';
-		require_once WC_STRIPE_PLUGIN_PATH . '/includes/agentic-commerce/class-wc-stripe-agentic-customize-checkout-event.php';
-		require_once WC_STRIPE_PLUGIN_PATH . '/includes/agentic-commerce/class-wc-stripe-agentic-commerce-tax-calculator.php';
-		require_once WC_STRIPE_PLUGIN_PATH . '/includes/agentic-commerce/class-wc-stripe-agentic-shipping-calculator.php';
-
-		// Finalize checkout (manual approval) hook — used by the webhook handler.
-		require_once WC_STRIPE_PLUGIN_PATH . '/includes/agentic-commerce/class-wc-stripe-agentic-commerce-manual-approval.php';
-
 		new Allowed_Payment_Request_Button_Types_Update();
 		new Migrate_Payment_Request_Data_To_Express_Checkout_Data();
 		new Sepa_Tokens_For_Other_Methods_Settings_Update();

--- a/readme.txt
+++ b/readme.txt
@@ -146,6 +146,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.6.0 - xxxx-xx-xx =
+* Dev - Autoload all Agentic Commerce classes via Composer classmap, removing manual require_once calls
 * Update - Show "Payment Options" as the Optimized Checkout title on classic checkout and "Payment Methods" on Blocks checkout instead of "Stripe"
 * Dev - Separate Agentic Commerce merchant-controlled is_enabled setting from the developer feature flag
 * Fix - Render the Adaptive Pricing currency selector immediately above the payment element in classic checkout

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -156,8 +156,6 @@ function wcstripe_deactivated(): void {
 
 	// Cancel scheduled Agentic Commerce feed syncs.
 	if ( interface_exists( 'Automattic\WooCommerce\Internal\ProductFeed\Feed\FeedInterface' ) ) {
-		require_once WC_STRIPE_PLUGIN_PATH . '/includes/agentic-commerce/class-wc-stripe-agentic-commerce-integration.php';
-
 		$integration = new WC_Stripe_Agentic_Commerce_Integration();
 		$integration->deactivate();
 	}


### PR DESCRIPTION
Fixes STRIPE-1070

## Summary

- Adds `includes/agentic-commerce/` to the Composer classmap autoload in `composer.json`, mirroring how `includes/ajax-handlers/` is already handled.
- Removes 18 `require_once` calls for agentic-commerce classes from `includes/class-wc-stripe.php` and one from `woocommerce-gateway-stripe.php` (deactivation hook).
- Composer classmap is regenerated via `composer dump-autoload` — all 35 agentic-commerce class entries are now in the generated classmap.

## Test plan

- [ ] Verify plugin loads without fatal errors on the local Docker environment (`npm run up`)
- [ ] Confirm Agentic Commerce features work as expected (product feed sync, checkout sessions)
- [ ] Run PHPUnit: `npm run test:php`
- [ ] Run PHPStan: `npm run phpstan` (clean ✅)

\* You may need to run `composer dump-autoload` first

🤖 Generated with [Claude Code](https://claude.com/claude-code)