### PR TITLE
Fix failing E2E tests

### DIFF
--- a/tests/e2e/tests/express-checkout/utils.js
+++ b/tests/e2e/tests/express-checkout/utils.js
@@ -14,20 +14,16 @@ export const getLinkButton = async ( page, isBlockPage = false ) => {
 
 export const assertLinkModalLoads = async ( page, isBlockPage = false ) => {
 	const linkButton = await getLinkButton( page, isBlockPage );
-	await expect( linkButton ).toBeVisible();
+	await expect( linkButton ).toBeVisible( { timeout: 60 * 1000 } );
 	await expect( linkButton ).toBeEnabled();
 
 	const context = page.context();
 	const [ popup ] = await Promise.all( [
-		context.waitForEvent( 'page' ),
+		context.waitForEvent( 'page', { timeout: 60 * 1000 } ),
 		linkButton.click(),
 	] );
 
 	await popup.waitForLoadState();
 
-	await expect(
-		page.getByRole( 'button', {
-			name: 'Continue payment',
-		} )
-	).toBeVisible();
+	await expect( popup.getByTestId( 'pay-button' ) ).toBeVisible();
 };

--- a/tests/e2e/tests/express-checkout/utils.js
+++ b/tests/e2e/tests/express-checkout/utils.js
@@ -25,5 +25,7 @@ export const assertLinkModalLoads = async ( page, isBlockPage = false ) => {
 
 	await popup.waitForLoadState();
 
-	await expect( popup.getByTestId( 'pay-button' ) ).toBeVisible();
+	await expect( popup.getByTestId( 'pay-button' ) ).toBeVisible( {
+		timeout: 60 * 1000,
+	} );
 };


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Fixes the `customer can use Link express checkout` E2E suite in `tests/e2e/tests/express-checkout/express-checkout.spec.js`, which was failing on three separate flows. All fixes are scoped to `tests/e2e/tests/express-checkout/utils.js`.

- **Pay button selector (popup)** — the Link auth flow opens a separate window, but the assertion was searching for `getByRole('button', { name: 'Continue payment' })` on the parent `page`. Switched to `popup.getByTestId('pay-button')`, which both targets the correct browser context and uses a stable test id instead of localizable button copy.
- **Link button render timeout (product page)** — after #5100 deferred WC session creation on product pages, the ECE takes longer to mount on first load in a clean test context (no prior session from `addToCart`). Bumped `expect(linkButton).toBeVisible()` to 60s.
- **Popup open timeout (block cart)** — `context.waitForEvent('page')` was inheriting the 15s `actionTimeout` from `playwright.config.js`, which wasn't enough for Stripe's Link popup to open on the block cart page. Passed an explicit 60s timeout.

## Testing instructions

- Setup the E2E environment: `npm run test:e2e-setup`
- Run the default E2E project: `npm run test:e2e`
- Verify all tests pass, and specifically all five tests in `link express checkout` pass:
  - inside the product page
  - inside the cart page (classic)
  - inside the checkout page (classic)
  - inside the cart page (block)
  - inside the checkout page (block)

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment 

Link E2E test stability fixes only — no runtime behavior changes.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
