### PR TITLE
[RSM - Diagnostics Mode] Add WC_Stripe_Diagnostics_Trace_Store

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@ xxxx-xx-xx - version 10.7.0
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails
-* Dev - Add WC_Stripe_Diagnostics_Trace_Store (options-backed trace storage with FIFO eviction and size caps) for the upcoming diagnostics recorder
+* Dev - Add WC_Stripe_Diagnostics_Trace_Store (file-backed trace storage with FIFO eviction and size caps) for the upcoming diagnostics recorder
 
 2026-04-23 - version 10.6.1
 * Fix - Fix Optimized Checkout Suite bugs that could result in duplicate subscription charges and generic payment methods names

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ xxxx-xx-xx - version 10.7.0
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails
+* Dev - Add WC_Stripe_Diagnostics_Trace_Store (options-backed trace storage with FIFO eviction and size caps) for the upcoming diagnostics recorder
 
 2026-04-23 - version 10.6.1
 * Fix - Fix Optimized Checkout Suite bugs that could result in duplicate subscription charges and generic payment methods names

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -134,6 +134,7 @@ class WC_Stripe {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-database-cache.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-payment-method-configurations.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-database-cache-prefetch.php';
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/diagnostics/class-wc-stripe-diagnostics-trace-store.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-api.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-mode.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/compat/class-wc-stripe-subscriptions-helper.php';

--- a/includes/diagnostics/class-wc-stripe-diagnostics-trace-store.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-trace-store.php
@@ -1,29 +1,36 @@
 <?php
 
+use Automattic\WooCommerce\Internal\Utilities\FilesystemUtil;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Option-backed store for diagnostics traces.
+ * File-backed store for diagnostics traces.
  *
  * A "trace" is the redacted record of a single checkout session keyed by a
- * client-generated sessionId. The store is deliberately plain: each trace
- * is a single `wp_options` row keyed by `wc_stripe_diag_trace_<id>` plus a
- * shared index row (`wc_stripe_diag_index`) holding the ordered list of ids.
+ * client-generated sessionId. Each trace is persisted as a single JSON file
+ * inside a dedicated, non-indexable directory under the WordPress uploads
+ * folder, alongside an `index.json` file holding the ordered list of trace
+ * ids.
+ *
+ * Storing traces as files (rather than wp_options rows) makes it easy to
+ * download, attach, or hand off an individual trace, and keeps diagnostics
+ * data out of regular database backups.
  *
  * Invariants enforced here:
  * - at most {@see self::MAX_TRACES} traces exist at any time (FIFO eviction)
  * - at most {@see self::MAX_EVENTS_PER_TRACE} events per trace
  * - the serialized trace blob is capped at {@see self::MAX_TRACE_BYTES}
  *
- * A transient lock serializes writers so concurrent requests never clobber
- * each other's index updates.
+ * An advisory `flock()` on a dedicated lock file serializes writers so
+ * concurrent requests never clobber each other's index updates.
  */
 class WC_Stripe_Diagnostics_Trace_Store {
 
-	const TRACE_OPTION_PREFIX = 'wc_stripe_diag_trace_';
-	const INDEX_OPTION        = 'wc_stripe_diag_index';
-	const LOCK_TRANSIENT      = 'wc_stripe_diag_index_lock';
-	const LOCK_TIMEOUT        = 10;
+	const STORAGE_SUBDIR = 'wc-stripe-diagnostics';
+	const INDEX_FILENAME = 'index.json';
+	const LOCK_FILENAME  = '.index.lock';
+	const TRACE_SUFFIX   = '.json';
 
 	const MAX_TRACES           = 200;
 	const MAX_EVENTS_PER_TRACE = 200;
@@ -34,6 +41,13 @@ class WC_Stripe_Diagnostics_Trace_Store {
 	const STATUS_ABANDONED = 'abandoned';
 
 	/**
+	 * Cached absolute path (with trailing slash) to the trace storage dir.
+	 *
+	 * @var string|null
+	 */
+	private $base_dir;
+
+	/**
 	 * Create a new trace record. No-op if a trace with this id already exists.
 	 *
 	 * @param string $session_id Client-generated session identifier.
@@ -42,10 +56,10 @@ class WC_Stripe_Diagnostics_Trace_Store {
 	 */
 	public function create( $session_id, array $meta = [] ) {
 		$session_id = self::sanitize_id( $session_id );
-		if ( '' === $session_id ) {
+		if ( '' === $session_id || ! $this->ensure_storage_dir() ) {
 			return false;
 		}
-		if ( false !== get_option( self::option_name( $session_id ), false ) ) {
+		if ( file_exists( $this->trace_path( $session_id ) ) ) {
 			return false;
 		}
 
@@ -60,7 +74,9 @@ class WC_Stripe_Diagnostics_Trace_Store {
 
 		return (bool) $this->with_lock(
 			function () use ( $session_id, $trace ) {
-				update_option( self::option_name( $session_id ), wp_json_encode( $trace ), false );
+				if ( ! $this->write_trace( $session_id, $trace ) ) {
+					return false;
+				}
 				$index = $this->read_index();
 				if ( ! in_array( $session_id, $index, true ) ) {
 					$index[] = $session_id;
@@ -84,7 +100,7 @@ class WC_Stripe_Diagnostics_Trace_Store {
 	 */
 	public function append_event( $session_id, array $event ) {
 		$session_id = self::sanitize_id( $session_id );
-		if ( '' === $session_id ) {
+		if ( '' === $session_id || ! $this->ensure_storage_dir() ) {
 			return false;
 		}
 
@@ -103,8 +119,7 @@ class WC_Stripe_Diagnostics_Trace_Store {
 				if ( false === $encoded || strlen( $encoded ) > self::MAX_TRACE_BYTES ) {
 					return false;
 				}
-				update_option( self::option_name( $session_id ), $encoded, false );
-				return true;
+				return false !== @file_put_contents( $this->trace_path( $session_id ), $encoded ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 			}
 		);
 	}
@@ -121,6 +136,9 @@ class WC_Stripe_Diagnostics_Trace_Store {
 		if ( ! in_array( $status, [ self::STATUS_COMPLETED, self::STATUS_ABANDONED ], true ) ) {
 			return false;
 		}
+		if ( '' === $session_id || ! $this->ensure_storage_dir() ) {
+			return false;
+		}
 
 		return (bool) $this->with_lock(
 			function () use ( $session_id, $status ) {
@@ -130,8 +148,7 @@ class WC_Stripe_Diagnostics_Trace_Store {
 				}
 				$trace['status']     = $status;
 				$trace['updated_at'] = time();
-				update_option( self::option_name( $session_id ), wp_json_encode( $trace ), false );
-				return true;
+				return $this->write_trace( $session_id, $trace );
 			}
 		);
 	}
@@ -164,9 +181,31 @@ class WC_Stripe_Diagnostics_Trace_Store {
 
 		return (bool) $this->with_lock(
 			function () use ( $session_id ) {
-				delete_option( self::option_name( $session_id ) );
+				$this->delete_trace_file( $session_id );
 				$index = array_values( array_diff( $this->read_index(), [ $session_id ] ) );
 				$this->write_index( $index );
+				return true;
+			}
+		);
+	}
+
+	/**
+	 * Wipe every trace plus the index. Intended for tests and future uninstall.
+	 */
+	public function delete_all(): void {
+		if ( null === $this->base_dir && ! is_dir( $this->base_dir() ) ) {
+			return;
+		}
+
+		$this->with_lock(
+			function () {
+				foreach ( $this->read_index() as $id ) {
+					$this->delete_trace_file( (string) $id );
+				}
+				$index_path = $this->index_path();
+				if ( file_exists( $index_path ) ) {
+					@unlink( $index_path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.unlink_unlink
+				}
 				return true;
 			}
 		);
@@ -200,7 +239,22 @@ class WC_Stripe_Diagnostics_Trace_Store {
 	}
 
 	/**
-	 * Evict oldest trace rows until the index is under {@see self::MAX_TRACES}.
+	 * Absolute filesystem path to a trace file. Useful for downstream code
+	 * that wants to stream or attach the raw JSON without re-decoding.
+	 *
+	 * @param string $session_id Session identifier (raw or sanitized).
+	 * @return string|null Path, or null when the id is invalid.
+	 */
+	public function get_trace_path( $session_id ) {
+		$session_id = self::sanitize_id( $session_id );
+		if ( '' === $session_id ) {
+			return null;
+		}
+		return $this->trace_path( $session_id );
+	}
+
+	/**
+	 * Evict the oldest trace files until the index is under {@see self::MAX_TRACES}.
 	 *
 	 * @param string[] $index The current index.
 	 * @return string[] The (possibly trimmed) index.
@@ -210,7 +264,7 @@ class WC_Stripe_Diagnostics_Trace_Store {
 		while ( $count > self::MAX_TRACES ) {
 			$oldest = array_shift( $index );
 			if ( is_string( $oldest ) ) {
-				delete_option( self::option_name( $oldest ) );
+				$this->delete_trace_file( $oldest );
 			}
 			--$count;
 		}
@@ -218,14 +272,18 @@ class WC_Stripe_Diagnostics_Trace_Store {
 	}
 
 	/**
-	 * Read and decode a single trace row.
+	 * Read and decode a single trace file.
 	 *
 	 * @param string $session_id Sanitized session id.
 	 * @return array|null Decoded trace, or null when absent or malformed.
 	 */
 	private function read_trace( string $session_id ): ?array {
-		$raw = get_option( self::option_name( $session_id ), false );
-		if ( false === $raw || ! is_string( $raw ) ) {
+		$path = $this->trace_path( $session_id );
+		if ( ! is_readable( $path ) ) {
+			return null;
+		}
+		$raw = @file_get_contents( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		if ( false === $raw ) {
 			return null;
 		}
 		$decoded = json_decode( $raw, true );
@@ -233,13 +291,39 @@ class WC_Stripe_Diagnostics_Trace_Store {
 	}
 
 	/**
-	 * Read the trace id index from wp_options.
+	 * Encode and persist a trace to disk.
+	 *
+	 * @param string $session_id Sanitized session id.
+	 * @param array  $trace      Trace payload.
+	 * @return bool True on success.
+	 */
+	private function write_trace( string $session_id, array $trace ): bool {
+		$encoded = wp_json_encode( $trace );
+		if ( false === $encoded ) {
+			return false;
+		}
+		return false !== @file_put_contents( $this->trace_path( $session_id ), $encoded ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+	}
+
+	/**
+	 * Read the trace id index from disk.
 	 *
 	 * @return string[] Ordered list of trace ids, oldest first.
 	 */
 	private function read_index(): array {
-		$raw = get_option( self::INDEX_OPTION, [] );
-		return is_array( $raw ) ? array_values( $raw ) : [];
+		$path = $this->index_path();
+		if ( ! is_readable( $path ) ) {
+			return [];
+		}
+		$raw = @file_get_contents( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		if ( false === $raw ) {
+			return [];
+		}
+		$decoded = json_decode( $raw, true );
+		if ( ! is_array( $decoded ) ) {
+			return [];
+		}
+		return array_values( array_filter( $decoded, 'is_string' ) );
 	}
 
 	/**
@@ -248,32 +332,90 @@ class WC_Stripe_Diagnostics_Trace_Store {
 	 * @param string[] $index Ordered list of trace ids.
 	 */
 	private function write_index( array $index ): void {
-		update_option( self::INDEX_OPTION, array_values( $index ), false );
+		$encoded = wp_json_encode( array_values( $index ) );
+		if ( false !== $encoded ) {
+			@file_put_contents( $this->index_path(), $encoded ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		}
+	}
+
+	private function delete_trace_file( string $session_id ): void {
+		$path = $this->trace_path( $session_id );
+		if ( file_exists( $path ) ) {
+			@unlink( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.unlink_unlink
+		}
 	}
 
 	/**
-	 * Acquire a short-lived transient lock and run $callback. Returns the
-	 * callback's return value, or null if the lock could not be acquired.
+	 * Acquire an exclusive flock on the lock file and run $callback. Returns
+	 * the callback's return value (or null when the lock file cannot be
+	 * opened — best-effort: better to risk a rare lost write than drop the
+	 * event entirely).
 	 *
 	 * @param callable $callback The critical section to run under the lock.
 	 * @return mixed|null
 	 */
 	private function with_lock( callable $callback ) {
-		// Best-effort lock: transients can silently fail under object-cache
-		// contention, and we'd rather accept a rare lost write than drop the
-		// event entirely. The failure mode is a concurrent reader's stale view,
-		// not corruption (each trace row is a single atomic option write).
-		set_transient( self::LOCK_TRANSIENT, 1, self::LOCK_TIMEOUT );
+		if ( ! $this->ensure_storage_dir() ) {
+			return null;
+		}
+
+		$fp = @fopen( $this->base_dir() . self::LOCK_FILENAME, 'c' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		if ( false === $fp ) {
+			return $callback();
+		}
 		try {
+			@flock( $fp, LOCK_EX ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			return $callback();
 		} finally {
-			delete_transient( self::LOCK_TRANSIENT );
+			@flock( $fp, LOCK_UN ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			@fclose( $fp ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 		}
 	}
 
 	/**
+	 * Resolve and lazily create the storage directory. Returns false if the
+	 * directory cannot be created (read-only filesystem, missing uploads dir).
+	 *
+	 * @return bool
+	 */
+	private function ensure_storage_dir(): bool {
+		$dir = rtrim( $this->base_dir(), '/' );
+		if ( is_dir( $dir ) ) {
+			return true;
+		}
+		if ( class_exists( FilesystemUtil::class ) ) {
+			FilesystemUtil::mkdir_p_not_indexable( $dir );
+		} else {
+			wp_mkdir_p( $dir );
+		}
+		return is_dir( $dir );
+	}
+
+	/**
+	 * Resolve the storage directory path (uploads/wc-stripe-diagnostics/).
+	 *
+	 * @return string Path with trailing slash.
+	 */
+	private function base_dir(): string {
+		if ( null !== $this->base_dir ) {
+			return $this->base_dir;
+		}
+		$uploads        = wp_upload_dir( null, false );
+		$this->base_dir = trailingslashit( $uploads['basedir'] ) . self::STORAGE_SUBDIR . '/';
+		return $this->base_dir;
+	}
+
+	private function trace_path( string $session_id ): string {
+		return $this->base_dir() . $session_id . self::TRACE_SUFFIX;
+	}
+
+	private function index_path(): string {
+		return $this->base_dir() . self::INDEX_FILENAME;
+	}
+
+	/**
 	 * Reduce an id to a slug-safe form. Session ids are client-generated so
-	 * we must never trust them as option-name fragments.
+	 * we must never trust them as filename fragments.
 	 *
 	 * @param string $id Raw session identifier.
 	 * @return string
@@ -284,9 +426,5 @@ class WC_Stripe_Diagnostics_Trace_Store {
 		}
 		$id = preg_replace( '/[^a-zA-Z0-9_-]/', '', $id );
 		return is_string( $id ) ? substr( $id, 0, 64 ) : '';
-	}
-
-	private static function option_name( string $session_id ): string {
-		return self::TRACE_OPTION_PREFIX . $session_id;
 	}
 }

--- a/includes/diagnostics/class-wc-stripe-diagnostics-trace-store.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-trace-store.php
@@ -133,10 +133,13 @@ class WC_Stripe_Diagnostics_Trace_Store {
 	 */
 	public function set_status( $session_id, $status ) {
 		$session_id = self::sanitize_id( $session_id );
+		if ( '' === $session_id ) {
+			return false;
+		}
 		if ( ! in_array( $status, [ self::STATUS_COMPLETED, self::STATUS_ABANDONED ], true ) ) {
 			return false;
 		}
-		if ( '' === $session_id || ! $this->ensure_storage_dir() ) {
+		if ( ! $this->ensure_storage_dir() ) {
 			return false;
 		}
 

--- a/includes/diagnostics/class-wc-stripe-diagnostics-trace-store.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-trace-store.php
@@ -13,10 +13,6 @@ defined( 'ABSPATH' ) || exit;
  * folder, alongside an `index.json` file holding the ordered list of trace
  * ids.
  *
- * Storing traces as files (rather than wp_options rows) makes it easy to
- * download, attach, or hand off an individual trace, and keeps diagnostics
- * data out of regular database backups.
- *
  * Invariants enforced here:
  * - at most {@see self::MAX_TRACES} traces exist at any time (FIFO eviction)
  * - at most {@see self::MAX_EVENTS_PER_TRACE} events per trace

--- a/includes/diagnostics/class-wc-stripe-diagnostics-trace-store.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-trace-store.php
@@ -1,0 +1,292 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Option-backed store for diagnostics traces.
+ *
+ * A "trace" is the redacted record of a single checkout session keyed by a
+ * client-generated sessionId. The store is deliberately plain: each trace
+ * is a single `wp_options` row keyed by `wc_stripe_diag_trace_<id>` plus a
+ * shared index row (`wc_stripe_diag_index`) holding the ordered list of ids.
+ *
+ * Invariants enforced here:
+ * - at most {@see self::MAX_TRACES} traces exist at any time (FIFO eviction)
+ * - at most {@see self::MAX_EVENTS_PER_TRACE} events per trace
+ * - the serialized trace blob is capped at {@see self::MAX_TRACE_BYTES}
+ *
+ * A transient lock serializes writers so concurrent requests never clobber
+ * each other's index updates.
+ */
+class WC_Stripe_Diagnostics_Trace_Store {
+
+	const TRACE_OPTION_PREFIX = 'wc_stripe_diag_trace_';
+	const INDEX_OPTION        = 'wc_stripe_diag_index';
+	const LOCK_TRANSIENT      = 'wc_stripe_diag_index_lock';
+	const LOCK_TIMEOUT        = 10;
+
+	const MAX_TRACES           = 200;
+	const MAX_EVENTS_PER_TRACE = 200;
+	const MAX_TRACE_BYTES      = 102400; // 100 KB.
+
+	const STATUS_PENDING   = 'pending';
+	const STATUS_COMPLETED = 'completed';
+	const STATUS_ABANDONED = 'abandoned';
+
+	/**
+	 * Create a new trace record. No-op if a trace with this id already exists.
+	 *
+	 * @param string $session_id Client-generated session identifier.
+	 * @param array  $meta       Optional top-level metadata (order_id, source page, etc.).
+	 * @return bool True if the trace was newly created.
+	 */
+	public function create( $session_id, array $meta = [] ) {
+		$session_id = self::sanitize_id( $session_id );
+		if ( '' === $session_id ) {
+			return false;
+		}
+		if ( false !== get_option( self::option_name( $session_id ), false ) ) {
+			return false;
+		}
+
+		$trace = [
+			'id'         => $session_id,
+			'status'     => self::STATUS_PENDING,
+			'created_at' => time(),
+			'updated_at' => time(),
+			'meta'       => $meta,
+			'events'     => [],
+		];
+
+		return (bool) $this->with_lock(
+			function () use ( $session_id, $trace ) {
+				update_option( self::option_name( $session_id ), wp_json_encode( $trace ), false );
+				$index = $this->read_index();
+				if ( ! in_array( $session_id, $index, true ) ) {
+					$index[] = $session_id;
+				}
+				$index = $this->evict_oldest( $index );
+				$this->write_index( $index );
+				return true;
+			}
+		);
+	}
+
+	/**
+	 * Append a single event to an existing trace.
+	 *
+	 * Drops the event silently if the trace hits either cap. Callers can check
+	 * the return value to decide whether to emit a "capped" signal.
+	 *
+	 * @param string $session_id Session identifier.
+	 * @param array  $event      Event payload (already redacted by the caller).
+	 * @return bool True if the event was appended.
+	 */
+	public function append_event( $session_id, array $event ) {
+		$session_id = self::sanitize_id( $session_id );
+		if ( '' === $session_id ) {
+			return false;
+		}
+
+		return (bool) $this->with_lock(
+			function () use ( $session_id, $event ) {
+				$trace = $this->read_trace( $session_id );
+				if ( null === $trace ) {
+					return false;
+				}
+				if ( count( $trace['events'] ) >= self::MAX_EVENTS_PER_TRACE ) {
+					return false;
+				}
+				$trace['events'][]   = $event;
+				$trace['updated_at'] = time();
+				$encoded             = wp_json_encode( $trace );
+				if ( false === $encoded || strlen( $encoded ) > self::MAX_TRACE_BYTES ) {
+					return false;
+				}
+				update_option( self::option_name( $session_id ), $encoded, false );
+				return true;
+			}
+		);
+	}
+
+	/**
+	 * Promote a trace to a terminal status (completed | abandoned).
+	 *
+	 * @param string $session_id Session identifier.
+	 * @param string $status     One of STATUS_COMPLETED, STATUS_ABANDONED.
+	 * @return bool True if status was updated.
+	 */
+	public function set_status( $session_id, $status ) {
+		$session_id = self::sanitize_id( $session_id );
+		if ( ! in_array( $status, [ self::STATUS_COMPLETED, self::STATUS_ABANDONED ], true ) ) {
+			return false;
+		}
+
+		return (bool) $this->with_lock(
+			function () use ( $session_id, $status ) {
+				$trace = $this->read_trace( $session_id );
+				if ( null === $trace ) {
+					return false;
+				}
+				$trace['status']     = $status;
+				$trace['updated_at'] = time();
+				update_option( self::option_name( $session_id ), wp_json_encode( $trace ), false );
+				return true;
+			}
+		);
+	}
+
+	/**
+	 * Read a single trace. Returns null when the trace does not exist.
+	 *
+	 * @param string $session_id Session identifier.
+	 * @return array|null
+	 */
+	public function get( $session_id ) {
+		$session_id = self::sanitize_id( $session_id );
+		if ( '' === $session_id ) {
+			return null;
+		}
+		return $this->read_trace( $session_id );
+	}
+
+	/**
+	 * Delete a trace and remove it from the index.
+	 *
+	 * @param string $session_id Session identifier.
+	 * @return bool True if the trace was removed.
+	 */
+	public function delete( $session_id ) {
+		$session_id = self::sanitize_id( $session_id );
+		if ( '' === $session_id ) {
+			return false;
+		}
+
+		return (bool) $this->with_lock(
+			function () use ( $session_id ) {
+				delete_option( self::option_name( $session_id ) );
+				$index = array_values( array_diff( $this->read_index(), [ $session_id ] ) );
+				$this->write_index( $index );
+				return true;
+			}
+		);
+	}
+
+	/**
+	 * Return the ordered list of trace ids, oldest first.
+	 *
+	 * @return string[]
+	 */
+	public function get_all_ids() {
+		return $this->read_index();
+	}
+
+	/**
+	 * Return the number of traces currently stored.
+	 *
+	 * @return int
+	 */
+	public function count() {
+		return count( $this->read_index() );
+	}
+
+	/**
+	 * Whether the store is saturated (at {@see self::MAX_TRACES}).
+	 *
+	 * @return bool
+	 */
+	public function is_full() {
+		return $this->count() >= self::MAX_TRACES;
+	}
+
+	/**
+	 * Evict oldest trace rows until the index is under {@see self::MAX_TRACES}.
+	 *
+	 * @param string[] $index The current index.
+	 * @return string[] The (possibly trimmed) index.
+	 */
+	private function evict_oldest( array $index ) {
+		$count = count( $index );
+		while ( $count > self::MAX_TRACES ) {
+			$oldest = array_shift( $index );
+			if ( is_string( $oldest ) ) {
+				delete_option( self::option_name( $oldest ) );
+			}
+			--$count;
+		}
+		return $index;
+	}
+
+	/**
+	 * Read and decode a single trace row.
+	 *
+	 * @param string $session_id Sanitized session id.
+	 * @return array|null Decoded trace, or null when absent or malformed.
+	 */
+	private function read_trace( string $session_id ): ?array {
+		$raw = get_option( self::option_name( $session_id ), false );
+		if ( false === $raw || ! is_string( $raw ) ) {
+			return null;
+		}
+		$decoded = json_decode( $raw, true );
+		return is_array( $decoded ) ? $decoded : null;
+	}
+
+	/**
+	 * Read the trace id index from wp_options.
+	 *
+	 * @return string[] Ordered list of trace ids, oldest first.
+	 */
+	private function read_index(): array {
+		$raw = get_option( self::INDEX_OPTION, [] );
+		return is_array( $raw ) ? array_values( $raw ) : [];
+	}
+
+	/**
+	 * Persist the trace id index.
+	 *
+	 * @param string[] $index Ordered list of trace ids.
+	 */
+	private function write_index( array $index ): void {
+		update_option( self::INDEX_OPTION, array_values( $index ), false );
+	}
+
+	/**
+	 * Acquire a short-lived transient lock and run $callback. Returns the
+	 * callback's return value, or null if the lock could not be acquired.
+	 *
+	 * @param callable $callback The critical section to run under the lock.
+	 * @return mixed|null
+	 */
+	private function with_lock( callable $callback ) {
+		// Best-effort lock: transients can silently fail under object-cache
+		// contention, and we'd rather accept a rare lost write than drop the
+		// event entirely. The failure mode is a concurrent reader's stale view,
+		// not corruption (each trace row is a single atomic option write).
+		set_transient( self::LOCK_TRANSIENT, 1, self::LOCK_TIMEOUT );
+		try {
+			return $callback();
+		} finally {
+			delete_transient( self::LOCK_TRANSIENT );
+		}
+	}
+
+	/**
+	 * Reduce an id to a slug-safe form. Session ids are client-generated so
+	 * we must never trust them as option-name fragments.
+	 *
+	 * @param string $id Raw session identifier.
+	 * @return string
+	 */
+	public static function sanitize_id( $id ) {
+		if ( ! is_string( $id ) ) {
+			return '';
+		}
+		$id = preg_replace( '/[^a-zA-Z0-9_-]/', '', $id );
+		return is_string( $id ) ? substr( $id, 0, 64 ) : '';
+	}
+
+	private static function option_name( string $session_id ): string {
+		return self::TRACE_OPTION_PREFIX . $session_id;
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -152,6 +152,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails
-* Dev - Add WC_Stripe_Diagnostics_Trace_Store (options-backed trace storage with FIFO eviction and size caps) for the upcoming diagnostics recorder
+* Dev - Add WC_Stripe_Diagnostics_Trace_Store (file-backed trace storage with FIFO eviction and size caps) for the upcoming diagnostics recorder
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -152,5 +152,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails
+* Dev - Add WC_Stripe_Diagnostics_Trace_Store (options-backed trace storage with FIFO eviction and size caps) for the upcoming diagnostics recorder
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-trace-store-test.php
+++ b/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-trace-store-test.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Tests for WC_Stripe_Diagnostics_Trace_Store.
+ *
+ * @package WooCommerce/Stripe/Diagnostics
+ */
+class WC_Stripe_Diagnostics_Trace_Store_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var WC_Stripe_Diagnostics_Trace_Store
+	 */
+	private $store;
+
+	public function set_up() {
+		parent::set_up();
+		$this->store = new WC_Stripe_Diagnostics_Trace_Store();
+		$this->clear_all_traces();
+	}
+
+	public function tear_down() {
+		$this->clear_all_traces();
+		parent::tear_down();
+	}
+
+	private function clear_all_traces() {
+		foreach ( $this->store->get_all_ids() as $id ) {
+			$this->store->delete( $id );
+		}
+		delete_option( WC_Stripe_Diagnostics_Trace_Store::INDEX_OPTION );
+	}
+
+	public function test_create_and_get_round_trip() {
+		$this->assertTrue( $this->store->create( 'abc123', [ 'source' => 'checkout' ] ) );
+		$trace = $this->store->get( 'abc123' );
+		$this->assertSame( 'abc123', $trace['id'] );
+		$this->assertSame( WC_Stripe_Diagnostics_Trace_Store::STATUS_PENDING, $trace['status'] );
+		$this->assertSame( 'checkout', $trace['meta']['source'] );
+		$this->assertSame( [], $trace['events'] );
+	}
+
+	public function test_create_is_idempotent_for_same_id() {
+		$this->assertTrue( $this->store->create( 'same' ) );
+		$this->assertFalse( $this->store->create( 'same' ) );
+		$this->assertCount( 1, $this->store->get_all_ids() );
+	}
+
+	public function test_append_event_adds_to_trace() {
+		$this->store->create( 'trace1' );
+		$this->assertTrue( $this->store->append_event( 'trace1', [ 'kind' => 'paymentMethodCreated' ] ) );
+		$trace = $this->store->get( 'trace1' );
+		$this->assertCount( 1, $trace['events'] );
+		$this->assertSame( 'paymentMethodCreated', $trace['events'][0]['kind'] );
+	}
+
+	public function test_append_event_drops_past_event_cap() {
+		$this->store->create( 'capped' );
+		for ( $i = 0; $i < WC_Stripe_Diagnostics_Trace_Store::MAX_EVENTS_PER_TRACE; $i++ ) {
+			$this->assertTrue( $this->store->append_event( 'capped', [ 'n' => $i ] ) );
+		}
+		$this->assertFalse( $this->store->append_event( 'capped', [ 'n' => 'overflow' ] ) );
+		$trace = $this->store->get( 'capped' );
+		$this->assertCount( WC_Stripe_Diagnostics_Trace_Store::MAX_EVENTS_PER_TRACE, $trace['events'] );
+	}
+
+	public function test_append_event_drops_past_size_cap() {
+		$this->store->create( 'big' );
+		$big_event = [ 'payload' => str_repeat( 'x', WC_Stripe_Diagnostics_Trace_Store::MAX_TRACE_BYTES + 1 ) ];
+		$this->assertFalse( $this->store->append_event( 'big', $big_event ) );
+		$trace = $this->store->get( 'big' );
+		$this->assertCount( 0, $trace['events'] );
+	}
+
+	public function test_set_status_promotes_and_rejects_unknown_status() {
+		$this->store->create( 'promote' );
+		$this->assertTrue( $this->store->set_status( 'promote', WC_Stripe_Diagnostics_Trace_Store::STATUS_COMPLETED ) );
+		$this->assertSame(
+			WC_Stripe_Diagnostics_Trace_Store::STATUS_COMPLETED,
+			$this->store->get( 'promote' )['status']
+		);
+		$this->assertFalse( $this->store->set_status( 'promote', 'nonsense' ) );
+	}
+
+	public function test_fifo_eviction_at_trace_cap() {
+		$cap      = WC_Stripe_Diagnostics_Trace_Store::MAX_TRACES;
+		$overflow = 3;
+		for ( $i = 0; $i < $cap + $overflow; $i++ ) {
+			$this->store->create( 'id' . $i );
+		}
+		$ids = $this->store->get_all_ids();
+		$this->assertCount( $cap, $ids );
+		// First $overflow ids should have been evicted.
+		$this->assertSame( 'id' . $overflow, $ids[0] );
+		$this->assertNull( $this->store->get( 'id0' ) );
+	}
+
+	public function test_delete_removes_trace_and_index_entry() {
+		$this->store->create( 'gone' );
+		$this->assertTrue( $this->store->delete( 'gone' ) );
+		$this->assertNull( $this->store->get( 'gone' ) );
+		$this->assertNotContains( 'gone', $this->store->get_all_ids() );
+	}
+
+	public function test_sanitize_id_strips_unsafe_chars() {
+		$this->assertSame( 'abc_123-XYZ', WC_Stripe_Diagnostics_Trace_Store::sanitize_id( 'abc_123-XYZ' ) );
+		$this->assertSame( 'abc', WC_Stripe_Diagnostics_Trace_Store::sanitize_id( 'a/b;c' ) );
+		$this->assertSame( '', WC_Stripe_Diagnostics_Trace_Store::sanitize_id( '@#$' ) );
+		$this->assertSame( '', WC_Stripe_Diagnostics_Trace_Store::sanitize_id( null ) );
+	}
+
+	public function test_is_full_reflects_trace_count() {
+		$this->assertFalse( $this->store->is_full() );
+		for ( $i = 0; $i < WC_Stripe_Diagnostics_Trace_Store::MAX_TRACES; $i++ ) {
+			$this->store->create( 'f' . $i );
+		}
+		$this->assertTrue( $this->store->is_full() );
+	}
+}

--- a/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-trace-store-test.php
+++ b/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-trace-store-test.php
@@ -15,19 +15,12 @@ class WC_Stripe_Diagnostics_Trace_Store_Test extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		$this->store = new WC_Stripe_Diagnostics_Trace_Store();
-		$this->clear_all_traces();
+		$this->store->delete_all();
 	}
 
 	public function tear_down() {
-		$this->clear_all_traces();
+		$this->store->delete_all();
 		parent::tear_down();
-	}
-
-	private function clear_all_traces() {
-		foreach ( $this->store->get_all_ids() as $id ) {
-			$this->store->delete( $id );
-		}
-		delete_option( WC_Stripe_Diagnostics_Trace_Store::INDEX_OPTION );
 	}
 
 	public function test_create_and_get_round_trip() {
@@ -106,6 +99,20 @@ class WC_Stripe_Diagnostics_Trace_Store_Test extends WP_UnitTestCase {
 		$this->assertSame( 'abc', WC_Stripe_Diagnostics_Trace_Store::sanitize_id( 'a/b;c' ) );
 		$this->assertSame( '', WC_Stripe_Diagnostics_Trace_Store::sanitize_id( '@#$' ) );
 		$this->assertSame( '', WC_Stripe_Diagnostics_Trace_Store::sanitize_id( null ) );
+	}
+
+	public function test_get_trace_path_returns_file_on_disk_for_existing_trace() {
+		$this->store->create( 'on-disk', [ 'source' => 'checkout' ] );
+		$path = $this->store->get_trace_path( 'on-disk' );
+		$this->assertNotNull( $path );
+		$this->assertFileExists( $path );
+		$decoded = json_decode( file_get_contents( $path ), true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$this->assertSame( 'on-disk', $decoded['id'] );
+		$this->assertSame( 'checkout', $decoded['meta']['source'] );
+	}
+
+	public function test_get_trace_path_returns_null_for_invalid_id() {
+		$this->assertNull( $this->store->get_trace_path( '@#$' ) );
 	}
 
 	public function test_is_full_reflects_trace_count() {


### PR DESCRIPTION
Towards RSM-629
Fixes RSM-632

## Changes proposed in this Pull Request

Adds `WC_Stripe_Diagnostics_Trace_Store`: a plain, **file-backed** trace storage class for the upcoming diagnostics recorder. One class file + one test file + loader wiring + changelog.

### Storage layout
- Each trace → one JSON file at `wp-content/uploads/wc-stripe-diagnostics/<sanitized_id>.json`.
- Shared index → `index.json` in the same directory holding the ordered id list.
- An advisory `flock(LOCK_EX)` on a `.index.lock` file in the same directory serializes writers.
- The directory is created lazily on first write via `FilesystemUtil::mkdir_p_not_indexable()`, which drops a `.htaccess` (deny all) and an empty `index.html` to block direct web access. Falls back to `wp_mkdir_p()` on hosts where the helper is missing.

### Why files instead of `wp_options`?
- **Easier to share / hand off.** A trace is a single file you can attach to a support ticket, scp out, or stream from a REST endpoint without re-decoding. Pulling the same data out of `wp_options` means a DB dump or copy/paste.
- **Stays out of database backups.** Traces are short-lived debug data, not application state — no reason for them to round-trip through DB backup/restore.
- **No autoload concerns.** The previous design had to be careful about `autoload=no` on every `update_option`; with files, the question doesn't come up.

### Invariants
- **Trace count cap:** 200. On insert, the oldest trace file is deleted (FIFO) when the index exceeds the cap.
- **Events-per-trace cap:** 200. New events beyond the cap are silently dropped; `append_event()` returns `false`.
- **Serialized size cap:** 100 KB per trace. If appending an event would exceed the cap, the append is rejected.
- **Status machine:** `pending` → `completed` | `abandoned` via `set_status()`. Unknown statuses are rejected.

### Public surface
```php
$store = new WC_Stripe_Diagnostics_Trace_Store();
$store->create( $session_id, $meta );          // bool
$store->append_event( $session_id, $event );   // bool
$store->set_status( $session_id, $status );    // bool
$store->get( $session_id );                    // array|null
$store->delete( $session_id );                 // bool
$store->delete_all();                          // void  (tests + future uninstall)
$store->get_all_ids();                         // string[]
$store->count();                               // int
$store->is_full();                             // bool
$store->get_trace_path( $session_id );         // string|null  (for streaming/sharing)
WC_Stripe_Diagnostics_Trace_Store::sanitize_id( $raw );
```

Session ids are **client-generated**, so `sanitize_id()` strips every non-`[A-Za-z0-9_-]` char and truncates to 64 — no raw id ever becomes part of a filename.

### Concurrency note
Writers acquire `flock(LOCK_EX)` on a dedicated lock file before mutating the index. This is a real OS-level advisory lock (vs. the transient marker the earlier draft used), so concurrent writers serialize cleanly. Reads don't lock; the worst case for an in-flight write is a reader seeing a slightly stale view, not corruption — every per-trace `file_put_contents()` is atomic from the reader's perspective. If `fopen()` on the lock file fails (read-only fs, exhausted descriptors), the critical section still runs unguarded — better than dropping events.

## Testing instructions

No runtime effect yet — no subscribers, no UI, no REST endpoint. This is pure infrastructure. To verify:

1. Run the new PHPUnit test: `npm run test:php -- --filter 'WC_Stripe_Diagnostics_Trace_Store_Test'` — 12 tests pass.
2. Smoke-test in a WP shell (e.g., `wp shell` inside Docker):
   ```php
   $s = new WC_Stripe_Diagnostics_Trace_Store();
   $s->create( 'abc' );
   $s->append_event( 'abc', [ 'kind' => 'test' ] );
   var_dump( $s->get( 'abc' ) );
   echo $s->get_trace_path( 'abc' ); // wp-content/uploads/wc-stripe-diagnostics/abc.json
   ```
3. Inspect `wp-content/uploads/wc-stripe-diagnostics/` and confirm the JSON file is on disk plus a `.htaccess` denying access and an `index.json` listing the trace id.

## Test coverage
- 12 tests covering: round-trip, create idempotency, event append, event cap, size cap, status transitions, FIFO eviction at 200, delete, sanitize_id edge cases, is_full, **`get_trace_path()` returning a real on-disk file**, and `get_trace_path()` returning null for invalid ids.

Ran locally: `npm run lint:php` ✅ · `npm run phpstan` ✅ · targeted PHPUnit (CI)

## Dependencies / stacking
- Base branch: `feature/diagnostics`
- Companion PRs that build on this:
  - Redaction engine (independent, parallel)
  - Recorder singleton (needs this + redaction + #5344)
  - REST events endpoint (needs this — will use `get_trace_path()` for streaming)
  - Action Scheduler cleanup jobs (needs this)

## Changelog

- [x] Covered with tests
- [x] Tested on mobile — N/A (storage class)

Added as `Dev` in `changelog.txt` and `readme.txt`:
> Add WC_Stripe_Diagnostics_Trace_Store (file-backed trace storage with FIFO eviction and size caps) for the upcoming diagnostics recorder