### PR TITLE
Move test mode instructions above the Adaptive Pricing currency selector

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 xxxx-xx-xx - version 10.6.0
 * Update - Show "Payment Options" as the Optimized Checkout title on classic checkout and "Payment Methods" on Blocks checkout instead of "Stripe"
 * Dev - Separate Agentic Commerce merchant-controlled is_enabled setting from the developer feature flag
+* Fix - Move test mode instructions above the Adaptive Pricing currency selector in classic checkout
 * Fix - Render the Adaptive Pricing currency selector immediately above the payment element in classic checkout
 * Update - Show Express Checkout on block checkout when Adaptive Pricing is enabled
 * Fix - Fix checkout session creation for guest users

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -998,9 +998,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			$show_optimized_checkout = $this->oc_enabled && $this->is_valid_optimized_checkout_page();
 			$show_adaptive_pricing   = $show_optimized_checkout && $this->is_adaptive_pricing_supported();
 
-			if ( $show_adaptive_pricing ) {
-				echo '<div id="wc-stripe-currency-selector" class="wc-stripe-currency-selector" style="margin: 12px 0;"></div>';
-			}
 			// Output the form HTML.
 			?>
 			<?php if ( ! empty( $this->get_description() ) ) : ?>
@@ -1052,6 +1049,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 				</p>
 					<?php
 				endif;
+			endif;
+
+			if ( $show_adaptive_pricing ) :
+				echo '<div id="wc-stripe-currency-selector" class="wc-stripe-currency-selector" style="margin: 12px 0;"></div>';
 			endif;
 			?>
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1052,7 +1052,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			endif;
 
 			if ( $show_adaptive_pricing ) :
-				echo '<div id="wc-stripe-currency-selector" class="wc-stripe-currency-selector" style="margin: 12px 0;"></div>';
+				echo '<div id="wc-stripe-currency-selector" class="wc-stripe-currency-selector" style="margin-top: 12px;"></div>';
 			endif;
 			?>
 

--- a/readme.txt
+++ b/readme.txt
@@ -148,6 +148,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 = 10.6.0 - xxxx-xx-xx =
 * Update - Show "Payment Options" as the Optimized Checkout title on classic checkout and "Payment Methods" on Blocks checkout instead of "Stripe"
 * Dev - Separate Agentic Commerce merchant-controlled is_enabled setting from the developer feature flag
+* Fix - Move test mode instructions above the Adaptive Pricing currency selector in classic checkout
 * Fix - Render the Adaptive Pricing currency selector immediately above the payment element in classic checkout
 * Update - Show Express Checkout on block checkout when Adaptive Pricing is enabled
 * Fix - Fix checkout session creation for guest users

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -540,6 +540,51 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * Test that in test mode with Optimized Checkout and Adaptive Pricing enabled,
+	 * the test copy renders before the currency selector.
+	 */
+	public function test_payment_fields_renders_test_copy_before_currency_selector(): void {
+		$gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
+			->setConstructorArgs( [] )
+			->onlyMethods( [ 'get_return_url', 'is_valid_optimized_checkout_page', 'is_adaptive_pricing_supported' ] )
+			->getMock();
+		$gateway->method( 'get_return_url' )->willReturn( self::MOCK_RETURN_URL );
+		$gateway->method( 'is_valid_optimized_checkout_page' )->willReturn( true );
+		$gateway->method( 'is_adaptive_pricing_supported' )->willReturn( true );
+		$gateway->oc_enabled = true;
+		$gateway->testmode   = true;
+
+		add_filter( 'woocommerce_is_checkout', '__return_true' );
+
+		try {
+			ob_start();
+			$gateway->payment_fields();
+			$output = ob_get_clean();
+		} finally {
+			remove_filter( 'woocommerce_is_checkout', '__return_true' );
+		}
+
+		$selector_div         = '<div id="wc-stripe-currency-selector"';
+		$selector_position    = strpos( $output, $selector_div );
+		$test_copy_position   = strpos( $output, 'wc-stripe-payment-method-instruction' );
+		$upe_element_position = strpos( $output, 'class="wc-stripe-upe-element"' );
+
+		$this->assertNotFalse( $test_copy_position, 'Test copy should be present in output.' );
+		$this->assertNotFalse( $selector_position, 'Currency selector should be present in output.' );
+		$this->assertNotFalse( $upe_element_position, 'Payment element should be present in output.' );
+		$this->assertLessThan(
+			$selector_position,
+			$test_copy_position,
+			'Test copy should render before the currency selector.'
+		);
+		$this->assertLessThan(
+			$upe_element_position,
+			$selector_position,
+			'Currency selector should render before the payment element.'
+		);
+	}
+
+	/**
 	 * Data provider for test_payment_fields_renders_currency_selector_conditionally.
 	 *
 	 * @return array[]

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -522,7 +522,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			remove_filter( 'woocommerce_is_checkout', '__return_true' );
 		}
 
-		$selector_div = '<div id="wc-stripe-currency-selector" class="wc-stripe-currency-selector" style="margin: 12px 0;"></div>';
+		$selector_div = '<div id="wc-stripe-currency-selector" class="wc-stripe-currency-selector" style="margin-top: 12px;"></div>';
 		if ( $expect_selector ) {
 			$this->assertStringContainsString( $selector_div, $output );
 			$selector_position    = strpos( $output, $selector_div );


### PR DESCRIPTION
See: https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5166#issuecomment-4202491223

## Summary

Addresses review feedback from [#5166 (comment)](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5166#issuecomment-4202491223).

- Moves the test copy (test mode instructions) to render **before** the Adaptive Pricing currency selector in `payment_fields()`
- New render order: description → test instructions → currency selector → payment element
- Adds a PHPUnit test asserting the test-copy-before-selector ordering when testmode and adaptive pricing are both active

## Test plan

- [ ] Enable Optimized Checkout Suite and Adaptive Pricing; set store to test mode
- [ ] Visit classic checkout — confirm test mode instructions appear **above** the currency selector, which in turn appears above the payment element
- [ ] Verify existing test `test_payment_fields_renders_currency_selector_conditionally` still passes
- [ ] Verify new test `test_payment_fields_renders_test_copy_before_currency_selector` passes

### Changelog entry

* Fix - Move test mode instructions above the Adaptive Pricing currency selector in classic checkout

cc @pierorocca 

🤖 Generated with [Claude Code](https://claude.com/claude-code)