### PR TITLE
Fix handling of payer phone in checkout sessions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -40,7 +40,7 @@ xxxx-xx-xx - version 10.6.0
 * Dev - Add incremental inventory sync for Agentic Commerce: tracks stock changes via WooCommerce hooks and uploads a minimal inventory_feed CSV to Stripe one minute after the first change
 * Dev - Collapse PHPUnit tests using data providers to reduce duplication and improve test isolation
 * Fix - Fix UPE style transition keys for font smoothing properties
-* Fix - Only collect payer phone in Checkout Sessions when WooCommerce's checkout phone field is required, and only send it to Stripe when the customer is logged in and phone collection is required
+* Fix - Only collect and send payer phone in Checkout Sessions when the WooCommerce phone field is required
 * Dev - Remove @woocommerce/currency dev dependency to resolve locutus CVE-2026-32304 (GHSA-vh9h-29pq-r5m8)
 * Add - Handle Checkout Session failure webhook events for expired and async failed payments
 * Add - Process Checkout Session async payment success webhooks

--- a/changelog.txt
+++ b/changelog.txt
@@ -40,6 +40,7 @@ xxxx-xx-xx - version 10.6.0
 * Dev - Add incremental inventory sync for Agentic Commerce: tracks stock changes via WooCommerce hooks and uploads a minimal inventory_feed CSV to Stripe one minute after the first change
 * Dev - Collapse PHPUnit tests using data providers to reduce duplication and improve test isolation
 * Fix - Fix UPE style transition keys for font smoothing properties
+* Fix - Only collect payer phone in Checkout Sessions when WooCommerce's checkout phone field is required, and only send it to Stripe when the customer is logged in and phone collection is required
 * Dev - Remove @woocommerce/currency dev dependency to resolve locutus CVE-2026-32304 (GHSA-vh9h-29pq-r5m8)
 * Add - Handle Checkout Session failure webhook events for expired and async failed payments
 * Add - Process Checkout Session async payment success webhooks

--- a/client/blocks/checkout-sessions/__tests__/hooks.test.js
+++ b/client/blocks/checkout-sessions/__tests__/hooks.test.js
@@ -192,6 +192,7 @@ describe( 'CheckoutSessions hook tests', () => {
 				onCheckoutSuccess,
 				billing,
 				true,
+				false,
 				shippingData
 			);
 			expect( await onCheckoutSuccessResultPromise ).toEqual( {
@@ -217,6 +218,7 @@ describe( 'CheckoutSessions hook tests', () => {
 				onCheckoutSuccess,
 				billing,
 				true,
+				false,
 				shippingData
 			);
 			expect( await onCheckoutSuccessResultPromise ).toEqual( {
@@ -267,6 +269,7 @@ describe( 'CheckoutSessions hook tests', () => {
 				onCheckoutSuccess,
 				billing,
 				true,
+				false,
 				shippingData
 			);
 			expect( await onCheckoutSuccessResultPromise ).toEqual( {
@@ -295,6 +298,7 @@ describe( 'CheckoutSessions hook tests', () => {
 				onCheckoutSuccess,
 				billing,
 				false,
+				false,
 				shippingData
 			);
 			await onCheckoutSuccessResultPromise;
@@ -322,6 +326,7 @@ describe( 'CheckoutSessions hook tests', () => {
 				onCheckoutSuccess,
 				billing,
 				true,
+				false,
 				shippingData
 			);
 			await onCheckoutSuccessResultPromise;
@@ -351,6 +356,7 @@ describe( 'CheckoutSessions hook tests', () => {
 				checkoutState,
 				onCheckoutSuccess,
 				billing,
+				true,
 				true,
 				shippingData
 			);
@@ -384,6 +390,7 @@ describe( 'CheckoutSessions hook tests', () => {
 				onCheckoutSuccess,
 				billing,
 				true,
+				true,
 				shippingData
 			);
 			await onCheckoutSuccessResultPromise;
@@ -413,6 +420,7 @@ describe( 'CheckoutSessions hook tests', () => {
 				onCheckoutSuccess,
 				billing,
 				true,
+				false,
 				shippingData
 			);
 			await onCheckoutSuccessResultPromise;

--- a/client/blocks/checkout-sessions/checkout-form.js
+++ b/client/blocks/checkout-sessions/checkout-form.js
@@ -27,6 +27,7 @@ import {
  * @param {EventRegistrationProps} props.eventRegistration           Object containing event registration functions for payment setup, checkout success, and checkout failure.
  * @param {Object}                 props.billing                     Billing information for the checkout session.
  * @param {boolean}                props.isLoggedIn                  Whether the customer is logged-in.
+ * @param {boolean}                props.isPayerPhoneRequired        Whether the payer phone information is required.
  * @param {Object}                 props.shippingData                Shipping information for the checkout session.
  * @param {JSX.Element}            props.LoadingMask                 LoadingMask component to display while loading.
  * @param {Function}               props.onLoadError                 Callback function to handle load errors.
@@ -40,6 +41,7 @@ const CheckoutForm = ( {
 	eventRegistration: { onPaymentSetup, onCheckoutSuccess, onCheckoutFail },
 	billing,
 	isLoggedIn,
+	isPayerPhoneRequired,
 	shippingData,
 	LoadingMask,
 	onLoadError,
@@ -68,6 +70,7 @@ const CheckoutForm = ( {
 		onCheckoutSuccess,
 		billing,
 		isLoggedIn,
+		isPayerPhoneRequired,
 		shippingData
 	);
 	usePaymentFailHandler( onCheckoutFail, emitResponse );

--- a/client/blocks/checkout-sessions/hooks.js
+++ b/client/blocks/checkout-sessions/hooks.js
@@ -105,17 +105,19 @@ export const usePaymentSetupHandler = (
 /**
  * Handles the Block Checkout onCheckoutSuccess event for the Checkout Sessions integration.
  *
- * @param {*}       checkoutState     The checkout state.
- * @param {*}       onCheckoutSuccess The onCheckoutSuccess event.
- * @param {Object}  billing           The billing data from WooCommerce Blocks, containing billingAddress.
- * @param {boolean} isLoggedIn        Whether the customer is logged-in.
- * @param {Object}  shippingData      The shipping data from WooCommerce Blocks, containing shippingAddress.
+ * @param {*}       checkoutState        The checkout state.
+ * @param {*}       onCheckoutSuccess    The onCheckoutSuccess event.
+ * @param {Object}  billing              The billing data from WooCommerce Blocks, containing billingAddress.
+ * @param {boolean} isLoggedIn           Whether the customer is logged-in.
+ * @param {boolean} isPayerPhoneRequired Whether the payer phone information is required.
+ * @param {Object}  shippingData         The shipping data from WooCommerce Blocks, containing shippingAddress.
  */
 export const useCheckoutSuccessHandler = (
 	checkoutState,
 	onCheckoutSuccess,
 	billing,
 	isLoggedIn,
+	isPayerPhoneRequired,
 	shippingData
 ) => {
 	useEffect(
@@ -212,7 +214,7 @@ export const useCheckoutSuccessHandler = (
 						}
 					}
 
-					if ( isLoggedIn ) {
+					if ( isLoggedIn && isPayerPhoneRequired ) {
 						const userPhone =
 							document.getElementById( 'billing-phone' )?.value ||
 							document.getElementById( 'shipping-phone' )?.value;
@@ -237,7 +239,14 @@ export const useCheckoutSuccessHandler = (
 					};
 				}
 			),
-		[ onCheckoutSuccess, checkoutState, billing, isLoggedIn, shippingData ]
+		[
+			onCheckoutSuccess,
+			checkoutState,
+			billing,
+			isLoggedIn,
+			isPayerPhoneRequired,
+			shippingData,
+		]
 	);
 };
 

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
@@ -233,6 +233,7 @@ const PaymentElements = ( {
 			<CheckoutContainer
 				api={ api }
 				isLoggedIn={ stripeServerData?.isLoggedIn }
+				isPayerPhoneRequired={ stripeServerData?.isPayerPhoneRequired }
 				setPaymentProcessorLoadErrorMessage={
 					setPaymentProcessorLoadErrorMessage
 				}

--- a/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
+++ b/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
@@ -56,8 +56,11 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler {
 					throw new Exception( __( 'Unable to create or retrieve Stripe customer.', 'woocommerce-gateway-stripe' ) );
 				}
 
-				$request['customer']                = $stripe_customer->get_id();
-				$request['phone_number_collection'] = [ 'enabled' => true ];
+				$request['customer'] = $stripe_customer->get_id();
+
+				if ( 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' ) ) {
+					$request['phone_number_collection'] = [ 'enabled' => 'true' ];
+				}
 			}
 
 			$checkout_session = WC_Stripe_API::request( $request, 'checkout/sessions' );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -552,6 +552,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			|| ( $this->is_subscription_item_in_cart() && 'yes' === get_option( 'woocommerce_enable_signup_from_checkout_for_subscriptions', 'no' ) );
 
 		$stripe_params['isLoggedIn']                        = is_user_logged_in();
+		$stripe_params['isPayerPhoneRequired']              = 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' );
 		$stripe_params['isSignupOnCheckoutAllowed']         = $is_signup_on_checkout_allowed;
 		$stripe_params['isCheckout']                        = ( is_checkout() || has_block( 'woocommerce/checkout' ) ) && empty( $_GET['pay_for_order'] ); // wpcs: csrf ok.
 		$stripe_params['return_url']                        = $this->get_stripe_return_url();

--- a/readme.txt
+++ b/readme.txt
@@ -203,6 +203,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Add Ajax endpoint to update line items in a checkout session
 * Tweak - Hide the Adaptive Pricing currency selector from classic checkout when a saved payment method is selected
 * Add - Allow customers to save payment methods during checkout with adaptive pricing
-* Fix - Only collect payer phone in Checkout Sessions when WooCommerce's checkout phone field is required, and only send it to Stripe when the customer is logged in and phone collection is required
+* Fix - Only collect and send payer phone in Checkout Sessions when the WooCommerce phone field is required
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -203,5 +203,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Add Ajax endpoint to update line items in a checkout session
 * Tweak - Hide the Adaptive Pricing currency selector from classic checkout when a saved payment method is selected
 * Add - Allow customers to save payment methods during checkout with adaptive pricing
+* Fix - Only collect payer phone in Checkout Sessions when WooCommerce's checkout phone field is required, and only send it to Stripe when the customer is logged in and phone collection is required
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-checkout-sessions-ajax-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-checkout-sessions-ajax-handler-test.php
@@ -357,6 +357,124 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that phone_number_collection is included in the Checkout Session request only when
+	 * WooCommerce's checkout phone field is set to required.
+	 *
+	 * @param string $phone_field_setting   The value of the woocommerce_checkout_phone_field option.
+	 * @param bool   $expect_phone_collection Whether phone_number_collection should be present in the request.
+	 * @dataProvider provide_test_phone_number_collection
+	 */
+	public function test_phone_number_collection_based_on_wc_setting(
+		string $phone_field_setting,
+		bool $expect_phone_collection
+	): void {
+		Ajax_Test_Helper::init_hooks();
+
+		wp_set_current_user( 1 );
+		WC()->customer = new \WC_Customer( 1 );
+
+		$customer_data = [
+			'billing_first_name' => 'John',
+			'billing_last_name'  => 'Doe',
+			'billing_address_1'  => '123 Main St',
+			'billing_city'       => 'New York',
+			'billing_state'      => 'NY',
+			'billing_postcode'   => '10001',
+			'billing_country'    => 'US',
+			'billing_email'      => 'john@example.com',
+		];
+		foreach ( $customer_data as $key => $value ) {
+			update_user_meta( 1, $key, $value );
+		}
+
+		update_option( 'woocommerce_checkout_phone_field', $phone_field_setting );
+
+		WC()->session->init();
+		WC()->cart->empty_cart();
+		$product = WC_Helper_Product::create_simple_product( true, [ 'regular_price' => 10 ] );
+		$product->save();
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		$captured_request = null;
+		$capture_body     = static function ( $request, $api ) use ( &$captured_request ) {
+			if ( 'checkout/sessions' === $api ) {
+				$captured_request = $request;
+			}
+			return $request;
+		};
+		add_filter( 'wc_stripe_request_body', $capture_body, 10, 2 );
+
+		$test_request = static function ( $return_value, $parsed_args, $url ) {
+			if ( strpos( $url, '/v1/customers' ) !== false ) {
+				return [
+					'response' => 200,
+					'headers'  => [ 'Content-Type' => 'application/json' ],
+					'body'     => wp_json_encode( (object) [ 'id' => 'cus_123' ] ),
+				];
+			}
+			if ( 'https://api.stripe.com/v1/checkout/sessions' === $url ) {
+				return [
+					'response' => 200,
+					'headers'  => [ 'Content-Type' => 'application/json' ],
+					'body'     => wp_json_encode(
+						(object) [
+							'client_secret' => 'cs_test_secret',
+							'id'            => 'cs_test_123',
+						]
+					),
+				];
+			}
+			return $return_value;
+		};
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		$_REQUEST['_ajax_nonce'] = wp_create_nonce( 'wc_stripe_create_checkout_session_nonce' );
+
+		$ajax_handler = new WC_Stripe_Checkout_Sessions_Ajax_Handler();
+
+		try {
+			ob_start();
+			$ajax_handler->create_checkout_session();
+			ob_end_clean();
+		} finally {
+			remove_filter( 'pre_http_request', $test_request, 10, 3 );
+			remove_filter( 'wc_stripe_request_body', $capture_body, 10, 2 );
+			delete_option( 'woocommerce_checkout_phone_field' );
+			Ajax_Test_Helper::remove_hooks();
+		}
+
+		$this->assertIsArray( $captured_request );
+
+		if ( $expect_phone_collection ) {
+			$this->assertArrayHasKey( 'phone_number_collection', $captured_request );
+		} else {
+			$this->assertArrayNotHasKey( 'phone_number_collection', $captured_request );
+		}
+	}
+
+	/**
+	 * Data provider for `test_phone_number_collection_based_on_wc_setting`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_phone_number_collection(): array {
+		return [
+			'phone field required' => [
+				'phone_field_setting'     => 'required',
+				'expect_phone_collection' => true,
+			],
+			'phone field optional' => [
+				'phone_field_setting'     => 'optional',
+				'expect_phone_collection' => false,
+			],
+			'phone field hidden'   => [
+				'phone_field_setting'     => 'hidden',
+				'expect_phone_collection' => false,
+			],
+		];
+	}
+
+	/**
 	 * Data provider for `test_create_checkout_session`.
 	 *
 	 * @return array


### PR DESCRIPTION
Fixes STRIPE-1069

## Changes proposed in this Pull Request

This PR fixes two related issues with payer phone handling in Checkout Sessions:

1. **Conditional phone collection on Stripe side**: `phone_number_collection` is now only enabled in the Checkout Session request when WooCommerce's checkout phone field is set to "Required". Previously it was always enabled for logged-in users, which caused Stripe to require a phone number even when the store had it set to optional or hidden.

2. **Conditional phone forwarding on the client side**: The phone number read from the DOM is now only sent to Stripe when both conditions are met — the customer is logged in AND phone collection is required. Previously it was sent whenever the customer was logged in regardless of the phone field setting.

Both changes align Stripe's phone collection behavior with the store's WooCommerce settings (`WooCommerce > Settings > Accounts & Privacy > Phone field`).

## Testing instructions

**Prerequisites:** Enable the Optimized Checkout Suite and have a logged-in test account.

**Scenario 1 — Phone field set to Required (default)**
1. Go to WooCommerce > Settings > Accounts & Privacy. Set "Phone field" to **Required**.
2. Add a product to the cart and proceed to the Blocks checkout.
3. Complete checkout using the Optimized Checkout (Checkout Sessions) flow.
4. Confirm the Stripe Checkout Session is created successfully and the phone number is collected/forwarded without errors.

**Scenario 2 — Phone field set to Optional**
1. Set "Phone field" to **Optional**.
2. Add a product to the cart and proceed to the Blocks checkout.
3. Complete checkout using the Optimized Checkout flow.
4. Confirm the Stripe Checkout Session is created without `phone_number_collection` being requested, and checkout completes without errors (Stripe should not prompt for or require a phone number).

**Scenario 3 — Phone field Hidden**
1. Set "Phone field" to **Hidden**.
2. Same steps as Scenario 2 — confirm phone is neither collected nor sent.

**Scenario 4 — Guest user (any phone setting)**
1. Log out and checkout as a guest.
2. Confirm checkout completes successfully (phone forwarding is skipped for guest users).

---

- [x] Covered with tests
- [ ] Tested on mobile (does not apply)

### Changelog entry

- [x] Fix - Only collect payer phone in Checkout Sessions when WooCommerce's checkout phone field is required, and only send it to Stripe when the customer is logged in and phone collection is required

**Post merge**

- [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
- [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
- [ ] Included this PR in the Release Thread scope (or does not apply)