### PR TITLE
Detect Agentic Commerce sessions via payment_intent.agent_details

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.7.0
+* Fix - Detect Agentic Commerce checkout sessions from the payment intent's agent_details.network_business_profile so checkout.session.completed webhooks are no longer skipped as non-agentic
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.7.0
-* Fix - Detect Agentic Commerce checkout sessions from the payment intent's agent_details.network_business_profile so checkout.session.completed webhooks are no longer skipped as non-agentic
+* Fix - Detect Agentic Commerce sessions via payment_intent.agent_details so their checkout.session.completed webhooks aren't skipped
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails

--- a/includes/agentic-commerce/class-wc-stripe-agentic-checkout-session.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-checkout-session.php
@@ -285,19 +285,26 @@ class WC_Stripe_Agentic_Checkout_Session {
 	/**
 	 * Checks whether this checkout session originates from agentic commerce.
 	 *
-	 * A session is agentic when at least one line item has an
-	 * external_reference that resolves to a nonzero integer (product ID).
+	 * A session is agentic when its payment intent carries an
+	 * agent_details.network_business_profile, which Stripe populates to
+	 * identify the originating agent. The webhook handler expands
+	 * payment_intent.agent_details on retrieve for exactly this detection.
 	 *
 	 * @since 10.6.0
 	 * @return bool
 	 */
 	public function is_agentic(): bool {
-		foreach ( $this->get_line_items() as $line_item ) {
-			if ( $line_item->has_product_id() ) {
-				return true;
-			}
+		$payment_intent = $this->session->payment_intent ?? null;
+		if ( ! is_object( $payment_intent ) ) {
+			return false;
 		}
 
-		return false;
+		$agent_details = $payment_intent->agent_details ?? null;
+		if ( ! is_object( $agent_details ) ) {
+			return false;
+		}
+
+		$network_business_profile = $agent_details->network_business_profile ?? '';
+		return is_string( $network_business_profile ) && '' !== $network_business_profile;
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -149,7 +149,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 10.7.0 - xxxx-xx-xx =
 * Dev - Use paratest in CI workflow for faster PHP test execution
-* Fix - Detect Agentic Commerce checkout sessions from the payment intent's agent_details.network_business_profile so checkout.session.completed webhooks are no longer skipped as non-agentic
+* Fix - Detect Agentic Commerce sessions via payment_intent.agent_details so their checkout.session.completed webhooks aren't skipped
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails

--- a/readme.txt
+++ b/readme.txt
@@ -147,6 +147,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 10.7.0 - xxxx-xx-xx =
 * Dev - Use paratest in CI workflow for faster PHP test execution
+* Fix - Detect Agentic Commerce checkout sessions from the payment intent's agent_details.network_business_profile so checkout.session.completed webhooks are no longer skipped as non-agentic
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-checkout-session-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-checkout-session-test.php
@@ -438,71 +438,60 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	 */
 	public function provide_is_agentic_cases(): array {
 		return [
-			'has external_reference product ID' => [
+			'network_business_profile present'    => [
 				(object) [
-					'line_items' => (object) [
-						'data' => [
-							(object) [
-								'price' => (object) [ 'external_reference' => '42' ],
-							],
+					'payment_intent' => (object) [
+						'id'            => 'pi_test_agentic',
+						'agent_details' => (object) [
+							'network_business_profile' => 'profile_test_123',
 						],
 					],
 				],
 				true,
 			],
-			'multiple items one with reference' => [
+			'network_business_profile empty'      => [
 				(object) [
-					'line_items' => (object) [
-						'data' => [
-							(object) [
-								'price' => (object) [ 'external_reference' => null ],
-							],
-							(object) [
-								'price' => (object) [ 'external_reference' => '99' ],
-							],
-						],
-					],
-				],
-				true,
-			],
-			'no external_reference'             => [
-				(object) [
-					'line_items' => (object) [
-						'data' => [
-							(object) [ 'price' => (object) [] ],
+					'payment_intent' => (object) [
+						'id'            => 'pi_test_empty_nbp',
+						'agent_details' => (object) [
+							'network_business_profile' => '',
 						],
 					],
 				],
 				false,
 			],
-			'external_reference is zero string' => [
+			'agent_details without nbp'           => [
 				(object) [
-					'line_items' => (object) [
-						'data' => [
-							(object) [
-								'price' => (object) [ 'external_reference' => '0' ],
-							],
-						],
+					'payment_intent' => (object) [
+						'id'            => 'pi_test_no_nbp',
+						'agent_details' => (object) [],
 					],
 				],
 				false,
 			],
-			'empty line items'                  => [
+			'agent_details is null'               => [
 				(object) [
-					'line_items' => (object) [ 'data' => [] ],
+					'payment_intent' => (object) [
+						'id'            => 'pi_test_null_agent_details',
+						'agent_details' => null,
+					],
 				],
 				false,
 			],
-			'external_reference is non-numeric' => [
+			'payment_intent has no agent_details' => [
 				(object) [
-					'line_items' => (object) [
-						'data' => [
-							(object) [
-								'price' => (object) [ 'external_reference' => 'not-a-number' ],
-							],
-						],
-					],
+					'payment_intent' => (object) [ 'id' => 'pi_test_not_agentic' ],
 				],
+				false,
+			],
+			'payment_intent is unexpanded string' => [
+				(object) [
+					'payment_intent' => 'pi_test_not_expanded',
+				],
+				false,
+			],
+			'payment_intent missing'              => [
+				(object) [],
 				false,
 			],
 		];

--- a/tests/phpunit/class-wc-stripe-webhook-handler-agentic-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-agentic-test.php
@@ -476,9 +476,9 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 			'id'               => $session_id,
 			'payment_intent'   => (object) [
 				'id'            => 'pi_test_' . $session_id,
-				'agent_details' => (object) [
-					'network_business_profile' => 'nbp_test_123',
-				],
+				'agent_details' => $agentic
+					? (object) [ 'network_business_profile' => 'nbp_test_123' ]
+					: null,
 			],
 			'customer'         => 'cus_test_789',
 			'customer_email'   => 'test@example.com',


### PR DESCRIPTION
Fixes STRIPE-1103
Fixes #5340

## Changes proposed in this Pull Request:

`WC_Stripe_Agentic_Checkout_Session::is_agentic()` now keys off the Stripe-native signal the webhook handler already expands on retrieve: `payment_intent.agent_details.network_business_profile`.

The previous implementation inspected line-item `price.external_reference` and tried to resolve it to a numeric WC product ID. Stripe actually sends SKU strings there, so real agentic `checkout.session.completed` webhooks fell through the check and were logged as `Checkout session is not agentic, skipping agentic processing`. Switching to `agent_details.network_business_profile` uses the canonical Stripe signal that identifies an originating agent, and it matches what the webhook handler already expands.

This PR only changes detection. Once a session is flagged as agentic, the order mapper's SKU resolution still needs the same treatment that the `finalize_checkout`/`customize_checkout` paths got in #5317 — that will ship in a follow-up so each change stays focused.

**How can this code break?**
- A future Stripe schema change that moves or renames `agent_details.network_business_profile` would silently return `false` and re-skip agentic sessions. Existing debug logging (`Checkout session is not agentic…`) remains the early warning.
- If the webhook handler stops expanding `payment_intent` on retrieve, `$session->payment_intent` will be a string and detection will correctly return `false`; this is the intended fail-closed behavior.

**What are we doing to make sure this code doesn't break?**
- Data-provider PHPUnit coverage exercises: nbp present, nbp empty string, `network_business_profile` missing, `agent_details` absent, and unexpanded (string) `payment_intent`.
- The webhook handler test fixture (`build_checkout_session_response`) now only populates `agent_details` when the `$agentic` flag is set, so the non-agentic path in `test_process_checkout_session_completed_skips_non_agentic` exercises the new skip condition rather than a stale external_reference branch.

## Testing instructions

1. Check out this branch and run `npm run test:php -- --filter WC_Stripe_Agentic_Checkout_Session_Test` — all data-provider cases for `is_agentic()` should pass.
2. Run `npm run test:php -- --filter WC_Stripe_Webhook_Handler_Agentic_Test` — `test_process_checkout_session_completed_skips_non_agentic` and `test_skips_session_with_empty_network_business_profile` should still skip (now via absent / empty `agent_details.network_business_profile`).
3. Trigger an agentic `checkout.session.completed` webhook whose payment intent includes `agent_details.network_business_profile` populated (e.g. via an ACP partner). Confirm the `Checkout session is not agentic, skipping agentic processing` log line no longer appears and the agentic order flow runs.
4. Trigger a normal (non-agentic) `checkout.session.completed` webhook and confirm the skip log line still appears and no agentic processing runs.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply) — server-side webhook logic; no UI surface.

### Changelog entry

Added in `changelog.txt` under `10.7.0`:

> Fix - Detect Agentic Commerce sessions via payment_intent.agent_details so their checkout.session.completed webhooks aren't skipped

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

N/A — changelog entry included above.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
