### PR TITLE
Drop unused ORG_MEMBERS_READ_TOKEN secret passthrough

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -12,4 +12,3 @@ jobs:
     uses: woocommerce/.github/.github/workflows/ai-code-review.yml@trunk
     secrets:
       AI_CODE_REVIEW_ANTHROPIC_API_KEY: ${{ secrets.AI_CODE_REVIEW_ANTHROPIC_API_KEY }}
-      ORG_MEMBERS_READ_TOKEN: ${{ secrets.ORG_MEMBERS_READ_TOKEN }}


### PR DESCRIPTION
Follow-up to https://github.com/woocommerce/.github/pull/13 — the reusable AI review workflow no longer uses `ORG_MEMBERS_READ_TOKEN`, so the caller doesn't need to pass it.

Note: this PR's own AI review run will fail with a known `anthropics/claude-code-action` OIDC-validation error (the action requires the caller yml to be byte-identical to the default branch). That is expected and cosmetic — once merged, subsequent PRs' AI reviews work normally, as verified on https://github.com/woocommerce/automatewoo-birthdays/pull/264 and https://github.com/woocommerce/automatewoo-birthdays/pull/265.

Linear: QAO-411