### PR TITLE
Fix Agentic Commerce product lookup by SKU

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.7.0
+* Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 
 2026-04-20 - version 10.6.0
 * Remove - Remove EU adaptive pricing disclosure component from classic and Blocks checkout as it is shown natively within the Stripe currency selector element

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-manual-approval.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-manual-approval.php
@@ -84,13 +84,23 @@ class WC_Stripe_Agentic_Commerce_Manual_Approval {
 	 * @throws Exception When product resolution fails.
 	 */
 	private function validate_line_item( WC_Stripe_Agentic_Customize_Checkout_Line_Item $line_item ): ?array {
-		$product_id = wc_get_product_id_by_sku( $line_item->get_sku_id() );
+		$sku = $line_item->get_sku_id();
+		if ( '' === $sku ) {
+			throw new Exception(
+				sprintf(
+					'Line item %s has no sku_id.',
+					$line_item->get_id()
+				)
+			);
+		}
+
+		$product_id = wc_get_product_id_by_sku( $sku );
 		if ( ! $product_id ) {
 			throw new Exception(
 				sprintf(
 					'Product not found for line item %s with SKU "%s".',
 					$line_item->get_id(),
-					$line_item->get_sku_id()
+					$sku
 				)
 			);
 		}

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-manual-approval.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-manual-approval.php
@@ -84,8 +84,18 @@ class WC_Stripe_Agentic_Commerce_Manual_Approval {
 	 * @throws Exception When product resolution fails.
 	 */
 	private function validate_line_item( WC_Stripe_Agentic_Customize_Checkout_Line_Item $line_item ): ?array {
-		$product_id = (int) $line_item->get_sku_id();
-		$product    = WC_Stripe_Agentic_Commerce_Product_Resolver::resolve_product( $product_id );
+		$product_id = wc_get_product_id_by_sku( $line_item->get_sku_id() );
+		if ( ! $product_id ) {
+			throw new Exception(
+				sprintf(
+					'Product not found for line item %s with SKU "%s".',
+					$line_item->get_id(),
+					$line_item->get_sku_id()
+				)
+			);
+		}
+
+		$product = WC_Stripe_Agentic_Commerce_Product_Resolver::resolve_product( $product_id );
 
 		if ( ! $product->is_purchasable() ) {
 			return [

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-tax-calculator.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-tax-calculator.php
@@ -36,13 +36,23 @@ class WC_Stripe_Agentic_Commerce_Tax_Calculator {
 		$line_items = [];
 
 		foreach ( $event->get_line_items() as $line_item ) {
-			$product_id = wc_get_product_id_by_sku( $line_item->get_sku_id() );
+			$sku = $line_item->get_sku_id();
+			if ( '' === $sku ) {
+				throw new Exception(
+					sprintf(
+						'Line item %s has no sku_id.',
+						$line_item->get_id()
+					)
+				);
+			}
+
+			$product_id = wc_get_product_id_by_sku( $sku );
 			if ( ! $product_id ) {
 				throw new Exception(
 					sprintf(
 						'Product not found for line item %s with SKU "%s".',
 						$line_item->get_id(),
-						$line_item->get_sku_id()
+						$sku
 					)
 				);
 			}

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-tax-calculator.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-tax-calculator.php
@@ -27,7 +27,8 @@ class WC_Stripe_Agentic_Commerce_Tax_Calculator {
 	 *
 	 * @since 10.6.0
 	 * @param WC_Stripe_Agentic_Customize_Checkout_Event $event The customization hook event.
-	 * @return array<string,string> The line items hash. Line item ID => SKU ID.
+	 * @return array<string,int> The line items hash. Line item ID => Product ID.
+	 * @throws Exception When a SKU cannot be resolved to a product.
 	 */
 	public function extract_line_items_from_customization_hook(
 		WC_Stripe_Agentic_Customize_Checkout_Event $event
@@ -35,7 +36,18 @@ class WC_Stripe_Agentic_Commerce_Tax_Calculator {
 		$line_items = [];
 
 		foreach ( $event->get_line_items() as $line_item ) {
-			$line_items[ $line_item->get_id() ] = $line_item->get_sku_id();
+			$product_id = wc_get_product_id_by_sku( $line_item->get_sku_id() );
+			if ( ! $product_id ) {
+				throw new Exception(
+					sprintf(
+						'Product not found for line item %s with SKU "%s".',
+						$line_item->get_id(),
+						$line_item->get_sku_id()
+					)
+				);
+			}
+
+			$line_items[ $line_item->get_id() ] = $product_id;
 		}
 
 		return $line_items;
@@ -50,7 +62,7 @@ class WC_Stripe_Agentic_Commerce_Tax_Calculator {
 	 *
 	 * @since 10.6.0
 	 * @param WC_Stripe_Agentic_Customize_Checkout_Event $event      The customization hook event.
-	 * @param array<string,string>                       $line_items The line items hash. Line item ID => Product ID.
+	 * @param array<string,int>                          $line_items The line items hash. Line item ID => Product ID.
 	 * @return array The response array in Stripe's expected format.
 	 */
 	public function calculate(
@@ -96,25 +108,16 @@ class WC_Stripe_Agentic_Commerce_Tax_Calculator {
 	 *
 	 * @since 10.6.0
 	 * @param string                 $line_item_id The line item ID.
-	 * @param string                 $product_id   The product ID.
+	 * @param int                    $product_id   The product ID.
 	 * @param WC_Stripe_API_Address  $address      The tax address.
 	 * @return array The line item tax response.
 	 */
 	private function calculate_line_item_taxes(
 		string $line_item_id,
-		string $product_id,
+		int $product_id,
 		WC_Stripe_API_Address $address
 	): array {
-		if ( '' === $product_id ) {
-			throw new Exception(
-				sprintf(
-					'Line item %s has no sku_id.',
-					$line_item_id
-				)
-			);
-		}
-
-		$product = WC_Stripe_Agentic_Commerce_Product_Resolver::resolve_product( (int) $product_id );
+		$product = WC_Stripe_Agentic_Commerce_Product_Resolver::resolve_product( $product_id );
 
 		$tax_rates = WC_Tax::find_rates(
 			[

--- a/readme.txt
+++ b/readme.txt
@@ -146,5 +146,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.7.0 - xxxx-xx-xx =
+* Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-customization-hook-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-customization-hook-test.php
@@ -65,6 +65,7 @@ class WC_Stripe_Agentic_Commerce_Customization_Hook_Test extends WP_UnitTestCase
 			[
 				'regular_price' => '20.00',
 				'price'         => '20.00',
+				'sku'           => 'HOOK-TEST-MAIN',
 			]
 		);
 
@@ -242,7 +243,7 @@ class WC_Stripe_Agentic_Commerce_Customization_Hook_Test extends WP_UnitTestCase
 				'line_item_details' => [
 					(object) [
 						'id'     => 'li_test_0',
-						'sku_id' => (string) $this->product->get_id(),
+						'sku_id' => (string) $this->product->get_sku(),
 					],
 				],
 			],
@@ -269,7 +270,7 @@ class WC_Stripe_Agentic_Commerce_Customization_Hook_Test extends WP_UnitTestCase
 		foreach ( $products as $index => $product ) {
 			$items[] = (object) [
 				'id'     => 'li_test_' . $index,
-				'sku_id' => (string) $product->get_id(),
+				'sku_id' => (string) $product->get_sku(),
 			];
 		}
 

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-manual-approval-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-manual-approval-test.php
@@ -309,6 +309,7 @@ class WC_Stripe_Agentic_Commerce_Manual_Approval_Test extends WP_UnitTestCase {
 		$defaults = [
 			'regular_price' => '20.00',
 			'price'         => '20.00',
+			'sku'           => 'MANUAL-APPROVAL-' . uniqid(),
 		];
 
 		$product          = WC_Helper_Product::create_simple_product( true, array_merge( $defaults, $args ) );
@@ -329,7 +330,7 @@ class WC_Stripe_Agentic_Commerce_Manual_Approval_Test extends WP_UnitTestCase {
 		foreach ( $products as $index => $product ) {
 			$items[] = (object) [
 				'id'       => 'li_test_' . $index,
-				'sku_id'   => (string) $product->get_id(),
+				'sku_id'   => (string) $product->get_sku(),
 				'quantity' => $quantities[ $index ] ?? 1,
 				'name'     => $product->get_name(),
 			];

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-tax-calculator-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-tax-calculator-test.php
@@ -51,6 +51,7 @@ class WC_Stripe_Agentic_Commerce_Tax_Calculator_Test extends WP_UnitTestCase {
 			[
 				'regular_price' => '25.00',
 				'price'         => '25.00',
+				'sku'           => 'TAX-CALC-MAIN',
 			]
 		);
 
@@ -161,6 +162,7 @@ class WC_Stripe_Agentic_Commerce_Tax_Calculator_Test extends WP_UnitTestCase {
 			[
 				'regular_price' => '15.00',
 				'price'         => '15.00',
+				'sku'           => 'TAX-CALC-SECOND',
 			]
 		);
 
@@ -178,30 +180,28 @@ class WC_Stripe_Agentic_Commerce_Tax_Calculator_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that a missing product throws an exception.
+	 * Test that an unknown SKU throws an exception during extraction.
 	 */
-	public function test_calculate_throws_for_missing_product() {
+	public function test_extract_throws_for_unknown_sku() {
 		$event = $this->build_event_from_raw_items(
 			[
 				[
 					'id'     => 'li_missing',
-					'sku_id' => '999999',
+					'sku_id' => 'DOES-NOT-EXIST',
 				],
 			]
 		);
 
-		$line_items = $this->calculator->extract_line_items_from_customization_hook( $event );
-
 		$this->expectException( Exception::class );
-		$this->expectExceptionMessage( 'Product not found' );
+		$this->expectExceptionMessage( 'Product not found for line item li_missing with SKU "DOES-NOT-EXIST"' );
 
-		$this->calculator->calculate( $event, $line_items );
+		$this->calculator->extract_line_items_from_customization_hook( $event );
 	}
 
 	/**
-	 * Test that an empty sku_id throws an exception.
+	 * Test that an empty sku_id throws an exception during extraction.
 	 */
-	public function test_calculate_throws_for_empty_sku_id() {
+	public function test_extract_throws_for_empty_sku_id() {
 		$event = $this->build_event_from_raw_items(
 			[
 				[
@@ -211,12 +211,10 @@ class WC_Stripe_Agentic_Commerce_Tax_Calculator_Test extends WP_UnitTestCase {
 			]
 		);
 
-		$line_items = $this->calculator->extract_line_items_from_customization_hook( $event );
-
 		$this->expectException( Exception::class );
-		$this->expectExceptionMessage( 'has no sku_id' );
+		$this->expectExceptionMessage( 'Line item li_empty_sku has no sku_id' );
 
-		$this->calculator->calculate( $event, $line_items );
+		$this->calculator->extract_line_items_from_customization_hook( $event );
 	}
 
 	/**
@@ -277,6 +275,7 @@ class WC_Stripe_Agentic_Commerce_Tax_Calculator_Test extends WP_UnitTestCase {
 				'regular_price' => '20.00',
 				'price'         => '20.00',
 				'tax_class'     => 'reduced-rate',
+				'sku'           => 'TAX-CALC-REDUCED',
 			]
 		);
 
@@ -294,9 +293,9 @@ class WC_Stripe_Agentic_Commerce_Tax_Calculator_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test extract_line_items_from_customization_hook returns correct ID => sku_id mapping.
+	 * Test extract_line_items_from_customization_hook returns correct ID => product ID mapping.
 	 */
-	public function test_extract_line_items_returns_id_to_sku_map() {
+	public function test_extract_line_items_returns_id_to_product_id_map() {
 		$event  = $this->build_event_from_products( [ $this->product ] );
 		$result = $this->calculator->extract_line_items_from_customization_hook( $event );
 
@@ -305,6 +304,6 @@ class WC_Stripe_Agentic_Commerce_Tax_Calculator_Test extends WP_UnitTestCase {
 		$values = array_values( $result );
 
 		$this->assertStringStartsWith( 'li_', $keys[0] );
-		$this->assertEquals( (string) $this->product->get_id(), $values[0] );
+		$this->assertSame( $this->product->get_id(), $values[0] );
 	}
 }

--- a/tests/phpunit/agentic-commerce/trait-agentic-commerce-test-helpers.php
+++ b/tests/phpunit/agentic-commerce/trait-agentic-commerce-test-helpers.php
@@ -81,7 +81,7 @@ trait Trait_Agentic_Commerce_Test_Helpers {
 		foreach ( $products as $index => $product ) {
 			$items[] = (object) [
 				'id'     => 'li_test_' . $index,
-				'sku_id' => (string) $product->get_id(),
+				'sku_id' => (string) $product->get_sku(),
 			];
 		}
 


### PR DESCRIPTION
## Summary

### Root cause

The Agentic Commerce manual approval validator and tax calculator were treating Stripe's `sku_id` line-item field as if it were a WooCommerce product ID. Two call sites had an explicit `(int)` cast on the SKU:

- `WC_Stripe_Agentic_Commerce_Manual_Approval::validate_line_item()`: `$product_id = (int) $line_item->get_sku_id();`
- `WC_Stripe_Agentic_Commerce_Tax_Calculator::calculate_line_item_taxes()`: `resolve_product( (int) $product_id )` (variable name was misleading — the value was actually the SKU string).

PHP string-to-int coercion truncates at the first non-numeric character, so realistic SKUs produced broken lookups:
- `"ABC-123"` → `0`
- `"PROD-001"` → `0`
- `"42-blue"` → `42` (could silently resolve to an **unrelated** product whose ID happens to be 42)

`WC_Stripe_Agentic_Commerce_Product_Resolver::resolve_product( 0 )` then failed resolution, so every checkout with a non-numeric SKU errored out — and a checkout with a numeric-prefixed SKU could point at the wrong product.

The bug was hidden by tests because the shared fixture used `(string) $product->get_id()` as `sku_id`. Every test SKU was a numeric string equal to a real product ID, so the cast happened to round-trip.

### Fix

- Route both flows through `wc_get_product_id_by_sku()` — the correct WooCommerce API for resolving a SKU to a product.
- Guard against empty `sku_id` with a distinct `'Line item ... has no sku_id'` error. Without this, `wc_get_product_id_by_sku('')` matches any product with empty `_sku` meta, which could silently resolve a malformed request to an unintended product.
- Unknown SKUs now throw `'Product not found for line item ... with SKU "..."'` at extraction time; the now-unreachable zero guard in `calculate_line_item_taxes` is removed.
- Existing tax-calculator, manual-approval, and customization-hook tests (plus the shared trait helper) were relying on the buggy `(string) $product->get_id()` as `sku_id`. They now use `$product->get_sku()` with unique SKUs per product and updated assertions for the new contract.
- Adds matching 10.7.0 entries to `changelog.txt` and `readme.txt`.

## Test plan
- [x] `npm run test:php` — full suite green (1832 tests, 4178 assertions)
- [x] `npm run phpstan` — passed locally via pre-push hook
- [ ] Manual: simulate a Stripe `customize_checkout` and `finalize_checkout` webhook against a product with a non-numeric SKU and confirm the lookup resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)