### PR TITLE
Fix tokens not saved after duplicate hook registration fix

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -803,6 +803,22 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
+	 * Checks whether Optimized Checkout is the active payment strategy for the current request.
+	 *
+	 * Distinct from {@see self::is_valid_optimized_checkout_page()} which gates *rendering* to
+	 * actual checkout pages. This broader check is true wherever OCS-aware token handling should
+	 * apply (e.g. My Account → Payment Methods, where saved tokens for sub-gateways must still
+	 * surface under the consolidated 'stripe' gateway).
+	 *
+	 * @return bool
+	 */
+	public function is_optimized_checkout_active(): bool {
+		return $this->oc_enabled
+			&& ! $this->is_on_add_payment_method_page()
+			&& ! $this->is_changing_payment_method_for_subscription();
+	}
+
+	/**
 	 * Returns the payment method title.
 	 *
 	 * When Optimized Checkout is enabled, returns the title from the OC payment method class.
@@ -4634,7 +4650,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			return $tokens;
 		}
 
-		if ( ! $this->oc_enabled || ! $this->is_valid_optimized_checkout_page() ) {
+		if ( ! $this->is_optimized_checkout_active() ) {
 			return $tokens;
 		}
 

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -126,7 +126,7 @@ class WC_Stripe_Payment_Tokens {
 			$is_ocs_sub_gateway = WC_Stripe_UPE_Payment_Gateway::ID === $payment_method
 				&& in_array( $token->get_gateway_id(), self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD, true )
 				&& null !== $main_gateway
-				&& $main_gateway->oc_enabled && $main_gateway->is_valid_optimized_checkout_page();
+				&& $main_gateway->is_optimized_checkout_active();
 
 			if ( ! $is_ocs_sub_gateway ) {
 				return null;
@@ -237,7 +237,7 @@ class WC_Stripe_Payment_Tokens {
 				// When OCS is active, is_enabled_at_checkout() handles currency/capability; is_enabled()
 				// ensures explicitly disabled methods are still hidden.
 				// When OCS is not active, use the simple is_enabled() toggle check.
-				if ( $gateway->oc_enabled && $gateway->is_valid_optimized_checkout_page() ) {
+				if ( $gateway->is_optimized_checkout_active() ) {
 					if ( ! $method_obj->is_enabled() || ! $method_obj->is_enabled_at_checkout() ) {
 						// Preserve existing tokens in the DB but exclude them from the results.
 						// This avoids deleting tokens that are temporarily unavailable (e.g. currency change).
@@ -279,7 +279,7 @@ class WC_Stripe_Payment_Tokens {
 			// tokens without triggering the sync path. There is no recursion risk because the filter
 			// is absent for the duration of this try block.
 			// Only merge tokens for sub-gateways whose payment method is currently enabled.
-			if ( $gateway->oc_enabled && $gateway->is_valid_optimized_checkout_page() && WC_Stripe_UPE_Payment_Gateway::ID === $gateway_id ) {
+			if ( $gateway->is_optimized_checkout_active() && WC_Stripe_UPE_Payment_Gateway::ID === $gateway_id ) {
 				$sub_gateway_to_method_type = [];
 				foreach ( self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD as $method_type => $gw_id ) {
 					if ( WC_Stripe_UPE_Payment_Gateway::ID !== $gw_id ) {
@@ -627,7 +627,7 @@ class WC_Stripe_Payment_Tokens {
 		// (gateway ID 'stripe'). Remap sub-gateway tokens (e.g. stripe_sepa_debit) to the main stripe gateway ID
 		// so that PaymentUtils includes them in the blocks checkout saved methods list.
 		$main_gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
-		if ( $main_gateway->oc_enabled && $main_gateway->is_valid_optimized_checkout_page() && WC_Stripe_UPE_Payment_Gateway::ID !== $payment_token->get_gateway_id() ) {
+		if ( $main_gateway->is_optimized_checkout_active() && WC_Stripe_UPE_Payment_Gateway::ID !== $payment_token->get_gateway_id() ) {
 			$item['method']['gateway'] = WC_Stripe_UPE_Payment_Gateway::ID;
 		}
 
@@ -1073,7 +1073,7 @@ class WC_Stripe_Payment_Tokens {
 
 		// When OCS is enabled, all reusable payment methods can be used via the consolidated OCS element.
 		// Return all reusable types so existing tokens are verified against Stripe and not incorrectly orphaned.
-		if ( $gateway->oc_enabled && $gateway->is_valid_optimized_checkout_page() ) {
+		if ( $gateway->is_optimized_checkout_active() ) {
 			return $reusable_payment_method_types;
 		}
 

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -4816,6 +4816,68 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * Tests for `is_optimized_checkout_active`.
+	 *
+	 * Unlike `is_valid_optimized_checkout_page`, this helper must NOT depend on `is_checkout()`
+	 * because OCS-aware token handling has to fire on My Account → Payment Methods (where
+	 * `is_checkout()` is false) so that sub-gateway tokens still surface under the consolidated
+	 * 'stripe' gateway and existing tokens are not orphaned by the cleanup sweep.
+	 *
+	 * @dataProvider provide_test_is_optimized_checkout_active
+	 *
+	 * @param bool $oc_enabled                 Value of the `oc_enabled` property on the gateway.
+	 * @param bool $is_add_payment_method      Whether the current page is the "Add payment method" page.
+	 * @param bool $is_changing_payment_method Whether the customer is changing their payment method for a subscription.
+	 * @param bool $expected                   Whether `is_optimized_checkout_active` should return true.
+	 */
+	public function test_is_optimized_checkout_active( bool $oc_enabled, bool $is_add_payment_method, bool $is_changing_payment_method, bool $expected ) {
+		$gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'is_on_add_payment_method_page', 'is_changing_payment_method_for_subscription' ] )
+			->getMock();
+
+		$gateway->oc_enabled = $oc_enabled;
+		$gateway->method( 'is_on_add_payment_method_page' )->willReturn( $is_add_payment_method );
+		$gateway->method( 'is_changing_payment_method_for_subscription' )->willReturn( $is_changing_payment_method );
+
+		$this->assertSame( $expected, $gateway->is_optimized_checkout_active() );
+	}
+
+	/**
+	 * Data provider for `test_is_optimized_checkout_active`.
+	 *
+	 * @return array[]
+	 */
+	public function provide_test_is_optimized_checkout_active() {
+		return [
+			'OCS enabled, neutral page (e.g. My Account)' => [
+				'oc_enabled'                 => true,
+				'is_add_payment_method'      => false,
+				'is_changing_payment_method' => false,
+				'expected'                   => true,
+			],
+			'OCS disabled'                                => [
+				'oc_enabled'                 => false,
+				'is_add_payment_method'      => false,
+				'is_changing_payment_method' => false,
+				'expected'                   => false,
+			],
+			'OCS enabled, add payment method page'        => [
+				'oc_enabled'                 => true,
+				'is_add_payment_method'      => true,
+				'is_changing_payment_method' => false,
+				'expected'                   => false,
+			],
+			'OCS enabled, change payment method'          => [
+				'oc_enabled'                 => true,
+				'is_add_payment_method'      => false,
+				'is_changing_payment_method' => true,
+				'expected'                   => false,
+			],
+		];
+	}
+
+	/**
 	 * Build a minimal gateway mock suitable for exercising `javascript_params()`.
 	 *
 	 * All instance methods that reach out to Stripe or WooCommerce infrastructure are

--- a/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
+++ b/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
@@ -630,8 +630,6 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 		};
 		add_filter( 'pre_http_request', $mock_http_request, 10, 3 );
 
-		add_filter( 'woocommerce_is_checkout', '__return_true' );
-
 		// Enable OCS on the mock main gateway.
 		// Also populate payment_methods with a CashApp stub so the sub-gateway sync (triggered by
 		// the second WC_Stripe_Payment_Tokens instance created during plugin init) does not treat
@@ -651,7 +649,6 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 			$result = $this->stripe_payment_tokens->woocommerce_get_customer_payment_tokens( [], $user_id, WC_Stripe_UPE_Payment_Gateway::ID );
 		} finally {
 			remove_filter( 'pre_http_request', $mock_http_request, 10 );
-			remove_filter( 'woocommerce_is_checkout', '__return_true' );
 		}
 
 		// The CashApp token should appear in the result because OCS sub-gateway tokens are merged.
@@ -785,13 +782,7 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 		$sepa_token->set_user_id( 1 );
 		$sepa_token->save();
 
-		add_filter( 'woocommerce_is_checkout', '__return_true' );
-
-		try {
-			$result = $this->stripe_payment_tokens->get_account_saved_payment_methods_list_item( [ 'method' => [] ], $sepa_token );
-		} finally {
-			remove_filter( 'woocommerce_is_checkout', '__return_true' );
-		}
+		$result = $this->stripe_payment_tokens->get_account_saved_payment_methods_list_item( [ 'method' => [] ], $sepa_token );
 
 		$this->assertArrayHasKey( 'gateway', $result['method'], 'Gateway key should be set when OCS is enabled and token is from a sub-gateway.' );
 		$this->assertSame( WC_Stripe_UPE_Payment_Gateway::ID, $result['method']['gateway'], 'Gateway should be remapped to the main stripe gateway when OCS is enabled.' );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-<linear_issue_id>
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:

Reintroduce the is_optimized_checkout_active() helper that existed at commit 39c4980eb (later lost in develop):
```
public function is_optimized_checkout_active(): bool {
    return $this->oc_enabled;
}
```
Then replace `oc_enabled && is_valid_optimized_checkout_page()` with `is_optimized_checkout_active()` at the 6 token-handling call sites listed above. Leave the rendering call sites (`payment-gateway.php:631, 813, 850, 864, 1036`) and `upe-payment-method.php:215` using the new strict is_valid_optimized_checkout_page() — those genuinely want the checkout-page-only semantics.

More context: p1776873573056549/1776869226.930609-slack-C055WHLA98D

#### Original fix

- `get_title()` at `class-wc-stripe-upe-payment-gateway.php:847` no longer does new `WC_Stripe_UPE_Payment_Method_OC()`; it calls the new static
  `WC_Stripe_UPE_Payment_Method_OC::get_alternative_title()` — so no OC constructor, no `maybe_init_subscriptions()`, no duplicate hook attachment.

- `is_valid_optimized_checkout_page()` at `class-wc-stripe-upe-payment-gateway.php:795` now requires `is_checkout()`, so the other callers of that gate also can't trigger the OC path in cron/admin/REST contexts

## Testing instructions

Ran Kaushik's probe (https://pastebin.com/raw/VyftNKU1) calls `$gw->get_title()` in a non-checkout context and dumps the `woocommerce_scheduled_subscription_payment_stripe` hook callbacks before and after.

#### On develop (baseline — reproduces the bug)
```
== BEFORE ==
    [10] WC_Stripe_UPE_Payment_Gateway#1979::scheduled_subscription_payment
== AFTER ==
    [10] WC_Stripe_UPE_Payment_Gateway#1979::scheduled_subscription_payment
    [10] WC_Stripe_UPE_Payment_Method_OC#3691::scheduled_subscription_payment
```

Hook grew from 1 → 2 callbacks — during a real renewal this is what causes `process_subscription_payment` to run twice and charge the customer twice.

#### On this fix branch
```
== BEFORE ==
    [10] WC_Stripe_UPE_Payment_Gateway#1979::scheduled_subscription_payment
== AFTER ==
    [10] WC_Stripe_UPE_Payment_Gateway#1979::scheduled_subscription_payment
```

Hook unchanged — 1 callback before, 1 after. Confirmation after applying Dale's proposed snippet.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)