### PR TITLE
Defer checkout sessions webhooks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.6.0
+* Update - Defer checkout sessions webhook processing via Action Scheduler to prevent race conditions when webhook events arrive before order metadata is stored
 * Update - Show "Payment Options" as the Optimized Checkout title on classic checkout and "Payment Methods" on Blocks checkout instead of "Stripe"
 * Dev - Separate Agentic Commerce merchant-controlled is_enabled setting from the developer feature flag
 * Fix - Render the Adaptive Pricing currency selector immediately above the payment element in classic checkout

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1389,6 +1389,10 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				case 'checkout.session.async_payment_succeeded':
 					$this->handle_checkout_session_success( $notification );
 					break;
+				case 'checkout.session.expired':
+				case 'checkout.session.async_payment_failed':
+					$this->handle_checkout_session_failure( $notification );
+					break;
 				default:
 					throw new Exception( "Unsupported webhook type: {$webhook_type}" );
 					break;

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1731,6 +1731,38 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
+		$session_id = $checkout_session->id;
+
+		// Look for an order. If order exists, process the webhook immediately.
+		$order = WC_Stripe_Helper::get_order_by_checkout_session_id( $checkout_session->id );
+
+		// If order does not exist, defer the webhook processing.
+		// This might happen if a webhook arrived before the order metadata was stored.
+		if ( ! $order instanceof \WC_Order ) {
+			WC_Stripe_Logger::debug( "Deferring processing of {$notification->type} ($session_id) asynchronously." );
+
+			$this->defer_webhook_processing(
+				$notification,
+				[
+					'session_id' => $session_id,
+				]
+			);
+			return;
+		}
+
+		// If order exists, process the webhook immediately.
+		$this->handle_checkout_session_failure( $notification );
+	}
+
+	/**
+	 * Handles a deferred checkout session failure event.
+	 *
+	 * @param object $notification The Stripe notification containing the checkout session data.
+	 * @return void
+	 */
+	protected function handle_checkout_session_failure( object $notification ): void {
+		$checkout_session = $notification->data->object;
+
 		$order = WC_Stripe_Helper::get_order_by_checkout_session_id( $checkout_session->id );
 
 		if ( ! $order instanceof \WC_Order ) {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1385,6 +1385,10 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 					$this->handle_deferred_payment_intent_succeeded( $order, $intent_id );
 					break;
+				case 'checkout.session.completed':
+				case 'checkout.session.async_payment_succeeded':
+					$this->handle_checkout_session_success( $notification );
+					break;
 				default:
 					throw new Exception( "Unsupported webhook type: {$webhook_type}" );
 					break;
@@ -1509,6 +1513,38 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			WC_Stripe_Logger::error( 'Checkout session ID is missing from the event data.' );
 			return;
 		}
+
+		$session_id = $checkout_session->id;
+
+		// Look for an order. If order exists, process the webhook immediately.
+		$order = WC_Stripe_Helper::get_order_by_checkout_session_id( $checkout_session->id );
+
+		// If order does not exist, defer the webhook processing.
+		// This is either an agentic hook or a webhook arrived before the order metadata was stored.
+		if ( ! $order instanceof \WC_Order ) {
+			WC_Stripe_Logger::debug( "Deferring processing of {$notification->type} ($session_id) asynchronously." );
+
+			$this->defer_webhook_processing(
+				$notification,
+				[
+					'session_id' => $session_id,
+				]
+			);
+			return;
+		}
+
+		// If order exists, process the webhook immediately.
+		$this->handle_checkout_session_success( $notification );
+	}
+
+	/**
+	 * Handles a deferred checkout session success event.
+	 *
+	 * @param object        $notification The Stripe notification containing the checkout session data.
+	 * @return void
+	 */
+	protected function handle_checkout_session_success( object $notification ): void {
+		$checkout_session = $notification->data->object;
 
 		$session_id = $checkout_session->id;
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1521,7 +1521,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$session_id = $checkout_session->id;
 
 		// Look for an order. If order exists, process the webhook immediately.
-		$order = WC_Stripe_Helper::get_order_by_checkout_session_id( $checkout_session->id );
+		$order = WC_Stripe_Helper::get_order_by_checkout_session_id( $session_id );
 
 		// If order does not exist, defer the webhook processing.
 		// This is either an agentic hook or a webhook arrived before the order metadata was stored.
@@ -1739,7 +1739,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$session_id = $checkout_session->id;
 
 		// Look for an order. If order exists, process the webhook immediately.
-		$order = WC_Stripe_Helper::get_order_by_checkout_session_id( $checkout_session->id );
+		$order = WC_Stripe_Helper::get_order_by_checkout_session_id( $session_id );
 
 		// If order does not exist, defer the webhook processing.
 		// This might happen if a webhook arrived before the order metadata was stored.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1366,7 +1366,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					$order     = isset( $additional_data['order_id'] ) ? wc_get_order( $additional_data['order_id'] ) : null;
 					$intent_id = $additional_data['intent_id'] ?? '';
 
-					if ( empty( $order ) ) {
+					if ( ! $order instanceof \WC_Order ) {
 						throw new Exception( "Missing required data. 'order_id' is invalid or not found for the deferred '{$webhook_type}' event." );
 					}
 
@@ -1508,14 +1508,14 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * sessions, as well as agentic checkout sessions.
 	 *
 	 * @param object $notification The notification from Stripe
-	 * @return void
+	 * @return bool True if the event was deferred for async processing, false if handled inline.
 	 */
-	public function process_checkout_session_success( object $notification ): void {
+	public function process_checkout_session_success( object $notification ): bool {
 		$checkout_session = $notification->data->object;
 
 		if ( ! isset( $checkout_session->id ) ) {
 			WC_Stripe_Logger::error( 'Checkout session ID is missing from the event data.' );
-			return;
+			return false;
 		}
 
 		$session_id = $checkout_session->id;
@@ -1534,11 +1534,12 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					'session_id' => $session_id,
 				]
 			);
-			return;
+			return true;
 		}
 
 		// If order exists, process the webhook immediately.
 		$this->handle_checkout_session_success( $notification );
+		return false;
 	}
 
 	/**
@@ -1727,12 +1728,12 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @param object $notification The Stripe notification containing the checkout session data.
 	 */
-	public function process_checkout_session_failure( object $notification ): void {
+	public function process_checkout_session_failure( object $notification ): bool {
 		$checkout_session = $notification->data->object;
 
 		if ( ! isset( $checkout_session->id ) ) {
 			WC_Stripe_Logger::debug( 'Checkout session ID is missing from the event data.' );
-			return;
+			return false;
 		}
 
 		$session_id = $checkout_session->id;
@@ -1751,11 +1752,12 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					'session_id' => $session_id,
 				]
 			);
-			return;
+			return true;
 		}
 
 		// If order exists, process the webhook immediately.
 		$this->handle_checkout_session_failure( $notification );
+		return false;
 	}
 
 	/**
@@ -1778,24 +1780,32 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		$order_helper = WC_Stripe_Order_Helper::get_instance();
 
-		if ( $order_helper->is_stripe_status_final( $order ) ) {
+		if ( $order_helper->lock_order_payment( $order ) ) {
 			return;
 		}
 
-		if ( $order->has_status( [ OrderStatus::PROCESSING, OrderStatus::COMPLETED, OrderStatus::FAILED ] ) ) {
-			return;
+		try {
+			if ( $order_helper->is_stripe_status_final( $order ) ) {
+				return;
+			}
+
+			if ( $order->has_status( [ OrderStatus::PROCESSING, OrderStatus::COMPLETED, OrderStatus::FAILED ] ) ) {
+				return;
+			}
+
+			$message = 'checkout.session.expired' === $notification->type ? __( 'The checkout session has expired.', 'woocommerce-gateway-stripe' ) : __( 'The async payment for this checkout session has failed.', 'woocommerce-gateway-stripe' );
+
+			$status_update         = [];
+			$status_update['from'] = $order->get_status();
+			$status_update['to']   = OrderStatus::FAILED;
+			$order->update_status( OrderStatus::FAILED, $message );
+
+			do_action( 'wc_gateway_stripe_process_webhook_payment_error', $order, $notification );
+
+			$this->send_failed_order_email( $order->get_id(), $status_update );
+		} finally {
+			$order_helper->unlock_order_payment( $order );
 		}
-
-		$message = 'checkout.session.expired' === $notification->type ? __( 'The checkout session has expired.', 'woocommerce-gateway-stripe' ) : __( 'The async payment for this checkout session has failed.', 'woocommerce-gateway-stripe' );
-
-		$status_update         = [];
-		$status_update['from'] = $order->get_status();
-		$status_update['to']   = OrderStatus::FAILED;
-		$order->update_status( OrderStatus::FAILED, $message );
-
-		do_action( 'wc_gateway_stripe_process_webhook_payment_error', $order, $notification );
-
-		$this->send_failed_order_email( $order->get_id(), $status_update );
 	}
 
 	/**
@@ -1874,24 +1884,22 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				break;
 			case 'checkout.session.completed':
 			case 'checkout.session.async_payment_succeeded':
-				$this->process_checkout_session_success( $notification );
+				$checkout_session_deferred = $this->process_checkout_session_success( $notification );
 				break;
 			case 'checkout.session.expired':
 			case 'checkout.session.async_payment_failed':
-				$this->process_checkout_session_failure( $notification );
+				$checkout_session_deferred = $this->process_checkout_session_failure( $notification );
 				break;
 		}
 
-		// These events are always processed async (deferred). Skip the action trigger for them here. The trigger will be called inside process_deferred_webhook.
-		$deferred_event_types = [
+		// payment_intent.succeeded and payment_intent.amount_capturable_updated are always deferred via
+		// process_payment_intent(). checkout.session.* events may be handled inline or deferred depending
+		// on whether the order exists at webhook arrival time. Only skip the action when actually deferred.
+		$always_deferred_types = [
 			'payment_intent.succeeded',
 			'payment_intent.amount_capturable_updated',
-			'checkout.session.completed',
-			'checkout.session.async_payment_succeeded',
-			'checkout.session.expired',
-			'checkout.session.async_payment_failed',
 		];
-		if ( in_array( $notification->type, $deferred_event_types, true ) ) {
+		if ( ( $checkout_session_deferred ?? false ) || in_array( $notification->type, $always_deferred_types, true ) ) {
 			return;
 		}
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1810,8 +1810,16 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				break;
 		}
 
-		// These events might be processed async. Skip the action trigger for them here. The trigger will be called inside the specific methods.
-		if ( 'payment_intent.succeeded' === $notification->type || 'payment_intent.amount_capturable_updated' === $notification->type ) {
+		// These events are always processed async (deferred). Skip the action trigger for them here. The trigger will be called inside process_deferred_webhook.
+		$deferred_event_types = [
+			'payment_intent.succeeded',
+			'payment_intent.amount_capturable_updated',
+			'checkout.session.completed',
+			'checkout.session.async_payment_succeeded',
+			'checkout.session.expired',
+			'checkout.session.async_payment_failed',
+		];
+		if ( in_array( $notification->type, $deferred_event_types, true ) ) {
 			return;
 		}
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3159,7 +3159,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property object\:\:\$data\.$#'
 			identifier: property.notFound
-			count: 43
+			count: 45
 			path: includes/class-wc-stripe-webhook-handler.php
 
 		-
@@ -3183,7 +3183,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property object\:\:\$type\.$#'
 			identifier: property.notFound
-			count: 2
+			count: 4
 			path: includes/class-wc-stripe-webhook-handler.php
 
 		-
@@ -3508,6 +3508,12 @@ parameters:
 			message: '#^Parameter \#1 \$response of method WC_Stripe_Payment_Gateway\:\:process_response\(\) expects object, object\|string given\.$#'
 			identifier: argument.type
 			count: 3
+			path: includes/class-wc-stripe-webhook-handler.php
+
+		-
+			message: '#^Parameter \#1 \$webhook_notification of method WC_Stripe_Webhook_Handler\:\:defer_webhook_processing\(\) expects stdClass, object given\.$#'
+			identifier: argument.type
+			count: 2
 			path: includes/class-wc-stripe-webhook-handler.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3241,12 +3241,6 @@ parameters:
 			path: includes/class-wc-stripe-webhook-handler.php
 
 		-
-			message: '#^Cannot call method get_id\(\) on WC_Order\|WC_Order_Refund\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: includes/class-wc-stripe-webhook-handler.php
-
-		-
 			message: '#^Cannot call method get_id\(\) on WC_Order\|true\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -3254,12 +3248,6 @@ parameters:
 
 		-
 			message: '#^Cannot call method get_status\(\) on WC_Order\|true\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: includes/class-wc-stripe-webhook-handler.php
-
-		-
-			message: '#^Cannot call method has_status\(\) on WC_Order\|WC_Order_Refund\|true\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: includes/class-wc-stripe-webhook-handler.php
@@ -3481,12 +3469,6 @@ parameters:
 			path: includes/class-wc-stripe-webhook-handler.php
 
 		-
-			message: '#^Parameter \#1 \$order of method WC_Stripe_Webhook_Handler\:\:handle_deferred_payment_intent_succeeded\(\) expects WC_Order, WC_Order\|WC_Order_Refund\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wc-stripe-webhook-handler.php
-
-		-
 			message: '#^Parameter \#1 \$order_id of method WC_Stripe_Payment_Gateway\:\:has_pre_order\(\) expects int, WC_Order\|true given\.$#'
 			identifier: argument.type
 			count: 1
@@ -3519,12 +3501,6 @@ parameters:
 		-
 			message: '#^Parameter \#2 \$str of function explode expects string, array\|string given\.$#'
 			identifier: argument.type
-			count: 1
-			path: includes/class-wc-stripe-webhook-handler.php
-
-		-
-			message: '#^Property WC_Stripe_Webhook_Handler\:\:\$resolved_order \(WC_Order\|null\) does not accept WC_Order\|WC_Order_Refund\|true\.$#'
-			identifier: assign.propertyType
 			count: 1
 			path: includes/class-wc-stripe-webhook-handler.php
 

--- a/readme.txt
+++ b/readme.txt
@@ -146,6 +146,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.6.0 - xxxx-xx-xx =
+* Update - Defer checkout sessions webhook processing via Action Scheduler to prevent race conditions when webhook events arrive before order metadata is stored
 * Update - Show "Payment Options" as the Optimized Checkout title on classic checkout and "Payment Methods" on Blocks checkout instead of "Stripe"
 * Dev - Separate Agentic Commerce merchant-controlled is_enabled setting from the developer feature flag
 * Fix - Render the Adaptive Pricing currency selector immediately above the payment element in classic checkout

--- a/tests/phpunit/class-wc-stripe-webhook-handler-agentic-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-agentic-test.php
@@ -52,9 +52,13 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 		remove_filter( 'wc_stripe_is_agentic_commerce_enabled', '__return_true' );
 		add_filter( 'wc_stripe_is_agentic_commerce_enabled', '__return_false' );
 
-		$notification = $this->build_notification( 'cs_test_disabled' );
+		$session_id   = 'cs_test_disabled';
+		$notification = $this->build_notification( $session_id );
 
+		// Immediate phase: defers the webhook.
 		$this->handler->process_checkout_session_success( $notification );
+		// Deferred phase: feature flag off → agentic path skips → no order created.
+		$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
 
 		$orders = wc_get_orders(
 			[
@@ -71,11 +75,15 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 	 * Tests that non-agentic checkout sessions are ignored.
 	 */
 	public function test_process_checkout_session_completed_skips_non_agentic() {
-		$notification = $this->build_notification( 'cs_test_non_agentic' );
-		$mock_session = $this->build_checkout_session_response( 'cs_test_non_agentic', false );
+		$session_id   = 'cs_test_non_agentic';
+		$notification = $this->build_notification( $session_id );
+		$mock_session = $this->build_checkout_session_response( $session_id, false );
 		$this->mock_stripe_checkout_sessions_response( $mock_session );
 
+		// Immediate phase: defers the webhook.
 		$this->handler->process_checkout_session_success( $notification );
+		// Deferred phase: non-agentic session → skips without creating an order.
+		$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
 
 		$resolved = $this->get_resolved_order( $this->handler );
 		$this->assertNull( $resolved );
@@ -85,10 +93,11 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 	 * Tests that a session with empty network_business_profile is skipped.
 	 */
 	public function test_skips_session_with_empty_network_business_profile() {
-		$session = (object) [
-			'id'             => 'cs_test_empty_nbp',
+		$session_id = 'cs_test_empty_nbp';
+		$session    = (object) [
+			'id'             => $session_id,
 			'payment_intent' => (object) [
-				'id'            => 'pi_test_empty_nbp',
+				'id'            => 'pi_test_' . $session_id,
 				'agent_details' => (object) [
 					'network_business_profile' => '',
 				],
@@ -96,8 +105,12 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 		];
 		$this->mock_stripe_checkout_sessions_response( $session );
 
-		$notification = $this->build_notification( 'cs_test_empty_nbp' );
+		$notification = $this->build_notification( $session_id );
+
+		// Immediate phase: defers the webhook.
 		$this->handler->process_checkout_session_success( $notification );
+		// Deferred phase: empty network_business_profile → skips.
+		$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
 
 		$resolved = $this->get_resolved_order( $this->handler );
 		$this->assertNull( $resolved );
@@ -155,12 +168,15 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 			}
 		);
 
-		$notification = $this->build_notification( 'cs_test_mapper_fail' );
-		$mock_session = $this->build_checkout_session_response( 'cs_test_mapper_fail', true );
+		$session_id   = 'cs_test_mapper_fail';
+		$notification = $this->build_notification( $session_id );
+		$mock_session = $this->build_checkout_session_response( $session_id, true );
 		$this->mock_stripe_checkout_sessions_response( $mock_session );
 
-		// Should not throw — the handler catches the mapper's exception.
+		// Immediate phase: defers the webhook.
 		$this->handler->process_checkout_session_success( $notification );
+		// Deferred phase: mapper fails → fires failure action, does not throw.
+		$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
 
 		$this->assertTrue( $failure_action_fired );
 		$this->assertInstanceOf( Exception::class, $captured_exception );
@@ -188,11 +204,15 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 			}
 		);
 
-		$notification = $this->build_notification( 'cs_test_happy' );
-		$mock_session = $this->build_checkout_session_response( 'cs_test_happy', true, (string) $product->get_id() );
+		$session_id   = 'cs_test_happy';
+		$notification = $this->build_notification( $session_id );
+		$mock_session = $this->build_checkout_session_response( $session_id, true, (string) $product->get_id() );
 		$this->mock_stripe_checkout_sessions_response( $mock_session );
 
-		$this->handler->process_webhook( wp_json_encode( $notification ) );
+		// Immediate phase: defers the webhook.
+		$this->handler->process_checkout_session_success( $notification );
+		// Deferred phase: agentic session → creates order.
+		$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
 
 		try {
 			$this->assertTrue( $success_action_fired );
@@ -213,10 +233,14 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 	 * Tests that a failed API fetch is handled gracefully without creating an order.
 	 */
 	public function test_process_checkout_session_completed_handles_api_fetch_failure() {
-		$notification = $this->build_notification( 'cs_test_fetch_fail' );
+		$session_id   = 'cs_test_fetch_fail';
+		$notification = $this->build_notification( $session_id );
 		$this->mock_stripe_api_error();
 
-		$this->handler->process_webhook( wp_json_encode( $notification ) );
+		// Immediate phase: defers the webhook.
+		$this->handler->process_checkout_session_success( $notification );
+		// Deferred phase: Stripe API error → no order created.
+		$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
 
 		$orders = wc_get_orders(
 			[
@@ -231,8 +255,9 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 	 * Tests that a session with a missing payment intent ID is skipped without creating an order.
 	 */
 	public function test_process_checkout_session_completed_skips_when_payment_intent_missing() {
-		$notification                 = $this->build_notification( 'cs_test_no_intent' );
-		$mock_session                 = $this->build_checkout_session_response( 'cs_test_no_intent', true );
+		$session_id                   = 'cs_test_no_intent';
+		$notification                 = $this->build_notification( $session_id );
+		$mock_session                 = $this->build_checkout_session_response( $session_id, true );
 		$mock_session->payment_intent = (object) [
 			'id'            => null,
 			'agent_details' => (object) [
@@ -241,7 +266,10 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 		];
 		$this->mock_stripe_checkout_sessions_response( $mock_session );
 
-		$this->handler->process_webhook( wp_json_encode( $notification ) );
+		// Immediate phase: defers the webhook.
+		$this->handler->process_checkout_session_success( $notification );
+		// Deferred phase: missing payment intent ID → no order created.
+		$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
 
 		$orders = wc_get_orders(
 			[
@@ -259,10 +287,14 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 	public function test_request_headers_filter_is_removed_after_processing_failure() {
 		$this->assertFalse( has_filter( 'wc_stripe_request_headers' ) );
 
-		$notification = $this->build_notification( 'cs_test_filter_cleanup' );
+		$session_id   = 'cs_test_filter_cleanup';
+		$notification = $this->build_notification( $session_id );
 		$this->mock_stripe_api_error();
 
-		$this->handler->process_webhook( wp_json_encode( $notification ) );
+		// Immediate phase: defers the webhook.
+		$this->handler->process_checkout_session_success( $notification );
+		// Deferred phase: API error → filter must still be cleaned up.
+		$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
 
 		$this->assertFalse( has_filter( 'wc_stripe_request_headers' ) );
 	}
@@ -283,8 +315,13 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 
 		add_filter( 'pre_http_request', $this->http_filter, 10, 3 );
 
-		$notification = $this->build_notification( 'cs_test_version' );
+		$session_id   = 'cs_test_version';
+		$notification = $this->build_notification( $session_id );
+
+		// Immediate phase: defers the webhook.
 		$this->handler->process_checkout_session_success( $notification );
+		// Deferred phase: API retrieve call must include the Stripe-Version override header.
+		$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
 
 		$this->assertNotNull( $captured_headers );
 		$this->assertArrayHasKey( 'Stripe-Version', $captured_headers );

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -340,6 +340,111 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * When no order is linked yet, checkout session success defers processing via Action Scheduler.
+	 *
+	 * @return void
+	 */
+	public function test_process_checkout_session_success_defers_when_order_not_found(): void {
+		$checkout_session_id = 'cs_test_deferred_no_order';
+
+		$notification = (object) [
+			'type' => 'checkout.session.completed',
+			'data' => (object) [
+				'object' => (object) [
+					'id'             => $checkout_session_id,
+					'payment_intent' => 'pi_test_deferred',
+				],
+			],
+		];
+
+		$mock_scheduler = $this->createMock( WC_Stripe_Action_Scheduler_Service::class );
+		$mock_scheduler->expects( $this->once() )
+			->method( 'schedule_job' )
+			->with(
+				$this->callback(
+					function ( $timestamp ) {
+						$this->assertIsInt( $timestamp );
+						$this->assertGreaterThanOrEqual( time() + 2 * MINUTE_IN_SECONDS, $timestamp );
+
+						return true;
+					}
+				),
+				'wc_stripe_deferred_webhook',
+				$this->callback(
+					function ( $args ) use ( $notification, $checkout_session_id ) {
+						return isset( $args['type'], $args['data'], $args['notification'] )
+							&& 'checkout.session.completed' === $args['type']
+							&& isset( $args['data']['session_id'] )
+							&& $checkout_session_id === $args['data']['session_id']
+							&& $args['notification'] === $notification;
+					}
+				)
+			);
+
+		$handler = new WC_Stripe_Webhook_Handler();
+		$prop    = new ReflectionProperty( WC_Stripe_Webhook_Handler::class, 'action_scheduler_service' );
+		$prop->setAccessible( true );
+		$prop->setValue( $handler, $mock_scheduler );
+
+		$handler->process_checkout_session_success( $notification );
+	}
+
+	/**
+	 * Deferred checkout session success events should run handle_checkout_session_success when the job executes.
+	 *
+	 * @param string $event_type Stripe event type.
+	 * @return void
+	 * @dataProvider provide_deferred_checkout_session_success_event_types
+	 */
+	public function test_process_deferred_webhook_invokes_handle_checkout_session_success( string $event_type ): void {
+		$checkout_session_id = 'cs_test_deferred_job';
+
+		$notification = (object) [
+			'type' => $event_type,
+			'data' => (object) [
+				'object' => (object) [
+					'id'             => $checkout_session_id,
+					'payment_intent' => 'pi_test_job',
+				],
+			],
+		];
+
+		$handler = $this->getMockBuilder( WC_Stripe_Webhook_Handler::class )
+			->setMethods( [ 'handle_checkout_session_success' ] )
+			->getMock();
+
+		$handler->expects( $this->once() )
+			->method( 'handle_checkout_session_success' )
+			->with(
+				$this->callback(
+					function ( $passed ) use ( $notification ) {
+						return is_object( $passed )
+							&& isset( $passed->type )
+							&& $notification->type === $passed->type
+							&& isset( $passed->data->object->id )
+							&& $notification->data->object->id === $passed->data->object->id;
+					}
+				)
+			);
+
+		$handler->process_deferred_webhook(
+			$event_type,
+			[ 'session_id' => $checkout_session_id ],
+			$notification
+		);
+	}
+
+	/**
+	 * @return array<string, array{0: string}>
+	 */
+	public function provide_deferred_checkout_session_success_event_types(): array {
+		return [
+			'checkout.session.completed'               => [ 'checkout.session.completed' ],
+			'checkout.session.async_payment_succeeded' => [ 'checkout.session.async_payment_succeeded' ],
+		];
+	}
+
+	/**
 	 * Test for `process_webhook_charge_failed`.
 	 *
 	 * @param string $order_status       The order status.

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -357,14 +357,15 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			],
 		];
 
+		$start          = time();
 		$mock_scheduler = $this->createMock( WC_Stripe_Action_Scheduler_Service::class );
 		$mock_scheduler->expects( $this->once() )
 			->method( 'schedule_job' )
 			->with(
 				$this->callback(
-					function ( $timestamp ) {
+					function ( $timestamp ) use ( $start ) {
 						$this->assertIsInt( $timestamp );
-						$this->assertGreaterThanOrEqual( time() + 2 * MINUTE_IN_SECONDS, $timestamp );
+						$this->assertGreaterThanOrEqual( $start + 2 * MINUTE_IN_SECONDS, $timestamp );
 
 						return true;
 					}
@@ -441,6 +442,61 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		return [
 			'checkout.session.completed'               => [ 'checkout.session.completed' ],
 			'checkout.session.async_payment_succeeded' => [ 'checkout.session.async_payment_succeeded' ],
+		];
+	}
+
+	/**
+	 * Deferred checkout session failure events should run handle_checkout_session_failure when the job executes.
+	 *
+	 * @param string $event_type Stripe event type.
+	 * @return void
+	 * @dataProvider provide_deferred_checkout_session_failure_event_types
+	 */
+	public function test_process_deferred_webhook_invokes_handle_checkout_session_failure( string $event_type ): void {
+		$checkout_session_id = 'cs_test_deferred_failure_job';
+
+		$notification = (object) [
+			'type' => $event_type,
+			'data' => (object) [
+				'object' => (object) [
+					'id'             => $checkout_session_id,
+					'payment_intent' => 'pi_test_failure_job',
+				],
+			],
+		];
+
+		$handler = $this->getMockBuilder( WC_Stripe_Webhook_Handler::class )
+			->setMethods( [ 'handle_checkout_session_failure' ] )
+			->getMock();
+
+		$handler->expects( $this->once() )
+			->method( 'handle_checkout_session_failure' )
+			->with(
+				$this->callback(
+					function ( $passed ) use ( $notification ) {
+						return is_object( $passed )
+							&& isset( $passed->type )
+							&& $notification->type === $passed->type
+							&& isset( $passed->data->object->id )
+							&& $notification->data->object->id === $passed->data->object->id;
+					}
+				)
+			);
+
+		$handler->process_deferred_webhook(
+			$event_type,
+			[ 'session_id' => $checkout_session_id ],
+			$notification
+		);
+	}
+
+	/**
+	 * @return array<string, array{0: string}>
+	 */
+	public function provide_deferred_checkout_session_failure_event_types(): array {
+		return [
+			'checkout.session.expired'              => [ 'checkout.session.expired' ],
+			'checkout.session.async_payment_failed' => [ 'checkout.session.async_payment_failed' ],
 		];
 	}
 


### PR DESCRIPTION
Towards STRIPE-921

## Changes proposed in this Pull Request:
- If the checkout session events arrive before we set the checkout session ID in order meta in `process_payment_with_checkout_session` the event won't be processed correctly as `get_order_by_checkout_session_id` won't return the order. To avoid this scenario, added a safeguard here by deferring the webhook if order is not found.
- Process immediately if order is found.
- No logic changed in the main handler method.

## Testing instructions
- Enable OCS and adaptive pricing.
- As a shopper, checkout with adaptive pricing.
- Confirm that there is no regression.
- Hardcode `true` in [this if block](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/1a1fb400fa993b1f765257d071431b969abe69fa/includes/class-wc-stripe-webhook-handler.php#L1524) to intentionally send the webhook to deferred path.
- As a shopper, checkout with adaptive pricing.
- Check the order as an admin. It should be in a pending state.
- Wait for a while and check the order again.
- It should be in processing state with proper order notes.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
