### PR TITLE
Add Stripe PHP SDK with CheckoutSession DTO integration

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.6.0
+* Dev - Add Stripe PHP SDK and migrate Checkout Session API calls to typed DTOs
 * Add - Add exit survey to capture merchant feedback on plugin deactivation and gateway disablement
 * Update - Defer checkout sessions webhook processing via Action Scheduler to prevent race conditions when webhook events arrive before order metadata is stored
 * Fix - Hide duplicate store-level save checkbox when Stripe Link is enabled on checkout

--- a/composer.json
+++ b/composer.json
@@ -54,5 +54,8 @@
         "phpstan": "Run PHPStan static analysis on the Stripe extension",
         "phpstan:baseline": "Generate a PHPStan baseline file to ignore existing errors"
       }
+    },
+    "require": {
+        "stripe/stripe-php": "^19.4.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,68 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c8658b05455b7c8d835065847689fb1",
-    "packages": [],
+    "content-hash": "780f2d1015ed30ff6d2c8702a5af30fb",
+    "packages": [
+        {
+            "name": "stripe/stripe-php",
+            "version": "v19.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stripe/stripe-php.git",
+                "reference": "095384404587d07de2ad1154c389c4051c5ed92f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/095384404587d07de2ad1154c389c4051c5ed92f",
+                "reference": "095384404587d07de2ad1154c389c4051c5ed92f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "3.94.0",
+                "phpstan/phpstan": "^1.2",
+                "phpunit/phpunit": "^5.7 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Stripe\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stripe and contributors",
+                    "homepage": "https://github.com/stripe/stripe-php/contributors"
+                }
+            ],
+            "description": "Stripe PHP Library",
+            "homepage": "https://stripe.com/",
+            "keywords": [
+                "api",
+                "payment processing",
+                "stripe"
+            ],
+            "support": {
+                "issues": "https://github.com/stripe/stripe-php/issues",
+                "source": "https://github.com/stripe/stripe-php/tree/v19.4.1"
+            },
+            "time": "2026-03-06T22:53:13+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "composer/ca-bundle",
@@ -7667,5 +7727,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/includes/agentic-commerce/class-wc-stripe-agentic-checkout-session.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-checkout-session.php
@@ -24,19 +24,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Stripe_Agentic_Checkout_Session {
 
 	/**
-	 * The raw Stripe checkout session object.
+	 * The Stripe checkout session object.
 	 *
-	 * @var stdClass
+	 * @var \Stripe\Checkout\Session|stdClass
 	 */
-	private stdClass $session;
+	private object $session;
 
 	/**
 	 * Constructor.
 	 *
 	 * @since 10.6.0
-	 * @param stdClass $session The raw Stripe checkout session object.
+	 * @param \Stripe\Checkout\Session|stdClass $session The Stripe checkout session object.
 	 */
-	public function __construct( stdClass $session ) {
+	public function __construct( object $session ) {
 		$this->session = $session;
 	}
 

--- a/includes/agentic-commerce/class-wc-stripe-agentic-checkout-session.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-checkout-session.php
@@ -35,8 +35,18 @@ class WC_Stripe_Agentic_Checkout_Session {
 	 *
 	 * @since 10.6.0
 	 * @param \Stripe\Checkout\Session|stdClass $session The Stripe checkout session object.
+	 * @throws InvalidArgumentException When $session is not a stdClass or \Stripe\StripeObject instance.
 	 */
 	public function __construct( object $session ) {
+		// Broad `object` signature keeps PHP 7.4 compatibility, but we validate shape at
+		// construction to fail fast on malformed payloads rather than surface null reads
+		// across the getters downstream.
+		if ( ! $session instanceof stdClass && ! $session instanceof \Stripe\StripeObject ) {
+			throw new InvalidArgumentException(
+				sprintf( 'Expected stdClass or \Stripe\StripeObject, got %s.', get_class( $session ) )
+			);
+		}
+
 		$this->session = $session;
 	}
 

--- a/includes/agentic-commerce/class-wc-stripe-api-address.php
+++ b/includes/agentic-commerce/class-wc-stripe-api-address.php
@@ -19,22 +19,18 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Stripe_API_Address {
 	/**
-	 * The raw Stripe address object.
+	 * The Stripe address object.
 	 *
-	 * @var stdClass
+	 * @var object
 	 */
-	private stdClass $address;
+	private object $address;
 
 	/**
 	 * Constructor.
 	 *
-	 * @param object $address The raw Stripe address object.
-	 * @throws \InvalidArgumentException If the address is not a stdClass instance.
+	 * @param object $address The Stripe address object (stdClass or \Stripe\StripeObject).
 	 */
-	public function __construct( $address ) {
-		if ( ! $address instanceof stdClass ) {
-			throw new \InvalidArgumentException( 'Address must be a stdClass instance.' );
-		}
+	public function __construct( object $address ) {
 		$this->address = $address;
 	}
 

--- a/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
+++ b/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
@@ -63,12 +63,7 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler {
 				];
 			}
 
-			$checkout_session = WC_Stripe_API::request( $request, 'checkout/sessions' );
-
-			if ( ! empty( $checkout_session->error ) ) {
-				$message = empty( $checkout_session->error->message ) ? __( 'Checkout Sessions API returned an error', 'woocommerce-gateway-stripe' ) : $checkout_session->error->message;
-				throw new Exception( $message );
-			}
+			$checkout_session = WC_Stripe_API::create_checkout_session( $request );
 
 			if ( empty( $checkout_session->client_secret ) || empty( $checkout_session->id ) ) {
 				throw new Exception( __( 'Unable to create Stripe Checkout Session.', 'woocommerce-gateway-stripe' ) );
@@ -117,12 +112,7 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler {
 				'line_items' => $this->build_line_items(),
 			];
 
-			$checkout_session = WC_Stripe_API::request( $request, "checkout/sessions/$session_id" );
-
-			if ( ! empty( $checkout_session->error ) ) {
-				$message = empty( $checkout_session->error->message ) ? __( 'Checkout Sessions update API returned an error', 'woocommerce-gateway-stripe' ) : $checkout_session->error->message;
-				throw new Exception( $message );
-			}
+			WC_Stripe_API::update_checkout_session( $session_id, $request );
 
 			wp_send_json_success( [ 'result' => 'success' ] );
 

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -801,6 +801,9 @@ class WC_Stripe_API {
 	 * @throws WC_Stripe_Exception On API error.
 	 */
 	public static function create_checkout_session( array $params ): \Stripe\Checkout\Session {
+		$params = self::apply_checkout_session_body_filters( $params );
+		$opts   = self::build_checkout_session_request_options( 'POST', $params );
+
 		try {
 			WC_Stripe_Logger::debug(
 				'Stripe SDK request: create checkout session',
@@ -810,7 +813,7 @@ class WC_Stripe_API {
 				]
 			);
 
-			$session = self::get_sdk()->checkout->sessions->create( $params );
+			$session = self::get_sdk()->checkout->sessions->create( $params, $opts );
 
 			WC_Stripe_Logger::debug(
 				'Stripe SDK response: create checkout session',
@@ -822,14 +825,7 @@ class WC_Stripe_API {
 
 			return $session;
 		} catch ( \Stripe\Exception\ApiErrorException $e ) {
-			WC_Stripe_Logger::error(
-				'Stripe SDK error: create checkout session',
-				[
-					'stripe_api_key' => self::get_masked_secret_key(),
-					'error_message'  => $e->getMessage(),
-				]
-			);
-			throw new WC_Stripe_Exception( $e->getMessage(), $e->getMessage() );
+			self::handle_checkout_session_api_error( $e, 'create checkout session' );
 		}
 	}
 
@@ -843,6 +839,10 @@ class WC_Stripe_API {
 	 * @throws WC_Stripe_Exception On API error.
 	 */
 	public static function retrieve_checkout_session( string $session_id, array $params = [], array $opts = [] ): \Stripe\Checkout\Session {
+		self::throw_if_invalid_api_key_backoff_active();
+
+		$opts = self::build_checkout_session_request_options( 'GET', [], $opts );
+
 		try {
 			WC_Stripe_Logger::debug(
 				'Stripe SDK request: retrieve checkout session',
@@ -856,6 +856,8 @@ class WC_Stripe_API {
 
 			$session = self::get_sdk()->checkout->sessions->retrieve( $session_id, $params, $opts );
 
+			self::clear_invalid_api_key_backoff();
+
 			WC_Stripe_Logger::debug(
 				'Stripe SDK response: retrieve checkout session',
 				[
@@ -865,16 +867,11 @@ class WC_Stripe_API {
 			);
 
 			return $session;
+		} catch ( \Stripe\Exception\AuthenticationException $e ) {
+			self::record_invalid_api_key_error();
+			self::handle_checkout_session_api_error( $e, 'retrieve checkout session', [ 'session_id' => $session_id ] );
 		} catch ( \Stripe\Exception\ApiErrorException $e ) {
-			WC_Stripe_Logger::error(
-				'Stripe SDK error: retrieve checkout session',
-				[
-					'stripe_api_key' => self::get_masked_secret_key(),
-					'session_id'     => $session_id,
-					'error_message'  => $e->getMessage(),
-				]
-			);
-			throw new WC_Stripe_Exception( $e->getMessage(), $e->getMessage() );
+			self::handle_checkout_session_api_error( $e, 'retrieve checkout session', [ 'session_id' => $session_id ] );
 		}
 	}
 
@@ -887,6 +884,9 @@ class WC_Stripe_API {
 	 * @throws WC_Stripe_Exception On API error.
 	 */
 	public static function update_checkout_session( string $session_id, array $params ): \Stripe\Checkout\Session {
+		$params = self::apply_checkout_session_body_filters( $params );
+		$opts   = self::build_checkout_session_request_options( 'POST', $params );
+
 		try {
 			WC_Stripe_Logger::debug(
 				'Stripe SDK request: update checkout session',
@@ -897,7 +897,7 @@ class WC_Stripe_API {
 				]
 			);
 
-			$session = self::get_sdk()->checkout->sessions->update( $session_id, $params );
+			$session = self::get_sdk()->checkout->sessions->update( $session_id, $params, $opts );
 
 			WC_Stripe_Logger::debug(
 				'Stripe SDK response: update checkout session',
@@ -909,15 +909,146 @@ class WC_Stripe_API {
 
 			return $session;
 		} catch ( \Stripe\Exception\ApiErrorException $e ) {
-			WC_Stripe_Logger::error(
-				'Stripe SDK error: update checkout session',
+			self::handle_checkout_session_api_error( $e, 'update checkout session', [ 'session_id' => $session_id ] );
+		}
+	}
+
+	/**
+	 * Applies the wc_stripe_request_body filter (and its deprecated predecessor) to the
+	 * given params so SDK-based checkout session calls preserve the same extension surface
+	 * as the legacy request() path.
+	 *
+	 * @param array $params The request params.
+	 * @return array The filtered params.
+	 */
+	private static function apply_checkout_session_body_filters( array $params ): array {
+		$params = apply_filters_deprecated(
+			'woocommerce_stripe_request_body',
+			[ $params, 'checkout/sessions' ],
+			'9.7.0',
+			'wc_stripe_request_body',
+			'The woocommerce_stripe_request_body filter is deprecated since WooCommerce Stripe Gateway 9.7.0, and will be removed in a future version. Use wc_stripe_request_body instead.'
+		);
+
+		return apply_filters( 'wc_stripe_request_body', $params, 'checkout/sessions' );
+	}
+
+	/**
+	 * Builds SDK request options for checkout session calls, preserving the
+	 * `wc_stripe_idempotency_key` and `wc_stripe_request_headers` extension filters.
+	 *
+	 * Reserved headers owned by the SDK (Authorization, Stripe-Version) are stripped
+	 * before being forwarded so extensions cannot conflict with the client's own auth.
+	 *
+	 * @param string $method     HTTP method (for idempotency key generation).
+	 * @param array  $params     Request params (passed to the idempotency filter).
+	 * @param array  $extra_opts Caller-supplied SDK opts to merge into (e.g. stripe_version).
+	 * @return array The SDK request options.
+	 */
+	private static function build_checkout_session_request_options( string $method, array $params, array $extra_opts = [] ): array {
+		$opts = $extra_opts;
+
+		$idempotency_key = apply_filters(
+			'wc_stripe_idempotency_key',
+			self::get_idempotency_key( 'checkout/sessions', $method, $params ),
+			$params
+		);
+		if ( $idempotency_key && ! isset( $opts['idempotency_key'] ) ) {
+			$opts['idempotency_key'] = $idempotency_key;
+		}
+
+		$reserved_headers = [
+			'Authorization'  => 'Basic ' . base64_encode( self::get_secret_key() . ':' ),
+			'Stripe-Version' => self::STRIPE_API_VERSION,
+		];
+
+		$filtered_headers = apply_filters_deprecated(
+			'woocommerce_stripe_request_headers',
+			[ $reserved_headers ],
+			'9.7.0',
+			'wc_stripe_request_headers',
+			'The woocommerce_stripe_request_headers filter is deprecated since WooCommerce Stripe Gateway 9.7.0, and will be removed in a future version. Use wc_stripe_request_headers instead.'
+		);
+		$filtered_headers = apply_filters( 'wc_stripe_request_headers', $filtered_headers );
+
+		$custom_headers = is_array( $filtered_headers ) ? array_diff_key( $filtered_headers, $reserved_headers ) : [];
+		if ( ! empty( $custom_headers ) ) {
+			$opts['headers'] = isset( $opts['headers'] ) && is_array( $opts['headers'] )
+				? array_merge( $custom_headers, $opts['headers'] )
+				: $custom_headers;
+		}
+
+		return $opts;
+	}
+
+	/**
+	 * Throws a WC_Stripe_Exception when the invalid-API-key backoff threshold is active,
+	 * mirroring the behavior of retrieve() on the legacy path.
+	 *
+	 * @throws WC_Stripe_Exception When the threshold has been exceeded.
+	 */
+	private static function throw_if_invalid_api_key_backoff_active(): void {
+		$count = WC_Stripe_Database_Cache::get( self::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY );
+		if ( ! empty( $count ) && self::INVALID_API_KEY_ERROR_COUNT_THRESHOLD <= $count ) {
+			throw new WC_Stripe_Exception(
+				'Invalid API keys request rate limit exceeded',
+				__( 'Stripe API requests are temporarily paused due to invalid API keys. Please update your keys and try again.', 'woocommerce-gateway-stripe' )
+			);
+		}
+	}
+
+	/**
+	 * Clears the invalid-API-key backoff counter after a successful request.
+	 */
+	private static function clear_invalid_api_key_backoff(): void {
+		if ( null !== WC_Stripe_Database_Cache::get( self::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY ) ) {
+			WC_Stripe_Database_Cache::delete( self::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY );
+		}
+	}
+
+	/**
+	 * Logs and rethrows an SDK API error as a WC_Stripe_Exception. Never returns.
+	 *
+	 * @param \Stripe\Exception\ApiErrorException $e       The SDK exception.
+	 * @param string                              $label   Human-readable operation label for logs.
+	 * @param array                               $context Extra log context (e.g. session_id).
+	 * @throws WC_Stripe_Exception Always.
+	 *
+	 * @phpstan-return never
+	 */
+	private static function handle_checkout_session_api_error( \Stripe\Exception\ApiErrorException $e, string $label, array $context = [] ): void {
+		WC_Stripe_Logger::error(
+			'Stripe SDK error: ' . $label,
+			array_merge(
 				[
 					'stripe_api_key' => self::get_masked_secret_key(),
-					'session_id'     => $session_id,
 					'error_message'  => $e->getMessage(),
+				],
+				$context
+			)
+		);
+
+		throw new WC_Stripe_Exception( $e->getMessage(), $e->getMessage() );
+	}
+
+	/**
+	 * Increments the invalid-API-key counter and invalidates the account cache once the
+	 * threshold is reached, mirroring the 401 handling in retrieve() on the legacy path.
+	 */
+	private static function record_invalid_api_key_error(): void {
+		$count = (int) WC_Stripe_Database_Cache::get( self::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY ) + 1;
+		WC_Stripe_Database_Cache::set( self::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY, $count, self::INVALID_API_KEY_ERROR_COUNT_CACHE_TIMEOUT );
+
+		if ( $count >= self::INVALID_API_KEY_ERROR_COUNT_THRESHOLD ) {
+			WC_Stripe_Logger::error(
+				'Invalid API keys request rate limit exceeded',
+				[
+					'stripe_api_key' => self::get_masked_secret_key(),
+					'count'          => $count,
+					'next_retry'     => date_i18n( 'Y-m-d H:i:sP', time() + self::INVALID_API_KEY_ERROR_COUNT_CACHE_TIMEOUT ),
 				]
 			);
-			throw new WC_Stripe_Exception( $e->getMessage(), $e->getMessage() );
+			WC_Stripe_Database_Cache::delete( WC_Stripe_Account::ACCOUNT_CACHE_KEY );
 		}
 	}
 }

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -40,6 +40,21 @@ class WC_Stripe_API {
 	protected const INVALID_API_KEY_ERROR_COUNT_THRESHOLD = 5;
 
 	/**
+	 * Cached Stripe SDK client instance.
+	 *
+	 * @var \Stripe\StripeClient|null
+	 */
+	private static ?\Stripe\StripeClient $sdk = null;
+
+	/**
+	 * The secret key used to create the current SDK instance.
+	 * Tracked so we can invalidate the SDK when the key changes (e.g. live/test mode switch).
+	 *
+	 * @var string
+	 */
+	private static string $sdk_secret = '';
+
+	/**
 	 * Secret API Key.
 	 *
 	 * @var string
@@ -736,5 +751,173 @@ class WC_Stripe_API {
 			return 'secret_key_not_configured';
 		}
 		return substr( $key, 0, 8 ) . '...' . substr( $key, -6 );
+	}
+
+	/**
+	 * Inject a StripeClient for testing. Pass null to clear.
+	 *
+	 * @param \Stripe\StripeClient|null $client The client to inject, or null to clear.
+	 */
+	public static function set_sdk_for_testing( ?\Stripe\StripeClient $client ): void {
+		self::$sdk        = $client;
+		self::$sdk_secret = $client ? self::get_secret_key() : '';
+	}
+
+	/**
+	 * Returns a cached StripeClient singleton, automatically invalidated when the secret key changes.
+	 *
+	 * @return \Stripe\StripeClient
+	 */
+	public static function get_sdk(): \Stripe\StripeClient {
+		$secret = self::get_secret_key();
+
+		if ( ! self::$sdk || self::$sdk_secret !== $secret ) {
+			$user_agent = self::get_user_agent();
+			$app_info   = $user_agent['application'];
+
+			self::$sdk        = new \Stripe\StripeClient(
+				[
+					'api_key'        => $secret,
+					'stripe_version' => self::STRIPE_API_VERSION,
+					'app_info'       => [
+						'name'       => $app_info['name'],
+						'version'    => $app_info['version'],
+						'url'        => $app_info['url'],
+						'partner_id' => $app_info['partner_id'],
+					],
+				]
+			);
+			self::$sdk_secret = $secret;
+		}
+
+		return self::$sdk;
+	}
+
+	/**
+	 * Create a Stripe Checkout Session via the SDK.
+	 *
+	 * @param array $params Parameters for session creation.
+	 * @return \Stripe\Checkout\Session
+	 * @throws WC_Stripe_Exception On API error.
+	 */
+	public static function create_checkout_session( array $params ): \Stripe\Checkout\Session {
+		try {
+			WC_Stripe_Logger::debug(
+				'Stripe SDK request: create checkout session',
+				[
+					'stripe_api_key' => self::get_masked_secret_key(),
+					'request'        => $params,
+				]
+			);
+
+			$session = self::get_sdk()->checkout->sessions->create( $params );
+
+			WC_Stripe_Logger::debug(
+				'Stripe SDK response: create checkout session',
+				[
+					'stripe_api_key' => self::get_masked_secret_key(),
+					'session_id'     => $session->id,
+				]
+			);
+
+			return $session;
+		} catch ( \Stripe\Exception\ApiErrorException $e ) {
+			WC_Stripe_Logger::error(
+				'Stripe SDK error: create checkout session',
+				[
+					'stripe_api_key' => self::get_masked_secret_key(),
+					'error_message'  => $e->getMessage(),
+				]
+			);
+			throw new WC_Stripe_Exception( $e->getMessage(), $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Retrieve a Stripe Checkout Session via the SDK.
+	 *
+	 * @param string $session_id The checkout session ID.
+	 * @param array  $params     Optional parameters (e.g. expand).
+	 * @param array  $opts       Optional request options (e.g. stripe_version).
+	 * @return \Stripe\Checkout\Session
+	 * @throws WC_Stripe_Exception On API error.
+	 */
+	public static function retrieve_checkout_session( string $session_id, array $params = [], array $opts = [] ): \Stripe\Checkout\Session {
+		try {
+			WC_Stripe_Logger::debug(
+				'Stripe SDK request: retrieve checkout session',
+				[
+					'stripe_api_key' => self::get_masked_secret_key(),
+					'session_id'     => $session_id,
+					'params'         => $params,
+					'opts'           => $opts,
+				]
+			);
+
+			$session = self::get_sdk()->checkout->sessions->retrieve( $session_id, $params, $opts );
+
+			WC_Stripe_Logger::debug(
+				'Stripe SDK response: retrieve checkout session',
+				[
+					'stripe_api_key' => self::get_masked_secret_key(),
+					'session_id'     => $session->id,
+				]
+			);
+
+			return $session;
+		} catch ( \Stripe\Exception\ApiErrorException $e ) {
+			WC_Stripe_Logger::error(
+				'Stripe SDK error: retrieve checkout session',
+				[
+					'stripe_api_key' => self::get_masked_secret_key(),
+					'session_id'     => $session_id,
+					'error_message'  => $e->getMessage(),
+				]
+			);
+			throw new WC_Stripe_Exception( $e->getMessage(), $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Update a Stripe Checkout Session via the SDK.
+	 *
+	 * @param string $session_id The checkout session ID.
+	 * @param array  $params     Parameters to update.
+	 * @return \Stripe\Checkout\Session
+	 * @throws WC_Stripe_Exception On API error.
+	 */
+	public static function update_checkout_session( string $session_id, array $params ): \Stripe\Checkout\Session {
+		try {
+			WC_Stripe_Logger::debug(
+				'Stripe SDK request: update checkout session',
+				[
+					'stripe_api_key' => self::get_masked_secret_key(),
+					'session_id'     => $session_id,
+					'request'        => $params,
+				]
+			);
+
+			$session = self::get_sdk()->checkout->sessions->update( $session_id, $params );
+
+			WC_Stripe_Logger::debug(
+				'Stripe SDK response: update checkout session',
+				[
+					'stripe_api_key' => self::get_masked_secret_key(),
+					'session_id'     => $session->id,
+				]
+			);
+
+			return $session;
+		} catch ( \Stripe\Exception\ApiErrorException $e ) {
+			WC_Stripe_Logger::error(
+				'Stripe SDK error: update checkout session',
+				[
+					'stripe_api_key' => self::get_masked_secret_key(),
+					'session_id'     => $session_id,
+					'error_message'  => $e->getMessage(),
+				]
+			);
+			throw new WC_Stripe_Exception( $e->getMessage(), $e->getMessage() );
+		}
 	}
 }

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1423,10 +1423,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_checkout_session_metadata( string $checkout_session_id, array $metadata ): void {
 		try {
-			$response = WC_Stripe_API::request( [ 'metadata' => $metadata ], 'checkout/sessions/' . $checkout_session_id, 'POST' );
-			if ( ! empty( $response->error->message ) ) {
-				throw new WC_Stripe_Exception( $response->error->message );
-			}
+			WC_Stripe_API::update_checkout_session( $checkout_session_id, [ 'metadata' => $metadata ] );
 		} catch ( Exception $e ) {
 			WC_Stripe_Logger::error( 'Failed to update checkout session metadata: ' . $e->getMessage() );
 
@@ -2124,118 +2121,82 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			]
 		);
 
-		// Temporarily override the API version to get the right fields.
-		$override_version = function ( $headers ) {
-			$headers['Stripe-Version'] = WC_Stripe_API::AGENTIC_COMMERCE_API_VERSION;
-			return $headers;
-		};
-		add_filter( 'wc_stripe_request_headers', $override_version );
+		try {
+			$expand      = array_merge( [ 'payment_intent.agent_details' ], WC_Stripe_Agentic_Checkout_Session::get_fields_to_expand() );
+			$raw_session = WC_Stripe_API::retrieve_checkout_session(
+				$notification->data->object->id,
+				[ 'expand' => $expand ],
+				[ 'stripe_version' => WC_Stripe_API::AGENTIC_COMMERCE_API_VERSION ]
+			);
+		} catch ( WC_Stripe_Exception $e ) {
+			WC_Stripe_Logger::error(
+				'Failed to retrieve checkout session with expand params.',
+				[
+					'session_id' => $notification->data->object->id,
+					'error'      => $e->getMessage(),
+				]
+			);
+			return;
+		}
+
+		$session = new WC_Stripe_Agentic_Checkout_Session( $raw_session );
+
+		if ( ! $session->is_agentic() ) {
+			WC_Stripe_Logger::info(
+				'Checkout session is not agentic, skipping agentic processing: ' . $session->get_id()
+			);
+			return;
+		}
+
+		$payment_intent_id = $session->get_payment_intent_id();
+		if ( null === $payment_intent_id || empty( $payment_intent_id ) ) {
+			WC_Stripe_Logger::error(
+				'Checkout session is missing the payment intent id.',
+				[
+					'session_id' => $session->get_id(),
+				]
+			);
+			return;
+		}
 
 		try {
-			$url         = $this->build_checkout_session_retrieve_url(
-				$notification->data->object->id,
-				WC_Stripe_Agentic_Checkout_Session::get_fields_to_expand()
+			$order_mapper         = new WC_Stripe_Agentic_Commerce_Order_Mapper();
+			$order                = $order_mapper->create_order_from_checkout_session( $session );
+			$this->resolved_order = $order;
+
+			WC_Stripe_Logger::info(
+				'Agentic order created from checkout session.',
+				[
+					'session_id' => $session->get_id(),
+					'order_id'   => $order->get_id(),
+				]
 			);
-			$raw_session = WC_Stripe_API::retrieve( $url );
 
-			if ( is_wp_error( $raw_session ) || ! is_object( $raw_session ) ) {
-				WC_Stripe_Logger::error(
-					'Failed to retrieve checkout session with expand params.',
-					[
-						'url'   => $url,
-						'error' => is_wp_error( $raw_session ) ? $raw_session->get_error_message() : 'Unexpected response from Stripe API.',
-					]
-				);
-				return;
-			}
+			/**
+			 * Fires after an agentic commerce order is created from a checkout session.
+			 *
+			 * @since 10.6.0
+			 * @param WC_Order                           $order   The created order.
+			 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
+			 */
+			do_action( 'wc_stripe_agentic_order_created', $order, $session );
+		} catch ( Exception $e ) {
+			WC_Stripe_Logger::error(
+				'Failed to create agentic order from checkout session.',
+				[
+					'session_id' => $session->get_id(),
+					'error'      => $e->getMessage(),
+				]
+			);
 
-			assert( $raw_session instanceof stdClass );
-			$session = new WC_Stripe_Agentic_Checkout_Session( $raw_session );
-
-			if ( ! $session->is_agentic() ) {
-				WC_Stripe_Logger::info(
-					'Checkout session is not agentic, skipping agentic processing: ' . $session->get_id()
-				);
-				return;
-			}
-
-			$payment_intent_id = $session->get_payment_intent_id();
-			if ( null === $payment_intent_id || empty( $payment_intent_id ) ) {
-				WC_Stripe_Logger::error(
-					'Checkout session is missing the payment intent id.',
-					[
-						'session_id' => $session->get_id(),
-					]
-				);
-				return;
-			}
-
-			try {
-				$order_mapper         = new WC_Stripe_Agentic_Commerce_Order_Mapper();
-				$order                = $order_mapper->create_order_from_checkout_session( $session );
-				$this->resolved_order = $order;
-
-				WC_Stripe_Logger::info(
-					'Agentic order created from checkout session.',
-					[
-						'session_id' => $session->get_id(),
-						'order_id'   => $order->get_id(),
-					]
-				);
-
-				/**
-				 * Fires after an agentic commerce order is created from a checkout session.
-				 *
-				 * @since 10.6.0
-				 * @param WC_Order                           $order   The created order.
-				 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
-				 */
-				do_action( 'wc_stripe_agentic_order_created', $order, $session );
-			} catch ( Exception $e ) {
-				WC_Stripe_Logger::error(
-					'Failed to create agentic order from checkout session.',
-					[
-						'session_id' => $session->get_id(),
-						'error'      => $e->getMessage(),
-					]
-				);
-
-				/**
-				 * Fires when agentic commerce order creation fails.
-				 *
-				 * @since 10.6.0
-				 * @param Exception                          $e       The exception that was thrown.
-				 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
-				 */
-				do_action( 'wc_stripe_agentic_order_creation_failed', $e, $session );
-			}
-		} finally {
-			remove_filter( 'wc_stripe_request_headers', $override_version );
+			/**
+			 * Fires when agentic commerce order creation fails.
+			 *
+			 * @since 10.6.0
+			 * @param Exception                          $e       The exception that was thrown.
+			 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
+			 */
+			do_action( 'wc_stripe_agentic_order_creation_failed', $e, $session );
 		}
-	}
-
-	/**
-	 * Builds the Stripe API URL for retrieving a checkout session with expanded fields.
-	 *
-	 * Expands the payment intent's agent_details (to detect agentic sessions)
-	 * and any additional fields required by the checkout session wrapper.
-	 *
-	 * @since 10.6.0
-	 * @param string   $session_id       The Stripe checkout session ID.
-	 * @param string[] $additional_expand Additional fields to expand beyond payment_intent.agent_details.
-	 * @return string The API URL with expand query parameters.
-	 *
-	 * @see https://docs.stripe.com/agentic-commerce/enable-in-context-selling-on-ai-agents?order-monitoring=webhooks#checkout-session-field-reference
-	 */
-	private function build_checkout_session_retrieve_url( string $session_id, array $additional_expand = [] ): string {
-		$url    = 'checkout/sessions/' . rawurlencode( $session_id );
-		$expand = array_merge( [ 'payment_intent.agent_details' ], $additional_expand );
-
-		$params = [];
-		foreach ( $expand as $field ) {
-			$params[] = 'expand[]=' . rawurlencode( $field );
-		}
-
-		return $url . '?' . implode( '&', $params );
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -4448,7 +4448,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		$checkout_session = WC_Stripe_Database_Cache::get( $cache_key );
 		if ( ! $checkout_session ) {
 			try {
-				$checkout_session = WC_Stripe_API::retrieve_checkout_session( $checkout_session_id );
+				$sdk_session = WC_Stripe_API::retrieve_checkout_session( $checkout_session_id );
 			} catch ( WC_Stripe_Exception $e ) {
 				WC_Stripe_Logger::error(
 					'Exception fetching checkout session for order.',
@@ -4459,6 +4459,16 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 					]
 				);
 
+				return null;
+			}
+
+			// Sanitize the SDK object before caching: \Stripe\StripeObject carries a protected
+			// `_opts` property (RequestOptions) that includes the raw API key, which would be
+			// persisted by update_option()'s serialization. Convert to a plain stdClass so only
+			// public JSON-visible data is stored.
+			$json             = wp_json_encode( $sdk_session );
+			$checkout_session = false === $json ? null : json_decode( $json );
+			if ( null === $checkout_session ) {
 				return null;
 			}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -4448,7 +4448,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		$checkout_session = WC_Stripe_Database_Cache::get( $cache_key );
 		if ( ! $checkout_session ) {
 			try {
-				$checkout_session = $this->stripe_request( 'checkout/sessions/' . $checkout_session_id, [], null, 'GET' );
+				$checkout_session = WC_Stripe_API::retrieve_checkout_session( $checkout_session_id );
 			} catch ( WC_Stripe_Exception $e ) {
 				WC_Stripe_Logger::error(
 					'Exception fetching checkout session for order.',
@@ -4456,19 +4456,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 						'order_id'            => $order->get_id(),
 						'checkout_session_id' => $checkout_session_id,
 						'error_message'       => $e->getMessage(),
-					]
-				);
-
-				return null;
-			}
-
-			if ( ! empty( $checkout_session->error ) ) {
-				WC_Stripe_Logger::error(
-					'Error fetching checkout session for order.',
-					[
-						'order_id'            => $order->get_id(),
-						'checkout_session_id' => $checkout_session_id,
-						'error_message'       => $checkout_session->error->message,
 					]
 				);
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3153,7 +3153,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property object\:\:\$data\.$#'
 			identifier: property.notFound
-			count: 45
+			count: 46
 			path: includes/class-wc-stripe-webhook-handler.php
 
 		-

--- a/readme.txt
+++ b/readme.txt
@@ -146,6 +146,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.6.0 - xxxx-xx-xx =
+* Dev - Add Stripe PHP SDK and migrate Checkout Session API calls to typed DTOs
 * Add - Add exit survey to capture merchant feedback on plugin deactivation and gateway disablement
 * Update - Defer checkout sessions webhook processing via Action Scheduler to prevent race conditions when webhook events arrive before order metadata is stored
 * Fix - Hide duplicate store-level save checkbox when Stripe Link is enabled on checkout

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-checkout-session-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-checkout-session-test.php
@@ -658,4 +658,30 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 		$this->assertNull( $address->get_line1() );
 		$this->assertNull( $address->get_line2() );
 	}
+
+	/**
+	 * The constructor accepts a stdClass payload (e.g. from webhook json_decode).
+	 */
+	public function test_constructor_accepts_stdclass() {
+		$session = new WC_Stripe_Agentic_Checkout_Session( (object) [ 'id' => 'cs_test_stdclass' ] );
+		$this->assertSame( 'cs_test_stdclass', $session->get_id() );
+	}
+
+	/**
+	 * The constructor accepts a Stripe\StripeObject (e.g. from the SDK).
+	 */
+	public function test_constructor_accepts_stripe_object() {
+		$session = new WC_Stripe_Agentic_Checkout_Session(
+			\Stripe\Checkout\Session::constructFrom( [ 'id' => 'cs_test_sdk' ] )
+		);
+		$this->assertSame( 'cs_test_sdk', $session->get_id() );
+	}
+
+	/**
+	 * The constructor fails fast when given an unrelated object type.
+	 */
+	public function test_constructor_rejects_other_object_types() {
+		$this->expectException( \InvalidArgumentException::class );
+		new WC_Stripe_Agentic_Checkout_Session( new \ArrayObject( [ 'id' => 'cs_bad' ] ) );
+	}
 }

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -73,3 +73,4 @@ require_once __DIR__ . '/helpers/class-ajax-test-helper.php';
 require_once __DIR__ . '/helpers/class-oc-test-helper.php';
 require_once __DIR__ . '/helpers/class-pmc-test-helper.php';
 require_once __DIR__ . '/helpers/class-upe-test-helper.php';
+require_once __DIR__ . '/helpers/class-wc-stripe-sdk-test-helper.php';

--- a/tests/phpunit/class-wc-stripe-api-sdk-test.php
+++ b/tests/phpunit/class-wc-stripe-api-sdk-test.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * Tests for the Stripe SDK integration in WC_Stripe_API.
+ *
+ * @package WooCommerce\Tests
+ */
+class WC_Stripe_API_SDK_Test extends WP_UnitTestCase {
+
+	/**
+	 * Original SDK instance to restore after each test.
+	 *
+	 * @var \Stripe\StripeClient|null
+	 */
+	private $original_sdk = null;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		// Store original and set a test secret key so SDK methods don't fail.
+		update_option(
+			'woocommerce_stripe_settings',
+			[
+				'enabled'         => 'yes',
+				'testmode'        => 'yes',
+				'test_secret_key' => 'sk_test_mock_key',
+			]
+		);
+		WC_Stripe_API::set_secret_key( 'sk_test_mock_key' );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down(): void {
+		// Clear any injected mock SDK.
+		WC_Stripe_API::set_sdk_for_testing( null );
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that get_sdk() returns a StripeClient instance.
+	 */
+	public function test_get_sdk_returns_stripe_client(): void {
+		$sdk = WC_Stripe_API::get_sdk();
+		$this->assertInstanceOf( \Stripe\StripeClient::class, $sdk );
+	}
+
+	/**
+	 * Tests that get_sdk() returns the same instance on repeated calls.
+	 */
+	public function test_get_sdk_returns_cached_instance(): void {
+		$sdk1 = WC_Stripe_API::get_sdk();
+		$sdk2 = WC_Stripe_API::get_sdk();
+		$this->assertSame( $sdk1, $sdk2 );
+	}
+
+	/**
+	 * Tests that get_sdk() creates a new instance when the secret key changes.
+	 */
+	public function test_get_sdk_invalidates_on_key_change(): void {
+		$sdk1 = WC_Stripe_API::get_sdk();
+
+		WC_Stripe_API::set_secret_key( 'sk_test_different_key' );
+		$sdk2 = WC_Stripe_API::get_sdk();
+
+		$this->assertNotSame( $sdk1, $sdk2 );
+	}
+
+	/**
+	 * Tests that set_sdk_for_testing() injects a mock client.
+	 */
+	public function test_set_sdk_for_testing_injects_client(): void {
+		$mock = $this->createMock( \Stripe\StripeClient::class );
+		WC_Stripe_API::set_sdk_for_testing( $mock );
+
+		$this->assertSame( $mock, WC_Stripe_API::get_sdk() );
+	}
+
+	/**
+	 * Tests that create_checkout_session returns a Session DTO.
+	 */
+	public function test_create_checkout_session_success(): void {
+		$expected = WC_Stripe_SDK_Test_Helper::create_checkout_session_object(
+			[
+				'id'            => 'cs_test_create_success',
+				'client_secret' => 'cs_secret_test_create_success',
+			]
+		);
+
+		$mock_sdk = WC_Stripe_SDK_Test_Helper::create_mock_sdk(
+			$this,
+			[ 'create_response' => $expected ]
+		);
+		WC_Stripe_API::set_sdk_for_testing( $mock_sdk );
+
+		$result = WC_Stripe_API::create_checkout_session(
+			[
+				'mode'       => 'payment',
+				'ui_mode'    => 'custom',
+				'line_items' => [
+					[
+						'price_data' => [
+							'currency'     => 'usd',
+							'product_data' => [ 'name' => 'Test' ],
+							'unit_amount'  => 1000,
+						],
+						'quantity'   => 1,
+					],
+				],
+			]
+		);
+
+		$this->assertInstanceOf( \Stripe\Checkout\Session::class, $result );
+		$this->assertSame( 'cs_test_create_success', $result->id );
+		$this->assertSame( 'cs_secret_test_create_success', $result->client_secret );
+	}
+
+	/**
+	 * Tests that create_checkout_session throws WC_Stripe_Exception on API error.
+	 */
+	public function test_create_checkout_session_api_error(): void {
+		$api_error = \Stripe\Exception\InvalidRequestException::factory(
+			'Invalid params',
+			400,
+			null,
+			null,
+			null,
+			'invalid_request_error'
+		);
+
+		$mock_sdk = WC_Stripe_SDK_Test_Helper::create_mock_sdk(
+			$this,
+			[ 'create_exception' => $api_error ]
+		);
+		WC_Stripe_API::set_sdk_for_testing( $mock_sdk );
+
+		$this->expectException( WC_Stripe_Exception::class );
+		$this->expectExceptionMessage( 'Invalid params' );
+
+		WC_Stripe_API::create_checkout_session( [ 'mode' => 'payment' ] );
+	}
+
+	/**
+	 * Tests that retrieve_checkout_session returns a Session DTO.
+	 */
+	public function test_retrieve_checkout_session_success(): void {
+		$expected = WC_Stripe_SDK_Test_Helper::create_checkout_session_object(
+			[
+				'id'     => 'cs_test_retrieve_success',
+				'status' => 'complete',
+			]
+		);
+
+		$mock_sdk = WC_Stripe_SDK_Test_Helper::create_mock_sdk(
+			$this,
+			[ 'retrieve_response' => $expected ]
+		);
+		WC_Stripe_API::set_sdk_for_testing( $mock_sdk );
+
+		$result = WC_Stripe_API::retrieve_checkout_session( 'cs_test_retrieve_success' );
+
+		$this->assertInstanceOf( \Stripe\Checkout\Session::class, $result );
+		$this->assertSame( 'cs_test_retrieve_success', $result->id );
+		$this->assertSame( 'complete', $result->status );
+	}
+
+	/**
+	 * Tests that retrieve_checkout_session throws WC_Stripe_Exception on API error.
+	 */
+	public function test_retrieve_checkout_session_api_error(): void {
+		$api_error = \Stripe\Exception\InvalidRequestException::factory(
+			'No such checkout session',
+			404,
+			null,
+			null,
+			null,
+			'resource_missing'
+		);
+
+		$mock_sdk = WC_Stripe_SDK_Test_Helper::create_mock_sdk(
+			$this,
+			[ 'retrieve_exception' => $api_error ]
+		);
+		WC_Stripe_API::set_sdk_for_testing( $mock_sdk );
+
+		$this->expectException( WC_Stripe_Exception::class );
+		$this->expectExceptionMessage( 'No such checkout session' );
+
+		WC_Stripe_API::retrieve_checkout_session( 'cs_test_nonexistent' );
+	}
+
+	/**
+	 * Tests that update_checkout_session returns a Session DTO.
+	 */
+	public function test_update_checkout_session_success(): void {
+		$expected = WC_Stripe_SDK_Test_Helper::create_checkout_session_object(
+			[ 'id' => 'cs_test_update_success' ]
+		);
+
+		$mock_sdk = WC_Stripe_SDK_Test_Helper::create_mock_sdk(
+			$this,
+			[ 'update_response' => $expected ]
+		);
+		WC_Stripe_API::set_sdk_for_testing( $mock_sdk );
+
+		$result = WC_Stripe_API::update_checkout_session(
+			'cs_test_update_success',
+			[ 'metadata' => [ 'order_id' => '123' ] ]
+		);
+
+		$this->assertInstanceOf( \Stripe\Checkout\Session::class, $result );
+		$this->assertSame( 'cs_test_update_success', $result->id );
+	}
+
+	/**
+	 * Tests that update_checkout_session throws WC_Stripe_Exception on API error.
+	 */
+	public function test_update_checkout_session_api_error(): void {
+		$api_error = \Stripe\Exception\InvalidRequestException::factory(
+			'Session already expired',
+			400,
+			null,
+			null,
+			null,
+			'invalid_request_error'
+		);
+
+		$mock_sdk = WC_Stripe_SDK_Test_Helper::create_mock_sdk(
+			$this,
+			[ 'update_exception' => $api_error ]
+		);
+		WC_Stripe_API::set_sdk_for_testing( $mock_sdk );
+
+		$this->expectException( WC_Stripe_Exception::class );
+		$this->expectExceptionMessage( 'Session already expired' );
+
+		WC_Stripe_API::update_checkout_session(
+			'cs_test_expired',
+			[ 'metadata' => [ 'order_id' => '456' ] ]
+		);
+	}
+}

--- a/tests/phpunit/class-wc-stripe-api-sdk-test.php
+++ b/tests/phpunit/class-wc-stripe-api-sdk-test.php
@@ -19,7 +19,7 @@ class WC_Stripe_API_SDK_Test extends WP_UnitTestCase {
 	public function set_up(): void {
 		parent::set_up();
 
-		// Store original and set a test secret key so SDK methods don't fail.
+		// Set a test secret key so SDK methods don't fail.
 		update_option(
 			'woocommerce_stripe_settings',
 			[
@@ -29,14 +29,18 @@ class WC_Stripe_API_SDK_Test extends WP_UnitTestCase {
 			]
 		);
 		WC_Stripe_API::set_secret_key( 'sk_test_mock_key' );
+
+		// Ensure backoff counter from other test suites doesn't leak into these tests.
+		WC_Stripe_Database_Cache::delete( WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY );
 	}
 
 	/**
 	 * Tear down test fixtures.
 	 */
 	public function tear_down(): void {
-		// Clear any injected mock SDK.
+		// Clear any injected mock SDK and reset backoff state.
 		WC_Stripe_API::set_sdk_for_testing( null );
+		WC_Stripe_Database_Cache::delete( WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY );
 		parent::tear_down();
 	}
 
@@ -241,5 +245,117 @@ class WC_Stripe_API_SDK_Test extends WP_UnitTestCase {
 			'cs_test_expired',
 			[ 'metadata' => [ 'order_id' => '456' ] ]
 		);
+	}
+
+	/**
+	 * The wc_stripe_request_body filter runs on create_checkout_session.
+	 */
+	public function test_create_checkout_session_applies_request_body_filter(): void {
+		$captured_params = null;
+		$session_service = $this->getMockBuilder( \Stripe\Service\Checkout\SessionService::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'create' ] )
+			->getMock();
+		$session_service->method( 'create' )->willReturnCallback(
+			// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+			function ( $params, $opts ) use ( &$captured_params ) {
+				$captured_params = $params;
+				return WC_Stripe_SDK_Test_Helper::create_checkout_session_object( [ 'id' => 'cs_test_filter' ] );
+			}
+		);
+		$checkout           = new stdClass();
+		$checkout->sessions = $session_service;
+		$mock_sdk           = $this->getMockBuilder( \Stripe\StripeClient::class )->disableOriginalConstructor()->getMock();
+		$mock_sdk->checkout = $checkout;
+		WC_Stripe_API::set_sdk_for_testing( $mock_sdk );
+
+		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$callback = function ( $body, $api ) {
+			$body['metadata']['injected_by_filter'] = 'yes';
+			return $body;
+		};
+		add_filter( 'wc_stripe_request_body', $callback, 10, 2 );
+		try {
+			WC_Stripe_API::create_checkout_session(
+				[
+					'mode'     => 'payment',
+					'metadata' => [],
+				]
+			);
+		} finally {
+			remove_filter( 'wc_stripe_request_body', $callback, 10 );
+		}
+
+		$this->assertSame( 'yes', $captured_params['metadata']['injected_by_filter'] ?? null );
+	}
+
+	/**
+	 * retrieve_checkout_session throws immediately when the backoff threshold is reached.
+	 */
+	public function test_retrieve_checkout_session_throws_when_backoff_active(): void {
+		WC_Stripe_Database_Cache::set(
+			WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY,
+			10,
+			HOUR_IN_SECONDS
+		);
+
+		$this->expectException( WC_Stripe_Exception::class );
+		try {
+			WC_Stripe_API::retrieve_checkout_session( 'cs_should_not_be_called' );
+		} finally {
+			WC_Stripe_Database_Cache::delete( WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY );
+		}
+	}
+
+	/**
+	 * A successful retrieve clears any lingering invalid-API-key counter.
+	 */
+	public function test_retrieve_checkout_session_clears_backoff_on_success(): void {
+		WC_Stripe_Database_Cache::set(
+			WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY,
+			2,
+			HOUR_IN_SECONDS
+		);
+
+		$mock_sdk = WC_Stripe_SDK_Test_Helper::create_mock_sdk(
+			$this,
+			[ 'retrieve_response' => WC_Stripe_SDK_Test_Helper::create_checkout_session_object( [ 'id' => 'cs_ok' ] ) ]
+		);
+		WC_Stripe_API::set_sdk_for_testing( $mock_sdk );
+
+		WC_Stripe_API::retrieve_checkout_session( 'cs_ok' );
+
+		$this->assertNull(
+			WC_Stripe_Database_Cache::get( WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY )
+		);
+	}
+
+	/**
+	 * A 401 from retrieve increments the invalid-API-key counter.
+	 */
+	public function test_retrieve_checkout_session_increments_counter_on_auth_error(): void {
+		$auth_error = \Stripe\Exception\AuthenticationException::factory(
+			'Invalid API Key',
+			401,
+			null,
+			null,
+			null,
+			'invalid_api_key'
+		);
+		$mock_sdk   = WC_Stripe_SDK_Test_Helper::create_mock_sdk(
+			$this,
+			[ 'retrieve_exception' => $auth_error ]
+		);
+		WC_Stripe_API::set_sdk_for_testing( $mock_sdk );
+
+		try {
+			WC_Stripe_API::retrieve_checkout_session( 'cs_test_bad_key' );
+			$this->fail( 'Expected WC_Stripe_Exception' );
+		} catch ( WC_Stripe_Exception $e ) {
+			$this->assertSame(
+				1,
+				(int) WC_Stripe_Database_Cache::get( WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY )
+			);
+		}
 	}
 }

--- a/tests/phpunit/class-wc-stripe-checkout-sessions-ajax-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-checkout-sessions-ajax-handler-test.php
@@ -68,9 +68,8 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler_Test extends WP_UnitTestCase {
 			WC()->cart->add_to_cart( $product->get_id(), 1 );
 		}
 
-		// Mock response from Stripe API.
-		$test_request = function ( $return_value, $parsed_args, $url ) use ( $checkout_session_response ) {
-			// Mock the customer retrieval response.
+		// Mock customer API responses (still uses raw HTTP).
+		$test_request = function ( $return_value, $parsed_args, $url ) {
 			if ( strpos( $url, '/v1/customers' ) !== false ) {
 				return [
 					'response' => 200,
@@ -78,19 +77,35 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler_Test extends WP_UnitTestCase {
 					'body'     => json_encode( (object) [ 'id' => 'cus_123' ] ),
 				];
 			}
-
-			if ( 'https://api.stripe.com/v1/checkout/sessions' === $url ) {
-				return [
-					'response' => 200,
-					'headers'  => [ 'Content-Type' => 'application/json' ],
-					'body'     => json_encode( $checkout_session_response ),
-				];
-			}
-
 			return $return_value;
 		};
-
 		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		// Mock checkout session SDK responses.
+		if ( null !== $checkout_session_response ) {
+			if ( ! empty( $checkout_session_response->error ) ) {
+				$mock_sdk = WC_Stripe_SDK_Test_Helper::create_mock_sdk(
+					$this,
+					[
+						'create_exception' => \Stripe\Exception\InvalidRequestException::factory(
+							$checkout_session_response->error->message,
+							400
+						),
+					]
+				);
+			} else {
+				// Use constructFrom directly (no defaults) so tests for missing fields work correctly.
+				$session_data           = (array) $checkout_session_response;
+				$session_data['object'] = 'checkout.session';
+				$mock_sdk               = WC_Stripe_SDK_Test_Helper::create_mock_sdk(
+					$this,
+					[
+						'create_response' => \Stripe\Checkout\Session::constructFrom( $session_data ),
+					]
+				);
+			}
+			WC_Stripe_API::set_sdk_for_testing( $mock_sdk );
+		}
 
 		// Set up the AJAX request nonce.
 		$_REQUEST['_ajax_nonce'] = $is_valid_nonce ? wp_create_nonce( 'wc_stripe_create_checkout_session_nonce' ) : 'invalid_nonce_value';
@@ -107,6 +122,7 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler_Test extends WP_UnitTestCase {
 		} finally {
 			// Clean up.
 			remove_filter( 'pre_http_request', $test_request, 10, 3 );
+			WC_Stripe_API::set_sdk_for_testing( null );
 			Ajax_Test_Helper::remove_hooks();
 		}
 
@@ -143,15 +159,35 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler_Test extends WP_UnitTestCase {
 		$product->save();
 		WC()->cart->add_to_cart( $product->get_id(), 2 );
 
+		// Capture the params passed to the SDK's create() method.
 		$captured_request = null;
-		$capture_body     = static function ( $request, $api ) use ( &$captured_request ) {
-			if ( 'checkout/sessions' === $api ) {
-				$captured_request = $request;
-			}
-			return $request;
-		};
-		add_filter( 'wc_stripe_request_body', $capture_body, 10, 2 );
+		$session_service  = $this->getMockBuilder( \Stripe\Service\Checkout\SessionService::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'create' ] )
+			->getMock();
 
+		$session_service->method( 'create' )
+			->willReturnCallback(
+				function ( $params ) use ( &$captured_request ) {
+					$captured_request = $params;
+					return WC_Stripe_SDK_Test_Helper::create_checkout_session_object(
+						[
+							'id'            => 'cs_test_line_item',
+							'client_secret' => 'cs_secret_test_line_item',
+						]
+					);
+				}
+			);
+
+		$checkout_service           = new stdClass();
+		$checkout_service->sessions = $session_service;
+
+		$mock_client           = $this->createMock( \Stripe\StripeClient::class );
+		$mock_client->checkout = $checkout_service;
+
+		WC_Stripe_API::set_sdk_for_testing( $mock_client );
+
+		// Mock customer API responses (still uses raw HTTP).
 		$test_request = static function ( $return_value, $parsed_args, $url ) {
 			if ( strpos( $url, '/v1/customers' ) !== false ) {
 				return [
@@ -160,18 +196,8 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler_Test extends WP_UnitTestCase {
 					'body'     => wp_json_encode( (object) [ 'id' => 'cus_123' ] ),
 				];
 			}
-
-			if ( 'https://api.stripe.com/v1/checkout/sessions' === $url ) {
-				return [
-					'response' => 200,
-					'headers'  => [ 'Content-Type' => 'application/json' ],
-					'body'     => wp_json_encode( (object) [ 'client_secret' => 'cs_test_secret' ] ),
-				];
-			}
-
 			return $return_value;
 		};
-
 		add_filter( 'pre_http_request', $test_request, 10, 3 );
 
 		$_REQUEST['_ajax_nonce'] = wp_create_nonce( 'wc_stripe_create_checkout_session_nonce' );
@@ -184,7 +210,7 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler_Test extends WP_UnitTestCase {
 			ob_end_clean();
 		} finally {
 			remove_filter( 'pre_http_request', $test_request, 10, 3 );
-			remove_filter( 'wc_stripe_request_body', $capture_body, 10, 2 );
+			WC_Stripe_API::set_sdk_for_testing( null );
 			Ajax_Test_Helper::remove_hooks();
 		}
 
@@ -228,21 +254,29 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler_Test extends WP_UnitTestCase {
 		$product->save();
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
 
-		$test_request = null;
+		// Mock checkout session SDK responses.
 		if ( null !== $checkout_session_response ) {
-			$test_request = function ( $return_value, $parsed_args, $url ) use ( $checkout_session_id, $checkout_session_response ) {
-				$expected_path = 'checkout/sessions/' . $checkout_session_id;
-				if ( is_string( $url ) && strpos( $url, $expected_path ) !== false ) {
-					return [
-						'response' => 200,
-						'headers'  => [ 'Content-Type' => 'application/json' ],
-						'body'     => wp_json_encode( $checkout_session_response ),
-					];
-				}
-
-				return $return_value;
-			};
-			add_filter( 'pre_http_request', $test_request, 10, 3 );
+			if ( ! empty( $checkout_session_response->error ) ) {
+				$mock_sdk = WC_Stripe_SDK_Test_Helper::create_mock_sdk(
+					$this,
+					[
+						'update_exception' => \Stripe\Exception\InvalidRequestException::factory(
+							$checkout_session_response->error->message,
+							400
+						),
+					]
+				);
+			} else {
+				$mock_sdk = WC_Stripe_SDK_Test_Helper::create_mock_sdk(
+					$this,
+					[
+						'update_response' => WC_Stripe_SDK_Test_Helper::create_checkout_session_object(
+							(array) $checkout_session_response
+						),
+					]
+				);
+			}
+			WC_Stripe_API::set_sdk_for_testing( $mock_sdk );
 		}
 
 		$_REQUEST['_ajax_nonce'] = $is_valid_nonce ? wp_create_nonce( 'wc_stripe_update_checkout_session_nonce' ) : 'invalid_nonce_value';
@@ -264,9 +298,7 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler_Test extends WP_UnitTestCase {
 			throw $e;
 		} finally {
 			$_POST = $post_before;
-			if ( null !== $test_request ) {
-				remove_filter( 'pre_http_request', $test_request, 10, 3 );
-			}
+			WC_Stripe_API::set_sdk_for_testing( null );
 			Ajax_Test_Helper::remove_hooks();
 		}
 
@@ -395,33 +427,41 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler_Test extends WP_UnitTestCase {
 		$product->save();
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
 
+		// Capture the params passed to the SDK's create() method.
 		$captured_request = null;
-		$capture_body     = static function ( $request, $api ) use ( &$captured_request ) {
-			if ( 'checkout/sessions' === $api ) {
-				$captured_request = $request;
-			}
-			return $request;
-		};
-		add_filter( 'wc_stripe_request_body', $capture_body, 10, 2 );
+		$session_service  = $this->getMockBuilder( \Stripe\Service\Checkout\SessionService::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'create' ] )
+			->getMock();
 
+		$session_service->method( 'create' )
+			->willReturnCallback(
+				function ( $params ) use ( &$captured_request ) {
+					$captured_request = $params;
+					return WC_Stripe_SDK_Test_Helper::create_checkout_session_object(
+						[
+							'id'            => 'cs_test_phone',
+							'client_secret' => 'cs_secret_test_phone',
+						]
+					);
+				}
+			);
+
+		$checkout_service           = new stdClass();
+		$checkout_service->sessions = $session_service;
+
+		$mock_client           = $this->createMock( \Stripe\StripeClient::class );
+		$mock_client->checkout = $checkout_service;
+
+		WC_Stripe_API::set_sdk_for_testing( $mock_client );
+
+		// Mock customer API responses (still uses raw HTTP).
 		$test_request = static function ( $return_value, $parsed_args, $url ) {
 			if ( strpos( $url, '/v1/customers' ) !== false ) {
 				return [
 					'response' => 200,
 					'headers'  => [ 'Content-Type' => 'application/json' ],
 					'body'     => wp_json_encode( (object) [ 'id' => 'cus_123' ] ),
-				];
-			}
-			if ( 'https://api.stripe.com/v1/checkout/sessions' === $url ) {
-				return [
-					'response' => 200,
-					'headers'  => [ 'Content-Type' => 'application/json' ],
-					'body'     => wp_json_encode(
-						(object) [
-							'client_secret' => 'cs_test_secret',
-							'id'            => 'cs_test_123',
-						]
-					),
 				];
 			}
 			return $return_value;
@@ -438,7 +478,7 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler_Test extends WP_UnitTestCase {
 			ob_end_clean();
 		} finally {
 			remove_filter( 'pre_http_request', $test_request, 10, 3 );
-			remove_filter( 'wc_stripe_request_body', $capture_body, 10, 2 );
+			WC_Stripe_API::set_sdk_for_testing( null );
 			delete_option( 'woocommerce_checkout_phone_field' );
 			Ajax_Test_Helper::remove_hooks();
 		}

--- a/tests/phpunit/class-wc-stripe-webhook-handler-agentic-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-agentic-test.php
@@ -13,32 +13,23 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 	private $handler;
 
 	/**
-	 * @var callable|null HTTP mock filter callback to remove in tear_down.
-	 */
-	private $http_filter;
-
-	/**
 	 * Set up the test.
 	 */
 	public function set_up() {
 		parent::set_up();
-		$this->handler     = new WC_Stripe_Webhook_Handler();
-		$this->http_filter = null;
+		$this->handler = new WC_Stripe_Webhook_Handler();
 
-		// Clear any invalid API key cache left by other tests so that
-		// WC_Stripe_API::retrieve() actually fires HTTP requests.
-		WC_Stripe_Database_Cache::delete( WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY );
+		// Ensure SDK test key is set.
+		WC_Stripe_API::set_secret_key( 'sk_test_mock_key' );
 
 		add_filter( 'wc_stripe_is_agentic_commerce_enabled', '__return_true' );
 	}
 
 	/**
-	 * Tear down the test — always remove filters to prevent leaks.
+	 * Tear down the test — always clean up SDK mocks and filters.
 	 */
 	public function tear_down() {
-		if ( null !== $this->http_filter ) {
-			remove_filter( 'pre_http_request', $this->http_filter );
-		}
+		WC_Stripe_API::set_sdk_for_testing( null );
 		remove_filter( 'wc_stripe_is_agentic_commerce_enabled', '__return_true' );
 
 		parent::tear_down();
@@ -281,122 +272,91 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the wc_stripe_request_headers filter is always removed after processing,
-	 * even when an error occurs before order creation.
+	 * Tests that SDK errors are handled gracefully without leaking state.
 	 */
-	public function test_request_headers_filter_is_removed_after_processing_failure() {
-		$this->assertFalse( has_filter( 'wc_stripe_request_headers' ) );
-
-		$session_id   = 'cs_test_filter_cleanup';
+	public function test_sdk_error_does_not_leak_state() {
+		$session_id   = 'cs_test_sdk_cleanup';
 		$notification = $this->build_notification( $session_id );
 		$this->mock_stripe_api_error();
 
 		// Immediate phase: defers the webhook.
 		$this->handler->process_checkout_session_success( $notification );
-		// Deferred phase: API error → filter must still be cleaned up.
+		// Deferred phase: SDK error → no order created, no state leaked.
 		$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
 
-		$this->assertFalse( has_filter( 'wc_stripe_request_headers' ) );
+		$resolved = $this->get_resolved_order( $this->handler );
+		$this->assertNull( $resolved );
 	}
 
 	/**
-	 * Tests that the Stripe API version override header is applied during the retrieve call.
+	 * Tests that the Stripe API version override is passed as an SDK request option.
 	 */
 	public function test_api_version_override_applied() {
-		$captured_headers  = null;
-		$this->http_filter = function ( $preempt, $parsed_args ) use ( &$captured_headers ) {
-			$captured_headers = $parsed_args['headers'] ?? [];
-			return [
-				'response' => 200,
-				'headers'  => [ 'Content-Type' => 'application/json' ],
-				'body'     => wp_json_encode( $this->build_checkout_session_response( 'cs_test_version', true ) ),
-			];
-		};
+		$captured_opts   = null;
+		$session_service = $this->getMockBuilder( \Stripe\Service\Checkout\SessionService::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'retrieve' ] )
+			->getMock();
 
-		add_filter( 'pre_http_request', $this->http_filter, 10, 3 );
+		$mock_response = $this->build_checkout_session_response( 'cs_test_version', true );
+		$session_service->method( 'retrieve' )
+			->willReturnCallback(
+				function ( $id, $params, $opts ) use ( &$captured_opts, $mock_response ) {
+					$captured_opts = $opts;
+					return \Stripe\Checkout\Session::constructFrom( $this->object_to_array( $mock_response ) );
+				}
+			);
+
+		$checkout_service           = new stdClass();
+		$checkout_service->sessions = $session_service;
+		$mock_client                = $this->createMock( \Stripe\StripeClient::class );
+		$mock_client->checkout      = $checkout_service;
+		WC_Stripe_API::set_sdk_for_testing( $mock_client );
 
 		$session_id   = 'cs_test_version';
 		$notification = $this->build_notification( $session_id );
 
 		// Immediate phase: defers the webhook.
 		$this->handler->process_checkout_session_success( $notification );
-		// Deferred phase: API retrieve call must include the Stripe-Version override header.
+		// Deferred phase: API retrieve call must pass stripe_version in opts.
 		$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
 
-		$this->assertNotNull( $captured_headers );
-		$this->assertArrayHasKey( 'Stripe-Version', $captured_headers );
-		$this->assertEquals( WC_Stripe_API::AGENTIC_COMMERCE_API_VERSION, $captured_headers['Stripe-Version'] );
-	}
-
-	/**
-	 * Tests that build_checkout_session_retrieve_url produces correct URLs.
-	 *
-	 * @dataProvider provide_build_url_cases
-	 */
-	public function test_build_checkout_session_retrieve_url( $session_id, $additional_expand, $expected_url ) {
-		$method = new \ReflectionMethod( WC_Stripe_Webhook_Handler::class, 'build_checkout_session_retrieve_url' );
-		$method->setAccessible( true );
-
-		$result = $method->invoke( $this->handler, $session_id, $additional_expand );
-		$this->assertEquals( $expected_url, $result );
-	}
-
-	public function provide_build_url_cases() {
-		return [
-			'default expand only'           => [
-				'cs_123',
-				[],
-				'checkout/sessions/cs_123?expand[]=payment_intent.agent_details',
-			],
-			'with additional expand'        => [
-				'cs_456',
-				[ 'line_items' ],
-				'checkout/sessions/cs_456?expand[]=payment_intent.agent_details&expand[]=line_items',
-			],
-			'session id with special chars' => [
-				'cs_test/special&chars',
-				[],
-				'checkout/sessions/cs_test%2Fspecial%26chars?expand[]=payment_intent.agent_details',
-			],
-		];
+		$this->assertNotNull( $captured_opts );
+		$this->assertArrayHasKey( 'stripe_version', $captured_opts );
+		$this->assertEquals( WC_Stripe_API::AGENTIC_COMMERCE_API_VERSION, $captured_opts['stripe_version'] );
 	}
 
 	// ---- Helpers ----
 
 	/**
-	 * Intercepts HTTP requests to the Stripe checkout sessions API and returns a mock response.
+	 * Injects a mock SDK that returns the given session object on retrieve().
 	 *
-	 * @param object $response_body The mock response body object.
+	 * @param object $response_body The mock response body object (stdClass).
 	 */
 	private function mock_stripe_checkout_sessions_response( $response_body ) {
-		$this->http_filter = function ( $preempt, $args, $url ) use ( $response_body ) {
-			if ( str_starts_with( $url, 'https://api.stripe.com/v1/checkout/sessions/' ) ) {
-				return [
-					'response' => [
-						'code'    => 200,
-						'message' => 'OK',
-					],
-					'body'     => wp_json_encode( $response_body ),
-				];
-			}
-			return $preempt;
-		};
-
-		add_filter( 'pre_http_request', $this->http_filter, 10, 3 );
+		$session_data = $this->object_to_array( $response_body );
+		$mock_sdk     = WC_Stripe_SDK_Test_Helper::create_mock_sdk(
+			$this,
+			[
+				'retrieve_response' => \Stripe\Checkout\Session::constructFrom( $session_data ),
+			]
+		);
+		WC_Stripe_API::set_sdk_for_testing( $mock_sdk );
 	}
 
 	/**
-	 * Intercepts HTTP requests to the Stripe API and returns an error response.
+	 * Injects a mock SDK that throws an API error on retrieve().
 	 */
 	private function mock_stripe_api_error() {
-		$this->http_filter = function ( $preempt, $args, $url ) {
-			if ( false !== strpos( $url, 'api.stripe.com' ) ) {
-				return new \WP_Error( 'http_request_failed', 'Simulated Stripe API failure' );
-			}
-			return $preempt;
-		};
-
-		add_filter( 'pre_http_request', $this->http_filter, 10, 3 );
+		$mock_sdk = WC_Stripe_SDK_Test_Helper::create_mock_sdk(
+			$this,
+			[
+				'retrieve_exception' => \Stripe\Exception\ApiConnectionException::factory(
+					'Simulated Stripe API failure'
+				),
+			]
+		);
+		WC_Stripe_API::set_sdk_for_testing( $mock_sdk );
 	}
 
 	/**
@@ -517,5 +477,21 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 		$prop = new \ReflectionProperty( WC_Stripe_Webhook_Handler::class, 'resolved_order' );
 		$prop->setAccessible( true );
 		return $prop->getValue( $webhook_handler );
+	}
+
+	/**
+	 * Recursively converts an stdClass/object tree to a nested array for Stripe SDK constructFrom().
+	 *
+	 * @param mixed $obj The object or value to convert.
+	 * @return mixed
+	 */
+	private function object_to_array( $obj ) {
+		if ( is_object( $obj ) ) {
+			$obj = (array) $obj;
+		}
+		if ( is_array( $obj ) ) {
+			return array_map( [ $this, 'object_to_array' ], $obj );
+		}
+		return $obj;
 	}
 }

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -1319,35 +1319,40 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			'tax_amount' => 10,
 		];
 
-		$request_captured = false;
-		$pre_http_filter  = function ( $return_value, $parsed_args, $url ) use ( $checkout_session_id, $metadata, &$request_captured ) {
-			$expected_url = WC_Stripe_API::ENDPOINT . 'checkout/sessions/' . $checkout_session_id;
-			if ( $url !== $expected_url ) {
-				return $return_value;
-			}
-			$request_captured = true;
-			$this->assertEquals( 'POST', $parsed_args['method'] );
-			$this->assertEquals( $metadata, $parsed_args['body']['metadata'] );
-			return [
-				'headers'  => [],
-				'body'     => wp_json_encode( [ 'id' => $checkout_session_id ] ),
-				'response' => [
-					'code'    => 200,
-					'message' => 'OK',
-				],
-				'cookies'  => [],
-				'filename' => null,
-			];
-		};
+		// Capture the params passed to the SDK's update() method.
+		$captured_params = null;
+		$session_service = $this->getMockBuilder( \Stripe\Service\Checkout\SessionService::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'update' ] )
+			->getMock();
 
-		add_filter( 'pre_http_request', $pre_http_filter, 10, 3 );
+		$session_service->method( 'update' )
+			->willReturnCallback(
+				function ( $id, $params ) use ( &$captured_params, $checkout_session_id ) {
+					$captured_params = [
+						'id'     => $id,
+						'params' => $params,
+					];
+					return WC_Stripe_SDK_Test_Helper::create_checkout_session_object( [ 'id' => $checkout_session_id ] );
+				}
+			);
 
-		$handler = new WC_Stripe_Webhook_Handler();
-		$handler->process_checkout_session_metadata( $checkout_session_id, $metadata );
+		$checkout_service           = new stdClass();
+		$checkout_service->sessions = $session_service;
+		$mock_client                = $this->createMock( \Stripe\StripeClient::class );
+		$mock_client->checkout      = $checkout_service;
+		WC_Stripe_API::set_sdk_for_testing( $mock_client );
 
-		remove_filter( 'pre_http_request', $pre_http_filter );
+		try {
+			$handler = new WC_Stripe_Webhook_Handler();
+			$handler->process_checkout_session_metadata( $checkout_session_id, $metadata );
+		} finally {
+			WC_Stripe_API::set_sdk_for_testing( null );
+		}
 
-		$this->assertTrue( $request_captured, 'Expected the API request to be made.' );
+		$this->assertNotNull( $captured_params, 'Expected the SDK update() call to be made.' );
+		$this->assertSame( $checkout_session_id, $captured_params['id'] );
+		$this->assertEquals( $metadata, $captured_params['params']['metadata'] );
 	}
 
 	/**
@@ -1364,27 +1369,21 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			'tax_amount' => 10,
 		];
 
-		$error_message   = 'No such checkout session.';
-		$pre_http_filter = function () use ( $error_message ) {
-			return [
-				'headers'  => [],
-				'body'     => wp_json_encode(
-					[
-						'error' => [
-							'message' => $error_message,
-						],
-					]
+		$error_message = 'No such checkout session.';
+		$mock_sdk      = WC_Stripe_SDK_Test_Helper::create_mock_sdk(
+			$this,
+			[
+				'update_exception' => \Stripe\Exception\InvalidRequestException::factory(
+					$error_message,
+					404,
+					null,
+					null,
+					null,
+					'resource_missing'
 				),
-				'response' => [
-					'code'    => 404,
-					'message' => 'Not Found',
-				],
-				'cookies'  => [],
-				'filename' => null,
-			];
-		};
-
-		add_filter( 'pre_http_request', $pre_http_filter, 10, 3 );
+			]
+		);
+		WC_Stripe_API::set_sdk_for_testing( $mock_sdk );
 
 		$handler = new WC_Stripe_Webhook_Handler();
 		$caught  = null;
@@ -1392,9 +1391,9 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			$handler->process_checkout_session_metadata( $checkout_session_id, $metadata );
 		} catch ( Exception $e ) {
 			$caught = $e;
+		} finally {
+			WC_Stripe_API::set_sdk_for_testing( null );
 		}
-
-		remove_filter( 'pre_http_request', $pre_http_filter );
 
 		$this->assertNotNull( $caught, 'Expected an exception to be thrown.' );
 		$this->assertInstanceOf( \WC_Stripe_Exception::class, $caught, 'Expected an instance of WC_Stripe_Exception.' );

--- a/tests/phpunit/helpers/class-wc-stripe-sdk-test-helper.php
+++ b/tests/phpunit/helpers/class-wc-stripe-sdk-test-helper.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Helper class for mocking the Stripe SDK in tests.
+ *
+ * @package WooCommerce\Tests
+ */
+
+/**
+ * Creates a mock StripeClient that returns configurable responses for checkout session operations.
+ */
+class WC_Stripe_SDK_Test_Helper {
+
+	/**
+	 * Create a mock StripeClient with configurable checkout session responses.
+	 *
+	 * @param array $config {
+	 *     @type \Stripe\Checkout\Session|null $create_response   Response for create().
+	 *     @type \Stripe\Checkout\Session|null $retrieve_response Response for retrieve().
+	 *     @type \Stripe\Checkout\Session|null $update_response   Response for update().
+	 *     @type \Stripe\Exception\ApiErrorException|null $create_exception   Exception for create().
+	 *     @type \Stripe\Exception\ApiErrorException|null $retrieve_exception Exception for retrieve().
+	 *     @type \Stripe\Exception\ApiErrorException|null $update_exception   Exception for update().
+	 * }
+	 * @return \Stripe\StripeClient&\PHPUnit\Framework\MockObject\MockObject
+	 */
+	public static function create_mock_sdk( \PHPUnit\Framework\TestCase $test_case, array $config = [] ) {
+		$session_service = $test_case->getMockBuilder( \Stripe\Service\Checkout\SessionService::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'create', 'retrieve', 'update' ] )
+			->getMock();
+
+		if ( isset( $config['create_response'] ) ) {
+			$session_service->method( 'create' )->willReturn( $config['create_response'] );
+		} elseif ( isset( $config['create_exception'] ) ) {
+			$session_service->method( 'create' )->willThrowException( $config['create_exception'] );
+		}
+
+		if ( isset( $config['retrieve_response'] ) ) {
+			$session_service->method( 'retrieve' )->willReturn( $config['retrieve_response'] );
+		} elseif ( isset( $config['retrieve_exception'] ) ) {
+			$session_service->method( 'retrieve' )->willThrowException( $config['retrieve_exception'] );
+		}
+
+		if ( isset( $config['update_response'] ) ) {
+			$session_service->method( 'update' )->willReturn( $config['update_response'] );
+		} elseif ( isset( $config['update_exception'] ) ) {
+			$session_service->method( 'update' )->willThrowException( $config['update_exception'] );
+		}
+
+		$checkout_service           = new stdClass();
+		$checkout_service->sessions = $session_service;
+
+		$mock_client = $test_case->getMockBuilder( \Stripe\StripeClient::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$mock_client->checkout = $checkout_service;
+
+		return $mock_client;
+	}
+
+	/**
+	 * Create a \Stripe\Checkout\Session from an array of properties.
+	 *
+	 * @param array $data Checkout session properties.
+	 * @return \Stripe\Checkout\Session
+	 */
+	public static function create_checkout_session_object( array $data = [] ): \Stripe\Checkout\Session {
+		$defaults = [
+			'id'            => 'cs_test_' . wp_generate_password( 24, false ),
+			'object'        => 'checkout.session',
+			'client_secret' => 'cs_secret_test_' . wp_generate_password( 24, false ),
+			'status'        => 'open',
+			'mode'          => 'payment',
+		];
+
+		return \Stripe\Checkout\Session::constructFrom( array_merge( $defaults, $data ) );
+	}
+}


### PR DESCRIPTION
Fixes STRIPE-957

## Summary

- Adds `stripe/stripe-php ^19.4.0` as a production Composer dependency and introduces a cached `StripeClient` singleton via `WC_Stripe_API::get_sdk()` with automatic invalidation when the secret key changes (e.g. live/test mode switch).
- Migrates all `checkout/sessions` raw HTTP API calls to the official Stripe PHP SDK, returning typed `\Stripe\Checkout\Session` DTOs instead of untyped `stdClass` objects:
  - **Create** — ajax handler session creation
  - **Update** — ajax handler line item updates, webhook metadata updates
  - **Retrieve** — payment gateway order page (with caching), agentic commerce (with API version override and field expansion)
- Replaces the `pre_http_request` filter-based API version override for agentic commerce with the SDK's native `stripe_version` request option, removing the `build_checkout_session_retrieve_url` helper and manual header filter management.
- Widens `WC_Stripe_Agentic_Checkout_Session` and `WC_Stripe_API_Address` type constraints to accept both `stdClass` (webhook payloads from `json_decode`) and `\Stripe\StripeObject` (SDK responses). `WC_Stripe_Agentic_Checkout_Session` performs a runtime shape check so malformed payloads fail fast at construction instead of surfacing null reads across the getters.
- Preserves the existing public-API compatibility surface on the SDK path for checkout sessions: the `wc_stripe_request_body` / deprecated `woocommerce_stripe_request_body` filter, the `wc_stripe_idempotency_key` filter, and the `wc_stripe_request_headers` filter (for non-SDK-reserved headers) are all still applied on create / update / retrieve. `retrieve_checkout_session()` keeps the invalid-API-key 401 backoff behavior that `WC_Stripe_API::retrieve()` implements.
- Sanitizes the `\Stripe\Checkout\Session` DTO via `json_decode( wp_json_encode( $session ) )` before caching it in `WC_Stripe_Database_Cache`, so the protected `_opts` / `RequestOptions` carrying the raw API key never lands in the `wp_options` table.
- Adds `WC_Stripe_SDK_Test_Helper` for consistent SDK mocking in tests, and a comprehensive `WC_Stripe_API_SDK_Test` suite covering create/retrieve/update happy paths, API error handling, SDK cache invalidation, body-filter pass-through, constructor guards on the agentic wrapper, and the 401 backoff lifecycle (increment on auth error, clear on success, throw when threshold active).
- Updates all existing checkout session tests to use SDK mocking instead of `pre_http_request` filter interception.

## Why this shape (wrappers + domain objects + SDK DTOs)

A few reviewer questions came up about whether the wrapper methods and `WC_Stripe_Agentic_Checkout_Session` should be dissolved once we adopt the SDK. They shouldn't — each layer is doing different work:

- **Type safety at the boundary.** `\Stripe\Checkout\Session` replaces `json_decode`'s `stdClass`, so PHPStan level 8 can actually verify property access and return types — the old path was opaque.
- **A single seam.** `WC_Stripe_API::get_sdk()` + `set_sdk_for_testing()` gives one place to mock; tests no longer fake HTTP responses via `pre_http_request`.
- **Consistent edge behavior.** Logging, `ApiErrorException` → `WC_Stripe_Exception` translation, filter/idempotency pass-through, and the 401 backoff live in the wrappers, not duplicated at call sites.
- **Domain vs. DTO separation.** `WC_Stripe_Agentic_Checkout_Session` keeps business rules (fallbacks, `is_agentic()`, metadata reads like `metadata.wc_rate_id`) out of the transport layer, so SDK upgrades don't touch domain logic. Extending `\Stripe\Checkout\Session` directly is fragile — the SDK hydrates objects through `StripeObject`'s magic accessors and internal constructors, and subclassing locks us to that lifecycle while breaking stdClass test fixtures.
- **Repeatable migration pattern.** The same shape applies to PaymentIntents, Customers, Refunds, SetupIntents, etc. — we can retire the legacy `WC_Stripe_API::request()` path one endpoint at a time without a big-bang rewrite.

## Test plan

- [x] Run PHPUnit: `npm run test:php` — directly impacted suites pass (303 tests: API SDK, agentic checkout session, webhook handler, checkout sessions ajax handler, UPE payment gateway). Four unrelated pre-existing ordering-flaky tests remain, they pass in isolation on both `develop` and this branch.
- [x] Run PHPStan: `npm run phpstan` — no new errors from this PR.
- [x] Run PHP lint: `npm run lint:php` — no new errors from this PR.
- [ ] In a local Docker environment (`npm run up`), perform a test-mode checkout with a card payment and verify the order is processed successfully.
- [ ] In a local Docker environment, verify the Adaptive Pricing presentment details appear on the order page after a checkout session payment.
- [ ] Confirm that the `vendor/autoload.php` inclusion in `woocommerce-gateway-stripe.php` (already present) loads the Stripe SDK classes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
