### PR TITLE
Add AI code review caller workflow

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -1,0 +1,15 @@
+name: AI Code Review
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+concurrency:
+  group: ai-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    uses: woocommerce/.github/.github/workflows/ai-code-review.yml@trunk
+    secrets:
+      AI_CODE_REVIEW_ANTHROPIC_API_KEY: ${{ secrets.AI_CODE_REVIEW_ANTHROPIC_API_KEY }}
+      ORG_MEMBERS_READ_TOKEN: ${{ secrets.ORG_MEMBERS_READ_TOKEN }}


### PR DESCRIPTION
Adds the AI code review caller workflow for this repo. Calls the shared reusable workflow from woocommerce/.github. Reviews PRs from happiness-engineers and qualityops team members.

Linear: QAO-392