### PR TITLE
Improve OCS with Stripe first method notice UX

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -67,6 +67,7 @@ xxxx-xx-xx - version 10.6.0
 * Fix - Restrict Checkout Session saved payment method options to logged-in customers so guest checkout session creation succeeds
 * Add - Add an admin notice and one-click action to move Stripe payment methods to the top of WooCommerce payment gateway order for Optimized Checkout
 * Add - Handle redirect payment flow in classic checkout for Checkout Sessions
+* Fix: Improve UX for the "Stripe first method" notice for Optimized Checkout
 
 2026-03-19 - version 10.5.3
 * Fix - Restore default layout when Optimized Checkout is disabled

--- a/client/settings/advanced-settings-section/__tests__/optimized-checkout-first-method-notice.test.js
+++ b/client/settings/advanced-settings-section/__tests__/optimized-checkout-first-method-notice.test.js
@@ -12,7 +12,6 @@ jest.mock( '@wordpress/data', () => ( {
 	__esModule: true,
 	dispatch: jest.fn( () => ( {
 		createSuccessNotice: mockCreateSuccessNotice,
-		// Required so `.catch( showErrorNotice )` does not throw if the move promise rejects.
 		createErrorNotice: mockCreateErrorNotice,
 	} ) ),
 } ) );
@@ -189,6 +188,30 @@ describe( 'OptimizedCheckoutFirstMethodNotice', () => {
 				Object.defineProperty( window, 'location', locationDescriptor );
 			}
 		}
+	} );
+
+	it( 'dispatches an error notice when moveStripeToTop rejects', async () => {
+		moveStripeToTop.mockRejectedValueOnce( new Error( 'network' ) );
+
+		render( <OptimizedCheckoutFirstMethodNotice isOCEnabled={ true } /> );
+
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'Move to top' } )
+		);
+
+		await waitFor( () => {
+			expect( mockCreateErrorNotice ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
+			'Error moving Stripe to the top of the payment methods list.',
+			expect.objectContaining( {
+				id: 'wc_stripe_stripe_first_checkout_error',
+				speak: false,
+			} )
+		);
+		expect( mockCreateSuccessNotice ).not.toHaveBeenCalled();
+		expect( screen.getByText( noticeCopy ) ).toBeInTheDocument();
 	} );
 
 	it( 'calls dismissNotice and hides the notice when the notice is dismissed', async () => {

--- a/client/settings/advanced-settings-section/__tests__/optimized-checkout-first-method-notice.test.js
+++ b/client/settings/advanced-settings-section/__tests__/optimized-checkout-first-method-notice.test.js
@@ -1,8 +1,27 @@
 import React from 'react';
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { dispatch } from '@wordpress/data';
 import OptimizedCheckoutFirstMethodNotice from 'wcstripe/settings/advanced-settings-section/optimized-checkout-first-method-notice';
 import { dismissNotice, moveStripeToTop } from 'wcstripe/utils';
+
+const mockCreateSuccessNotice = jest.fn();
+const mockCreateErrorNotice = jest.fn();
+
+jest.mock( '@wordpress/data', () => ( {
+	__esModule: true,
+	dispatch: jest.fn( () => ( {
+		createSuccessNotice: mockCreateSuccessNotice,
+		// Required so `.catch( showErrorNotice )` does not throw if the move promise rejects.
+		createErrorNotice: mockCreateErrorNotice,
+	} ) ),
+} ) );
+
+jest.mock( '@woocommerce/settings', () => ( {
+	getAdminLink: jest.fn(
+		( path ) => `https://example.com/wp-admin/${ path }`
+	),
+} ) );
 
 jest.mock( '@wordpress/components', () => ( {
 	Notice: ( { children, actions, onRemove } ) => (
@@ -95,12 +114,81 @@ describe( 'OptimizedCheckoutFirstMethodNotice', () => {
 
 		expect( moveStripeToTop ).toHaveBeenCalled();
 
-		await act( () => {
+		await act( async () => {
 			resolveMove();
-			return Promise.resolve();
+			await Promise.resolve();
 		} );
 
 		expect( screen.queryByText( noticeCopy ) ).not.toBeInTheDocument();
+
+		await waitFor( () => {
+			expect( mockCreateSuccessNotice ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		expect( dispatch ).toHaveBeenCalledWith( 'core/notices' );
+		expect( mockCreateSuccessNotice ).toHaveBeenCalledWith(
+			'Stripe is now the first option in checkout.',
+			expect.objectContaining( {
+				id: 'wc_stripe_stripe_first_checkout_success',
+				speak: false,
+				actions: [
+					{
+						url: 'https://example.com/wp-admin/admin.php?page=wc-settings&tab=checkout',
+						label: 'Review the payment method order',
+						openInNewTab: true,
+					},
+				],
+			} )
+		);
+		expect( mockCreateErrorNotice ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not dispatch success notice when refreshPage is true', async () => {
+		const reloadMock = jest.fn();
+		const locationDescriptor = Object.getOwnPropertyDescriptor(
+			window,
+			'location'
+		);
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			value: {
+				...window.location,
+				reload: reloadMock,
+			},
+		} );
+
+		let resolveMove;
+		moveStripeToTop.mockImplementation(
+			() =>
+				new Promise( ( resolve ) => {
+					resolveMove = resolve;
+				} )
+		);
+
+		try {
+			render(
+				<OptimizedCheckoutFirstMethodNotice
+					isOCEnabled={ true }
+					refreshPage={ true }
+				/>
+			);
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'Move to top' } )
+			);
+
+			await act( async () => {
+				resolveMove();
+				await Promise.resolve();
+			} );
+
+			expect( reloadMock ).toHaveBeenCalled();
+			expect( mockCreateSuccessNotice ).not.toHaveBeenCalled();
+		} finally {
+			if ( locationDescriptor ) {
+				Object.defineProperty( window, 'location', locationDescriptor );
+			}
+		}
 	} );
 
 	it( 'calls dismissNotice and hides the notice when the notice is dismissed', async () => {

--- a/client/settings/advanced-settings-section/optimized-checkout-first-method-notice.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-first-method-notice.js
@@ -48,7 +48,7 @@ const OptimizedCheckoutFirstMethodNotice = ( {
 		return null;
 	}
 
-	const dispatchSuccessNotice = () => {
+	const showSuccessNotice = () => {
 		const paymentMethodsUrl = getAdminLink(
 			PAYMENT_METHODS_CHECKOUT_SETTINGS_PATH
 		);
@@ -75,16 +75,34 @@ const OptimizedCheckoutFirstMethodNotice = ( {
 		);
 	};
 
-	const handleAction = () => {
-		moveStripeToTop().then( () => {
-			setShowNotice( false );
-
-			if ( refreshPage ) {
-				window.location.reload();
-			} else {
-				dispatchSuccessNotice();
+	const showErrorNotice = () => {
+		dispatch( 'core/notices' ).createErrorNotice(
+			__(
+				'Error moving Stripe to the top of the payment methods list.',
+				'woocommerce-gateway-stripe'
+			),
+			{
+				id: 'wc_stripe_stripe_first_checkout_error',
+				speak: false,
 			}
-		} );
+		);
+	};
+
+	const handleAction = () => {
+		moveStripeToTop()
+			.then( () => {
+				setShowNotice( false );
+
+				// Refresh the page on the WooCommerce > Settings > Payments page.
+				if ( refreshPage ) {
+					window.location.reload();
+				} else {
+					showSuccessNotice();
+				}
+			} )
+			.catch( () => {
+				showErrorNotice();
+			} );
 	};
 
 	const handleRemove = () => {

--- a/client/settings/advanced-settings-section/optimized-checkout-first-method-notice.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-first-method-notice.js
@@ -1,10 +1,15 @@
 /* global wc_stripe_settings_params */
+import { getAdminLink } from '@woocommerce/settings';
 import React, { useState } from 'react';
 import GridIcon from 'gridicons';
-import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { dismissNotice, moveStripeToTop } from 'wcstripe/utils';
+import { dispatch } from '@wordpress/data';
 import './style.scss';
+
+const PAYMENT_METHODS_CHECKOUT_SETTINGS_PATH =
+	'admin.php?page=wc-settings&tab=checkout';
 
 const WarningIcon = () => {
 	return (
@@ -43,12 +48,41 @@ const OptimizedCheckoutFirstMethodNotice = ( {
 		return null;
 	}
 
+	const dispatchSuccessNotice = () => {
+		const paymentMethodsUrl = getAdminLink(
+			PAYMENT_METHODS_CHECKOUT_SETTINGS_PATH
+		);
+
+		dispatch( 'core/notices' ).createSuccessNotice(
+			__(
+				'Stripe is now the first option in checkout.',
+				'woocommerce-gateway-stripe'
+			),
+			{
+				id: 'wc_stripe_stripe_first_checkout_success',
+				actions: [
+					{
+						url: paymentMethodsUrl,
+						label: __(
+							'Review the payment method order',
+							'woocommerce-gateway-stripe'
+						),
+						openInNewTab: true,
+					},
+				],
+				speak: false,
+			}
+		);
+	};
+
 	const handleAction = () => {
 		moveStripeToTop().then( () => {
 			setShowNotice( false );
 
 			if ( refreshPage ) {
 				window.location.reload();
+			} else {
+				dispatchSuccessNotice();
 			}
 		} );
 	};

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -855,10 +855,11 @@ class WC_Stripe_Helper {
 			}
 		}
 
-		update_option( 'woocommerce_gateway_order', $updated_gateway_order );
-
-		// set the user notice option to yes to show the notice if it was dismissed and Stripe is not the first available gateway after the update.
-		update_option( 'wc_stripe_show_stripe_first_method_notice', 'yes' );
+		$gateway_order_updated = update_option( 'woocommerce_gateway_order', $updated_gateway_order );
+		if ( $gateway_order_updated ) {
+			// set the user notice option to yes to show the notice if it was dismissed and Stripe is not the first available gateway after the update.
+			update_option( 'wc_stripe_show_stripe_first_method_notice', 'yes' );
+		}
 	}
 
 	/**

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -856,6 +856,9 @@ class WC_Stripe_Helper {
 		}
 
 		update_option( 'woocommerce_gateway_order', $updated_gateway_order );
+
+		// set the user notice option to yes to show the notice if it was dismissed and Stripe is not the first available gateway after the update.
+		update_option( 'wc_stripe_show_stripe_first_method_notice', 'yes' );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -215,5 +215,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Restrict Checkout Session saved payment method options to logged-in customers so guest checkout session creation succeeds
 * Add - Add an admin notice and one-click action to move Stripe payment methods to the top of WooCommerce payment gateway order for Optimized Checkout
 * Add - Handle redirect payment flow in classic checkout for Checkout Sessions
+* Fix: Improve UX for the "Stripe first method" notice for Optimized Checkout
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -721,6 +721,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		$this->assertTrue( $gateway_order['stripe_klarna'] < $gateway_order['stripe'] );
 		$this->assertTrue( $gateway_order['stripe'] < $gateway_order['stripe_affirm'] );
 		$this->assertTrue( $gateway_order['stripe_affirm'] < $gateway_order['cheque'] );
+		$this->assertSame( 'yes', get_option( 'wc_stripe_show_stripe_first_method_notice' ) );
 	}
 
 	/**


### PR DESCRIPTION
Discussed in p1775852979066589-slack-C055WHLA98D

## Changes proposed in this Pull Request:
- Showing a snackbar notice after move to top succeeds.
- Showing the notice again if user changes the gateways order again and makes Stripe a non-first gateway after dismissing the notice.

## Testing instructions

- Go to **WooCommerce > Settings > Payment methods** and enable a few gateways including Stripe.
- Move Stripe to non-first position. (2nd/3rd)
- Go to the Stripe settings page and scroll down to the **Advanced settings** section.
- A notice should be present below OCS checkbox.
- Dismiss the notice.
- Refresh the page the notice should still be hidden.
- **WooCommerce > Settings > Payment methods** and move Stripe another non-first position. (3rd/4th) (move to position 1 first and then to the previous non-first position)
- Go to the Stripe settings page and confirm that the notice is displayed again.
- Now click the `Move to top` button.
- A snackbar should appear in the bottom-left corner.

<img width="941" height="767" alt="Screenshot 2026-04-13 at 10 14 57 PM" src="https://github.com/user-attachments/assets/8465f098-6247-4985-97e2-150844d7c692" />


### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)