### PR TITLE
Fix payment method title on order received page

### DIFF
--- a/client/classic/upe/index.js
+++ b/client/classic/upe/index.js
@@ -313,6 +313,17 @@ jQuery( function ( $ ) {
 				removeCashAppLimitNotice();
 			}
 
+			// Change the payment method container title when the Optimized Checkout is enabled
+			const stripeServerData = getStripeServerData();
+			if (
+				stripeServerData?.shouldShowOptimizedCheckout &&
+				$( 'input#payment_method_stripe' ).is( ':checked' )
+			) {
+				$( 'label[for=payment_method_stripe]' ).text(
+					'Payment options'
+				);
+			}
+
 			maybeClearBlikCodeValidation();
 		} );
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
@@ -61,11 +61,6 @@ class WC_Stripe_UPE_Payment_Method_OC extends WC_Stripe_UPE_Payment_Method {
 			return __( 'Payment methods', 'woocommerce-gateway-stripe' );
 		}
 
-		// Classic checkout page.
-		if ( is_checkout() ) {
-			return __( 'Payment options', 'woocommerce-gateway-stripe' );
-		}
-
 		return parent::get_title();
 	}
 

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-oc-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-oc-test.php
@@ -23,15 +23,11 @@ class WC_Stripe_UPE_Payment_Method_OC_Test extends WP_UnitTestCase {
 	 * @param mixed    $payment_details Payment details or false.
 	 * @param string[] $query_params    Query string parameters merged into $_GET.
 	 * @param string   $expected        Expected title.
-	 * @param bool     $is_checkout     When true, `is_checkout()` is forced via filter (classic checkout).
 	 * @return void
 	 *
 	 * @dataProvider provide_test_get_title
 	 */
-	public function test_get_title( $payment_details, ?array $query_params, string $expected, bool $is_checkout = false ) {
-		if ( $is_checkout ) {
-			add_filter( 'woocommerce_is_checkout', '__return_true' );
-		}
+	public function test_get_title( $payment_details, ?array $query_params, string $expected ) {
 		$original_get = $_GET;
 		try {
 			if ( is_array( $payment_details ) ) {
@@ -46,9 +42,6 @@ class WC_Stripe_UPE_Payment_Method_OC_Test extends WP_UnitTestCase {
 
 			$this->assertEquals( $expected, $actual );
 		} finally {
-			if ( $is_checkout ) {
-				remove_filter( 'woocommerce_is_checkout', '__return_true' );
-			}
 			$_GET = $original_get;
 		}
 	}
@@ -66,7 +59,6 @@ class WC_Stripe_UPE_Payment_Method_OC_Test extends WP_UnitTestCase {
 				],
 				'query params'    => [],
 				'expected'        => 'Alipay',
-				'is checkout'     => false,
 			],
 			'block checkout page / pay for order' => [
 				'payment details' => false,
@@ -74,19 +66,11 @@ class WC_Stripe_UPE_Payment_Method_OC_Test extends WP_UnitTestCase {
 					'pay_for_order' => 'true',
 				],
 				'expected'        => 'Payment methods',
-				'is checkout'     => false,
-			],
-			'classic checkout page'               => [
-				'payment details' => false,
-				'query params'    => [],
-				'expected'        => 'Payment options',
-				'is checkout'     => true,
 			],
 			'default, hardcoded'                  => [
 				'payment details' => false,
 				'query params'    => [],
 				'expected'        => 'Stripe',
-				'is checkout'     => false,
 			],
 		];
 	}


### PR DESCRIPTION
This fixes a regression caused by https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5210 and https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5211.

## Changes proposed in this Pull Request:
- In https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5211 we removed the JS update of the OCS title on the classic checkout page and updated it in the backend. But that caused regression. In this PR, I am re-adding the JS override to set the label on classic checkout.
- Also fixes the wrong title for split PE

<img width="445" height="466" alt="Screenshot 2026-04-10 at 11 52 50 AM" src="https://github.com/user-attachments/assets/bf37804c-c673-48b2-a4d3-f858aa9cd44c" />


## Testing instructions
- Enable OCS and adaptive pricing.
- As a shopper, go to the classic checkout page.
- Verify the payment method label reads "Payment options" in classic checkout.
- Complete checkout with card.
- In `develop` notice that in the order received page and in the order notes the title is `Payment options`
- In this branch, the title should be `Stripe` on the order received page and in the order notes.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

The changelog for https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5210 should be enough as all 3 PRs are going in the same version.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
