### PR TITLE
Only set savePaymentMethod on Checkout Session confirm for logged-in customers

### DIFF
--- a/client/blocks/checkout-sessions/hooks.js
+++ b/client/blocks/checkout-sessions/hooks.js
@@ -156,8 +156,12 @@ export const useCheckoutSuccessHandler = (
 						},
 						returnUrl: redirect,
 						redirect: 'if_required',
-						savePaymentMethod: isSavePaymentMethodCheckboxChecked(),
 					};
+
+					if ( isLoggedIn ) {
+						confirmArgs.savePaymentMethod =
+							isSavePaymentMethodCheckboxChecked();
+					}
 
 					// Only include shipping information if the min. requirement is met.
 					if (

--- a/client/classic/upe/__tests__/payment-processing.test.js
+++ b/client/classic/upe/__tests__/payment-processing.test.js
@@ -516,7 +516,6 @@ describe( 'payment-processing', () => {
 				expect( mockActions.confirm ).toHaveBeenCalledWith( {
 					returnUrl: window.location.href,
 					redirect: 'if_required',
-					savePaymentMethod: false,
 				} );
 				expect(
 					stripeUtils.appendCheckoutSessionIdToForm
@@ -524,7 +523,7 @@ describe( 'payment-processing', () => {
 				expect( form.trigger ).toHaveBeenCalledWith( 'submit' );
 			} );
 
-			it( 'passes savePaymentMethod true when the save card checkbox is checked', async () => {
+			it( 'passes savePaymentMethod true when logged in and the save card checkbox is checked', async () => {
 				const mockActions = {
 					confirm: jest.fn().mockResolvedValue( {
 						session: { id: 'cs_session_xyz' },
@@ -538,17 +537,72 @@ describe( 'payment-processing', () => {
 					actions: mockActions,
 				} );
 
-				const form = createMockForm( {
-					savePaymentMethodChecked: true,
-				} );
-				paymentProcessing.processPayment( api, form, 'card' );
-				await flushPromises();
+				const apServerData = {
+					...BASE_SERVER_DATA,
+					isAdaptivePricingEnabled: true,
+					isLoggedIn: true,
+				};
 
-				expect( mockActions.confirm ).toHaveBeenCalledWith( {
-					returnUrl: window.location.href,
-					redirect: 'if_required',
-					savePaymentMethod: true,
+				stripeUtils.getStripeServerData.mockReturnValue( apServerData );
+
+				try {
+					const form = createMockForm( {
+						savePaymentMethodChecked: true,
+					} );
+					paymentProcessing.processPayment( api, form, 'card' );
+					await flushPromises();
+
+					expect( mockActions.confirm ).toHaveBeenCalledWith( {
+						returnUrl: window.location.href,
+						redirect: 'if_required',
+						savePaymentMethod: true,
+					} );
+				} finally {
+					stripeUtils.getStripeServerData.mockReturnValue(
+						apServerData
+					);
+				}
+			} );
+
+			it( 'does not pass savePaymentMethod for guests even when the save card checkbox is checked', async () => {
+				const mockActions = {
+					confirm: jest.fn().mockResolvedValue( {
+						session: { id: 'cs_session_xyz' },
+					} ),
+				};
+				const checkoutElements = createMockElements();
+				const api = createMockApi( checkoutElements );
+
+				await mountAndConfigureForProcess( api, checkoutElements, {
+					type: 'success',
+					actions: mockActions,
 				} );
+
+				const apServerData = {
+					...BASE_SERVER_DATA,
+					isAdaptivePricingEnabled: true,
+					isLoggedIn: false,
+				};
+
+				stripeUtils.getStripeServerData.mockReturnValue( apServerData );
+
+				try {
+					const form = createMockForm( {
+						savePaymentMethodChecked: true,
+					} );
+					paymentProcessing.processPayment( api, form, 'card' );
+					await flushPromises();
+
+					expect( mockActions.confirm ).toHaveBeenCalledWith( {
+						returnUrl: window.location.href,
+						redirect: 'if_required',
+					} );
+				} finally {
+					stripeUtils.getStripeServerData.mockReturnValue( {
+						...BASE_SERVER_DATA,
+						isAdaptivePricingEnabled: true,
+					} );
+				}
 			} );
 
 			it( 'shows error and does not submit when loadActions returns an error', async () => {

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -853,11 +853,16 @@ export const processPayment = (
 					.find( '#wc-stripe-new-payment-method' )
 					.is( ':checked' );
 
-				const confirmResult = await actions.confirm( {
+				const confirmArgs = {
 					returnUrl: window.location.href,
 					redirect: 'if_required',
-					savePaymentMethod: shouldSavePaymentMethod,
-				} );
+				};
+
+				if ( getStripeServerData()?.isLoggedIn ) {
+					confirmArgs.savePaymentMethod = shouldSavePaymentMethod;
+				}
+
+				const confirmResult = await actions.confirm( confirmArgs );
 
 				if ( confirmResult.type === 'error' ) {
 					throw new Error(


### PR DESCRIPTION
Related to https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5243

## Changes proposed in this Pull Request:
Added the logged in check in frontend also to prevent the following error-

<img width="1045" height="183" alt="Screenshot 2026-04-10 at 4 07 34 AM" src="https://github.com/user-attachments/assets/6251feb1-90af-4805-8c87-d974739537fa" />


## Testing instructions
- Code review should be sufficient.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
The changelog for https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5243 should be enough.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
