### PR TITLE
Surface PHP Throwables from the agentic checkout.session.completed flow

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.7.0
+* Fix - Catch PHP Throwables (not just Exceptions) in the Agentic Commerce checkout.session.completed flow so fatal errors are logged and the order rollback runs instead of being silently swallowed; also stop a return-inside-finally from swallowing those throwables at the webhook handler level
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.7.0
-* Fix - Catch PHP Throwables (not just Exceptions) in the Agentic Commerce checkout.session.completed flow so fatal errors are logged and the order rollback runs instead of being silently swallowed; also stop a return-inside-finally from swallowing those throwables at the webhook handler level
+* Fix - Surface PHP Throwables from the Agentic Commerce checkout.session.completed flow so fatals are logged, the order rollback runs, and Action Scheduler marks the job failed
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
@@ -58,7 +58,7 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 
 			// Confirm everything is right.
 			$this->verify_order_total( $order, $session );
-		} catch ( Exception $e ) {
+		} catch ( Throwable $e ) {
 			$order->delete( true );
 			throw $e;
 		}

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1575,11 +1575,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				$this->handle_agentic_checkout_session( $notification );
 			} finally {
 				WC_Stripe_Database_Cache::delete( $lock_key );
-				return;
 			}
-		} else {
-			WC_Stripe_Database_Cache::delete( $lock_key );
+			return;
 		}
+
+		WC_Stripe_Database_Cache::delete( $lock_key );
 
 		/**
 		 * Filters the valid order statuses for payment processing.
@@ -2191,12 +2191,16 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
 				 */
 				do_action( 'wc_stripe_agentic_order_created', $order, $session );
-			} catch ( Exception $e ) {
+			} catch ( Throwable $e ) {
 				WC_Stripe_Logger::error(
 					'Failed to create agentic order from checkout session.',
 					[
 						'session_id' => $session->get_id(),
 						'error'      => $e->getMessage(),
+						'exception'  => get_class( $e ),
+						'file'       => $e->getFile(),
+						'line'       => $e->getLine(),
+						'trace'      => $e->getTraceAsString(),
 					]
 				);
 
@@ -2204,7 +2208,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				 * Fires when agentic commerce order creation fails.
 				 *
 				 * @since 10.6.0
-				 * @param Exception                          $e       The exception that was thrown.
+				 * @param Throwable                          $e       The throwable that was thrown.
 				 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
 				 */
 				do_action( 'wc_stripe_agentic_order_creation_failed', $e, $session );

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -2192,6 +2192,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				 */
 				do_action( 'wc_stripe_agentic_order_created', $order, $session );
 			} catch ( Throwable $e ) {
+				// Cap trace length to avoid overwhelming log handlers that may
+				// truncate or reject very large context fields.
+				$trace = $e->getTraceAsString();
+				if ( strlen( $trace ) > 4000 ) {
+					$trace = substr( $trace, 0, 4000 ) . '... [truncated]';
+				}
+
 				WC_Stripe_Logger::error(
 					'Failed to create agentic order from checkout session.',
 					[
@@ -2200,7 +2207,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 						'exception'  => get_class( $e ),
 						'file'       => $e->getFile(),
 						'line'       => $e->getLine(),
-						'trace'      => $e->getTraceAsString(),
+						'trace'      => $trace,
 					]
 				);
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -2212,6 +2212,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
 				 */
 				do_action( 'wc_stripe_agentic_order_creation_failed', $e, $session );
+
+				// Re-throw so Action Scheduler marks the job as failed. The inner
+				// catch exists to log with full context and fire the failure hook;
+				// swallowing here would make AS report the run as complete.
+				throw $e;
 			}
 		} finally {
 			remove_filter( 'wc_stripe_request_headers', $override_version );

--- a/readme.txt
+++ b/readme.txt
@@ -149,7 +149,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 10.7.0 - xxxx-xx-xx =
 * Dev - Use paratest in CI workflow for faster PHP test execution
-* Fix - Catch PHP Throwables (not just Exceptions) in the Agentic Commerce checkout.session.completed flow so fatal errors are logged and the order rollback runs instead of being silently swallowed; also stop a return-inside-finally from swallowing those throwables at the webhook handler level
+* Fix - Surface PHP Throwables from the Agentic Commerce checkout.session.completed flow so fatals are logged, the order rollback runs, and Action Scheduler marks the job failed
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails

--- a/readme.txt
+++ b/readme.txt
@@ -147,6 +147,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 10.7.0 - xxxx-xx-xx =
 * Dev - Use paratest in CI workflow for faster PHP test execution
+* Fix - Catch PHP Throwables (not just Exceptions) in the Agentic Commerce checkout.session.completed flow so fatal errors are logged and the order rollback runs instead of being silently swallowed; also stop a return-inside-finally from swallowing those throwables at the webhook handler level
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails

--- a/tests/phpunit/class-wc-stripe-webhook-handler-agentic-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-agentic-test.php
@@ -183,6 +183,70 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a PHP Throwable (not just Exception) thrown during order
+	 * mapping is caught, logged, and fires the failure action without
+	 * crashing the webhook worker.
+	 */
+	public function test_process_checkout_session_completed_handles_mapper_throwable() {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			[
+				'regular_price' => '20.00',
+				'price'         => '20.00',
+				'sku'           => 'THROWABLE-TEST-' . uniqid(),
+			]
+		);
+
+		$failure_action_fired = false;
+		$captured_throwable   = null;
+		add_action(
+			'wc_stripe_agentic_order_creation_failed',
+			function ( $e ) use ( &$failure_action_fired, &$captured_throwable ) {
+				$failure_action_fired = true;
+				$captured_throwable   = $e;
+			}
+		);
+
+		// Force a non-Exception Throwable from inside the mapper flow.
+		// The mapper calls $order->calculate_totals() in verify_order_total,
+		// which runs the woocommerce_calculated_total filter.
+		$throw_filter = function () {
+			throw new \TypeError( 'Simulated fatal inside order mapping' );
+		};
+		add_filter( 'woocommerce_calculated_total', $throw_filter );
+
+		try {
+			$session_id   = 'cs_test_throwable';
+			$notification = $this->build_notification( $session_id );
+			$mock_session = $this->build_checkout_session_response( $session_id, true, (string) $product->get_sku() );
+			$this->mock_stripe_checkout_sessions_response( $mock_session );
+
+			// Immediate phase: defers the webhook.
+			$this->handler->process_checkout_session_success( $notification );
+			// Deferred phase: TypeError is thrown from calculate_totals via the filter.
+			// The handler must catch it (Throwable, not just Exception), log it,
+			// fire the failure action, and return normally.
+			$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
+		} finally {
+			remove_filter( 'woocommerce_calculated_total', $throw_filter );
+		}
+
+		$this->assertTrue( $failure_action_fired );
+		$this->assertInstanceOf( \Throwable::class, $captured_throwable );
+		$this->assertInstanceOf( \TypeError::class, $captured_throwable );
+
+		// The order created by the mapper must be rolled back: the mapper's
+		// inner Throwable catch deletes the order before rethrowing.
+		$orders = wc_get_orders(
+			[
+				'meta_key'   => '_stripe_intent_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value' => 'pi_test_cs_test_throwable', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			]
+		);
+		$this->assertEmpty( $orders );
+	}
+
+	/**
 	 * Tests that a valid agentic session creates an order and fires the success action.
 	 */
 	public function test_process_checkout_session_completed_creates_order() {

--- a/tests/phpunit/class-wc-stripe-webhook-handler-agentic-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-agentic-test.php
@@ -193,7 +193,6 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 			[
 				'regular_price' => '20.00',
 				'price'         => '20.00',
-				'sku'           => 'THROWABLE-TEST-' . uniqid(),
 			]
 		);
 
@@ -207,28 +206,29 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 			}
 		);
 
-		// Force a non-Exception Throwable from inside the mapper flow.
-		// The mapper calls $order->calculate_totals() in verify_order_total,
-		// which runs the woocommerce_calculated_total filter.
-		$throw_filter = function () {
+		// Force a non-Exception Throwable from inside the mapper's try block.
+		// woocommerce_new_order_item fires during $order->add_product() in
+		// map_line_items(), which runs inside the try/catch(Throwable) that the
+		// mapper's rollback depends on.
+		$throw_action = function () {
 			throw new \TypeError( 'Simulated fatal inside order mapping' );
 		};
-		add_filter( 'woocommerce_calculated_total', $throw_filter );
+		add_action( 'woocommerce_new_order_item', $throw_action );
 
 		try {
 			$session_id   = 'cs_test_throwable';
 			$notification = $this->build_notification( $session_id );
-			$mock_session = $this->build_checkout_session_response( $session_id, true, (string) $product->get_sku() );
+			$mock_session = $this->build_checkout_session_response( $session_id, true, (string) $product->get_id() );
 			$this->mock_stripe_checkout_sessions_response( $mock_session );
 
 			// Immediate phase: defers the webhook.
 			$this->handler->process_checkout_session_success( $notification );
-			// Deferred phase: TypeError is thrown from calculate_totals via the filter.
-			// The handler must catch it (Throwable, not just Exception), log it,
-			// fire the failure action, and return normally.
+			// Deferred phase: TypeError is thrown from woocommerce_new_order_item
+			// via the action. The handler must catch it (Throwable, not just
+			// Exception), log it, fire the failure action, and return normally.
 			$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
 		} finally {
-			remove_filter( 'woocommerce_calculated_total', $throw_filter );
+			remove_action( 'woocommerce_new_order_item', $throw_action );
 		}
 
 		$this->assertTrue( $failure_action_fired );

--- a/tests/phpunit/class-wc-stripe-webhook-handler-agentic-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-agentic-test.php
@@ -151,11 +151,11 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the mapper is called and errors are handled gracefully.
+	 * Tests that the mapper is called, errors fire the failure hook, and the
+	 * exception is re-thrown so Action Scheduler marks the job as failed.
 	 *
 	 * The order mapper will fail because the mock session references
-	 * a non-existent product, and the handler should catch and log
-	 * without crashing.
+	 * a non-existent product.
 	 */
 	public function test_process_checkout_session_completed_handles_mapper_failure() {
 		$failure_action_fired = false;
@@ -175,17 +175,24 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 
 		// Immediate phase: defers the webhook.
 		$this->handler->process_checkout_session_success( $notification );
-		// Deferred phase: mapper fails → fires failure action, does not throw.
-		$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
+		// Deferred phase: mapper fails → fires failure action, then rethrows so
+		// Action Scheduler marks the job failed.
+		$rethrown = null;
+		try {
+			$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
+		} catch ( \Throwable $t ) {
+			$rethrown = $t;
+		}
 
 		$this->assertTrue( $failure_action_fired );
 		$this->assertInstanceOf( Exception::class, $captured_exception );
+		$this->assertSame( $captured_exception, $rethrown );
 	}
 
 	/**
 	 * Tests that a PHP Throwable (not just Exception) thrown during order
-	 * mapping is caught, logged, and fires the failure action without
-	 * crashing the webhook worker.
+	 * mapping is caught, logged, fires the failure hook, and is re-thrown so
+	 * Action Scheduler marks the job as failed rather than silently complete.
 	 */
 	public function test_process_checkout_session_completed_handles_mapper_throwable() {
 		$product = WC_Helper_Product::create_simple_product(
@@ -215,6 +222,7 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 		};
 		add_action( 'woocommerce_new_order_item', $throw_action );
 
+		$rethrown = null;
 		try {
 			$session_id   = 'cs_test_throwable';
 			$notification = $this->build_notification( $session_id );
@@ -225,8 +233,13 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 			$this->handler->process_checkout_session_success( $notification );
 			// Deferred phase: TypeError is thrown from woocommerce_new_order_item
 			// via the action. The handler must catch it (Throwable, not just
-			// Exception), log it, fire the failure action, and return normally.
-			$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
+			// Exception), log it, fire the failure action, and then rethrow so
+			// Action Scheduler sees the job as failed.
+			try {
+				$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
+			} catch ( \Throwable $t ) {
+				$rethrown = $t;
+			}
 		} finally {
 			remove_action( 'woocommerce_new_order_item', $throw_action );
 		}
@@ -234,6 +247,7 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 		$this->assertTrue( $failure_action_fired );
 		$this->assertInstanceOf( \Throwable::class, $captured_throwable );
 		$this->assertInstanceOf( \TypeError::class, $captured_throwable );
+		$this->assertSame( $captured_throwable, $rethrown );
 
 		// The order created by the mapper must be rolled back: the mapper's
 		// inner Throwable catch deletes the order before rethrowing.
@@ -384,8 +398,17 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 
 		// Immediate phase: defers the webhook.
 		$this->handler->process_checkout_session_success( $notification );
-		// Deferred phase: API retrieve call must include the Stripe-Version override header.
-		$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
+		// Deferred phase: API retrieve call must include the Stripe-Version override
+		// header. The stub session references a non-existent product, so the mapper
+		// fails and re-throws — that's fine for this test; we only care that the
+		// override filter was applied before the HTTP call.
+		$mapper_threw = null;
+		try {
+			$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
+		} catch ( \Throwable $t ) {
+			$mapper_threw = $t;
+		}
+		$this->assertInstanceOf( \Throwable::class, $mapper_threw );
 
 		$this->assertNotNull( $captured_headers );
 		$this->assertArrayHasKey( 'Stripe-Version', $captured_headers );


### PR DESCRIPTION
Fixes STRIPE-1106
Fixes #5343

## Changes proposed in this Pull Request:

A PHP `Error` / `TypeError` (subclass of `Throwable` but not `Exception`) thrown during agentic order mapping was silently swallowed: the mapper and webhook handler both caught only `Exception`, and a `return` inside a `finally` block at `class-wc-stripe-webhook-handler.php:1576-1578` suppressed any still-propagating throwable as the stack unwound. The visible result was:

- The order created at the top of the mapper was never rolled back (inner catch never fired).
- No `Failed to create agentic order from checkout session` entry reached the Stripe log.
- Action Scheduler marked the run **complete** (the `finally`-suppressed return looked like success).
- The order was left stuck in **Pending payment** indefinitely.

Observed in production during demo testing: a `Call to a member function get() on null` `Error` from `WC_Shipping::calculate_shipping_for_package` (null `WC()->session` under Action Scheduler / WP Cron — addressed in #5333) disappeared completely until the catch was widened.

Four narrow changes close the visibility gap:

1. **Mapper's inner catch** in `WC_Stripe_Agentic_Commerce_Order_Mapper::create_order_from_checkout_session` widened from `Exception` to `Throwable`, so the `$order->delete()` rollback fires for fatals as well as exceptions.
2. **Handler's inner catch** in `WC_Stripe_Webhook_Handler::handle_agentic_checkout_session` widened to `Throwable`. The failure log now includes `exception` (class name), `file`, `line`, and full `trace`, so the cause is diagnosable from a single Stripe log entry instead of needing the PHP error log.
3. **Handler's inner catch now re-throws after logging and firing the failure hook.** Previously the catch logged and fired the hook but swallowed the throwable, so `handle_agentic_checkout_session` returned normally and Action Scheduler still recorded the job as **complete** — contradicting the stated goal. The re-throw lets the error propagate through `handle_checkout_session_success` to AS so the run is correctly marked **failed**. Exception subclasses bubble past `process_deferred_webhook`'s existing `catch (Exception)` with an extra generic log line; `Error` / `TypeError` subclasses propagate directly to AS.
4. **Removed `return` from inside `finally`** in `handle_checkout_session_success`. The early return now lives *after* the `finally` block, so throwables that bypass the inner catch (API-retrieve errors, feature-flag-off path, etc.) also reach Action Scheduler.

This PR is independent of #5331 (is_agentic detection), #5332 (SKU lookup), and #5333 (shipping rate fallback). It's a visibility/correctness fix for the error-handling path; if it had existed from the start, the other three would have surfaced immediately instead of showing up as stuck pending orders.

**How can this code break?**
- Widening to `Throwable` means any fatal now triggers order deletion. If a merchant was relying on the historical behavior of "order stays pending on fatal" (intentionally or otherwise), they'll instead see the order removed. This is the documented design — the mapper already rolls back on `Exception` — so this aligns fatal behavior with exception behavior.
- Removing the `return` from `finally` changes control flow: an exception previously swallowed now surfaces as an AS failure. Downstream monitoring that treated AS success as "webhook handled OK" will now correctly see failures. Intentional.
- The log payload grew (added `file`, `line`, `trace`). Log volume per failure increases, but only on the failure path.

**What are we doing to make sure this code doesn't break?**
- Added `test_process_checkout_session_completed_handles_mapper_throwable` which forces a `TypeError` from inside the mapper's `try` block (via a `woocommerce_new_order_item` action) and asserts:
  - the failure action receives a `Throwable` and specifically a `TypeError`;
  - the deferred webhook re-throws the same `Throwable` instance — i.e. AS sees a failure, not a success;
  - no order survives with the session's payment intent meta (rollback fired).
- Updated the existing `test_process_checkout_session_completed_handles_mapper_failure` to match the new contract: the thrown `Exception` is also re-thrown out of `process_deferred_webhook` rather than swallowed.

## Testing instructions

1. `npm run test:php -- --filter WC_Stripe_Webhook_Handler_Agentic_Test` — the new throwable test and the existing exception test both pass.
2. `npm run phpstan` — clean.
3. Force a fatal anywhere in the mapper path (e.g. add a `woocommerce_calculated_total` filter that returns an object → `TypeError`).
4. Trigger an agentic `checkout.session.completed` webhook.
5. Verify the Stripe log shows `Failed to create agentic order from checkout session.` with `exception`, `file`, `line`, and `trace` populated.
6. Verify the order was rolled back — no draft/pending order remains with the session's payment intent meta.
7. Verify **Scheduled actions** (`WooCommerce → Status → Scheduled actions`) shows the action as **failed** with the error, not **complete**.
8. Remove the forced fatal and confirm a happy-path webhook still processes normally (order created, action marked complete, no failure log).

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply) — server-side webhook logic; no UI surface.

### Changelog entry

Added in `changelog.txt` under `10.7.0`:

> Fix - Surface PHP Throwables from the Agentic Commerce checkout.session.completed flow so fatals are logged, the order rollback runs, and Action Scheduler marks the job failed

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

N/A — changelog entry included above.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
