### PR TITLE
Fix duplicate hook registration for optimized checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ xxxx-xx-xx - version 10.7.0
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails
+* Fix - Fix Optimized Checkout Suite bugs that could result in duplicate subscription charges and generic payment methods names
 
 2026-04-20 - version 10.6.0
 * Remove - Remove EU adaptive pricing disclosure component from classic and Blocks checkout as it is shown natively within the Stripe currency selector element

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -83,6 +83,11 @@ trait WC_Stripe_Subscriptions_Trait {
 		if ( WC_Stripe_UPE_Payment_Gateway::ID !== $this->id ) {
 			return;
 		}
+		// Secondary check to skip registration for the OC payment method, which mimics the Stripe ID.
+		$current_class = get_class( $this );
+		if ( WC_Stripe_UPE_Payment_Gateway::class !== $current_class ) {
+			return;
+		}
 
 		add_action( 'woocommerce_subscriptions_change_payment_before_submit', [ $this, 'differentiate_change_payment_method_form' ] );
 		add_action( 'wcs_resubscribe_order_created', [ $this, 'delete_resubscribe_meta' ], 10 );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -803,6 +803,22 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
+	 * Checks whether Optimized Checkout is the active payment strategy for the current request.
+	 *
+	 * Distinct from {@see self::is_valid_optimized_checkout_page()} which gates *rendering* to
+	 * actual checkout pages. This broader check is true wherever OCS-aware token handling should
+	 * apply (e.g. My Account → Payment Methods, where saved tokens for sub-gateways must still
+	 * surface under the consolidated 'stripe' gateway).
+	 *
+	 * @return bool
+	 */
+	public function is_optimized_checkout_active(): bool {
+		return $this->oc_enabled
+			&& ! $this->is_on_add_payment_method_page()
+			&& ! $this->is_changing_payment_method_for_subscription();
+	}
+
+	/**
 	 * Returns the payment method title.
 	 *
 	 * When Optimized Checkout is enabled, returns the title from the OC payment method class.
@@ -4634,7 +4650,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			return $tokens;
 		}
 
-		if ( ! $this->oc_enabled || ! $this->is_valid_optimized_checkout_page() ) {
+		if ( ! $this->is_optimized_checkout_active() ) {
 			return $tokens;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -824,7 +824,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 				}
 			}
 
-			return ( new WC_Stripe_UPE_Payment_Method_OC() )->get_title();
+			return WC_Stripe_UPE_Payment_Method_OC::get_alternative_title();
 		}
 		return parent::get_title();
 	}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -795,7 +795,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 * @return bool True if we are on a page where the optimized checkout can be shown, false otherwise.
 	 */
 	public function is_valid_optimized_checkout_page(): bool {
-		return ! $this->is_on_add_payment_method_page() && ! $this->is_changing_payment_method_for_subscription();
+		if ( $this->is_on_add_payment_method_page() || $this->is_changing_payment_method_for_subscription() ) {
+			return false;
+		}
+
+		return is_checkout();
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
@@ -16,6 +16,8 @@ class WC_Stripe_UPE_Payment_Method_OC extends WC_Stripe_UPE_Payment_Method {
 
 	const STRIPE_ID = WC_Stripe_Payment_Methods::OC;
 
+	private const DEFAULT_TITLE = 'Stripe';
+
 	/**
 	 * Constructor for the Optimized Checkout payment method (which renders all methods).
 	 */
@@ -27,7 +29,7 @@ class WC_Stripe_UPE_Payment_Method_OC extends WC_Stripe_UPE_Payment_Method {
 		$this->enabled     = $is_stripe_enabled && $this->oc_enabled ? 'yes' : 'no';
 		$this->id          = WC_Stripe_UPE_Payment_Gateway::ID; // Force the ID to be the same as the main payment gateway.
 		$this->stripe_id   = self::STRIPE_ID;
-		$this->title       = 'Stripe';
+		$this->title       = self::DEFAULT_TITLE;
 		$this->is_reusable = true;
 		$this->supports[]  = PaymentGatewayFeature::TOKENIZATION;
 
@@ -56,12 +58,21 @@ class WC_Stripe_UPE_Payment_Method_OC extends WC_Stripe_UPE_Payment_Method {
 			return $payment_method instanceof self ? parent::get_title() : $payment_method->get_title();
 		}
 
+		return self::get_alternative_title();
+	}
+
+	/**
+	 * Returns the alternative title for the Optimized Checkout payment method.
+	 *
+	 * @return string
+	 */
+	public static function get_alternative_title(): string {
 		// Block checkout and pay for order (checkout) page.
 		if ( ( has_block( 'woocommerce/checkout' ) || ! empty( $_GET['pay_for_order'] ) ) && ! is_wc_endpoint_url( 'order-received' ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return __( 'Payment methods', 'woocommerce-gateway-stripe' );
 		}
 
-		return parent::get_title();
+		return self::DEFAULT_TITLE;
 	}
 
 	/**

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -126,7 +126,7 @@ class WC_Stripe_Payment_Tokens {
 			$is_ocs_sub_gateway = WC_Stripe_UPE_Payment_Gateway::ID === $payment_method
 				&& in_array( $token->get_gateway_id(), self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD, true )
 				&& null !== $main_gateway
-				&& $main_gateway->oc_enabled && $main_gateway->is_valid_optimized_checkout_page();
+				&& $main_gateway->is_optimized_checkout_active();
 
 			if ( ! $is_ocs_sub_gateway ) {
 				return null;
@@ -237,7 +237,7 @@ class WC_Stripe_Payment_Tokens {
 				// When OCS is active, is_enabled_at_checkout() handles currency/capability; is_enabled()
 				// ensures explicitly disabled methods are still hidden.
 				// When OCS is not active, use the simple is_enabled() toggle check.
-				if ( $gateway->oc_enabled && $gateway->is_valid_optimized_checkout_page() ) {
+				if ( $gateway->is_optimized_checkout_active() ) {
 					if ( ! $method_obj->is_enabled() || ! $method_obj->is_enabled_at_checkout() ) {
 						// Preserve existing tokens in the DB but exclude them from the results.
 						// This avoids deleting tokens that are temporarily unavailable (e.g. currency change).
@@ -279,7 +279,7 @@ class WC_Stripe_Payment_Tokens {
 			// tokens without triggering the sync path. There is no recursion risk because the filter
 			// is absent for the duration of this try block.
 			// Only merge tokens for sub-gateways whose payment method is currently enabled.
-			if ( $gateway->oc_enabled && $gateway->is_valid_optimized_checkout_page() && WC_Stripe_UPE_Payment_Gateway::ID === $gateway_id ) {
+			if ( $gateway->is_optimized_checkout_active() && WC_Stripe_UPE_Payment_Gateway::ID === $gateway_id ) {
 				$sub_gateway_to_method_type = [];
 				foreach ( self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD as $method_type => $gw_id ) {
 					if ( WC_Stripe_UPE_Payment_Gateway::ID !== $gw_id ) {
@@ -627,7 +627,7 @@ class WC_Stripe_Payment_Tokens {
 		// (gateway ID 'stripe'). Remap sub-gateway tokens (e.g. stripe_sepa_debit) to the main stripe gateway ID
 		// so that PaymentUtils includes them in the blocks checkout saved methods list.
 		$main_gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
-		if ( $main_gateway->oc_enabled && $main_gateway->is_valid_optimized_checkout_page() && WC_Stripe_UPE_Payment_Gateway::ID !== $payment_token->get_gateway_id() ) {
+		if ( $main_gateway->is_optimized_checkout_active() && WC_Stripe_UPE_Payment_Gateway::ID !== $payment_token->get_gateway_id() ) {
 			$item['method']['gateway'] = WC_Stripe_UPE_Payment_Gateway::ID;
 		}
 
@@ -1073,7 +1073,7 @@ class WC_Stripe_Payment_Tokens {
 
 		// When OCS is enabled, all reusable payment methods can be used via the consolidated OCS element.
 		// Return all reusable types so existing tokens are verified against Stripe and not incorrectly orphaned.
-		if ( $gateway->oc_enabled && $gateway->is_valid_optimized_checkout_page() ) {
+		if ( $gateway->is_optimized_checkout_active() ) {
 			return $reusable_payment_method_types;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -150,5 +150,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails
+* Fix - Fix Optimized Checkout Suite bugs that could result in duplicate subscription charges and generic payment methods names
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -4816,6 +4816,68 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * Tests for `is_optimized_checkout_active`.
+	 *
+	 * Unlike `is_valid_optimized_checkout_page`, this helper must NOT depend on `is_checkout()`
+	 * because OCS-aware token handling has to fire on My Account → Payment Methods (where
+	 * `is_checkout()` is false) so that sub-gateway tokens still surface under the consolidated
+	 * 'stripe' gateway and existing tokens are not orphaned by the cleanup sweep.
+	 *
+	 * @dataProvider provide_test_is_optimized_checkout_active
+	 *
+	 * @param bool $oc_enabled                 Value of the `oc_enabled` property on the gateway.
+	 * @param bool $is_add_payment_method      Whether the current page is the "Add payment method" page.
+	 * @param bool $is_changing_payment_method Whether the customer is changing their payment method for a subscription.
+	 * @param bool $expected                   Whether `is_optimized_checkout_active` should return true.
+	 */
+	public function test_is_optimized_checkout_active( bool $oc_enabled, bool $is_add_payment_method, bool $is_changing_payment_method, bool $expected ) {
+		$gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'is_on_add_payment_method_page', 'is_changing_payment_method_for_subscription' ] )
+			->getMock();
+
+		$gateway->oc_enabled = $oc_enabled;
+		$gateway->method( 'is_on_add_payment_method_page' )->willReturn( $is_add_payment_method );
+		$gateway->method( 'is_changing_payment_method_for_subscription' )->willReturn( $is_changing_payment_method );
+
+		$this->assertSame( $expected, $gateway->is_optimized_checkout_active() );
+	}
+
+	/**
+	 * Data provider for `test_is_optimized_checkout_active`.
+	 *
+	 * @return array[]
+	 */
+	public function provide_test_is_optimized_checkout_active() {
+		return [
+			'OCS enabled, neutral page (e.g. My Account)' => [
+				'oc_enabled'                 => true,
+				'is_add_payment_method'      => false,
+				'is_changing_payment_method' => false,
+				'expected'                   => true,
+			],
+			'OCS disabled'                                => [
+				'oc_enabled'                 => false,
+				'is_add_payment_method'      => false,
+				'is_changing_payment_method' => false,
+				'expected'                   => false,
+			],
+			'OCS enabled, add payment method page'        => [
+				'oc_enabled'                 => true,
+				'is_add_payment_method'      => true,
+				'is_changing_payment_method' => false,
+				'expected'                   => false,
+			],
+			'OCS enabled, change payment method'          => [
+				'oc_enabled'                 => true,
+				'is_add_payment_method'      => false,
+				'is_changing_payment_method' => true,
+				'expected'                   => false,
+			],
+		];
+	}
+
+	/**
 	 * Build a minimal gateway mock suitable for exercising `javascript_params()`.
 	 *
 	 * All instance methods that reach out to Stripe or WooCommerce infrastructure are

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -4793,17 +4793,26 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	 *
 	 * @param bool $is_add_payment_method      Whether the current page is the "Add payment method" page.
 	 * @param bool $is_changing_payment_method Whether the customer is changing their payment method for a subscription.
+	 * @param bool $is_checkout                Whether the current page is the checkout page.
 	 * @param bool $expected                   Whether `is_valid_optimized_checkout_page` should return true.
 	 */
-	public function test_is_valid_optimized_checkout_page( bool $is_add_payment_method, bool $is_changing_payment_method, bool $expected ) {
+	public function test_is_valid_optimized_checkout_page( bool $is_add_payment_method, bool $is_changing_payment_method, bool $is_checkout, bool $expected ) {
 		$gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
 			->onlyMethods( [ 'is_on_add_payment_method_page', 'is_changing_payment_method_for_subscription' ] )
 			->getMock();
 
 		$gateway->method( 'is_on_add_payment_method_page' )->willReturn( $is_add_payment_method );
 		$gateway->method( 'is_changing_payment_method_for_subscription' )->willReturn( $is_changing_payment_method );
+		$is_checkout_return = $is_checkout ? '__return_true' : '__return_false';
+		add_filter( 'woocommerce_is_checkout', $is_checkout_return );
 
-		$this->assertSame( $expected, $gateway->is_valid_optimized_checkout_page() );
+		try {
+			$result = $gateway->is_valid_optimized_checkout_page();
+		} finally {
+			remove_filter( 'woocommerce_is_checkout', $is_checkout_return );
+		}
+
+		$this->assertSame( $expected, $result );
 	}
 
 	/**
@@ -4959,21 +4968,31 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			'Regular checkout page'                  => [
 				'is_add_payment_method'      => false,
 				'is_changing_payment_method' => false,
+				'is_checkout'                => true,
 				'expected'                   => true,
 			],
 			'Add payment method page'                => [
 				'is_add_payment_method'      => true,
 				'is_changing_payment_method' => false,
+				'is_checkout'                => true,
 				'expected'                   => false,
 			],
 			'Change payment method for subscription' => [
 				'is_add_payment_method'      => false,
 				'is_changing_payment_method' => true,
+				'is_checkout'                => true,
 				'expected'                   => false,
 			],
 			'All special pages'                      => [
 				'is_add_payment_method'      => true,
 				'is_changing_payment_method' => true,
+				'is_checkout'                => true,
+				'expected'                   => false,
+			],
+			'Non-checkout page'                      => [
+				'is_add_payment_method'      => false,
+				'is_changing_payment_method' => false,
+				'is_checkout'                => false,
 				'expected'                   => false,
 			],
 		];

--- a/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
+++ b/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
@@ -630,8 +630,6 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 		};
 		add_filter( 'pre_http_request', $mock_http_request, 10, 3 );
 
-		add_filter( 'woocommerce_is_checkout', '__return_true' );
-
 		// Enable OCS on the mock main gateway.
 		// Also populate payment_methods with a CashApp stub so the sub-gateway sync (triggered by
 		// the second WC_Stripe_Payment_Tokens instance created during plugin init) does not treat
@@ -651,7 +649,6 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 			$result = $this->stripe_payment_tokens->woocommerce_get_customer_payment_tokens( [], $user_id, WC_Stripe_UPE_Payment_Gateway::ID );
 		} finally {
 			remove_filter( 'pre_http_request', $mock_http_request, 10 );
-			remove_filter( 'woocommerce_is_checkout', '__return_true' );
 		}
 
 		// The CashApp token should appear in the result because OCS sub-gateway tokens are merged.
@@ -785,13 +782,7 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 		$sepa_token->set_user_id( 1 );
 		$sepa_token->save();
 
-		add_filter( 'woocommerce_is_checkout', '__return_true' );
-
-		try {
-			$result = $this->stripe_payment_tokens->get_account_saved_payment_methods_list_item( [ 'method' => [] ], $sepa_token );
-		} finally {
-			remove_filter( 'woocommerce_is_checkout', '__return_true' );
-		}
+		$result = $this->stripe_payment_tokens->get_account_saved_payment_methods_list_item( [ 'method' => [] ], $sepa_token );
 
 		$this->assertArrayHasKey( 'gateway', $result['method'], 'Gateway key should be set when OCS is enabled and token is from a sub-gateway.' );
 		$this->assertSame( WC_Stripe_UPE_Payment_Gateway::ID, $result['method']['gateway'], 'Gateway should be remapped to the main stripe gateway when OCS is enabled.' );

--- a/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
+++ b/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
@@ -630,6 +630,8 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 		};
 		add_filter( 'pre_http_request', $mock_http_request, 10, 3 );
 
+		add_filter( 'woocommerce_is_checkout', '__return_true' );
+
 		// Enable OCS on the mock main gateway.
 		// Also populate payment_methods with a CashApp stub so the sub-gateway sync (triggered by
 		// the second WC_Stripe_Payment_Tokens instance created during plugin init) does not treat
@@ -649,6 +651,7 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 			$result = $this->stripe_payment_tokens->woocommerce_get_customer_payment_tokens( [], $user_id, WC_Stripe_UPE_Payment_Gateway::ID );
 		} finally {
 			remove_filter( 'pre_http_request', $mock_http_request, 10 );
+			remove_filter( 'woocommerce_is_checkout', '__return_true' );
 		}
 
 		// The CashApp token should appear in the result because OCS sub-gateway tokens are merged.
@@ -782,7 +785,13 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 		$sepa_token->set_user_id( 1 );
 		$sepa_token->save();
 
-		$result = $this->stripe_payment_tokens->get_account_saved_payment_methods_list_item( [ 'method' => [] ], $sepa_token );
+		add_filter( 'woocommerce_is_checkout', '__return_true' );
+
+		try {
+			$result = $this->stripe_payment_tokens->get_account_saved_payment_methods_list_item( [ 'method' => [] ], $sepa_token );
+		} finally {
+			remove_filter( 'woocommerce_is_checkout', '__return_true' );
+		}
 
 		$this->assertArrayHasKey( 'gateway', $result['method'], 'Gateway key should be set when OCS is enabled and token is from a sub-gateway.' );
 		$this->assertSame( WC_Stripe_UPE_Payment_Gateway::ID, $result['method']['gateway'], 'Gateway should be remapped to the main stripe gateway when OCS is enabled.' );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-1097

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR addresses some subtle issues in 10.6.0 that stem from two related sets of changes:
 * As part of trying to display better titles when Optimized Checkout Suite is enabled, we were instantiating the `WC_Stripe_UPE_Payment_Method_OC` class to get the relevant payment method title, which was resulting in some crucial hooks being registered twice
    - One critical failure mode for this issue was that subscriptions could trigger duplicate charges
 * The `WC_Stripe_UPE_Payment_Gateway->is_valid_optimized_checkout_page()` method was returning true in a large number of contexts where Optimized Checkout should _not_ be shown.
    - A side effect of this was that Optimized Checkout Suite logic was incorrectly being triggered in contexts where it should not be, which could cause the order received and order details pages to show "Stripe" as the payment method instead of the underlying payment method that was used through OCS
    - A separate side effect is that some logic that should only be checking whether Optimized Checkout is enabled and might be in use was also using the method above

To address the issues above, this PR does the following:
 - The logic for getting the alternative/custom title has been shifted into a static method on `WC_Stripe_UPE_Payment_Method_OC` so we don't need to instantiate the class to get the title.
 - `WC_Stripe_UPE_Payment_Gateway->is_valid_optimized_checkout_page()` now checks that we are on a checkout page via the WooCommerce `is_checkout()` method. This method should be used to work out whether OCS should be rendered in the current context.
 - We have introduced the `WC_Stripe_UPE_Payment_Gateway->is_optimized_checkout_active()` helper to indicate whether OCS is active in the current context, and we have updated some code related to saved payment methods to use this flag instead.
 - We have added a small check in our subscriptions trait to prevent hooks being incorrectly attached to an instance of `WC_Stripe_UPE_Payment_Method_OC`

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Things that need to be tested:
 * Purchase flows with OCS enabled
   - Verify that Order Received page, My Orders, wp-admin order details, and receipt show the correct payment method
 * Verify that saved payment methods show up correctly in my account with OCS on and off
 * Verify that new payment methods can be saved with OCS on and off, and that the saved payment methods can be used to make new purchases
   - We need to test purchases with and without subscriptions
 * Verify that we still hide OCS on the add payment method and change payment method pages when OCS is enabled
 * Verify that the snippet from https://pastebin.com/raw/VyftNKU1 doesn't result in multiple sets of hooks

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
