### PR TITLE
Fix fatal error in WP Admin due to overly narrow type definition

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ xxxx-xx-xx - version 10.7.0
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails
+* Fix - Prevent fatal error in wp-admin from overly strict argument type
 
 2026-04-23 - version 10.6.1
 * Fix - Fix Optimized Checkout Suite bugs that could result in duplicate subscription charges and generic payment methods names

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@ xxxx-xx-xx - version 10.7.0
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails
-* Fix - Prevent fatal error in wp-admin from overly strict argument type
+* Fix - Prevent fatal error in wp-admin from overly narrow argument type
 
 2026-04-23 - version 10.6.1
 * Fix - Fix Optimized Checkout Suite bugs that could result in duplicate subscription charges and generic payment methods names

--- a/includes/admin/class-wc-stripe-plugins-page-controller.php
+++ b/includes/admin/class-wc-stripe-plugins-page-controller.php
@@ -32,10 +32,10 @@ class WC_Stripe_Plugins_Page_Controller {
 	/**
 	 * Enqueue the plugins page script and styles.
 	 *
-	 * @param string $hook_suffix The current admin page hook suffix.
+	 * @param string|null $hook_suffix The current admin page hook suffix.
 	 * @return void
 	 */
-	public function enqueue_scripts( string $hook_suffix ) {
+	public function enqueue_scripts( ?string $hook_suffix = null ) {
 		if ( 'plugins.php' !== $hook_suffix ) {
 			return;
 		}

--- a/includes/admin/class-wc-stripe-plugins-page-controller.php
+++ b/includes/admin/class-wc-stripe-plugins-page-controller.php
@@ -35,7 +35,7 @@ class WC_Stripe_Plugins_Page_Controller {
 	 * @param string|null $hook_suffix The current admin page hook suffix.
 	 * @return void
 	 */
-	public function enqueue_scripts( ?string $hook_suffix = null ) {
+	public function enqueue_scripts( $hook_suffix = null ) {
 		if ( 'plugins.php' !== $hook_suffix ) {
 			return;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -152,6 +152,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails
-* Fix - Prevent fatal error in wp-admin from overly strict argument type
+* Fix - Prevent fatal error in wp-admin from overly narrow argument type
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -152,5 +152,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails
+* Fix - Prevent fatal error in wp-admin from overly strict argument type
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/admin/class-wc-stripe-plugins-page-controller-test.php
+++ b/tests/phpunit/admin/class-wc-stripe-plugins-page-controller-test.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * WC_Stripe_Plugins_Page_Controller_Test class
+ *
+ * @package WooCommerce_Stripe/Tests/WP_UnitTestCase
+ */
+class WC_Stripe_Plugins_Page_Controller_Test extends WP_UnitTestCase {
+
+	/**
+	 * Test suite tear down.
+	 *
+	 * Ensure that scripts/styles enqueued during one test do not leak into the next.
+	 *
+	 * @inheritDoc
+	 */
+	public function tearDown(): void {
+		wp_dequeue_script( 'wc-stripe-plugins-page' );
+		wp_dequeue_style( 'wc-stripe-plugins-page' );
+		wp_deregister_script( 'wc-stripe-plugins-page' );
+		wp_deregister_style( 'wc-stripe-plugins-page' );
+
+		parent::tearDown();
+	}
+
+	protected function get_mock_controller(): WC_Stripe_Plugins_Page_Controller {
+		$account_mock = $this->getMockBuilder( WC_Stripe_Account::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		return new WC_Stripe_Plugins_Page_Controller( $account_mock );
+	}
+
+	/**
+	 * Tests that `enqueue_scripts` only registers/enqueues the plugins page assets
+	 * on the plugins.php admin screen and is a no-op elsewhere.
+	 *
+	 * @dataProvider provide_enqueue_scripts_hook_suffixes
+	 *
+	 * @param string|null $hook_suffix    The admin page hook suffix passed by WordPress.
+	 * @param bool        $should_enqueue Whether the assets should be registered/enqueued.
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_scripts( $hook_suffix, bool $should_enqueue ): void {
+		$controller = $this->get_mock_controller();
+
+		$controller->enqueue_scripts( $hook_suffix );
+
+		$this->assertSame( $should_enqueue, wp_script_is( 'wc-stripe-plugins-page', 'registered' ) );
+		$this->assertSame( $should_enqueue, wp_script_is( 'wc-stripe-plugins-page', 'enqueued' ) );
+		$this->assertSame( $should_enqueue, wp_style_is( 'wc-stripe-plugins-page', 'registered' ) );
+		$this->assertSame( $should_enqueue, wp_style_is( 'wc-stripe-plugins-page', 'enqueued' ) );
+	}
+
+	/**
+	 * Data provider for `test_enqueue_scripts`.
+	 *
+	 * @return array<string, array{0: string|null, 1: bool}>
+	 */
+	public function provide_enqueue_scripts_hook_suffixes(): array {
+		return [
+			'null hook suffix is a no-op'                  => [ null, false ],
+			'unrelated admin page does not enqueue assets' => [ 'admin.php', false ],
+			'plugins.php registers and enqueues assets'    => [ 'plugins.php', true ],
+		];
+	}
+}


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-1107

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR fixes a bug that could trigger fatal errors in WP Admin due to a specific admin page or iframe not having a hook suffix defined. The issue was reported as occurring due to an admin page passing `null` for the hook suffix, so this PR removes the type declaration, as the existing code already ignores all values that are not the plugins page.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
Code inspection should be sufficient.
<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
