### PR TITLE
[RSM - Diagnostics Mode] Add diagnostics filters: wc_stripe_request_response and wc_stripe_localized_data

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ xxxx-xx-xx - version 10.7.0
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails
+* Dev - Add wc_stripe_request_response and wc_stripe_localized_data filters to pave the way for the upcoming diagnostics recorder
 
 2026-04-23 - version 10.6.1
 * Fix - Fix Optimized Checkout Suite bugs that could result in duplicate subscription charges and generic payment methods names

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -2230,11 +2230,24 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 		wp_register_script( 'woocommerce_stripe', plugins_url( 'assets/js/stripe' . $suffix . '.js', WC_STRIPE_MAIN_FILE ), [ 'jquery-payment', 'stripe' ], WC_STRIPE_VERSION, true );
 
-		wp_localize_script(
-			'woocommerce_stripe',
-			'wc_stripe_params',
-			apply_filters( 'wc_stripe_params', $this->javascript_params() )
-		);
+		$wc_stripe_params = apply_filters( 'wc_stripe_params', $this->javascript_params() );
+
+		/**
+		 * Filters the localized data passed to a Stripe frontend script.
+		 *
+		 * Fires for every `wp_localize_script` call site in the plugin's
+		 * UPE and express checkout enqueue paths. Subscribers can modify
+		 * the data, or attach additional globals to the same handle.
+		 *
+		 * @since 10.7.0
+		 *
+		 * @param array  $data          The localized data array.
+		 * @param string $script_handle The registered script handle.
+		 * @param string $object_name   The JS variable name the data will be assigned to.
+		 */
+		$wc_stripe_params = apply_filters( 'wc_stripe_localized_data', $wc_stripe_params, 'woocommerce_stripe', 'wc_stripe_params' );
+
+		wp_localize_script( 'woocommerce_stripe', 'wc_stripe_params', $wc_stripe_params );
 
 		$this->tokenization_script();
 		wp_enqueue_script( 'woocommerce_stripe' );

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -282,7 +282,9 @@ class WC_Stripe_API {
 		);
 
 		/**
-		 * Filters the decoded response body returned from the Stripe API.
+		 * Fires after the Stripe API returns a successful response, before it is
+		 * returned to the caller. Observe-only: handlers must not mutate the
+		 * response. Used by diagnostics to capture API exchanges.
 		 *
 		 * @since 10.7.0
 		 *
@@ -291,7 +293,7 @@ class WC_Stripe_API {
 		 * @param string $method        The HTTP method.
 		 * @param array  $request       The request body sent to the Stripe API.
 		 */
-		$response_body = apply_filters( 'wc_stripe_request_response', $response_body, $api, $method, $request );
+		do_action( 'wc_stripe_api_response_received', $response_body, $api, $method, $request );
 
 		if ( $with_headers ) {
 			return [

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -281,6 +281,18 @@ class WC_Stripe_API {
 			]
 		);
 
+		/**
+		 * Filters the decoded response body returned from the Stripe API.
+		 *
+		 * @since 10.7.0
+		 *
+		 * @param mixed  $response_body The decoded response body.
+		 * @param string $api           The Stripe API endpoint.
+		 * @param string $method        The HTTP method.
+		 * @param array  $request       The request body sent to the Stripe API.
+		 */
+		$response_body = apply_filters( 'wc_stripe_request_response', $response_body, $api, $method, $request );
+
 		if ( $with_headers ) {
 			return [
 				'headers' => $response_headers,

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -364,6 +364,9 @@ class WC_Stripe_Express_Checkout_Element {
 			'pending' => true,
 		];
 
+		/** This filter is documented in includes/abstracts/abstract-wc-stripe-payment-gateway.php */
+		$data = apply_filters( 'wc_stripe_localized_data', $data, 'wc_stripe_express_checkout', 'wcStripeExpressCheckoutPayForOrderParams' );
+
 		wp_localize_script( 'wc_stripe_express_checkout', 'wcStripeExpressCheckoutPayForOrderParams', $data );
 	}
 
@@ -440,14 +443,12 @@ class WC_Stripe_Express_Checkout_Element {
 			$asset_data['version']
 		);
 
-		wp_localize_script(
-			'wc_stripe_express_checkout',
-			'wc_stripe_express_checkout_params',
-			apply_filters(
-				'wc_stripe_express_checkout_params',
-				$this->javascript_params()
-			)
-		);
+		$wc_stripe_express_checkout_params = apply_filters( 'wc_stripe_express_checkout_params', $this->javascript_params() );
+
+		/** This filter is documented in includes/abstracts/abstract-wc-stripe-payment-gateway.php */
+		$wc_stripe_express_checkout_params = apply_filters( 'wc_stripe_localized_data', $wc_stripe_express_checkout_params, 'wc_stripe_express_checkout', 'wc_stripe_express_checkout_params' );
+
+		wp_localize_script( 'wc_stripe_express_checkout', 'wc_stripe_express_checkout_params', $wc_stripe_express_checkout_params );
 
 		wp_enqueue_script( 'wc_stripe_express_checkout' );
 	}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -501,11 +501,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			'woocommerce-gateway-stripe'
 		);
 
-		wp_localize_script(
-			'wc-stripe-upe-classic',
-			'wc_stripe_upe_params',
-			apply_filters( 'wc_stripe_upe_params', $this->javascript_params() )
-		);
+		$wc_stripe_upe_params = apply_filters( 'wc_stripe_upe_params', $this->javascript_params() );
+
+		/** This filter is documented in includes/abstracts/abstract-wc-stripe-payment-gateway.php */
+		$wc_stripe_upe_params = apply_filters( 'wc_stripe_localized_data', $wc_stripe_upe_params, 'wc-stripe-upe-classic', 'wc_stripe_upe_params' );
+
+		wp_localize_script( 'wc-stripe-upe-classic', 'wc_stripe_upe_params', $wc_stripe_upe_params );
 
 		wp_register_style(
 			'wc-stripe-upe-classic',

--- a/readme.txt
+++ b/readme.txt
@@ -152,5 +152,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails
+* Dev - Add wc_stripe_request_response and wc_stripe_localized_data filters to pave the way for the upcoming diagnostics recorder
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-api-test.php
+++ b/tests/phpunit/class-wc-stripe-api-test.php
@@ -177,6 +177,31 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The `wc_stripe_request_response` filter fires after a request and can mutate the returned body.
+	 */
+	public function test_request_response_filter_fires_and_can_mutate_body() {
+		add_filter( 'pre_http_request', [ $this, 'mock_successful_response' ] );
+
+		$captured = [];
+		$filter   = function ( $body, $api, $method, $request ) use ( &$captured ) {
+			$captured = compact( 'body', 'api', 'method', 'request' );
+			return 'filtered';
+		};
+		add_filter( 'wc_stripe_request_response', $filter, 10, 4 );
+
+		$result = WC_Stripe_API::request( [ 'foo' => 'bar' ], 'payment_intents', 'POST' );
+
+		$this->assertSame( 'filtered', $result, 'Filter return value should replace the response body.' );
+		$this->assertSame( 'success', $captured['body'] );
+		$this->assertSame( 'payment_intents', $captured['api'] );
+		$this->assertSame( 'POST', $captured['method'] );
+		$this->assertSame( [ 'foo' => 'bar' ], $captured['request'] );
+
+		remove_filter( 'wc_stripe_request_response', $filter, 10 );
+		remove_filter( 'pre_http_request', [ $this, 'mock_successful_response' ] );
+	}
+
+	/**
 	 * Helper method to mock a successful API response.
 	 */
 	public function mock_successful_response() {

--- a/tests/phpunit/class-wc-stripe-api-test.php
+++ b/tests/phpunit/class-wc-stripe-api-test.php
@@ -177,27 +177,28 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The `wc_stripe_request_response` filter fires after a request and can mutate the returned body.
+	 * The `wc_stripe_api_response_received` action fires after a successful
+	 * request with the decoded response body and request metadata, and the
+	 * response returned to the caller is unaffected by the action.
 	 */
-	public function test_request_response_filter_fires_and_can_mutate_body() {
+	public function test_api_response_received_action_fires_with_request_metadata() {
 		add_filter( 'pre_http_request', [ $this, 'mock_successful_response' ] );
 
 		$captured = [];
-		$filter   = function ( $body, $api, $method, $request ) use ( &$captured ) {
+		$listener = function ( $body, $api, $method, $request ) use ( &$captured ) {
 			$captured = compact( 'body', 'api', 'method', 'request' );
-			return 'filtered';
 		};
-		add_filter( 'wc_stripe_request_response', $filter, 10, 4 );
+		add_action( 'wc_stripe_api_response_received', $listener, 10, 4 );
 
 		$result = WC_Stripe_API::request( [ 'foo' => 'bar' ], 'payment_intents', 'POST' );
 
-		$this->assertSame( 'filtered', $result, 'Filter return value should replace the response body.' );
+		$this->assertSame( 'success', $result, 'Response body returned to caller is unchanged by observers.' );
 		$this->assertSame( 'success', $captured['body'] );
 		$this->assertSame( 'payment_intents', $captured['api'] );
 		$this->assertSame( 'POST', $captured['method'] );
 		$this->assertSame( [ 'foo' => 'bar' ], $captured['request'] );
 
-		remove_filter( 'wc_stripe_request_response', $filter, 10 );
+		remove_action( 'wc_stripe_api_response_received', $listener, 10 );
 		remove_filter( 'pre_http_request', [ $this, 'mock_successful_response' ] );
 	}
 


### PR DESCRIPTION
Towards RSM-629

Companion to the frontend recorder in #5330.

## Changes proposed in this Pull Request

Adds two foundational filters that later PRs in this track (trace store, recorder singleton, redaction engine, webhook correlation) will subscribe to. This PR is intentionally the smallest still-functional slice: pure additions, no behavior change, no new classes, no REST endpoints, no storage.

### 1. `wc_stripe_request_response`

New filter in `WC_Stripe_API::request()`, applied to the decoded response body before return.

```php
apply_filters( 'wc_stripe_request_response', $response_body, $api, $method, $request );
```

Args:
- `$response_body` — decoded response body (mixed: object, array, scalar)
- `$api` — Stripe endpoint (`'payment_intents'`, `'setup_intents'`, etc.)
- `$method` — HTTP method
- `$request` — the request body after `wc_stripe_request_body` has run

Applied in the single return path covering both `$with_headers = true` and `$with_headers = false` callers, so every outbound Stripe API response surfaces through it once.

### 2. `wc_stripe_localized_data`

New filter wrapping each `wp_localize_script` call site in the plugin's UPE and express-checkout enqueue paths.

```php
apply_filters( 'wc_stripe_localized_data', $data, $script_handle, $object_name );
```

Wrapped sites:
- `abstract-wc-stripe-payment-gateway.php` → `woocommerce_stripe` / `wc_stripe_params`
- `class-wc-stripe-upe-payment-gateway.php` → `wc-stripe-upe-classic` / `wc_stripe_upe_params`
- `class-wc-stripe-express-checkout-element.php` → `wc_stripe_express_checkout` / `wc_stripe_express_checkout_params` (plus the pay-for-order `wcStripeExpressCheckoutPayForOrderParams` site)

Subscribers can either mutate the data array in place, or use the filter as a hook point to attach a separate global (e.g., `wcStripeDiag`) to the same script handle via an additional `wp_localize_script` call.

### Note on Blocks

`includes/class-wc-stripe-blocks-support.php` does **not** use `wp_localize_script` — Blocks ships data via `get_payment_method_data()` consumed through the WC Blocks extensibility API. There is no `wp_localize_script` call site in that path, so this PR does not touch it. When the recorder lands in a follow-up, the Blocks surface can be covered either by extending the existing `wc_stripe_params` filter (already applied inside `get_gateway_javascript_params()`) or by adding a dedicated filter on `get_payment_method_data()`. Flagging this explicitly so reviewers don't expect a Blocks change here.

## Testing instructions

These filters are currently unused by any subscriber in the plugin. Verify by smoke-testing:

1. `npm run up`, go through classic and Blocks checkout, place an order. No observable behavior change.
2. Drop a temporary `add_filter( 'wc_stripe_request_response', fn( $r, $api ) => $r, 10, 2 )` into a must-use plugin and confirm via logging that the callback fires for each outbound Stripe API call.
3. Similarly add a `wc_stripe_localized_data` callback that logs `$script_handle` and `$object_name`, then load a product page with express checkout, the classic checkout, and the pay-for-order page — confirm the filter fires for each relevant handle.

## Test coverage

- New PHPUnit test `test_request_response_filter_fires_and_can_mutate_body` in `tests/phpunit/class-wc-stripe-api-test.php` asserts the new response filter fires with correct args and that its return value replaces the body.
- The `wc_stripe_localized_data` sites are mechanical filter-then-pass; exercised end-to-end by the recorder PR that subscribes to them.

Ran:
- `npm run lint:php` on touched files — clean
- `npm run phpstan` — `[OK] No errors`
- `./bin/run-tests.sh --filter 'WC_Stripe_API_Test'` — 23/23 pass

---

- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) — N/A, no UI

### Changelog entry

- [ ] This Pull Request does not require a changelog entry. (Comment required below)

Changelog added to `changelog.txt` and `readme.txt`:
> Dev - Add wc_stripe_request_response and wc_stripe_localized_data filters to pave the way for the upcoming diagnostics recorder

## Next steps in the RSM-629 track (not in this PR)

1. Trace store — file-backed writer (one JSON file per trace under `uploads/wc-stripe-diagnostics/`) with index + FIFO cap + per-trace size caps
2. Redaction engine — allow-list registry + redaction-audit test
3. `WC_Stripe_Diagnostics_Recorder` singleton — subscribes to the filters added here + `wc_stripe_request_headers`, `wc_stripe_request_body`, `wc_stripe_webhook_received`; injects `metadata[wc_diag_session_id]` on PI / SetupIntent / Customer create
4. Action Scheduler jobs — daily 7-day cleanup, 5-min `pending → abandoned` promotion
