### PR TITLE
Add WC_Stripe_Payment_Method domain wrapper

### DIFF
--- a/includes/class-wc-stripe-payment-method.php
+++ b/includes/class-wc-stripe-payment-method.php
@@ -1,0 +1,333 @@
+<?php
+/**
+ * Class WC_Stripe_Payment_Method
+ *
+ * Typed domain wrapper around a Stripe PaymentMethod object.
+ *
+ * @package WooCommerce_Stripe
+ * @since   10.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Provides typed, null-safe access to Stripe PaymentMethod data.
+ *
+ * Wraps either a `\Stripe\PaymentMethod` (SDK) or a `stdClass` (legacy
+ * `json_decode`) and consolidates the fallback chains (card brand, billing
+ * email), null-guarded sub-object accessors (sepa_debit, us_bank_account,
+ * link), and type predicates that were previously repeated across the
+ * payment-tokens layer, UPE payment-method classes, subscription compat
+ * trait, and the UPE gateway.
+ *
+ * @since 10.7.0
+ */
+class WC_Stripe_Payment_Method {
+
+	/**
+	 * The underlying PaymentMethod payload.
+	 *
+	 * @var \Stripe\StripeObject|stdClass
+	 */
+	private object $payment_method;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 10.7.0
+	 * @param \Stripe\StripeObject|stdClass $payment_method The Stripe payment method payload.
+	 * @throws InvalidArgumentException When $payment_method is not a stdClass or \Stripe\StripeObject instance.
+	 */
+	public function __construct( object $payment_method ) {
+		if ( ! $payment_method instanceof stdClass && ! $payment_method instanceof \Stripe\StripeObject ) {
+			throw new InvalidArgumentException(
+				sprintf( 'Expected stdClass or \Stripe\StripeObject, got %s.', get_class( $payment_method ) )
+			);
+		}
+
+		$this->payment_method = $payment_method;
+	}
+
+	/**
+	 * Returns the underlying raw object for legacy callers.
+	 *
+	 * Prefer named getters; this is an escape hatch for incremental migration.
+	 *
+	 * @since 10.7.0
+	 * @return \Stripe\StripeObject|stdClass
+	 */
+	public function raw(): object {
+		return $this->payment_method;
+	}
+
+	/**
+	 * Returns the payment method ID, or null when absent.
+	 *
+	 * @since 10.7.0
+	 */
+	public function get_id(): ?string {
+		return isset( $this->payment_method->id ) ? (string) $this->payment_method->id : null;
+	}
+
+	/**
+	 * Returns the payment method type (e.g. `card`, `sepa_debit`, `us_bank_account`,
+	 * `link`, `amazon_pay`), or null when absent.
+	 *
+	 * @since 10.7.0
+	 */
+	public function get_type(): ?string {
+		return isset( $this->payment_method->type ) ? (string) $this->payment_method->type : null;
+	}
+
+	/**
+	 * Returns the `object` field — usually `payment_method` for PaymentMethod objects.
+	 *
+	 * Used to disambiguate legacy `source` objects that share some field layout.
+	 *
+	 * @since 10.7.0
+	 */
+	public function get_object(): ?string {
+		return isset( $this->payment_method->object ) ? (string) $this->payment_method->object : null;
+	}
+
+	/**
+	 * Whether this object is a Stripe PaymentMethod (as opposed to a legacy `source`).
+	 *
+	 * @since 10.7.0
+	 */
+	public function is_payment_method_object(): bool {
+		return 'payment_method' === $this->get_object();
+	}
+
+	/**
+	 * Whether the payment method is of a given type.
+	 *
+	 * @since 10.7.0
+	 * @param string $type A type constant (e.g. `WC_Stripe_Payment_Methods::CARD`).
+	 */
+	public function is_type( string $type ): bool {
+		return $type === $this->get_type();
+	}
+
+	/**
+	 * Whether the payment method is a card.
+	 *
+	 * @since 10.7.0
+	 */
+	public function is_card(): bool {
+		return $this->is_type( WC_Stripe_Payment_Methods::CARD );
+	}
+
+	/**
+	 * Returns the Stripe customer ID, handling expanded and string forms.
+	 *
+	 * @since 10.7.0
+	 */
+	public function get_customer_id(): ?string {
+		return $this->resolve_id( $this->payment_method->customer ?? null );
+	}
+
+	// ---------------------------------------------------------------------
+	// Card
+	// ---------------------------------------------------------------------
+
+	/**
+	 * Returns the card brand, applying the canonical fallback chain used by
+	 * payment-tokens and the UPE CC payment method:
+	 *
+	 * `card.display_brand` → `card.networks.preferred` → `card.brand`.
+	 *
+	 * `display_brand` is the user-facing brand returned by Stripe for
+	 * co-branded cards; when absent, the preferred network (e.g. cartes_bancaires
+	 * over visa) takes precedence over the primary `brand` string.
+	 *
+	 * @since 10.7.0
+	 * @return string|null
+	 */
+	public function get_card_brand(): ?string {
+		$brand = $this->payment_method->card->display_brand
+			?? $this->payment_method->card->networks->preferred
+			?? $this->payment_method->card->brand
+			?? null;
+
+		return null === $brand ? null : (string) $brand;
+	}
+
+	public function get_card_last4(): ?string {
+		return isset( $this->payment_method->card->last4 ) ? (string) $this->payment_method->card->last4 : null;
+	}
+
+	public function get_card_fingerprint(): ?string {
+		return isset( $this->payment_method->card->fingerprint ) ? (string) $this->payment_method->card->fingerprint : null;
+	}
+
+	public function get_card_exp_month(): ?int {
+		return isset( $this->payment_method->card->exp_month ) ? (int) $this->payment_method->card->exp_month : null;
+	}
+
+	public function get_card_exp_year(): ?int {
+		return isset( $this->payment_method->card->exp_year ) ? (int) $this->payment_method->card->exp_year : null;
+	}
+
+	public function get_card_country(): ?string {
+		return isset( $this->payment_method->card->country ) ? (string) $this->payment_method->card->country : null;
+	}
+
+	public function get_card_funding(): ?string {
+		return isset( $this->payment_method->card->funding ) ? (string) $this->payment_method->card->funding : null;
+	}
+
+	/**
+	 * Whether the underlying card is a prepaid card (relevant for prepaid-card
+	 * restrictions enforced by the UPE gateway).
+	 *
+	 * @since 10.7.0
+	 */
+	public function is_prepaid_card(): bool {
+		return 'prepaid' === $this->get_card_funding();
+	}
+
+	/**
+	 * Whether the card is issued in India (relevant for Indian SCA flows).
+	 *
+	 * @since 10.7.0
+	 */
+	public function is_india_card(): bool {
+		return $this->is_card() && WC_Stripe_Country_Code::INDIA === $this->get_card_country();
+	}
+
+	/**
+	 * Returns the preferred card network (e.g. `cartes_bancaires`, `visa`), or null.
+	 *
+	 * @since 10.7.0
+	 */
+	public function get_card_preferred_network(): ?string {
+		$preferred = $this->payment_method->card->networks->preferred ?? null;
+		return null === $preferred ? null : (string) $preferred;
+	}
+
+	// ---------------------------------------------------------------------
+	// SEPA Direct Debit
+	// ---------------------------------------------------------------------
+
+	public function get_sepa_last4(): ?string {
+		return isset( $this->payment_method->sepa_debit->last4 ) ? (string) $this->payment_method->sepa_debit->last4 : null;
+	}
+
+	public function get_sepa_fingerprint(): ?string {
+		return isset( $this->payment_method->sepa_debit->fingerprint ) ? (string) $this->payment_method->sepa_debit->fingerprint : null;
+	}
+
+	// ---------------------------------------------------------------------
+	// US bank account (ACH)
+	// ---------------------------------------------------------------------
+
+	public function get_us_bank_last4(): ?string {
+		return isset( $this->payment_method->us_bank_account->last4 ) ? (string) $this->payment_method->us_bank_account->last4 : null;
+	}
+
+	public function get_us_bank_fingerprint(): ?string {
+		return isset( $this->payment_method->us_bank_account->fingerprint ) ? (string) $this->payment_method->us_bank_account->fingerprint : null;
+	}
+
+	public function get_us_bank_bank_name(): ?string {
+		return isset( $this->payment_method->us_bank_account->bank_name ) ? (string) $this->payment_method->us_bank_account->bank_name : null;
+	}
+
+	public function get_us_bank_account_type(): ?string {
+		return isset( $this->payment_method->us_bank_account->account_type ) ? (string) $this->payment_method->us_bank_account->account_type : null;
+	}
+
+	/**
+	 * Whether the payload contains a populated `us_bank_account` sub-object.
+	 *
+	 * Used by the ACH payment-token early-return guard so callers don't have
+	 * to re-check `isset( $payment_method->id ) && isset( $payment_method->us_bank_account )`.
+	 *
+	 * @since 10.7.0
+	 */
+	public function has_us_bank_details(): bool {
+		return null !== $this->get_id() && isset( $this->payment_method->us_bank_account );
+	}
+
+	// ---------------------------------------------------------------------
+	// Link
+	// ---------------------------------------------------------------------
+
+	/**
+	 * Returns the Link email (only populated for Link payment methods).
+	 *
+	 * @since 10.7.0
+	 */
+	public function get_link_email(): ?string {
+		return isset( $this->payment_method->link->email ) ? (string) $this->payment_method->link->email : null;
+	}
+
+	// ---------------------------------------------------------------------
+	// Billing details
+	// ---------------------------------------------------------------------
+
+	/**
+	 * Returns the billing email. When absent, returns the provided $fallback
+	 * (call sites historically use `?? ''` to avoid nulls at persistence time).
+	 *
+	 * @since 10.7.0
+	 * @param string|null $fallback Value returned when no email is present. Defaults to null.
+	 */
+	public function get_billing_email( ?string $fallback = null ): ?string {
+		$email = $this->payment_method->billing_details->email ?? null;
+		if ( null === $email || '' === $email ) {
+			return $fallback;
+		}
+		return (string) $email;
+	}
+
+	public function get_billing_name(): ?string {
+		return isset( $this->payment_method->billing_details->name ) ? (string) $this->payment_method->billing_details->name : null;
+	}
+
+	public function get_billing_phone(): ?string {
+		return isset( $this->payment_method->billing_details->phone ) ? (string) $this->payment_method->billing_details->phone : null;
+	}
+
+	/**
+	 * Returns the raw billing address object, or null when absent.
+	 *
+	 * @since 10.7.0
+	 */
+	public function get_billing_address(): ?object {
+		$address = $this->payment_method->billing_details->address ?? null;
+		return is_object( $address ) ? $address : null;
+	}
+
+	// ---------------------------------------------------------------------
+	// Metadata
+	// ---------------------------------------------------------------------
+
+	/**
+	 * Returns an arbitrary metadata value by key, or null when absent.
+	 *
+	 * @since 10.7.0
+	 */
+	public function get_metadata_value( string $key ): ?string {
+		$value = $this->payment_method->metadata->$key ?? null;
+		return null === $value ? null : (string) $value;
+	}
+
+	/**
+	 * Resolves an expanded-or-string reference to its ID.
+	 *
+	 * @param mixed $value The raw value (string ID, object with ->id, or null).
+	 */
+	private function resolve_id( $value ): ?string {
+		if ( is_string( $value ) && '' !== $value ) {
+			return $value;
+		}
+		if ( is_object( $value ) && isset( $value->id ) ) {
+			return (string) $value->id;
+		}
+		return null;
+	}
+}

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -135,6 +135,7 @@ class WC_Stripe {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-payment-method-configurations.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-database-cache-prefetch.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-api.php';
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-payment-method.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-mode.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/compat/class-wc-stripe-subscriptions-helper.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/compat/trait-wc-stripe-subscriptions-utilities.php';

--- a/tests/phpunit/class-wc-stripe-payment-method-test.php
+++ b/tests/phpunit/class-wc-stripe-payment-method-test.php
@@ -1,0 +1,312 @@
+<?php
+/**
+ * Tests for WC_Stripe_Payment_Method
+ *
+ * @package WooCommerce\Stripe\Tests
+ */
+
+/**
+ * @covers WC_Stripe_Payment_Method
+ */
+class WC_Stripe_Payment_Method_Test extends WP_UnitTestCase {
+
+	public function test_constructor_accepts_stdclass() {
+		$pm = new WC_Stripe_Payment_Method( (object) [ 'id' => 'pm_std' ] );
+		$this->assertSame( 'pm_std', $pm->get_id() );
+	}
+
+	public function test_constructor_accepts_stripe_object() {
+		$pm = new WC_Stripe_Payment_Method( \Stripe\PaymentMethod::constructFrom( [ 'id' => 'pm_sdk' ] ) );
+		$this->assertSame( 'pm_sdk', $pm->get_id() );
+	}
+
+	public function test_constructor_rejects_unrelated_types() {
+		$this->expectException( \InvalidArgumentException::class );
+		new WC_Stripe_Payment_Method( new \ArrayObject( [ 'id' => 'nope' ] ) );
+	}
+
+	public function test_raw_returns_underlying_object() {
+		$raw = (object) [ 'id' => 'pm_raw' ];
+		$pm  = new WC_Stripe_Payment_Method( $raw );
+		$this->assertSame( $raw, $pm->raw() );
+	}
+
+	public function test_type_and_object_predicates() {
+		$card_pm = new WC_Stripe_Payment_Method(
+			(object) [
+				'type'   => WC_Stripe_Payment_Methods::CARD,
+				'object' => 'payment_method',
+			]
+		);
+		$this->assertTrue( $card_pm->is_payment_method_object() );
+		$this->assertTrue( $card_pm->is_type( WC_Stripe_Payment_Methods::CARD ) );
+		$this->assertTrue( $card_pm->is_card() );
+		$this->assertSame( WC_Stripe_Payment_Methods::CARD, $card_pm->get_type() );
+		$this->assertSame( 'payment_method', $card_pm->get_object() );
+
+		$sepa_pm = new WC_Stripe_Payment_Method(
+			(object) [
+				'type'   => WC_Stripe_Payment_Methods::SEPA_DEBIT,
+				'object' => 'payment_method',
+			]
+		);
+		$this->assertFalse( $sepa_pm->is_card() );
+		$this->assertTrue( $sepa_pm->is_type( WC_Stripe_Payment_Methods::SEPA_DEBIT ) );
+
+		$legacy_source = new WC_Stripe_Payment_Method( (object) [ 'object' => 'source' ] );
+		$this->assertFalse( $legacy_source->is_payment_method_object() );
+
+		$missing = new WC_Stripe_Payment_Method( (object) [] );
+		$this->assertNull( $missing->get_type() );
+		$this->assertNull( $missing->get_object() );
+		$this->assertFalse( $missing->is_card() );
+	}
+
+	public function test_customer_id_resolves_string_and_expanded() {
+		$string   = new WC_Stripe_Payment_Method( (object) [ 'customer' => 'cus_string' ] );
+		$expanded = new WC_Stripe_Payment_Method( (object) [ 'customer' => (object) [ 'id' => 'cus_expanded' ] ] );
+		$missing  = new WC_Stripe_Payment_Method( (object) [] );
+
+		$this->assertSame( 'cus_string', $string->get_customer_id() );
+		$this->assertSame( 'cus_expanded', $expanded->get_customer_id() );
+		$this->assertNull( $missing->get_customer_id() );
+	}
+
+	/**
+	 * @dataProvider provide_card_brand_cases
+	 */
+	public function test_card_brand_fallback_chain( object $card, string $expected ) {
+		$pm = new WC_Stripe_Payment_Method(
+			(object) [
+				'type' => WC_Stripe_Payment_Methods::CARD,
+				'card' => $card,
+			]
+		);
+		$this->assertSame( $expected, $pm->get_card_brand() );
+	}
+
+	public function provide_card_brand_cases(): array {
+		return [
+			'display_brand takes priority'       => [
+				(object) [
+					'display_brand' => 'cartes_bancaires',
+					'networks'      => (object) [ 'preferred' => 'visa' ],
+					'brand'         => 'visa',
+				],
+				'cartes_bancaires',
+			],
+			'fallback to networks.preferred'     => [
+				(object) [
+					'networks' => (object) [ 'preferred' => 'cartes_bancaires' ],
+					'brand'    => 'visa',
+				],
+				'cartes_bancaires',
+			],
+			'final fallback to brand'            => [
+				(object) [ 'brand' => 'visa' ],
+				'visa',
+			],
+			'null networks.preferred falls thru' => [
+				(object) [
+					'networks' => (object) [ 'preferred' => null ],
+					'brand'    => 'mastercard',
+				],
+				'mastercard',
+			],
+		];
+	}
+
+	public function test_card_brand_returns_null_when_no_brand() {
+		$pm = new WC_Stripe_Payment_Method( (object) [ 'card' => (object) [] ] );
+		$this->assertNull( $pm->get_card_brand() );
+
+		$missing = new WC_Stripe_Payment_Method( (object) [] );
+		$this->assertNull( $missing->get_card_brand() );
+	}
+
+	public function test_card_fields() {
+		$pm = new WC_Stripe_Payment_Method(
+			(object) [
+				'card' => (object) [
+					'last4'       => '4242',
+					'fingerprint' => 'fp_x',
+					'exp_month'   => 10,
+					'exp_year'    => 2030,
+					'country'     => 'US',
+					'funding'     => 'credit',
+				],
+			]
+		);
+		$this->assertSame( '4242', $pm->get_card_last4() );
+		$this->assertSame( 'fp_x', $pm->get_card_fingerprint() );
+		$this->assertSame( 10, $pm->get_card_exp_month() );
+		$this->assertSame( 2030, $pm->get_card_exp_year() );
+		$this->assertSame( 'US', $pm->get_card_country() );
+		$this->assertSame( 'credit', $pm->get_card_funding() );
+		$this->assertFalse( $pm->is_prepaid_card() );
+
+		$missing = new WC_Stripe_Payment_Method( (object) [] );
+		$this->assertNull( $missing->get_card_last4() );
+		$this->assertNull( $missing->get_card_exp_month() );
+	}
+
+	public function test_is_prepaid_card() {
+		$prepaid = new WC_Stripe_Payment_Method( (object) [ 'card' => (object) [ 'funding' => 'prepaid' ] ] );
+		$credit  = new WC_Stripe_Payment_Method( (object) [ 'card' => (object) [ 'funding' => 'credit' ] ] );
+		$missing = new WC_Stripe_Payment_Method( (object) [] );
+
+		$this->assertTrue( $prepaid->is_prepaid_card() );
+		$this->assertFalse( $credit->is_prepaid_card() );
+		$this->assertFalse( $missing->is_prepaid_card() );
+	}
+
+	public function test_is_india_card() {
+		$indian_card = new WC_Stripe_Payment_Method(
+			(object) [
+				'type' => WC_Stripe_Payment_Methods::CARD,
+				'card' => (object) [ 'country' => WC_Stripe_Country_Code::INDIA ],
+			]
+		);
+		$this->assertTrue( $indian_card->is_india_card() );
+
+		$us_card = new WC_Stripe_Payment_Method(
+			(object) [
+				'type' => WC_Stripe_Payment_Methods::CARD,
+				'card' => (object) [ 'country' => 'US' ],
+			]
+		);
+		$this->assertFalse( $us_card->is_india_card() );
+
+		$sepa_india = new WC_Stripe_Payment_Method(
+			(object) [
+				'type' => WC_Stripe_Payment_Methods::SEPA_DEBIT,
+				'card' => (object) [ 'country' => WC_Stripe_Country_Code::INDIA ],
+			]
+		);
+		$this->assertFalse( $sepa_india->is_india_card(), 'India detection must be gated on card type' );
+	}
+
+	public function test_get_card_preferred_network() {
+		$with_preferred = new WC_Stripe_Payment_Method(
+			(object) [
+				'card' => (object) [ 'networks' => (object) [ 'preferred' => 'cartes_bancaires' ] ],
+			]
+		);
+		$this->assertSame( 'cartes_bancaires', $with_preferred->get_card_preferred_network() );
+
+		$without = new WC_Stripe_Payment_Method( (object) [ 'card' => (object) [] ] );
+		$this->assertNull( $without->get_card_preferred_network() );
+	}
+
+	public function test_sepa_accessors() {
+		$pm = new WC_Stripe_Payment_Method(
+			(object) [
+				'sepa_debit' => (object) [
+					'last4'       => '3000',
+					'fingerprint' => 'sepa_fp',
+				],
+			]
+		);
+		$this->assertSame( '3000', $pm->get_sepa_last4() );
+		$this->assertSame( 'sepa_fp', $pm->get_sepa_fingerprint() );
+
+		$missing = new WC_Stripe_Payment_Method( (object) [] );
+		$this->assertNull( $missing->get_sepa_last4() );
+		$this->assertNull( $missing->get_sepa_fingerprint() );
+	}
+
+	public function test_us_bank_accessors() {
+		$pm = new WC_Stripe_Payment_Method(
+			(object) [
+				'id'              => 'pm_ach',
+				'us_bank_account' => (object) [
+					'last4'        => '6789',
+					'fingerprint'  => 'ach_fp',
+					'bank_name'    => 'Stripe Test Bank',
+					'account_type' => 'checking',
+				],
+			]
+		);
+		$this->assertSame( '6789', $pm->get_us_bank_last4() );
+		$this->assertSame( 'ach_fp', $pm->get_us_bank_fingerprint() );
+		$this->assertSame( 'Stripe Test Bank', $pm->get_us_bank_bank_name() );
+		$this->assertSame( 'checking', $pm->get_us_bank_account_type() );
+		$this->assertTrue( $pm->has_us_bank_details() );
+
+		$missing_bank = new WC_Stripe_Payment_Method( (object) [ 'id' => 'pm_no_bank' ] );
+		$this->assertFalse( $missing_bank->has_us_bank_details() );
+
+		$missing_id = new WC_Stripe_Payment_Method( (object) [ 'us_bank_account' => (object) [ 'last4' => '1234' ] ] );
+		$this->assertFalse( $missing_id->has_us_bank_details(), 'has_us_bank_details requires an id per ACH token guard' );
+	}
+
+	public function test_link_email() {
+		$pm = new WC_Stripe_Payment_Method( (object) [ 'link' => (object) [ 'email' => 'link@example.com' ] ] );
+		$this->assertSame( 'link@example.com', $pm->get_link_email() );
+
+		$missing = new WC_Stripe_Payment_Method( (object) [] );
+		$this->assertNull( $missing->get_link_email() );
+	}
+
+	public function test_billing_email_with_default() {
+		$pm = new WC_Stripe_Payment_Method(
+			(object) [
+				'billing_details' => (object) [ 'email' => 'buyer@example.com' ],
+			]
+		);
+		$this->assertSame( 'buyer@example.com', $pm->get_billing_email() );
+		$this->assertSame( 'buyer@example.com', $pm->get_billing_email( 'fallback@x.com' ) );
+
+		$missing = new WC_Stripe_Payment_Method( (object) [] );
+		$this->assertNull( $missing->get_billing_email() );
+		$this->assertSame( '', $missing->get_billing_email( '' ) );
+		$this->assertSame( 'fallback@x.com', $missing->get_billing_email( 'fallback@x.com' ) );
+
+		$empty_email = new WC_Stripe_Payment_Method(
+			(object) [
+				'billing_details' => (object) [ 'email' => '' ],
+			]
+		);
+		$this->assertSame( '', $empty_email->get_billing_email( '' ), 'Empty string is treated as absent and replaced by default' );
+	}
+
+	public function test_billing_name_phone_address() {
+		$address = (object) [
+			'line1'       => '1 Test St',
+			'city'        => 'Testville',
+			'country'     => 'US',
+			'postal_code' => '94103',
+		];
+		$pm      = new WC_Stripe_Payment_Method(
+			(object) [
+				'billing_details' => (object) [
+					'name'    => 'Jane Tester',
+					'phone'   => '+15551234567',
+					'address' => $address,
+				],
+			]
+		);
+
+		$this->assertSame( 'Jane Tester', $pm->get_billing_name() );
+		$this->assertSame( '+15551234567', $pm->get_billing_phone() );
+		$this->assertSame( $address, $pm->get_billing_address() );
+
+		$missing = new WC_Stripe_Payment_Method( (object) [] );
+		$this->assertNull( $missing->get_billing_name() );
+		$this->assertNull( $missing->get_billing_phone() );
+		$this->assertNull( $missing->get_billing_address() );
+	}
+
+	public function test_metadata_value() {
+		$pm = new WC_Stripe_Payment_Method(
+			(object) [
+				'metadata' => (object) [ 'source' => 'test-script' ],
+			]
+		);
+		$this->assertSame( 'test-script', $pm->get_metadata_value( 'source' ) );
+		$this->assertNull( $pm->get_metadata_value( 'unknown' ) );
+
+		$missing = new WC_Stripe_Payment_Method( (object) [] );
+		$this->assertNull( $missing->get_metadata_value( 'anything' ) );
+	}
+}


### PR DESCRIPTION
## Summary

- Introduces `WC_Stripe_Payment_Method`, a typed domain wrapper around a Stripe PaymentMethod object (accepts `\Stripe\PaymentMethod` / `\Stripe\StripeObject` from the SDK or `stdClass` from legacy `json_decode`).
- Consolidates the heaviest property-scatter in the codebase — PaymentMethod fields are currently accessed at 40+ call sites across 11 files (payment-tokens layer, UPE payment-method subclasses, UPE gateway, subscriptions compat trait, customer, helper). The wrapper folds those into:
  - **Type predicates** (`is_card`, `is_type`, `is_payment_method_object`) so call sites stop repeating `$pm->type === WC_Stripe_Payment_Methods::CARD` and the `$pm->object === 'payment_method'` check used to disambiguate legacy source objects.
  - **Canonical card-brand fallback chain** — `card.display_brand` → `card.networks.preferred` → `card.brand` — centralized in `get_card_brand()`, replacing the verbatim 3-way null-coalesce copy-pasted in `class-wc-stripe-upe-payment-method-cc.php:97` and `class-wc-stripe-payment-tokens.php:573`.
  - **Typed card accessors** (`last4`, `fingerprint`, `exp_month`, `exp_year`, `country`, `funding`) plus the two business predicates the UPE gateway needs against card country/funding: `is_prepaid_card()` and `is_india_card()`.
  - **Sub-object accessors** for `sepa_debit` (last4, fingerprint), `us_bank_account` (last4, fingerprint, bank_name, account_type) with `has_us_bank_details()` for the ACH payment-token early-return guard, and `link` (email).
  - **Billing-detail accessors** (`get_billing_email` with optional fallback, `get_billing_name`, `get_billing_phone`, `get_billing_address`) that fold in the `?? ''` pattern sprinkled through the payment-tokens and subscriptions code.
  - **Expanded-or-string customer ID** resolution via `get_customer_id()`, and `get_metadata_value()` for consistent null-safety on metadata reads.
- Fail-fast constructor guard (throws `InvalidArgumentException` on unrelated object types) plus a `raw()` escape hatch for incremental migration.

## Why this shape

Same rationale as the prior domain-class PRs (#5276, #5277, #5278, #5298):

- **Type safety at the boundary.** PHPStan can verify property access across all 11 call sites that currently touch `$payment_method->...` directly.
- **Eliminates the biggest fallback-chain scatter.** The card-brand fallback is the single most-duplicated null-coalesce pattern in the repo around Stripe data.
- **Domain vs. DTO separation.** Business predicates (`is_india_card`, `is_prepaid_card`) live on the domain object; the SDK DTO keeps doing transport.
- **Consistent null-safety.** The payment-tokens layer uses `isset()` guards inconsistently around `sepa_debit`/`us_bank_account`/`link` sub-objects; the wrapper handles all those with uniform `?? null` chains.

The migration target is `includes/payment-tokens/class-wc-stripe-payment-tokens.php` (the largest concentration, ~8 distinct call sites), the UPE payment-method subclasses (`-cc.php`, `-ach.php`, `-amazon-pay.php`, `-link.php`), `class-wc-stripe-upe-payment-gateway.php` (prepaid-card + Link detection), and `includes/compat/trait-wc-stripe-subscriptions.php` (the payment-method display-name switch and the India-card guard). Those should move to the typed accessors in a follow-up PR.

## Test plan

- [x] Run PHPUnit: `npm run test:php -- --filter=WC_Stripe_Payment_Method_Test` — 21 tests pass (data-provider parameterized for the card-brand fallback, targeted checks per payment-method variant).
- [x] Run PHPStan: `npm run phpstan` — no new errors.
- [x] Run PHP lint: `npm run lint:php` on the new files — clean.
- [ ] Follow-up PR: migrate the 40+ call sites in payment-tokens / UPE payment-methods / UPE gateway / subscriptions trait to use `WC_Stripe_Payment_Method`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)