### PR TITLE
Drop redundant "Test mode:" label on Blocks checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.8.0
+* Tweak - Drop redundant "Test mode:" label from test card instructions on Blocks checkout, which already shows a Test Mode badge
 * Fix - Prevent Stripe from rendering an unexpected "Address Line 2" field inside the Payment Element
 * Update - Ensure payment method restrictions based on account and shopper countries are up to date
 * Fix - Store transaction IDs for orders when we get charges to ensure we can refund correctly

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.8.0
-* Tweak - Drop redundant "Test mode:" label from test card instructions on Blocks checkout, which already shows a Test Mode badge
+* Tweak - Drop redundant "Test mode:" label from test payment instructions on Blocks checkout, which already shows a Test Mode badge
 * Fix - Prevent Stripe from rendering an unexpected "Address Line 2" field inside the Payment Element
 * Update - Ensure payment method restrictions based on account and shopper countries are up to date
 * Fix - Store transaction IDs for orders when we get charges to ensure we can refund correctly

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -904,7 +904,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 				'isReusable'             => $payment_method->is_reusable(),
 				'title'                  => $payment_method->get_title(),
 				'description'            => $payment_method->get_description(),
-				'testingInstructions'    => self::expand_copy_button_markup( $payment_method->get_testing_instructions() ),
+				'testingInstructions'    => self::expand_copy_button_markup( $payment_method->get_testing_instructions( false, false ) ),
 				'showSaveOption'         => $this->should_upe_payment_method_show_save_option( $payment_method ),
 				'supportsDeferredIntent' => $payment_method->supports_deferred_intent(),
 				'countries'              => $payment_method->get_available_billing_countries(),

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-blik.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-blik.php
@@ -60,9 +60,11 @@ class WC_Stripe_UPE_Payment_Method_BLIK extends WC_Stripe_UPE_Payment_Method {
 	 * Returns testing instructions to be printed at checkout in test mode.
 	 *
 	 * @param bool $show_optimized_checkout_instruction Deprecated. Whether to show optimized checkout instructions.
+	 * @param bool $include_test_mode_label Whether to include the "Test mode:" label prefix. Pass false for
+	 *                                      Blocks checkout, which already displays a Test Mode badge.
 	 * @return string
 	 */
-	public function get_testing_instructions( $show_optimized_checkout_instruction = false, bool $include_test_mode_label = true ) {
+	public function get_testing_instructions( bool $show_optimized_checkout_instruction = false, bool $include_test_mode_label = true ) {
 		if ( false !== $show_optimized_checkout_instruction ) {
 			_deprecated_argument(
 				__FUNCTION__,

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-blik.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-blik.php
@@ -62,7 +62,7 @@ class WC_Stripe_UPE_Payment_Method_BLIK extends WC_Stripe_UPE_Payment_Method {
 	 * @param bool $show_optimized_checkout_instruction Deprecated. Whether to show optimized checkout instructions.
 	 * @return string
 	 */
-	public function get_testing_instructions( $show_optimized_checkout_instruction = false ) {
+	public function get_testing_instructions( $show_optimized_checkout_instruction = false, bool $include_test_mode_label = true ) {
 		if ( false !== $show_optimized_checkout_instruction ) {
 			_deprecated_argument(
 				__FUNCTION__,
@@ -70,12 +70,16 @@ class WC_Stripe_UPE_Payment_Method_BLIK extends WC_Stripe_UPE_Payment_Method {
 			);
 		}
 
-		return sprintf(
-			/* translators: 1) HTML strong open tag 2) HTML strong closing tag */
-			esc_html__( '%1$sTest mode:%2$s use any 6-digit number.', 'woocommerce-gateway-stripe' ),
-			'<strong>',
-			'</strong>',
-		);
+		if ( $include_test_mode_label ) {
+			return sprintf(
+				/* translators: 1) HTML strong open tag 2) HTML strong closing tag */
+				esc_html__( '%1$sTest mode:%2$s use any 6-digit number.', 'woocommerce-gateway-stripe' ),
+				'<strong>',
+				'</strong>',
+			);
+		}
+
+		return esc_html__( 'Use any 6-digit number.', 'woocommerce-gateway-stripe' );
 	}
 
 	public function payment_fields() {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
@@ -126,7 +126,7 @@ class WC_Stripe_UPE_Payment_Method_CC extends WC_Stripe_UPE_Payment_Method {
 	 *                                      Blocks checkout, which already displays a Test Mode badge.
 	 * @return string
 	 */
-	public function get_testing_instructions( $show_optimized_checkout_instruction = false, bool $include_test_mode_label = true ) {
+	public function get_testing_instructions( bool $show_optimized_checkout_instruction = false, bool $include_test_mode_label = true ) {
 		if ( false !== $show_optimized_checkout_instruction ) {
 			_deprecated_argument(
 				__FUNCTION__,

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
@@ -122,9 +122,11 @@ class WC_Stripe_UPE_Payment_Method_CC extends WC_Stripe_UPE_Payment_Method {
 	 * Returns testing credentials to be printed at checkout in test mode.
 	 *
 	 * @param bool $show_optimized_checkout_instruction Deprecated. Whether to show optimized checkout instructions.
+	 * @param bool $include_test_mode_label Whether to include the "Test mode:" label prefix. Pass false for
+	 *                                      Blocks checkout, which already displays a Test Mode badge.
 	 * @return string
 	 */
-	public function get_testing_instructions( $show_optimized_checkout_instruction = false ) {
+	public function get_testing_instructions( $show_optimized_checkout_instruction = false, bool $include_test_mode_label = true ) {
 		if ( false !== $show_optimized_checkout_instruction ) {
 			_deprecated_argument(
 				__FUNCTION__,
@@ -132,11 +134,22 @@ class WC_Stripe_UPE_Payment_Method_CC extends WC_Stripe_UPE_Payment_Method {
 			);
 		}
 
+		if ( $include_test_mode_label ) {
+			return sprintf(
+				/* translators: 1) HTML strong open tag 2) HTML strong closing tag 3) number open tag 4) number closing tag 5) HTML anchor open tag 6) HTML anchor closing tag */
+				esc_html__( '%1$sTest mode:%2$s use card %3$s4242 4242 4242 4242%4$s with any expiry and CVC. %5$sMore test cards%6$s.', 'woocommerce-gateway-stripe' ),
+				'<strong>',
+				'</strong>',
+				'<number>',
+				'</number>',
+				'<a href="https://docs.stripe.com/testing" target="_blank">',
+				'</a>'
+			);
+		}
+
 		return sprintf(
-			/* translators: 1) HTML strong open tag 2) HTML strong closing tag 3) number open tag 4) number closing tag 5) HTML anchor open tag 6) HTML anchor closing tag */
-			esc_html__( '%1$sTest mode:%2$s use card %3$s4242 4242 4242 4242%4$s with any expiry and CVC. %5$sMore test cards%6$s.', 'woocommerce-gateway-stripe' ),
-			'<strong>',
-			'</strong>',
+			/* translators: 1) number open tag 2) number closing tag 3) HTML anchor open tag 4) HTML anchor closing tag */
+			esc_html__( 'Use card %1$s4242 4242 4242 4242%2$s with any expiry and CVC. %3$sMore test cards%4$s.', 'woocommerce-gateway-stripe' ),
 			'<number>',
 			'</number>',
 			'<a href="https://docs.stripe.com/testing" target="_blank">',

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
@@ -151,9 +151,11 @@ class WC_Stripe_UPE_Payment_Method_OC extends WC_Stripe_UPE_Payment_Method {
 	 * Returns testing credentials to be printed at checkout in test mode.
 	 *
 	 * @param bool $show_optimized_checkout_instruction Deprecated. Whether to show optimized checkout instructions.
+	 * @param bool $include_test_mode_label Whether to include the "Test mode:" label prefix. Pass false for
+	 *                                      Blocks checkout, which already displays a Test Mode badge.
 	 * @return string
 	 */
-	public function get_testing_instructions( $show_optimized_checkout_instruction = false, bool $include_test_mode_label = true ) {
+	public function get_testing_instructions( bool $show_optimized_checkout_instruction = false, bool $include_test_mode_label = true ) {
 		if ( false !== $show_optimized_checkout_instruction ) {
 			_deprecated_argument(
 				__FUNCTION__,

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
@@ -153,7 +153,7 @@ class WC_Stripe_UPE_Payment_Method_OC extends WC_Stripe_UPE_Payment_Method {
 	 * @param bool $show_optimized_checkout_instruction Deprecated. Whether to show optimized checkout instructions.
 	 * @return string
 	 */
-	public function get_testing_instructions( $show_optimized_checkout_instruction = false ) {
+	public function get_testing_instructions( $show_optimized_checkout_instruction = false, bool $include_test_mode_label = true ) {
 		if ( false !== $show_optimized_checkout_instruction ) {
 			_deprecated_argument(
 				__FUNCTION__,
@@ -169,7 +169,7 @@ class WC_Stripe_UPE_Payment_Method_OC extends WC_Stripe_UPE_Payment_Method {
 				continue;
 			}
 
-			$payment_method_instructions = $payment_method->get_testing_instructions();
+			$payment_method_instructions = $payment_method->get_testing_instructions( false, $include_test_mode_label );
 			if ( $payment_method_instructions ) {
 				$instructions .= sprintf( $base_instruction_html, $payment_method::STRIPE_ID, $payment_method_instructions );
 			}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
@@ -101,9 +101,11 @@ class WC_Stripe_UPE_Payment_Method_Sepa extends WC_Stripe_UPE_Payment_Method {
 	 * Returns testing credentials to be printed at checkout in test mode.
 	 *
 	 * @param bool $show_optimized_checkout_instruction Deprecated. Whether to show optimized checkout instructions.
+	 * @param bool $include_test_mode_label Whether to include the "Test mode:" label prefix. Pass false for
+	 *                                      Blocks checkout, which already displays a Test Mode badge.
 	 * @return string
 	 */
-	public function get_testing_instructions( $show_optimized_checkout_instruction = false, bool $include_test_mode_label = true ) {
+	public function get_testing_instructions( bool $show_optimized_checkout_instruction = false, bool $include_test_mode_label = true ) {
 		if ( false !== $show_optimized_checkout_instruction ) {
 			_deprecated_argument(
 				__FUNCTION__,

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
@@ -103,7 +103,7 @@ class WC_Stripe_UPE_Payment_Method_Sepa extends WC_Stripe_UPE_Payment_Method {
 	 * @param bool $show_optimized_checkout_instruction Deprecated. Whether to show optimized checkout instructions.
 	 * @return string
 	 */
-	public function get_testing_instructions( $show_optimized_checkout_instruction = false ) {
+	public function get_testing_instructions( $show_optimized_checkout_instruction = false, bool $include_test_mode_label = true ) {
 		if ( false !== $show_optimized_checkout_instruction ) {
 			_deprecated_argument(
 				__FUNCTION__,
@@ -111,11 +111,22 @@ class WC_Stripe_UPE_Payment_Method_Sepa extends WC_Stripe_UPE_Payment_Method {
 			);
 		}
 
+		if ( $include_test_mode_label ) {
+			return sprintf(
+				/* translators: 1) HTML strong open tag 2) HTML strong closing tag 3) number open tag 4) number closing tag 5) HTML anchor open tag 6) HTML anchor closing tag */
+				esc_html__( '%1$sTest mode:%2$s use account %3$sAT611904300234573201%4$s. %5$sMore test methods%6$s.', 'woocommerce-gateway-stripe' ),
+				'<strong>',
+				'</strong>',
+				'<number>',
+				'</number>',
+				'<a href="https://docs.stripe.com/testing?payment-method=sepa-direct-debit#non-card-payments" target="_blank">',
+				'</a>'
+			);
+		}
+
 		return sprintf(
-			/* translators: 1) HTML strong open tag 2) HTML strong closing tag 3) number open tag 4) number closing tag 5) HTML anchor open tag 6) HTML anchor closing tag */
-			esc_html__( '%1$sTest mode:%2$s use account %3$sAT611904300234573201%4$s. %5$sMore test methods%6$s.', 'woocommerce-gateway-stripe' ),
-			'<strong>',
-			'</strong>',
+			/* translators: 1) number open tag 2) number closing tag 3) HTML anchor open tag 4) HTML anchor closing tag */
+			esc_html__( 'Use account %1$sAT611904300234573201%2$s. %3$sMore test methods%4$s.', 'woocommerce-gateway-stripe' ),
 			'<number>',
 			'</number>',
 			'<a href="https://docs.stripe.com/testing?payment-method=sepa-direct-debit#non-card-payments" target="_blank">',

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -658,9 +658,12 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	 *
 	 * @see WC_Stripe_UPE_Payment_Gateway::expand_copy_button_markup()
 	 *
+	 * @param bool $show_optimized_checkout_instruction Deprecated. Whether to show optimized checkout instructions.
+	 * @param bool $include_test_mode_label Whether to include the "Test mode:" label prefix. Pass false for
+	 *                                      Blocks checkout, which already displays a Test Mode badge.
 	 * @return string
 	 */
-	public function get_testing_instructions( bool $show_optimized_checkout_instruction = false ) {
+	public function get_testing_instructions( bool $show_optimized_checkout_instruction = false, bool $include_test_mode_label = true ) {
 		if ( $show_optimized_checkout_instruction ) {
 			_deprecated_argument(
 				__FUNCTION__,

--- a/readme.txt
+++ b/readme.txt
@@ -152,7 +152,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.8.0 - xxxx-xx-xx =
-* Tweak - Drop redundant "Test mode:" label from test card instructions on Blocks checkout, which already shows a Test Mode badge
+* Tweak - Drop redundant "Test mode:" label from test payment instructions on Blocks checkout, which already shows a Test Mode badge
 * Fix - Prevent Stripe from rendering an unexpected "Address Line 2" field inside the Payment Element
 * Update - Ensure payment method restrictions based on account and shopper countries are up to date
 * Fix - Store transaction IDs for orders when we get charges to ensure we can refund correctly

--- a/readme.txt
+++ b/readme.txt
@@ -152,6 +152,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.8.0 - xxxx-xx-xx =
+* Tweak - Drop redundant "Test mode:" label from test card instructions on Blocks checkout, which already shows a Test Mode badge
 * Fix - Prevent Stripe from rendering an unexpected "Address Line 2" field inside the Payment Element
 * Update - Ensure payment method restrictions based on account and shopper countries are up to date
 * Fix - Store transaction IDs for orders when we get charges to ensure we can refund correctly

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-cc-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-cc-test.php
@@ -123,15 +123,25 @@ class WC_Stripe_UPE_Payment_Method_CC_Test extends WP_UnitTestCase {
 	/**
 	 * Test for `get_testing_instructions`.
 	 *
+	 * @dataProvider provider_get_testing_instructions
 	 * @return void
 	 */
-	public function test_get_testing_instructions() {
-		$expected = '<strong>Test mode:</strong> use card <number>4242 4242 4242 4242</number> with any expiry and CVC. <a href="https://docs.stripe.com/testing" target="_blank">More test cards</a>.';
-
+	public function test_get_testing_instructions( bool $include_test_mode_label, string $expected ) {
 		$payment_method = new WC_Stripe_UPE_Payment_Method_CC();
-		$actual         = $payment_method->get_testing_instructions();
+		$this->assertEquals( $expected, $payment_method->get_testing_instructions( false, $include_test_mode_label ) );
+	}
 
-		$this->assertEquals( $expected, $actual );
+	public function provider_get_testing_instructions(): array {
+		return [
+			'with label (classic checkout)'   => [
+				true,
+				'<strong>Test mode:</strong> use card <number>4242 4242 4242 4242</number> with any expiry and CVC. <a href="https://docs.stripe.com/testing" target="_blank">More test cards</a>.',
+			],
+			'without label (blocks checkout)' => [
+				false,
+				'Use card <number>4242 4242 4242 4242</number> with any expiry and CVC. <a href="https://docs.stripe.com/testing" target="_blank">More test cards</a>.',
+			],
+		];
 	}
 
 	/**

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-test.php
@@ -358,6 +358,10 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 			'<strong>Test mode:</strong> use any 6-digit number.',
 			$blik_method->get_testing_instructions()
 		);
+		$this->assertEquals(
+			'Use any 6-digit number.',
+			$blik_method->get_testing_instructions( false, false )
+		);
 
 		$this->assertEquals( WC_Stripe_Payment_Methods::CARD, $card_method->get_id() );
 		$this->assertEquals( 'Credit / Debit Card', $card_method->get_label() );
@@ -367,6 +371,10 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 		$this->assertEquals(
 			'<strong>Test mode:</strong> use card <number>4242 4242 4242 4242</number> with any expiry and CVC. <a href="https://docs.stripe.com/testing" target="_blank">More test cards</a>.',
 			$card_method->get_testing_instructions()
+		);
+		$this->assertEquals(
+			'Use card <number>4242 4242 4242 4242</number> with any expiry and CVC. <a href="https://docs.stripe.com/testing" target="_blank">More test cards</a>.',
+			$card_method->get_testing_instructions( false, false )
 		);
 
 		$this->assertEquals( WC_Stripe_Payment_Methods::ALIPAY, $alipay_method->get_id() );
@@ -401,6 +409,10 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 		$this->assertEquals(
 			'<strong>Test mode:</strong> use account <number>AT611904300234573201</number>. <a href="https://docs.stripe.com/testing?payment-method=sepa-direct-debit#non-card-payments" target="_blank">More test methods</a>.',
 			$sepa_method->get_testing_instructions()
+		);
+		$this->assertEquals(
+			'Use account <number>AT611904300234573201</number>. <a href="https://docs.stripe.com/testing?payment-method=sepa-direct-debit#non-card-payments" target="_blank">More test methods</a>.',
+			$sepa_method->get_testing_instructions( false, false )
 		);
 
 		$this->assertEquals( WC_Stripe_Payment_Methods::SOFORT, $sofort_method->get_id() );


### PR DESCRIPTION
Fixes STRIPE-985

## Changes proposed in this Pull Request:

Blocks checkout already shows a **Test Mode** badge, making the bold "Test mode:" prefix in the test card instructions redundant. Classic checkout has no such badge, so it still needs the label.

This PR adds a `$include_test_mode_label` parameter to `get_testing_instructions()` with **two distinct i18n strings** per method (CC, SEPA, BLIK) rather than stripping the label from the output after the fact — keeping each string independently translatable.

| Method | Classic (unchanged) | Blocks (new) |
|--------|-------------------|--------------|
| CC | **Test mode:** use card 4242… | Use card 4242… |
| SEPA | **Test mode:** use account AT611… | Use account AT611… |
| BLIK | **Test mode:** use any 6-digit number. | Use any 6-digit number. |

**Files changed:**
- `class-wc-stripe-upe-payment-method.php` — new `$include_test_mode_label` param on base signature
- `class-wc-stripe-upe-payment-method-cc.php` — two distinct strings
- `class-wc-stripe-upe-payment-method-sepa.php` — two distinct strings
- `class-wc-stripe-upe-payment-method-blik.php` — two distinct strings
- `class-wc-stripe-upe-payment-method-oc.php` — passes param through to sub-methods
- `class-wc-stripe-upe-payment-gateway.php` — calls with `false` for Blocks settings

## Testing instructions

1. Enable **Test mode** in Stripe settings.
2. Enable **Card**, **SEPA**, and **BLIK** payment methods.
3. Go to **Blocks checkout**:
   - Verify test instructions show **without** the "Test mode:" prefix (e.g. "Use card 4242…").
   - Verify the Test Mode badge is still visible.
4. Go to **Classic checkout** (shortcode):
   - Verify test instructions still show **with** the bold "Test mode:" prefix.
5. If Optimized Checkout is enabled, verify OC classic checkout still shows the label.

---

- [x] Covered with tests
- [ ] Tested on mobile (or does not apply)

### Changelog entry

> Tweak - Drop redundant "Test mode:" label from test payment instructions on Blocks checkout, which already shows a Test Mode badge

**Post merge**

- [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
- [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
- [ ] Included this PR in the Release Thread scope (or does not apply)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
