### PR TITLE
Add WC_Stripe_Refund domain wrapper

### DIFF
--- a/includes/class-wc-stripe-refund.php
+++ b/includes/class-wc-stripe-refund.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * Class WC_Stripe_Refund
+ *
+ * Typed domain wrapper around a Stripe Refund object.
+ *
+ * @package WooCommerce_Stripe
+ * @since   10.8.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Provides typed, null-safe access to Stripe Refund data.
+ *
+ * Wraps the `stdClass` produced by `json_decode` of a Stripe Refund response and
+ * consolidates the status predicates, decimal-aware amount conversion, and
+ * expanded/string ID resolution that were previously repeated across the webhook
+ * handler and order-handler refund paths.
+ *
+ * @since 10.8.0
+ */
+class WC_Stripe_Refund {
+
+	/**
+	 * The underlying Refund payload.
+	 *
+	 * @var stdClass
+	 */
+	private stdClass $refund;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 10.8.0
+	 * @param stdClass $refund The Stripe refund payload (as returned by `json_decode`).
+	 */
+	public function __construct( stdClass $refund ) {
+		$this->refund = $refund;
+	}
+
+	/**
+	 * Returns the underlying raw object for legacy callers that still need arbitrary field access.
+	 *
+	 * Prefer named getters; this is an escape hatch for incremental migration.
+	 *
+	 * @since 10.8.0
+	 */
+	public function raw(): stdClass {
+		return $this->refund;
+	}
+
+	/**
+	 * Returns the refund ID, or null when absent.
+	 *
+	 * @since 10.8.0
+	 */
+	public function get_id(): ?string {
+		return isset( $this->refund->id ) ? (string) $this->refund->id : null;
+	}
+
+	/**
+	 * Returns the Stripe refund status (e.g. `succeeded`, `pending`, `failed`, `canceled`).
+	 *
+	 * @since 10.8.0
+	 */
+	public function get_status(): ?string {
+		return isset( $this->refund->status ) ? (string) $this->refund->status : null;
+	}
+
+	public function is_succeeded(): bool {
+		return 'succeeded' === $this->get_status();
+	}
+
+	public function is_pending(): bool {
+		return 'pending' === $this->get_status();
+	}
+
+	public function is_failed(): bool {
+		return 'failed' === $this->get_status();
+	}
+
+	public function is_canceled(): bool {
+		return 'canceled' === $this->get_status();
+	}
+
+	public function is_requires_action(): bool {
+		return 'requires_action' === $this->get_status();
+	}
+
+	/**
+	 * Whether the refund is in a terminal failure state.
+	 *
+	 * The webhook handler branches on this to update order refund state and
+	 * surface a friendly failure reason; consolidating it here avoids
+	 * `in_array( $status, [ 'failed', 'canceled' ], true )` duplication.
+	 *
+	 * @since 10.8.0
+	 */
+	public function is_failed_or_canceled(): bool {
+		$status = $this->get_status();
+		return null !== $status && in_array( $status, [ 'failed', 'canceled' ], true );
+	}
+
+	/**
+	 * Returns the currency (lowercase, Stripe's canonical form), or null.
+	 *
+	 * @since 10.8.0
+	 */
+	public function get_currency(): ?string {
+		return isset( $this->refund->currency ) ? strtolower( (string) $this->refund->currency ) : null;
+	}
+
+	/**
+	 * Returns the raw amount in the smallest currency unit, or null.
+	 *
+	 * @since 10.8.0
+	 */
+	public function get_amount(): ?int {
+		return isset( $this->refund->amount ) ? (int) $this->refund->amount : null;
+	}
+
+	/**
+	 * Returns the refund amount in presentation units (e.g. dollars, not cents).
+	 *
+	 * Decimal-currency-aware: zero-decimal currencies (JPY, KRW, etc.) are not divided.
+	 * An optional $currency_override is supported for webhook flows that have the
+	 * charge's currency readily available but the refund payload may lack its own.
+	 *
+	 * @since 10.8.0
+	 * @param string|null $currency_override Currency code to use instead of the refund's own.
+	 * @return float|null
+	 */
+	public function get_amount_decimal( ?string $currency_override = null ): ?float {
+		$amount = $this->get_amount();
+		if ( null === $amount ) {
+			return null;
+		}
+
+		$currency = null !== $currency_override ? strtolower( $currency_override ) : $this->get_currency();
+		if ( null !== $currency && in_array( $currency, WC_Stripe_Helper::no_decimal_currencies(), true ) ) {
+			return (float) $amount;
+		}
+
+		return $amount / 100;
+	}
+
+	/**
+	 * Returns the charge ID associated with the refund, handling expanded and string forms.
+	 *
+	 * @since 10.8.0
+	 */
+	public function get_charge_id(): ?string {
+		return $this->resolve_id( $this->refund->charge ?? null );
+	}
+
+	/**
+	 * Returns the payment intent ID associated with the refund, handling expanded and string forms.
+	 *
+	 * @since 10.8.0
+	 */
+	public function get_payment_intent_id(): ?string {
+		return $this->resolve_id( $this->refund->payment_intent ?? null );
+	}
+
+	/**
+	 * Returns the successful balance transaction ID, handling expanded and string forms.
+	 *
+	 * @since 10.8.0
+	 */
+	public function get_balance_transaction_id(): ?string {
+		return $this->resolve_id( $this->refund->balance_transaction ?? null );
+	}
+
+	/**
+	 * Returns the failure balance transaction ID (present when a refund fails after
+	 * being issued), handling expanded and string forms.
+	 *
+	 * @since 10.8.0
+	 */
+	public function get_failure_balance_transaction_id(): ?string {
+		return $this->resolve_id( $this->refund->failure_balance_transaction ?? null );
+	}
+
+	/**
+	 * Returns the Stripe-supplied `reason` for the refund
+	 * (e.g. `requested_by_customer`, `duplicate`, `fraudulent`), or null when absent.
+	 *
+	 * @since 10.8.0
+	 */
+	public function get_reason(): ?string {
+		return isset( $this->refund->reason ) ? (string) $this->refund->reason : null;
+	}
+
+	/**
+	 * Returns the Stripe-supplied `failure_reason` (only populated on failed refunds).
+	 *
+	 * @since 10.8.0
+	 */
+	public function get_failure_reason(): ?string {
+		return isset( $this->refund->failure_reason ) ? (string) $this->refund->failure_reason : null;
+	}
+
+	/**
+	 * Returns the end-user-friendly translation of `failure_reason` via
+	 * `WC_Stripe_Helper::get_refund_reason_description()`, or null when no failure.
+	 *
+	 * @since 10.8.0
+	 */
+	public function get_friendly_failure_reason(): ?string {
+		$reason = $this->get_failure_reason();
+		if ( null === $reason ) {
+			return null;
+		}
+		return WC_Stripe_Helper::get_refund_reason_description( $reason );
+	}
+
+	/**
+	 * Returns the refund's receipt number, or null when absent.
+	 *
+	 * @since 10.8.0
+	 */
+	public function get_receipt_number(): ?string {
+		return isset( $this->refund->receipt_number ) ? (string) $this->refund->receipt_number : null;
+	}
+
+	/**
+	 * Returns an arbitrary metadata value by key, or null when absent.
+	 *
+	 * @since 10.8.0
+	 */
+	public function get_metadata_value( string $key ): ?string {
+		$value = $this->refund->metadata->$key ?? null;
+		return null === $value ? null : (string) $value;
+	}
+
+	/**
+	 * Resolves an expanded-or-string reference to its ID.
+	 *
+	 * @param mixed $value The raw value (string ID, object with ->id, or null).
+	 */
+	private function resolve_id( $value ): ?string {
+		if ( is_string( $value ) && '' !== $value ) {
+			return $value;
+		}
+		if ( is_object( $value ) && isset( $value->id ) ) {
+			return (string) $value->id;
+		}
+		return null;
+	}
+}

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -138,6 +138,7 @@ class WC_Stripe {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-payment-method-configurations.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-database-cache-prefetch.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-api.php';
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-refund.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-mode.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/compat/class-wc-stripe-subscriptions-helper.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/compat/trait-wc-stripe-subscriptions-utilities.php';

--- a/tests/phpunit/class-wc-stripe-refund-test.php
+++ b/tests/phpunit/class-wc-stripe-refund-test.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Tests for WC_Stripe_Refund
+ *
+ * @package WooCommerce\Stripe\Tests
+ */
+
+/**
+ * @covers WC_Stripe_Refund
+ */
+class WC_Stripe_Refund_Test extends WP_UnitTestCase {
+
+	public function test_constructor_accepts_stdclass() {
+		$refund = new WC_Stripe_Refund( (object) [ 'id' => 're_std' ] );
+		$this->assertSame( 're_std', $refund->get_id() );
+	}
+
+	public function test_constructor_accepts_stripe_object() {
+		$refund = new WC_Stripe_Refund( \Stripe\Refund::constructFrom( [ 'id' => 're_sdk' ] ) );
+		$this->assertSame( 're_sdk', $refund->get_id() );
+	}
+
+	public function test_constructor_rejects_unrelated_types() {
+		$this->expectException( \InvalidArgumentException::class );
+		new WC_Stripe_Refund( new \ArrayObject( [ 'id' => 'nope' ] ) );
+	}
+
+	public function test_raw_returns_underlying_object() {
+		$raw    = (object) [ 'id' => 're_raw' ];
+		$refund = new WC_Stripe_Refund( $raw );
+		$this->assertSame( $raw, $refund->raw() );
+	}
+
+	public function test_get_id_returns_null_when_missing() {
+		$refund = new WC_Stripe_Refund( (object) [] );
+		$this->assertNull( $refund->get_id() );
+	}
+
+	/**
+	 * @dataProvider provide_status_predicate_cases
+	 */
+	public function test_status_predicates( string $status, string $method, bool $expected ) {
+		$refund = new WC_Stripe_Refund( (object) [ 'status' => $status ] );
+		$this->assertSame( $expected, $refund->$method() );
+	}
+
+	public function provide_status_predicate_cases(): array {
+		return [
+			'succeeded → is_succeeded'        => [ 'succeeded', 'is_succeeded', true ],
+			'pending → is_pending'            => [ 'pending', 'is_pending', true ],
+			'failed → is_failed'              => [ 'failed', 'is_failed', true ],
+			'canceled → is_canceled'          => [ 'canceled', 'is_canceled', true ],
+			'requires_action → is_req_action' => [ 'requires_action', 'is_requires_action', true ],
+			'succeeded → not is_failed'       => [ 'succeeded', 'is_failed', false ],
+			'pending → not is_succeeded'      => [ 'pending', 'is_succeeded', false ],
+		];
+	}
+
+	public function test_is_failed_or_canceled() {
+		$failed   = new WC_Stripe_Refund( (object) [ 'status' => 'failed' ] );
+		$canceled = new WC_Stripe_Refund( (object) [ 'status' => 'canceled' ] );
+		$success  = new WC_Stripe_Refund( (object) [ 'status' => 'succeeded' ] );
+		$missing  = new WC_Stripe_Refund( (object) [] );
+
+		$this->assertTrue( $failed->is_failed_or_canceled() );
+		$this->assertTrue( $canceled->is_failed_or_canceled() );
+		$this->assertFalse( $success->is_failed_or_canceled() );
+		$this->assertFalse( $missing->is_failed_or_canceled() );
+	}
+
+	public function test_get_currency_is_lowercase() {
+		$refund = new WC_Stripe_Refund( (object) [ 'currency' => 'USD' ] );
+		$this->assertSame( 'usd', $refund->get_currency() );
+	}
+
+	public function test_get_amount_raw() {
+		$refund = new WC_Stripe_Refund( (object) [ 'amount' => 2500 ] );
+		$this->assertSame( 2500, $refund->get_amount() );
+		$this->assertNull( ( new WC_Stripe_Refund( (object) [] ) )->get_amount() );
+	}
+
+	/**
+	 * @dataProvider provide_amount_decimal_cases
+	 */
+	public function test_get_amount_decimal( string $currency, int $amount, float $expected ) {
+		$refund = new WC_Stripe_Refund(
+			(object) [
+				'currency' => $currency,
+				'amount'   => $amount,
+			]
+		);
+		$this->assertSame( $expected, $refund->get_amount_decimal() );
+	}
+
+	public function provide_amount_decimal_cases(): array {
+		return [
+			'USD divides by 100' => [ 'usd', 2500, 25.0 ],
+			'EUR divides by 100' => [ 'eur', 1099, 10.99 ],
+			'JPY stays whole'    => [ 'jpy', 2500, 2500.0 ],
+			'KRW stays whole'    => [ 'krw', 9000, 9000.0 ],
+		];
+	}
+
+	public function test_get_amount_decimal_with_currency_override() {
+		// Refund missing its own currency (legacy webhook shape) — caller supplies charge currency.
+		$refund = new WC_Stripe_Refund( (object) [ 'amount' => 5000 ] );
+		$this->assertSame( 50.0, $refund->get_amount_decimal( 'usd' ) );
+		$this->assertSame( 5000.0, $refund->get_amount_decimal( 'JPY' ) );
+	}
+
+	public function test_get_amount_decimal_returns_null_when_amount_missing() {
+		$refund = new WC_Stripe_Refund( (object) [ 'currency' => 'usd' ] );
+		$this->assertNull( $refund->get_amount_decimal() );
+	}
+
+	/**
+	 * @dataProvider provide_id_resolution_cases
+	 */
+	public function test_id_resolution_for_refs( string $property, $value, ?string $expected, string $method ) {
+		$refund = new WC_Stripe_Refund( (object) [ $property => $value ] );
+		$this->assertSame( $expected, $refund->$method() );
+	}
+
+	public function provide_id_resolution_cases(): array {
+		return [
+			'charge string'                       => [ 'charge', 'ch_1', 'ch_1', 'get_charge_id' ],
+			'charge expanded'                     => [ 'charge', (object) [ 'id' => 'ch_2' ], 'ch_2', 'get_charge_id' ],
+			'charge null'                         => [ 'charge', null, null, 'get_charge_id' ],
+			'payment_intent string'               => [ 'payment_intent', 'pi_1', 'pi_1', 'get_payment_intent_id' ],
+			'balance_transaction string'          => [ 'balance_transaction', 'txn_1', 'txn_1', 'get_balance_transaction_id' ],
+			'balance_transaction expanded'        => [ 'balance_transaction', (object) [ 'id' => 'txn_2' ], 'txn_2', 'get_balance_transaction_id' ],
+			'failure_balance_transaction string'  => [ 'failure_balance_transaction', 'txn_fail', 'txn_fail', 'get_failure_balance_transaction_id' ],
+			'failure_balance_transaction missing' => [ 'other', 'anything', null, 'get_failure_balance_transaction_id' ],
+		];
+	}
+
+	public function test_reason_and_failure_reason() {
+		$refund = new WC_Stripe_Refund(
+			(object) [
+				'reason'         => 'requested_by_customer',
+				'failure_reason' => 'lost_or_stolen_card',
+			]
+		);
+		$this->assertSame( 'requested_by_customer', $refund->get_reason() );
+		$this->assertSame( 'lost_or_stolen_card', $refund->get_failure_reason() );
+
+		$empty = new WC_Stripe_Refund( (object) [] );
+		$this->assertNull( $empty->get_reason() );
+		$this->assertNull( $empty->get_failure_reason() );
+	}
+
+	public function test_get_friendly_failure_reason_delegates_to_helper() {
+		// Use a known code from WC_Stripe_Helper::get_refund_reason_description(): 'lost_or_stolen_card'.
+		$refund   = new WC_Stripe_Refund( (object) [ 'failure_reason' => 'lost_or_stolen_card' ] );
+		$friendly = $refund->get_friendly_failure_reason();
+
+		$this->assertNotNull( $friendly );
+		$this->assertSame( WC_Stripe_Helper::get_refund_reason_description( 'lost_or_stolen_card' ), $friendly );
+
+		$clean = new WC_Stripe_Refund( (object) [ 'status' => 'succeeded' ] );
+		$this->assertNull( $clean->get_friendly_failure_reason() );
+	}
+
+	public function test_receipt_number() {
+		$refund = new WC_Stripe_Refund( (object) [ 'receipt_number' => '1234-5678' ] );
+		$this->assertSame( '1234-5678', $refund->get_receipt_number() );
+		$this->assertNull( ( new WC_Stripe_Refund( (object) [] ) )->get_receipt_number() );
+	}
+
+	public function test_metadata_value() {
+		$refund = new WC_Stripe_Refund(
+			(object) [
+				'metadata' => (object) [
+					'order_id'      => '99',
+					'initiated_via' => 'admin',
+				],
+			]
+		);
+		$this->assertSame( '99', $refund->get_metadata_value( 'order_id' ) );
+		$this->assertSame( 'admin', $refund->get_metadata_value( 'initiated_via' ) );
+		$this->assertNull( $refund->get_metadata_value( 'unknown' ) );
+
+		$empty = new WC_Stripe_Refund( (object) [] );
+		$this->assertNull( $empty->get_metadata_value( 'anything' ) );
+	}
+}


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Introduces `WC_Stripe_Refund`, a typed domain wrapper around the `stdClass` produced by `json_decode` of a Stripe Refund response. Consolidates refund scatter currently duplicated across the webhook handler paths into a single, tested seam:

- Status predicates: `is_succeeded`, `is_pending`, `is_failed`, `is_canceled`, `is_requires_action`, plus `is_failed_or_canceled()` for the terminal-failure branch the webhook handler inspects.
- Decimal-aware `get_amount_decimal()` that handles zero-decimal currencies (JPY, KRW, etc.) correctly, with an optional currency override for legacy webhook payloads where the charge currency lives on the notification rather than on the refund itself.
- Expanded-or-string ID resolution for `charge`, `payment_intent`, `balance_transaction`, and `failure_balance_transaction`.
- Reason accessors: `get_reason()` (Stripe code), `get_failure_reason()`, and `get_friendly_failure_reason()` which delegates to `WC_Stripe_Helper::get_refund_reason_description()` for end-user display.
- `get_receipt_number()`, `get_metadata_value()`, and a `raw()` escape hatch for incremental migration.

**Why now.** The `$refund_object->amount / 100` vs. no-decimal-currency branch appears three times in `class-wc-stripe-webhook-handler.php` (`process_webhook_refund`, `process_webhook_refund_updated`, `get_refund_amount`), and the `in_array( $status, ['failed', 'canceled'], true )` predicate is inlined alongside it. Centralising the math and predicates removes the next decimal-currency regression risk and gives PHPStan something to verify across the refund path.

**Scope.** This PR only introduces the class (with tests). The wrapper is autoloaded via `WC_Stripe::init()` but no call site uses it yet — that migration lands in a follow-up so the wrapper can be reviewed in isolation. Candidate call sites for the follow-up:

- `WC_Stripe_Webhook_Handler::process_webhook_refund()` — `includes/class-wc-stripe-webhook-handler.php:740`
- `WC_Stripe_Webhook_Handler::process_webhook_refund_updated()` — `includes/class-wc-stripe-webhook-handler.php:833`
- `WC_Stripe_Webhook_Handler::get_refund_amount()` — `includes/class-wc-stripe-webhook-handler.php:1055`
- The `$refund_object->balance_transaction` access at `includes/class-wc-stripe-webhook-handler.php:557` (partial-capture path)

## Testing instructions

This PR introduces no user-visible behaviour. Reviewer verification is the test suite:

- `npm run test:php -- --filter=WC_Stripe_Refund_Test` — 33 PHPUnit cases pass (data-provider parameterised for decimal-currency math, status predicates, and ID resolution across expanded/string forms).
- `npm run phpstan` — no new errors at level 8.
- `npm run lint:php` on the two new files — clean.

End-to-end refund flows (Stripe Dashboard refund → `charge.refunded` webhook → order note, and the failed/cancelled `refund.updated` path) should be exercised by the follow-up migration PR; this one only adds dead-but-tested code.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Backend-only scaffolding: introduces a new internal class with no production call sites and no user-visible behaviour change. A changelog entry will land with the follow-up PR that migrates the webhook refund paths to use it.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)