### PR TITLE
Move checkout session DTOs to shared includes/dtos/ directory

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.6.0
+* Dev - Move checkout session DTOs to shared includes/dtos/ directory and refactor webhook handler and payment gateway to use typed DTO access instead of raw stdClass properties
 * Update - Defer checkout sessions webhook processing via Action Scheduler to prevent race conditions when webhook events arrive before order metadata is stored
 * Fix - Hide duplicate store-level save checkbox when Stripe Link is enabled on checkout
 * Update - Show "Payment Options" as the Optimized Checkout title on classic checkout and "Payment Methods" on Blocks checkout instead of "Stripe"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "autoload": {
       "classmap": [
         "includes/ajax-handlers/",
-        "includes/agentic-commerce/"
+        "includes/agentic-commerce/",
+        "includes/dtos/"
       ]
     },
     "autoload-dev": {

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
@@ -26,11 +26,11 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 	 * Creates a WooCommerce order from a Stripe checkout session.
 	 *
 	 * @since 10.6.0
-	 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
+	 * @param WC_Stripe_Checkout_Session $session The checkout session wrapper.
 	 * @return WC_Order The created order.
 	 * @throws Exception When the order cannot be created.
 	 */
-	public function create_order_from_checkout_session( WC_Stripe_Agentic_Checkout_Session $session ): WC_Order {
+	public function create_order_from_checkout_session( WC_Stripe_Checkout_Session $session ): WC_Order {
 		$this->validate_checkout_session( $session );
 
 		WC_Stripe_Logger::info(
@@ -83,10 +83,10 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 	 * Validates that the checkout session has all required fields.
 	 *
 	 * @since 10.6.0
-	 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
+	 * @param WC_Stripe_Checkout_Session $session The checkout session wrapper.
 	 * @throws Exception When required fields are missing or invalid.
 	 */
-	private function validate_checkout_session( WC_Stripe_Agentic_Checkout_Session $session ): void {
+	private function validate_checkout_session( WC_Stripe_Checkout_Session $session ): void {
 		if ( null === $session->get_id() ) {
 			throw new Exception( 'Checkout session is missing the id field.' );
 		}
@@ -120,11 +120,11 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 	 * Creates the WooCommerce order with basic settings.
 	 *
 	 * @since 10.6.0
-	 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
+	 * @param WC_Stripe_Checkout_Session $session The checkout session wrapper.
 	 * @return WC_Order The created order.
 	 * @throws Exception When wc_create_order fails.
 	 */
-	private function create_order( WC_Stripe_Agentic_Checkout_Session $session ): WC_Order {
+	private function create_order( WC_Stripe_Checkout_Session $session ): WC_Order {
 		$order = wc_create_order( [ 'status' => 'pending' ] );
 
 		if ( is_wp_error( $order ) ) {
@@ -163,10 +163,10 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 	 *
 	 * @since 10.6.0
 	 * @param WC_Order                           $order   The WooCommerce order.
-	 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
+	 * @param WC_Stripe_Checkout_Session $session The checkout session wrapper.
 	 * @throws Exception When the email is not present or invalid.
 	 */
-	private function map_customer( WC_Order $order, WC_Stripe_Agentic_Checkout_Session $session ): void {
+	private function map_customer( WC_Order $order, WC_Stripe_Checkout_Session $session ): void {
 		$email = $session->get_customer_email() ?? '';
 
 		if ( ! is_email( $email ) ) {
@@ -193,10 +193,10 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 	 *
 	 * @since 10.6.0
 	 * @param WC_Order                           $order   The WooCommerce order.
-	 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
+	 * @param WC_Stripe_Checkout_Session $session The checkout session wrapper.
 	 * @throws Exception When a product cannot be found for a line item.
 	 */
-	private function map_line_items( WC_Order $order, WC_Stripe_Agentic_Checkout_Session $session ): void {
+	private function map_line_items( WC_Order $order, WC_Stripe_Checkout_Session $session ): void {
 		$currency   = $session->get_currency() ?? '';
 		$line_items = $session->get_line_items();
 
@@ -334,9 +334,9 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 	 *
 	 * @since 10.6.0
 	 * @param WC_Order                           $order   The WooCommerce order.
-	 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
+	 * @param WC_Stripe_Checkout_Session $session The checkout session wrapper.
 	 */
-	private function map_addresses( WC_Order $order, WC_Stripe_Agentic_Checkout_Session $session ): void {
+	private function map_addresses( WC_Order $order, WC_Stripe_Checkout_Session $session ): void {
 		$billing_address = $session->get_billing_address();
 
 		$this->map_address(
@@ -379,9 +379,9 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 	 *
 	 * @since 10.6.0
 	 * @param WC_Order                           $order   The WooCommerce order.
-	 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
+	 * @param WC_Stripe_Checkout_Session $session The checkout session wrapper.
 	 */
-	private function store_stripe_metadata( WC_Order $order, WC_Stripe_Agentic_Checkout_Session $session ): void {
+	private function store_stripe_metadata( WC_Order $order, WC_Stripe_Checkout_Session $session ): void {
 		$order_helper = WC_Stripe_Order_Helper::get_instance();
 
 		// Store payment intent ID (also adds an order note).
@@ -413,10 +413,10 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 	 *
 	 * @since 10.6.0
 	 * @param WC_Order                           $order   The WooCommerce order.
-	 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
+	 * @param WC_Stripe_Checkout_Session $session The checkout session wrapper.
 	 * @throws Exception When no matching WC rate can be found.
 	 */
-	private function map_shipping( WC_Order $order, WC_Stripe_Agentic_Checkout_Session $session ): void {
+	private function map_shipping( WC_Order $order, WC_Stripe_Checkout_Session $session ): void {
 		$display_name = $session->get_chosen_shipping_rate_display_name();
 
 		if ( null === $display_name ) {
@@ -503,10 +503,10 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 	 *
 	 * @since 10.6.0
 	 * @param WC_Order                           $order   The WooCommerce order.
-	 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
+	 * @param WC_Stripe_Checkout_Session $session The checkout session wrapper.
 	 * @throws Exception When the totals diverge beyond rounding tolerance.
 	 */
-	private function verify_order_total( WC_Order $order, WC_Stripe_Agentic_Checkout_Session $session ): void {
+	private function verify_order_total( WC_Order $order, WC_Stripe_Checkout_Session $session ): void {
 		$order->calculate_totals();
 
 		$expected_total = WC_Stripe_Helper::convert_from_stripe_amount(

--- a/includes/agentic-commerce/class-wc-stripe-agentic-customize-checkout-line-item.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-customize-checkout-line-item.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Provides typed access to a single customize_checkout line item.
  *
- * Unlike WC_Stripe_Agentic_Line_Item (which wraps a completed checkout
+ * Unlike WC_Stripe_Checkout_Session_Line_Item (which wraps a completed checkout
  * session line item using price.external_reference), this class wraps
  * the line_item_details entries from the customize_checkout event
  * which use sku_id for product identification.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1511,14 +1511,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @return bool True if the event was deferred for async processing, false if handled inline.
 	 */
 	public function process_checkout_session_success( object $notification ): bool {
-		$checkout_session = $notification->data->object;
+		$session = new WC_Stripe_Checkout_Session( $notification->data->object );
 
-		if ( ! isset( $checkout_session->id ) ) {
+		$session_id = $session->get_id();
+		if ( null === $session_id ) {
 			WC_Stripe_Logger::error( 'Checkout session ID is missing from the event data.' );
 			return false;
 		}
-
-		$session_id = $checkout_session->id;
 
 		// Look for an order. If order exists, process the webhook immediately.
 		$order = WC_Stripe_Helper::get_order_by_checkout_session_id( $session_id );
@@ -1549,13 +1548,16 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @return void
 	 */
 	protected function handle_checkout_session_success( object $notification ): void {
-		$checkout_session = $notification->data->object;
+		$session = new WC_Stripe_Checkout_Session( $notification->data->object );
 
-		$session_id = $checkout_session->id;
+		$session_id = $session->get_id();
+		if ( null === $session_id ) {
+			return;
+		}
 
 		// Refresh the cached checkout session with the latest data from the webhook so that
 		// subsequent reads (e.g. presentment details on the order page) reflect the final state.
-		WC_Stripe_Database_Cache::set( 'checkout_session_' . $session_id, $checkout_session, HOUR_IN_SECONDS );
+		WC_Stripe_Database_Cache::set( 'checkout_session_' . $session_id, $notification->data->object, HOUR_IN_SECONDS );
 
 		// Acquire a lock to prevent duplicate order creation from concurrent agentic sessions.
 		$lock_key = 'checkout_session_lock_' . $session_id;
@@ -1569,7 +1571,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		WC_Stripe_Database_Cache::set( $lock_key, time(), 5 * MINUTE_IN_SECONDS );
 
 		// Look for an order. If one does not exists, this is probably an agentic hook.
-		$order = WC_Stripe_Helper::get_order_by_checkout_session_id( $checkout_session->id );
+		$order = WC_Stripe_Helper::get_order_by_checkout_session_id( $session_id );
 		if ( ! $order instanceof \WC_Order ) {
 			try {
 				$this->handle_agentic_checkout_session( $notification );
@@ -1611,7 +1613,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		try {
 
-			$intent_id = isset( $checkout_session->payment_intent ) ? $checkout_session->payment_intent : null;
+			$intent_id = $session->get_payment_intent_id();
 
 			// Store the payment intent ID on the order.
 			if ( ! empty( $intent_id ) ) {
@@ -1619,21 +1621,22 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			}
 
 			// Add presentment details if available.
-			$presentment_details = $checkout_session->presentment_details ?? null;
-			if ( $presentment_details && isset( $presentment_details->presentment_currency, $presentment_details->presentment_amount ) ) {
-				$order_helper->update_stripe_presentment_currency( $order, $presentment_details->presentment_currency );
-				$order_helper->update_stripe_presentment_amount( $order, $presentment_details->presentment_amount );
+			$presentment_currency = $session->get_presentment_currency();
+			$presentment_amount   = $session->get_presentment_amount();
+			if ( null !== $presentment_currency && null !== $presentment_amount ) {
+				$order_helper->update_stripe_presentment_currency( $order, $presentment_currency );
+				$order_helper->update_stripe_presentment_amount( $order, $presentment_amount );
 
 				$amount = WC_Stripe_Helper::get_woocommerce_amount_from_stripe_amount(
-					$presentment_details->presentment_amount,
-					$presentment_details->presentment_currency
+					$presentment_amount,
+					$presentment_currency
 				);
 
 				$order->add_order_note(
 					sprintf(
 						/* translators: 1) presentment currency 2) presentment amount */
 						__( 'Local currency purchase via Adaptive Pricing. Amount paid was: %1$s %2$s', 'woocommerce-gateway-stripe' ),
-						strtoupper( $presentment_details->presentment_currency ),
+						strtoupper( $presentment_currency ),
 						$amount
 					)
 				);
@@ -1687,7 +1690,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				time() + $this->process_checkout_session_metadata_delay,
 				$this->process_checkout_session_metadata_action,
 				[
-					'checkout_session_id' => $checkout_session->id,
+					'checkout_session_id' => $session_id,
 					'metadata'            => [
 						'order_id'   => $order->get_order_number(),
 						'order_key'  => $order->get_order_key(),
@@ -1738,14 +1741,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification The Stripe notification containing the checkout session data.
 	 */
 	public function process_checkout_session_failure( object $notification ): bool {
-		$checkout_session = $notification->data->object;
+		$session = new WC_Stripe_Checkout_Session( $notification->data->object );
 
-		if ( ! isset( $checkout_session->id ) ) {
+		$session_id = $session->get_id();
+		if ( null === $session_id ) {
 			WC_Stripe_Logger::debug( 'Checkout session ID is missing from the event data.' );
 			return false;
 		}
-
-		$session_id = $checkout_session->id;
 
 		// Look for an order. If order exists, process the webhook immediately.
 		$order = WC_Stripe_Helper::get_order_by_checkout_session_id( $session_id );
@@ -1776,12 +1778,17 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @return void
 	 */
 	protected function handle_checkout_session_failure( object $notification ): void {
-		$checkout_session = $notification->data->object;
+		$session    = new WC_Stripe_Checkout_Session( $notification->data->object );
+		$session_id = $session->get_id();
 
-		$order = WC_Stripe_Helper::get_order_by_checkout_session_id( $checkout_session->id );
+		if ( null === $session_id ) {
+			return;
+		}
+
+		$order = WC_Stripe_Helper::get_order_by_checkout_session_id( $session_id );
 
 		if ( ! $order instanceof \WC_Order ) {
-			WC_Stripe_Logger::debug( 'Could not find order via checkout session ID: ' . $checkout_session->id );
+			WC_Stripe_Logger::debug( 'Could not find order via checkout session ID: ' . $session_id );
 			return;
 		}
 
@@ -2109,18 +2116,23 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification The webhook notification from Stripe.
 	 */
 	private function handle_agentic_checkout_session( $notification ): void {
-		$checkout_session = $notification->data->object;
+		$preliminary_session = new WC_Stripe_Checkout_Session( $notification->data->object );
+		$session_id          = $preliminary_session->get_id();
+
+		if ( null === $session_id ) {
+			return;
+		}
 
 		if ( ! WC_Stripe_Feature_Flags::is_agentic_commerce_enabled() ) {
-			WC_Stripe_Logger::error( 'Agentic commerce is disabled, skipping agentic checkout session: ' . $checkout_session->id );
+			WC_Stripe_Logger::error( 'Agentic commerce is disabled, skipping agentic checkout session: ' . $session_id );
 			return;
 		}
 
 		WC_Stripe_Logger::info(
 			'Webhook checkout.session.completed received.',
 			[
-				'session_id'        => $notification->data->object->id ?? 'unknown',
-				'payment_intent_id' => $notification->data->object->payment_intent ?? 'unknown',
+				'session_id'        => $session_id,
+				'payment_intent_id' => $preliminary_session->get_payment_intent_id() ?? 'unknown',
 			]
 		);
 
@@ -2133,8 +2145,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		try {
 			$url         = $this->build_checkout_session_retrieve_url(
-				$notification->data->object->id,
-				WC_Stripe_Agentic_Checkout_Session::get_fields_to_expand()
+				$session_id,
+				WC_Stripe_Checkout_Session::get_fields_to_expand()
 			);
 			$raw_session = WC_Stripe_API::retrieve( $url );
 
@@ -2150,7 +2162,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			}
 
 			assert( $raw_session instanceof stdClass );
-			$session = new WC_Stripe_Agentic_Checkout_Session( $raw_session );
+			$session = new WC_Stripe_Checkout_Session( $raw_session );
 
 			if ( ! $session->is_agentic() ) {
 				WC_Stripe_Logger::info(
@@ -2188,7 +2200,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				 *
 				 * @since 10.6.0
 				 * @param WC_Order                           $order   The created order.
-				 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
+				 * @param WC_Stripe_Checkout_Session $session The checkout session wrapper.
 				 */
 				do_action( 'wc_stripe_agentic_order_created', $order, $session );
 			} catch ( Exception $e ) {
@@ -2205,7 +2217,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				 *
 				 * @since 10.6.0
 				 * @param Exception                          $e       The exception that was thrown.
-				 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
+				 * @param WC_Stripe_Checkout_Session $session The checkout session wrapper.
 				 */
 				do_action( 'wc_stripe_agentic_order_creation_failed', $e, $session );
 			}

--- a/includes/dtos/class-wc-stripe-api-address.php
+++ b/includes/dtos/class-wc-stripe-api-address.php
@@ -4,7 +4,7 @@
  *
  * Typed wrapper around raw Stripe address objects.
  *
- * @package WooCommerce_Stripe/Agentic_Commerce
+ * @package WooCommerce_Stripe/DTOs
  * @since   10.6.0
  */
 

--- a/includes/dtos/class-wc-stripe-checkout-session-line-item.php
+++ b/includes/dtos/class-wc-stripe-checkout-session-line-item.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Class WC_Stripe_Agentic_Line_Item
+ * Class WC_Stripe_Checkout_Session_Line_Item
  *
  * Typed wrapper around a raw Stripe checkout session line item.
  *
- * @package WooCommerce_Stripe/Agentic_Commerce
+ * @package WooCommerce_Stripe/DTOs
  * @since   10.6.0
  */
 
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 10.6.0
  */
-class WC_Stripe_Agentic_Line_Item {
+class WC_Stripe_Checkout_Session_Line_Item {
 
 	/**
 	 * The raw Stripe line item object.

--- a/includes/dtos/class-wc-stripe-checkout-session.php
+++ b/includes/dtos/class-wc-stripe-checkout-session.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Class WC_Stripe_Agentic_Checkout_Session
+ * Class WC_Stripe_Checkout_Session
  *
  * Typed wrapper around the raw Stripe checkout session object.
  *
- * @package WooCommerce_Stripe/Agentic_Commerce
+ * @package WooCommerce_Stripe/DTOs
  * @since   10.6.0
  */
 
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 10.6.0
  */
-class WC_Stripe_Agentic_Checkout_Session {
+class WC_Stripe_Checkout_Session {
 
 	/**
 	 * The raw Stripe checkout session object.
@@ -208,27 +208,36 @@ class WC_Stripe_Agentic_Checkout_Session {
 	 * Returns the line items array.
 	 *
 	 * @since 10.6.0
-	 * @return WC_Stripe_Agentic_Line_Item[]
+	 * @return WC_Stripe_Checkout_Session_Line_Item[]
 	 */
 	public function get_line_items(): array {
 		$raw_items = $this->session->line_items->data ?? [];
 
 		return array_map(
 			function ( $item ) {
-				return new WC_Stripe_Agentic_Line_Item( $item );
+				return new WC_Stripe_Checkout_Session_Line_Item( $item );
 			},
 			$raw_items
 		);
 	}
 
 	/**
-	 * Returns the expanded payment intent ID, or null when absent.
+	 * Returns the payment intent ID, or null when absent.
+	 *
+	 * Handles both a plain string payment intent ID and an expanded payment intent object.
 	 *
 	 * @since 10.6.0
 	 * @return string|null
 	 */
 	public function get_payment_intent_id(): ?string {
-		return isset( $this->session->payment_intent->id ) ? (string) $this->session->payment_intent->id : null;
+		$payment_intent = $this->session->payment_intent ?? null;
+		if ( is_string( $payment_intent ) ) {
+			return $payment_intent;
+		}
+		if ( is_object( $payment_intent ) && isset( $payment_intent->id ) ) {
+			return (string) $payment_intent->id;
+		}
+		return null;
 	}
 
 	/**
@@ -280,6 +289,40 @@ class WC_Stripe_Agentic_Checkout_Session {
 	 */
 	public function get_shipping_amount(): ?int {
 		return isset( $this->session->total_details->amount_shipping ) ? (int) $this->session->total_details->amount_shipping : null;
+	}
+
+	/**
+	 * Returns the presentment currency in lowercase, or null when absent.
+	 *
+	 * @since 10.6.0
+	 * @return string|null
+	 */
+	public function get_presentment_currency(): ?string {
+		return isset( $this->session->presentment_details->presentment_currency )
+			? (string) $this->session->presentment_details->presentment_currency
+			: null;
+	}
+
+	/**
+	 * Returns the presentment amount in the smallest currency unit, or null when absent.
+	 *
+	 * @since 10.6.0
+	 * @return int|null
+	 */
+	public function get_presentment_amount(): ?int {
+		return isset( $this->session->presentment_details->presentment_amount )
+			? (int) $this->session->presentment_details->presentment_amount
+			: null;
+	}
+
+	/**
+	 * Returns whether presentment details are available.
+	 *
+	 * @since 10.6.0
+	 * @return bool
+	 */
+	public function has_presentment_details(): bool {
+		return null !== $this->get_presentment_currency() && null !== $this->get_presentment_amount();
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -4412,19 +4412,19 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Fetches the checkout session object from the order meta and retrieves the session details from Stripe.
 	 *
-	 * @return object|null The checkout session object, or null if it could not be retrieved.
+	 * @return WC_Stripe_Checkout_Session|null The checkout session object, or null if it could not be retrieved.
 	 */
-	private function get_checkout_session_from_order( WC_Order $order ): ?object {
+	private function get_checkout_session_from_order( WC_Order $order ): ?WC_Stripe_Checkout_Session {
 		$checkout_session_id = WC_Stripe_Order_Helper::get_instance()->get_stripe_checkout_session_id( $order );
 		if ( ! $checkout_session_id ) {
 			return null;
 		}
 
-		$cache_key        = 'checkout_session_' . $checkout_session_id;
-		$checkout_session = WC_Stripe_Database_Cache::get( $cache_key );
-		if ( ! $checkout_session ) {
+		$cache_key   = 'checkout_session_' . $checkout_session_id;
+		$raw_session = WC_Stripe_Database_Cache::get( $cache_key );
+		if ( ! $raw_session ) {
 			try {
-				$checkout_session = $this->stripe_request( 'checkout/sessions/' . $checkout_session_id, [], null, 'GET' );
+				$raw_session = $this->stripe_request( 'checkout/sessions/' . $checkout_session_id, [], null, 'GET' );
 			} catch ( WC_Stripe_Exception $e ) {
 				WC_Stripe_Logger::error(
 					'Exception fetching checkout session for order.',
@@ -4438,23 +4438,23 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 				return null;
 			}
 
-			if ( ! empty( $checkout_session->error ) ) {
+			if ( ! empty( $raw_session->error ) ) {
 				WC_Stripe_Logger::error(
 					'Error fetching checkout session for order.',
 					[
 						'order_id'            => $order->get_id(),
 						'checkout_session_id' => $checkout_session_id,
-						'error_message'       => $checkout_session->error->message,
+						'error_message'       => $raw_session->error->message,
 					]
 				);
 
 				return null;
 			}
 
-			WC_Stripe_Database_Cache::set( $cache_key, $checkout_session, HOUR_IN_SECONDS );
+			WC_Stripe_Database_Cache::set( $cache_key, $raw_session, HOUR_IN_SECONDS );
 		}
 
-		return $checkout_session;
+		return new WC_Stripe_Checkout_Session( $raw_session );
 	}
 
 	/**
@@ -4472,23 +4472,23 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$checkout_session = $this->get_checkout_session_from_order( $order );
-		if (
-			empty( $checkout_session->presentment_details )
-			|| ! isset(
-				$checkout_session->presentment_details->presentment_amount,
-				$checkout_session->presentment_details->presentment_currency
-			)
-		) {
+		$session = $this->get_checkout_session_from_order( $order );
+		if ( null === $session ) {
+			return;
+		}
+
+		$presentment_amount   = $session->get_presentment_amount();
+		$presentment_currency = $session->get_presentment_currency();
+		if ( null === $presentment_amount || null === $presentment_currency ) {
 			return;
 		}
 
 		if ( ! $order_helper->get_stripe_presentment_amount( $order ) ) {
-			$order_helper->update_stripe_presentment_amount( $order, $checkout_session->presentment_details->presentment_amount );
+			$order_helper->update_stripe_presentment_amount( $order, $presentment_amount );
 		}
 
 		if ( ! $order_helper->get_stripe_presentment_currency( $order ) ) {
-			$order_helper->update_stripe_presentment_currency( $order, $checkout_session->presentment_details->presentment_currency );
+			$order_helper->update_stripe_presentment_currency( $order, $presentment_currency );
 		}
 
 		$order->save_meta_data();

--- a/readme.txt
+++ b/readme.txt
@@ -146,6 +146,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.6.0 - xxxx-xx-xx =
+* Dev - Move checkout session DTOs to shared includes/dtos/ directory and refactor webhook handler and payment gateway to use typed DTO access instead of raw stdClass properties
 * Update - Defer checkout sessions webhook processing via Action Scheduler to prevent race conditions when webhook events arrive before order metadata is stored
 * Fix - Hide duplicate store-level save checkbox when Stripe Link is enabled on checkout
 * Dev - Autoload all Agentic Commerce classes via Composer classmap, removing manual require_once calls

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
@@ -1396,9 +1396,9 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 	 *
 	 * @param array<string, mixed>  $overrides Fields to override on the default session.
 	 * @param \WC_Product|null      $product   Product to use for the default line item. Defaults to $this->default_product.
-	 * @return WC_Stripe_Agentic_Checkout_Session The checkout session wrapper.
+	 * @return WC_Stripe_Checkout_Session The checkout session wrapper.
 	 */
-	private function build_checkout_session( array $overrides = [], ?\WC_Product $product = null ): WC_Stripe_Agentic_Checkout_Session {
+	private function build_checkout_session( array $overrides = [], ?\WC_Product $product = null ): WC_Stripe_Checkout_Session {
 		$product  = $product ?? $this->default_product;
 		$defaults = [
 			'id'               => 'cs_test_123',
@@ -1454,7 +1454,7 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 
 		$merged = array_merge( $defaults, $overrides );
 
-		return new WC_Stripe_Agentic_Checkout_Session( (object) $merged );
+		return new WC_Stripe_Checkout_Session( (object) $merged );
 	}
 
 	/**

--- a/tests/phpunit/dtos/class-wc-stripe-checkout-session-line-item-test.php
+++ b/tests/phpunit/dtos/class-wc-stripe-checkout-session-line-item-test.php
@@ -1,30 +1,30 @@
 <?php
 /**
- * Tests for WC_Stripe_Agentic_Line_Item
+ * Tests for WC_Stripe_Checkout_Session_Line_Item
  *
  * @package WooCommerce\Stripe\Tests
  */
 
 /**
- * Class WC_Stripe_Agentic_Line_Item_Test
+ * Class WC_Stripe_Checkout_Session_Line_Item_Test
  *
  * Tests the typed wrapper around a Stripe checkout session line item.
  *
- * @covers WC_Stripe_Agentic_Line_Item
+ * @covers WC_Stripe_Checkout_Session_Line_Item
  */
-class WC_Stripe_Agentic_Line_Item_Test extends WP_UnitTestCase {
+class WC_Stripe_Checkout_Session_Line_Item_Test extends WP_UnitTestCase {
 
 	/**
 	 * Test simple scalar getters with present and missing values.
 	 *
-	 * @param array  $raw_props  Properties to pass to `WC_Stripe_Agentic_Line_Item`.
+	 * @param array  $raw_props  Properties to pass to `WC_Stripe_Checkout_Session_Line_Item`.
 	 * @param string $getter     The getter method to call.
 	 * @param mixed  $expected   The expected return value.
 	 * @return void
 	 * @dataProvider provide_test_scalar_getters
 	 */
 	public function test_scalar_getters( array $raw_props, string $getter, $expected ) {
-		$item = new WC_Stripe_Agentic_Line_Item( (object) $raw_props );
+		$item = new WC_Stripe_Checkout_Session_Line_Item( (object) $raw_props );
 		$this->assertSame( $expected, $item->$getter() );
 	}
 
@@ -52,7 +52,7 @@ class WC_Stripe_Agentic_Line_Item_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_product_id_cases
 	 */
 	public function test_get_product_id( object $raw, int $expected ) {
-		$item = new WC_Stripe_Agentic_Line_Item( $raw );
+		$item = new WC_Stripe_Checkout_Session_Line_Item( $raw );
 		$this->assertSame( $expected, $item->get_product_id() );
 	}
 
@@ -100,7 +100,7 @@ class WC_Stripe_Agentic_Line_Item_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_has_product_id_cases
 	 */
 	public function test_has_product_id( object $raw, bool $expected ) {
-		$item = new WC_Stripe_Agentic_Line_Item( $raw );
+		$item = new WC_Stripe_Checkout_Session_Line_Item( $raw );
 		$this->assertSame( $expected, $item->has_product_id() );
 	}
 

--- a/tests/phpunit/dtos/class-wc-stripe-checkout-session-test.php
+++ b/tests/phpunit/dtos/class-wc-stripe-checkout-session-test.php
@@ -1,24 +1,24 @@
 <?php
 /**
- * Tests for WC_Stripe_Agentic_Checkout_Session
+ * Tests for WC_Stripe_Checkout_Session
  *
  * @package WooCommerce\Stripe\Tests
  */
 
 /**
- * Class WC_Stripe_Agentic_Checkout_Session_Test
+ * Class WC_Stripe_Checkout_Session_Test
  *
  * Tests the typed wrapper around Stripe checkout session data.
  *
- * @covers WC_Stripe_Agentic_Checkout_Session
+ * @covers WC_Stripe_Checkout_Session
  */
-class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
+class WC_Stripe_Checkout_Session_Test extends WP_UnitTestCase {
 
 	/**
 	 * Test get_id returns the session ID.
 	 */
 	public function test_get_id() {
-		$session = new WC_Stripe_Agentic_Checkout_Session( (object) [ 'id' => 'cs_test_123' ] );
+		$session = new WC_Stripe_Checkout_Session( (object) [ 'id' => 'cs_test_123' ] );
 		$this->assertSame( 'cs_test_123', $session->get_id() );
 	}
 
@@ -26,7 +26,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * Test get_id returns null when missing.
 	 */
 	public function test_get_id_returns_null_when_missing() {
-		$session = new WC_Stripe_Agentic_Checkout_Session( (object) [] );
+		$session = new WC_Stripe_Checkout_Session( (object) [] );
 		$this->assertNull( $session->get_id() );
 	}
 
@@ -34,7 +34,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * Test get_currency returns uppercase.
 	 */
 	public function test_get_currency_returns_uppercase() {
-		$session = new WC_Stripe_Agentic_Checkout_Session( (object) [ 'currency' => 'usd' ] );
+		$session = new WC_Stripe_Checkout_Session( (object) [ 'currency' => 'usd' ] );
 		$this->assertSame( 'USD', $session->get_currency() );
 	}
 
@@ -42,7 +42,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * Test get_currency returns null when missing.
 	 */
 	public function test_get_currency_returns_null_when_missing() {
-		$session = new WC_Stripe_Agentic_Checkout_Session( (object) [] );
+		$session = new WC_Stripe_Checkout_Session( (object) [] );
 		$this->assertNull( $session->get_currency() );
 	}
 
@@ -50,7 +50,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * Test get_currency_lowercase returns lowercase.
 	 */
 	public function test_get_currency_lowercase() {
-		$session = new WC_Stripe_Agentic_Checkout_Session( (object) [ 'currency' => 'EUR' ] );
+		$session = new WC_Stripe_Checkout_Session( (object) [ 'currency' => 'EUR' ] );
 		$this->assertSame( 'eur', $session->get_currency_lowercase() );
 	}
 
@@ -58,7 +58,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_amount_total_cases
 	 */
 	public function test_get_amount_total( object $raw, ?int $expected ) {
-		$session = new WC_Stripe_Agentic_Checkout_Session( $raw );
+		$session = new WC_Stripe_Checkout_Session( $raw );
 		$this->assertSame( $expected, $session->get_amount_total() );
 	}
 
@@ -90,7 +90,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_customer_email_cases
 	 */
 	public function test_get_customer_email( object $raw, ?string $expected ) {
-		$session = new WC_Stripe_Agentic_Checkout_Session( $raw );
+		$session = new WC_Stripe_Checkout_Session( $raw );
 		$this->assertSame( $expected, $session->get_customer_email() );
 	}
 
@@ -124,7 +124,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_customer_name_cases
 	 */
 	public function test_get_customer_name( object $raw, ?string $expected ) {
-		$session = new WC_Stripe_Agentic_Checkout_Session( $raw );
+		$session = new WC_Stripe_Checkout_Session( $raw );
 		$this->assertSame( $expected, $session->get_customer_name() );
 	}
 
@@ -174,7 +174,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * Test get_billing_phone.
 	 */
 	public function test_get_billing_phone() {
-		$session = new WC_Stripe_Agentic_Checkout_Session(
+		$session = new WC_Stripe_Checkout_Session(
 			(object) [
 				'customer_details' => (object) [ 'phone' => '+15551234567' ],
 			]
@@ -186,7 +186,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * Test get_billing_phone returns null when missing.
 	 */
 	public function test_get_billing_phone_null_when_missing() {
-		$session = new WC_Stripe_Agentic_Checkout_Session( (object) [] );
+		$session = new WC_Stripe_Checkout_Session( (object) [] );
 		$this->assertNull( $session->get_billing_phone() );
 	}
 
@@ -198,7 +198,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 			'line1' => '123 Main St',
 			'city'  => 'Anytown',
 		];
-		$session = new WC_Stripe_Agentic_Checkout_Session(
+		$session = new WC_Stripe_Checkout_Session(
 			(object) [
 				'customer_details' => (object) [ 'address' => $address ],
 			]
@@ -214,7 +214,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_billing_address_null_when_missing() {
 		$this->expectException( \Exception::class );
-		$session = new WC_Stripe_Agentic_Checkout_Session( (object) [] );
+		$session = new WC_Stripe_Checkout_Session( (object) [] );
 		$session->get_billing_address();
 	}
 
@@ -222,7 +222,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_shipping_details_cases
 	 */
 	public function test_get_shipping_details( object $raw, bool $expect_non_null ) {
-		$session = new WC_Stripe_Agentic_Checkout_Session( $raw );
+		$session = new WC_Stripe_Checkout_Session( $raw );
 		if ( $expect_non_null ) {
 			$this->assertNotNull( $session->get_shipping_details() );
 		} else {
@@ -263,7 +263,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_shipping_phone_cases
 	 */
 	public function test_get_shipping_phone( object $raw, ?string $expected ) {
-		$session = new WC_Stripe_Agentic_Checkout_Session( $raw );
+		$session = new WC_Stripe_Checkout_Session( $raw );
 		$this->assertSame( $expected, $session->get_shipping_phone() );
 	}
 
@@ -299,7 +299,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * Test get_shipping_name.
 	 */
 	public function test_get_shipping_name() {
-		$session = new WC_Stripe_Agentic_Checkout_Session(
+		$session = new WC_Stripe_Checkout_Session(
 			(object) [
 				'shipping_details' => (object) [ 'name' => 'Bob Jones' ],
 			]
@@ -312,7 +312,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_shipping_address() {
 		$address = (object) [ 'line1' => '456 Oak Ave' ];
-		$session = new WC_Stripe_Agentic_Checkout_Session(
+		$session = new WC_Stripe_Checkout_Session(
 			(object) [
 				'shipping_details' => (object) [
 					'name'    => 'Test',
@@ -329,7 +329,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * Test get_shipping_address null when no shipping.
 	 */
 	public function test_get_shipping_address_null_when_no_shipping() {
-		$session = new WC_Stripe_Agentic_Checkout_Session( (object) [ 'shipping_details' => null ] );
+		$session = new WC_Stripe_Checkout_Session( (object) [ 'shipping_details' => null ] );
 		$this->assertNull( $session->get_shipping_address() );
 	}
 
@@ -338,15 +338,15 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_line_items() {
 		$items      = [ (object) [ 'id' => 'li_1' ], (object) [ 'id' => 'li_2' ] ];
-		$session    = new WC_Stripe_Agentic_Checkout_Session(
+		$session    = new WC_Stripe_Checkout_Session(
 			(object) [
 				'line_items' => (object) [ 'data' => $items ],
 			]
 		);
 		$line_items = $session->get_line_items();
 		$this->assertCount( 2, $line_items );
-		$this->assertInstanceOf( \WC_Stripe_Agentic_Line_Item::class, $line_items[0] );
-		$this->assertInstanceOf( \WC_Stripe_Agentic_Line_Item::class, $line_items[1] );
+		$this->assertInstanceOf( \WC_Stripe_Checkout_Session_Line_Item::class, $line_items[0] );
+		$this->assertInstanceOf( \WC_Stripe_Checkout_Session_Line_Item::class, $line_items[1] );
 		$this->assertSame( 'li_1', $line_items[0]->get_id() );
 		$this->assertSame( 'li_2', $line_items[1]->get_id() );
 	}
@@ -355,7 +355,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * Test get_line_items empty when missing.
 	 */
 	public function test_get_line_items_empty_when_missing() {
-		$session = new WC_Stripe_Agentic_Checkout_Session( (object) [] );
+		$session = new WC_Stripe_Checkout_Session( (object) [] );
 		$this->assertSame( [], $session->get_line_items() );
 	}
 
@@ -363,7 +363,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * Test get_payment_intent_id.
 	 */
 	public function test_get_payment_intent_id() {
-		$session = new WC_Stripe_Agentic_Checkout_Session(
+		$session = new WC_Stripe_Checkout_Session(
 			(object) [
 				'payment_intent' => (object) [ 'id' => 'pi_test_123' ],
 			]
@@ -375,7 +375,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * Test get_payment_intent_id null when missing.
 	 */
 	public function test_get_payment_intent_id_null_when_missing() {
-		$session = new WC_Stripe_Agentic_Checkout_Session( (object) [] );
+		$session = new WC_Stripe_Checkout_Session( (object) [] );
 		$this->assertNull( $session->get_payment_intent_id() );
 	}
 
@@ -383,7 +383,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * Test get_customer_id.
 	 */
 	public function test_get_customer_id() {
-		$session = new WC_Stripe_Agentic_Checkout_Session( (object) [ 'customer' => 'cus_test_abc' ] );
+		$session = new WC_Stripe_Checkout_Session( (object) [ 'customer' => 'cus_test_abc' ] );
 		$this->assertSame( 'cus_test_abc', $session->get_customer_id() );
 	}
 
@@ -391,7 +391,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * Test get_customer_id null when missing.
 	 */
 	public function test_get_customer_id_null_when_missing() {
-		$session = new WC_Stripe_Agentic_Checkout_Session( (object) [] );
+		$session = new WC_Stripe_Checkout_Session( (object) [] );
 		$this->assertNull( $session->get_customer_id() );
 	}
 
@@ -399,7 +399,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * Test get_customer_id returns id from expanded customer object.
 	 */
 	public function test_get_customer_id_from_expanded_object() {
-		$session = new WC_Stripe_Agentic_Checkout_Session(
+		$session = new WC_Stripe_Checkout_Session(
 			(object) [ 'customer' => (object) [ 'id' => 'cus_expanded' ] ]
 		);
 		$this->assertSame( 'cus_expanded', $session->get_customer_id() );
@@ -409,7 +409,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * Test get_shipping_amount.
 	 */
 	public function test_get_shipping_amount() {
-		$session = new WC_Stripe_Agentic_Checkout_Session(
+		$session = new WC_Stripe_Checkout_Session(
 			(object) [
 				'total_details' => (object) [ 'amount_shipping' => 500 ],
 			]
@@ -421,7 +421,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * Test get_shipping_amount returns null when missing.
 	 */
 	public function test_get_shipping_amount_null_when_missing() {
-		$session = new WC_Stripe_Agentic_Checkout_Session( (object) [] );
+		$session = new WC_Stripe_Checkout_Session( (object) [] );
 		$this->assertNull( $session->get_shipping_amount() );
 	}
 
@@ -429,7 +429,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_is_agentic_cases
 	 */
 	public function test_is_agentic( object $raw, bool $expected ) {
-		$session = new WC_Stripe_Agentic_Checkout_Session( $raw );
+		$session = new WC_Stripe_Checkout_Session( $raw );
 		$this->assertSame( $expected, $session->is_agentic() );
 	}
 
@@ -512,7 +512,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * Test get_fields_to_expand includes both line items and shipping cost.
 	 */
 	public function test_get_fields_to_expand() {
-		$fields = WC_Stripe_Agentic_Checkout_Session::get_fields_to_expand();
+		$fields = WC_Stripe_Checkout_Session::get_fields_to_expand();
 		$this->assertIsArray( $fields );
 		$this->assertContains( 'line_items.data.price.product', $fields );
 		$this->assertContains( 'shipping_cost.shipping_rate', $fields );
@@ -522,7 +522,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_chosen_shipping_rate_wc_id_cases
 	 */
 	public function test_get_chosen_shipping_rate_wc_id( object $raw, ?string $expected ) {
-		$session = new WC_Stripe_Agentic_Checkout_Session( $raw );
+		$session = new WC_Stripe_Checkout_Session( $raw );
 		$this->assertSame( $expected, $session->get_chosen_shipping_rate_wc_id() );
 	}
 
@@ -572,7 +572,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_chosen_shipping_rate_display_name_cases
 	 */
 	public function test_get_chosen_shipping_rate_display_name( object $raw, ?string $expected ) {
-		$session = new WC_Stripe_Agentic_Checkout_Session( $raw );
+		$session = new WC_Stripe_Checkout_Session( $raw );
 		$this->assertSame( $expected, $session->get_chosen_shipping_rate_display_name() );
 	}
 
@@ -608,7 +608,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * Test get_billing_address returns WC_Stripe_API_Address and throws when missing.
 	 */
 	public function test_get_billing_address_returns_api_address_type() {
-		$session = new WC_Stripe_Agentic_Checkout_Session(
+		$session = new WC_Stripe_Checkout_Session(
 			(object) [
 				'customer_details' => (object) [
 					'address' => (object) [
@@ -637,7 +637,7 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 * Test get_shipping_address returns WC_Stripe_API_Address.
 	 */
 	public function test_get_shipping_address_returns_api_address_type() {
-		$session = new WC_Stripe_Agentic_Checkout_Session(
+		$session = new WC_Stripe_Checkout_Session(
 			(object) [
 				'shipping_details' => (object) [
 					'name'    => 'Test',


### PR DESCRIPTION
## Summary

- Extracts checkout session DTOs (`WC_Stripe_Checkout_Session`, `WC_Stripe_Checkout_Session_Line_Item`, `WC_Stripe_API_Address`) from `includes/agentic-commerce/` into a new shared `includes/dtos/` directory so they can be reused by any part of the codebase.
- Refactors `WC_Stripe_Webhook_Handler` and `WC_Stripe_UPE_Payment_Gateway` to use the typed DTO instead of raw `stdClass` property access for checkout sessions.
- Adds missing `get_presentment_currency()`, `get_presentment_amount()`, and `has_presentment_details()` getters to the checkout session DTO, and fixes `get_payment_intent_id()` to handle both string and expanded object formats (matching the existing `get_customer_id()` pattern).

### Changes

| Area | What changed |
|------|-------------|
| `includes/dtos/` | New shared directory with 3 DTO classes (renamed from agentic-commerce) |
| `includes/agentic-commerce/` | Old DTO files removed; order mapper and customize checkout line item updated to use new class names |
| `includes/class-wc-stripe-webhook-handler.php` | `process_checkout_session_success()`, `handle_checkout_session_success()`, `process_checkout_session_failure()`, `handle_checkout_session_failure()`, and `handle_agentic_checkout_session()` now wrap the raw Stripe object in `WC_Stripe_Checkout_Session` |
| `includes/payment-methods/class-wc-stripe-upe-payment-gateway.php` | `get_checkout_session_from_order()` now returns `?WC_Stripe_Checkout_Session`; `maybe_add_presentment_metadata_to_order()` uses DTO getters |
| `composer.json` | Added `includes/dtos/` to the autoload classmap |
| `changelog.txt` / `readme.txt` | Added Dev changelog entry |
| `tests/phpunit/dtos/` | Moved and renamed test files to match new class names |

### Class renames

| Old name | New name |
|----------|----------|
| `WC_Stripe_Agentic_Checkout_Session` | `WC_Stripe_Checkout_Session` |
| `WC_Stripe_Agentic_Line_Item` | `WC_Stripe_Checkout_Session_Line_Item` |
| `WC_Stripe_API_Address` | `WC_Stripe_API_Address` (unchanged, moved to `includes/dtos/`) |

## Test plan

- [ ] All 1766 PHPUnit tests pass (`npm run test:php`)
- [ ] PHPStan level 8 passes with 0 errors (`npm run phpstan`)
- [ ] PHPCS passes (`npm run lint:php`)
- [ ] **Classic checkout:** Complete a card payment and verify the order is created correctly with payment intent and presentment metadata stored
- [ ] **Blocks/Optimized checkout:** Complete a card payment and verify the same
- [ ] **Adaptive Pricing:** Complete a payment in a non-store currency, verify the presentment currency/amount order note appears ("Local currency purchase via Adaptive Pricing...")
- [ ] **Checkout session failure:** Expire/abandon a checkout session and verify the order is marked as failed
- [ ] **Agentic commerce (if enabled):** Verify agentic checkout sessions still create orders correctly via the order mapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)