### PR TITLE
Fix stale token metadata when updating Credit Card expiry and CVC

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 xxxx-xx-xx - version 10.7.0
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails
+* Fix - Stale saved-card metadata after updating a card's expiry or CVC
 
 2026-04-20 - version 10.6.0
 * Remove - Remove EU adaptive pricing disclosure component from classic and Blocks checkout as it is shown natively within the Stripe currency selector element
@@ -75,7 +76,7 @@ xxxx-xx-xx - version 10.7.0
 * Add - Allow customers to save payment methods during checkout with adaptive pricing
 * Fix - Restrict Checkout Session saved payment method options to logged-in customers so guest checkout session creation succeeds
 * Add - Add an admin notice and one-click action to move Stripe payment methods to the top of WooCommerce payment gateway order for Optimized Checkout
-* Update - Allow Adaptive Pricing for merchant accounts based in EEA countries                                                                                                                               
+* Update - Allow Adaptive Pricing for merchant accounts based in EEA countries
 * Add - Show ECB interbank rate conversion fee notice to EEA-based shoppers on the order received page and in customer order confirmation emails
 * Fix - Confirm checkout session with user data in classic checkout for guest user
 * Add - Handle redirect payment flow in classic checkout for Checkout Sessions

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -768,6 +768,17 @@ class WC_Stripe_Payment_Tokens {
 				// Clear cached payment methods.
 				$customer->clear_cache();
 				$found_token->set_token( $payment_method->id );
+
+				// Card fingerprint hashes the card number only, so a fingerprint
+				// match can still carry a different expiry or brand. Refresh the
+				// mutable card metadata so the UI reflects the replacement.
+				if ( WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID === $payment_method_type ) {
+					$found_token->set_expiry_month( $payment_method->card->exp_month );
+					$found_token->set_expiry_year( $payment_method->card->exp_year );
+					$found_token->set_card_type( strtolower( $payment_method->card->display_brand ?? $payment_method->card->networks->preferred ?? $payment_method->card->brand ) );
+					$found_token->set_last4( $payment_method->card->last4 );
+				}
+
 				$found_token->save();
 			}
 			return $found_token;

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -772,7 +772,7 @@ class WC_Stripe_Payment_Tokens {
 				// Card fingerprint hashes the card number only, so a fingerprint
 				// match can still carry a different expiry or brand. Refresh the
 				// mutable card metadata so the UI reflects the replacement.
-				if ( WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID === $payment_method_type ) {
+				if ( WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID === $payment_method_type && $found_token instanceof WC_Stripe_Payment_Token_CC ) {
 					$found_token->set_expiry_month( $payment_method->card->exp_month );
 					$found_token->set_expiry_year( $payment_method->card->exp_year );
 					$found_token->set_card_type( strtolower( $payment_method->card->display_brand ?? $payment_method->card->networks->preferred ?? $payment_method->card->brand ) );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9897,7 +9897,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property object\:\:\$card\.$#'
 			identifier: property.notFound
-			count: 9
+			count: 13
 			path: includes/payment-tokens/class-wc-stripe-payment-tokens.php
 
 		-

--- a/readme.txt
+++ b/readme.txt
@@ -147,5 +147,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 10.7.0 - xxxx-xx-xx =
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails
+* Fix - Stale saved-card metadata after updating a card's expiry or CVC
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
+++ b/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
@@ -328,6 +328,64 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * When a new card is saved whose fingerprint matches an existing saved card,
+	 * `add_token_to_user` must refresh the mutable card metadata (expiry, brand,
+	 * last4) on the reused token. Otherwise the UI keeps showing the old expiry
+	 * even though the Stripe PaymentMethod id was replaced.
+	 *
+	 * Reproduces STRIPE-1082.
+	 *
+	 * @return void
+	 */
+	public function test_add_token_to_user_refreshes_cc_metadata_on_fingerprint_match() {
+		$user_id = $this->factory->user->create();
+		update_user_option( $user_id, '_stripe_customer_id', 'cus_test_stripe_1082', false );
+
+		$seed_token = new WC_Stripe_Payment_Token_CC();
+		$seed_token->set_token( 'pm_old' );
+		$seed_token->set_gateway_id( WC_Stripe_UPE_Payment_Gateway::ID );
+		$seed_token->set_user_id( $user_id );
+		$seed_token->set_expiry_month( '01' );
+		$seed_token->set_expiry_year( '2027' );
+		$seed_token->set_card_type( 'visa' );
+		$seed_token->set_last4( '4242' );
+		$seed_token->set_fingerprint( 'F_abc' );
+		$seed_token->save();
+		$seed_token_id = $seed_token->get_id();
+
+		$incoming_pm = (object) [
+			'id'                            => 'pm_new',
+			'type'                          => WC_Stripe_Payment_Methods::CARD,
+			WC_Stripe_Payment_Methods::CARD => (object) [
+				'brand'         => 'visa',
+				'display_brand' => 'visa',
+				'exp_month'     => 2,
+				'exp_year'      => 2028,
+				'last4'         => '4242',
+				'fingerprint'   => 'F_abc',
+			],
+		];
+
+		$customer = new WC_Stripe_Customer( $user_id );
+
+		$reflection = new ReflectionMethod( WC_Stripe_Payment_Tokens::class, 'add_token_to_user' );
+		$reflection->setAccessible( true );
+		$result = $reflection->invoke( $this->stripe_payment_tokens, $incoming_pm, $customer, [] );
+
+		$this->assertSame( $seed_token_id, $result->get_id(), 'Duplicate-matched token should be reused, not recreated.' );
+		$this->assertSame( 'pm_new', $result->get_token() );
+		$this->assertSame( '02', $result->get_expiry_month() );
+		$this->assertSame( '2028', $result->get_expiry_year() );
+		$this->assertSame( 'visa', $result->get_card_type() );
+		$this->assertSame( '4242', $result->get_last4() );
+
+		$reloaded = WC_Payment_Tokens::get( $seed_token_id );
+		$this->assertSame( 'pm_new', $reloaded->get_token(), 'Refreshed PM id must be persisted.' );
+		$this->assertSame( '02', $reloaded->get_expiry_month(), 'Refreshed expiry_month must be persisted.' );
+		$this->assertSame( '2028', $reloaded->get_expiry_year(), 'Refreshed expiry_year must be persisted.' );
+	}
+
+	/**
 	 * Test for `woocommerce_payment_token_class`.
 	 *
 	 * @return void

--- a/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
+++ b/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
@@ -372,15 +372,15 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 
 		$this->assertSame( $seed_token_id, $result->get_id(), 'Duplicate-matched token should be reused, not recreated.' );
 		$this->assertSame( 'pm_new', $result->get_token() );
-		$this->assertSame( '02', $result->get_expiry_month() );
-		$this->assertSame( '2028', $result->get_expiry_year() );
+		$this->assertEquals( '02', $result->get_expiry_month() );
+		$this->assertEquals( '2028', $result->get_expiry_year() );
 		$this->assertSame( 'visa', $result->get_card_type() );
 		$this->assertSame( '4242', $result->get_last4() );
 
 		$reloaded = WC_Payment_Tokens::get( $seed_token_id );
 		$this->assertSame( 'pm_new', $reloaded->get_token(), 'Refreshed PM id must be persisted.' );
-		$this->assertSame( '02', $reloaded->get_expiry_month(), 'Refreshed expiry_month must be persisted.' );
-		$this->assertSame( '2028', $reloaded->get_expiry_year(), 'Refreshed expiry_year must be persisted.' );
+		$this->assertEquals( '02', $reloaded->get_expiry_month(), 'Refreshed expiry_month must be persisted.' );
+		$this->assertEquals( '2028', $reloaded->get_expiry_year(), 'Refreshed expiry_year must be persisted.' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes [STRIPE-1082](https://linear.app/a8c/issue/STRIPE-1082/woocommerce-stripe-gateway-leaves-stale-token-metadata-when-replacing)
Fixes #5286

## Changes proposed in this Pull Request:

When a logged-in customer saves a card whose card number matches an already-saved card for the same user, `WC_Stripe_Payment_Tokens::add_token_to_user()` reuses the existing `WC_Payment_Token` row and points it at the new Stripe PaymentMethod id instead of creating a duplicate token. However, the associated `woocommerce_payment_tokenmeta` rows (expiry month/year, card brand, last4) were not refreshed at the same time, so the saved-card UI kept showing the old expiry even though the underlying Stripe token had been replaced.

This PR refreshes the mutable card metadata on the existing token whenever a fingerprint match occurs, so `woocommerce_payment_tokens` and `woocommerce_payment_tokenmeta` stay in sync after the replacement.

- The fix is intentionally scoped to **card** tokens. For other saved payment methods (SEPA, ACH, ACSS, Link, Cash App, etc.) the token metadata is derived from the same identifier that Stripe uses to compute the fingerprint, so a fingerprint match already implies identical metadata — nothing to refresh.

## Testing instructions

Mirrors the reproduction in the Linear issue.

1. Using a non-block theme (e.g. Storefront), connect Stripe in **test mode** and enable **Credit card / debit card** and **Enable saved payment methods**.
2. Log in as an existing customer, add a product to the cart, and go to the classic checkout page.
3. Enter a successful Stripe test card (`4242 4242 4242 4242`) with expiry `01/27` and any CVC. Tick **"Save payment information to my account"** and complete checkout.
4. Open the order in admin and follow the Stripe payment link at the top. Note the PaymentMethod id used (e.g. `pm_ABC`).
5. In the database, confirm `woocommerce_payment_tokens` has a new row for `pm_ABC`, and `woocommerce_payment_tokenmeta` for that `token_id` contains `expiry_year=2027`, `expiry_month=01`, `last4=4242`, `card_type=visa`.
6. As the **same** customer, add another product to the cart and go to the classic checkout page.
7. Enter the **same card number** (`4242 4242 4242 4242`) but with a **different expiry** such as `02/28`, and any CVC. Complete checkout.
8. Open the new order and follow the Stripe payment link. Confirm Stripe created a **new** PaymentMethod id (e.g. `pm_DEF`).
9. In the database, confirm the existing `woocommerce_payment_tokens` row's `token` column now holds `pm_DEF`.
10. **Expected (with this PR):** in `woocommerce_payment_tokenmeta`, the same `token_id` now has `expiry_year=2028` and `expiry_month=02`. **Before this PR:** the metadata still shows `2027` / `01`.
11. As the customer, visit **My Account → Payment Methods** and confirm the saved card's displayed expiry is `02/28`, not `01/27`.
12. Repeat steps 6–11 against the Blocks checkout (and, if enabled, the Optimized Checkout) to confirm consistent behavior.

---

- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- Add the changelog fragment via the standard flow for this repo -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)