### PR TITLE
[RSM - Diagnostics Mode] Add WC_Stripe_Diagnostics_Redactor

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ xxxx-xx-xx - version 10.7.0
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails
 * Dev - Add wc_stripe_api_response_received action and wc_stripe_localized_data filter to pave the way for the upcoming diagnostics recorder
 * Dev - Add WC_Stripe_Diagnostics_Trace_Store (file-backed trace storage with FIFO eviction and size caps) for the upcoming diagnostics recorder
+* Dev - Add WC_Stripe_Diagnostics_Redactor (allow-list registry + PII scrubbers) for the upcoming diagnostics recorder
 
 2026-04-23 - version 10.6.1
 * Fix - Fix Optimized Checkout Suite bugs that could result in duplicate subscription charges and generic payment methods names

--- a/includes/diagnostics/class-wc-stripe-diagnostics-redactor.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-redactor.php
@@ -7,10 +7,10 @@ defined( 'ABSPATH' ) || exit;
  *
  * Two layers run against every event before it reaches the trace store:
  *
- * 1. An **allow-list registry** keyed by event kind (`apiRequest`,
- *    `apiResponse`, `webhookReceived`, `consoleMessage`, ...). Any field not
- *    explicitly listed for the event's kind is dropped. Unknown kinds produce
- *    an empty event (fail-closed).
+ * 1. An **allow-list registry** keyed by event kind (`element.ready`,
+ *    `console.warn`, `stripe.confirmPayment.invoke`, `webhook.received`, ...).
+ *    Any field not explicitly listed for the event's kind is dropped. Unknown
+ *    kinds produce an empty event (fail-closed).
  *
  * 2. A set of **string scrubbers** applied to every remaining value: emails
  *    become `[email]`, IPv4/IPv6 become `[ip]`, URL query strings are
@@ -97,27 +97,70 @@ class WC_Stripe_Diagnostics_Redactor {
 	 * @return array<string, string[]>
 	 */
 	public static function default_allow_list(): array {
-		return [
-			'apiRequest'      => [
+		$list = [
+			// Stripe Element lifecycle (frontend: client/diagnostics/recorder.js).
+			'element.ready'                 => [ 'element_type' ],
+			'element.focus'                 => [ 'element_type' ],
+			'element.blur'                  => [ 'element_type' ],
+			'element.change'                => [
+				'element_type',
+				'complete',
+				'empty',
+				'valid',
+				'brand',
+				'error_code',
+				'error_type',
+			],
+			'element.loaderror'             => [
+				'element_type',
+				'error_code',
+				'error_type',
+				'error_message',
+			],
+
+			// Blocks onPaymentSetup brackets.
+			'blocks.payment_setup.start'    => [ 'site' ],
+			'blocks.payment_setup.end'      => [
+				'site',
+				'duration_ms',
+				'result_type',
+				'error_message',
+			],
+
+			// Express Checkout Element events.
+			'express.click'                 => [ 'wallet_type' ],
+			'express.confirm'               => [ 'wallet_type', 'payment_method_type' ],
+			'express.cancel'                => [ 'wallet_type' ],
+			'express.shippingratechange'    => [ 'wallet_type' ],
+			'express.shippingaddresschange' => [ 'wallet_type', 'country' ],
+			'express.paymentmethod'         => [ 'wallet_type', 'payment_method_type' ],
+
+			// Parent-frame console interception.
+			'console.warn'                  => [ 'message', 'source' ],
+			'console.error'                 => [ 'message', 'source' ],
+
+			// Server-side: Stripe API request / response.
+			'stripe.api.request'            => [
 				'api',
 				'method',
-				'request_id',
-				'fields',
 				'has_metadata',
 				'metadata.order_id',
 				'metadata.wc_diag_session_id',
+				'fields',
 			],
-			'apiResponse'     => [
+			'stripe.api.response'           => [
 				'api',
 				'method',
 				'status',
 				'request_id',
+				'latency_ms',
 				'error.code',
 				'error.type',
 				'error.decline_code',
-				'latency_ms',
 			],
-			'webhookReceived' => [
+
+			// Server-side: webhook receipt (correlated via metadata session id).
+			'webhook.received'              => [
 				'type',
 				'status',
 				'intent_id',
@@ -125,39 +168,37 @@ class WC_Stripe_Diagnostics_Redactor {
 				'order_id',
 				'session_id',
 			],
-			'consoleMessage'  => [
-				'level',
-				'message_truncated',
-				'source',
-			],
-			'elementEvent'    => [
-				'element',
-				'type',
-				'complete',
-				'empty',
-				'error_code',
-			],
-			'sdkCall'         => [
-				'method',
-				'ok',
-				'latency_ms',
-				'error_code',
-			],
-			'blocksEvent'     => [
-				'phase',
-				'type',
-				'ok',
-				'error_code',
-			],
-			'expressCheckout' => [
-				'phase',
-				'type',
-				'payment_method',
-			],
-			'sessionEnd'      => [
-				'reason',
-			],
 		];
+
+		// Stripe SDK call brackets emitted by the frontend recorder via
+		// `diagnostics.aroundStripeCall( method, fn )`. Each method gets
+		// .invoke / .resolve / .throw with method-agnostic shapes.
+		$sdk_call_methods = [
+			'confirmPayment',
+			'confirmSetup',
+			'confirmCashappSetup',
+			'confirmCashappPayment',
+			'createPaymentMethod',
+			'confirm', // Custom Checkout Sessions (Blocks).
+		];
+		foreach ( $sdk_call_methods as $method ) {
+			$list[ "stripe.{$method}.invoke" ]  = [ 'method' ];
+			$list[ "stripe.{$method}.resolve" ] = [
+				'method',
+				'intent_status',
+				'payment_method_type',
+				'has_error',
+				'error_type',
+				'error_code',
+				'error_decline_code',
+			];
+			$list[ "stripe.{$method}.throw" ]   = [
+				'method',
+				'error_message',
+			];
+		}
+
+		return $list;
 	}
 
 	/**

--- a/includes/diagnostics/class-wc-stripe-diagnostics-redactor.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-redactor.php
@@ -1,0 +1,252 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Enforces data scrubbing for diagnostics events.
+ *
+ * Two layers run against every event before it reaches the trace store:
+ *
+ * 1. An **allow-list registry** keyed by event kind (`apiRequest`,
+ *    `apiResponse`, `webhookReceived`, `consoleMessage`, ...). Any field not
+ *    explicitly listed for the event's kind is dropped. Unknown kinds produce
+ *    an empty event (fail-closed).
+ *
+ * 2. A set of **string scrubbers** applied to every remaining value: emails
+ *    become `[email]`, IPv4/IPv6 become `[ip]`, URL query strings are
+ *    truncated, and long opaque tokens / secrets are masked.
+ *
+ * The redactor is deliberately conservative. It is cheaper to drop a legitimate
+ * field than to ship PII.
+ */
+class WC_Stripe_Diagnostics_Redactor {
+
+	/**
+	 * Allow-listed field paths per event kind. Nested fields are declared with
+	 * dot notation (e.g. `meta.order_id`). Array elements share the parent
+	 * allow list.
+	 *
+	 * See docs/diagnostics-contracts.md §5.
+	 *
+	 * @var array<string, string[]>
+	 */
+	private $allow_list;
+
+	/**
+	 * Construct a redactor, optionally overriding the allow list (used in tests).
+	 *
+	 * @param array<string, string[]>|null $allow_list Optional override.
+	 */
+	public function __construct( ?array $allow_list = null ) {
+		$this->allow_list = $allow_list ?? self::default_allow_list();
+	}
+
+	/**
+	 * Redact a single event.
+	 *
+	 * @param array $event The event payload. Must include a `kind` string.
+	 * @return array The redacted event. May be empty for unknown kinds.
+	 */
+	public function redact( array $event ): array {
+		$kind = isset( $event['kind'] ) && is_string( $event['kind'] ) ? $event['kind'] : '';
+		if ( '' === $kind || ! isset( $this->allow_list[ $kind ] ) ) {
+			return [];
+		}
+
+		$allowed = $this->allow_list[ $kind ];
+		$kept    = [ 'kind' => $kind ];
+		if ( isset( $event['ts'] ) && ( is_int( $event['ts'] ) || is_float( $event['ts'] ) ) ) {
+			$kept['ts'] = (int) $event['ts'];
+		}
+
+		foreach ( $allowed as $path ) {
+			$value = self::pluck( $event, $path );
+			if ( null === $value ) {
+				continue;
+			}
+			self::assign( $kept, $path, $this->scrub_value( $value ) );
+		}
+
+		return $kept;
+	}
+
+	/**
+	 * Run the scrubbers on an already-structured value. Recurses into arrays.
+	 *
+	 * @param mixed $value
+	 * @return mixed
+	 */
+	public function scrub_value( $value ) {
+		if ( is_string( $value ) ) {
+			return self::scrub_string( $value );
+		}
+		if ( is_array( $value ) ) {
+			$out = [];
+			foreach ( $value as $k => $v ) {
+				$out[ $k ] = $this->scrub_value( $v );
+			}
+			return $out;
+		}
+		return $value;
+	}
+
+	/**
+	 * The default allow list. Keep this small — adding a field is an explicit
+	 * statement that it's safe to ship to a diagnostics bundle.
+	 *
+	 * @return array<string, string[]>
+	 */
+	public static function default_allow_list(): array {
+		return [
+			'apiRequest'      => [
+				'api',
+				'method',
+				'request_id',
+				'fields',
+				'has_metadata',
+				'metadata.order_id',
+				'metadata.wc_diag_session_id',
+			],
+			'apiResponse'     => [
+				'api',
+				'method',
+				'status',
+				'request_id',
+				'error.code',
+				'error.type',
+				'error.decline_code',
+				'latency_ms',
+			],
+			'webhookReceived' => [
+				'type',
+				'status',
+				'intent_id',
+				'charge_id',
+				'order_id',
+				'session_id',
+			],
+			'consoleMessage'  => [
+				'level',
+				'message_truncated',
+				'source',
+			],
+			'elementEvent'    => [
+				'element',
+				'type',
+				'complete',
+				'empty',
+				'error_code',
+			],
+			'sdkCall'         => [
+				'method',
+				'ok',
+				'latency_ms',
+				'error_code',
+			],
+			'blocksEvent'     => [
+				'phase',
+				'type',
+				'ok',
+				'error_code',
+			],
+			'expressCheckout' => [
+				'phase',
+				'type',
+				'payment_method',
+			],
+			'sessionEnd'      => [
+				'reason',
+			],
+		];
+	}
+
+	/**
+	 * Strip obvious PII patterns from a string. The regexes are intentionally
+	 * broad: false positives in a diagnostics trace are acceptable; PII leaks
+	 * are not.
+	 *
+	 * @param string $value
+	 * @return string
+	 */
+	private static function scrub_string( string $value ): string {
+		// Truncate extremely long strings — the redactor should never amplify them.
+		if ( strlen( $value ) > 512 ) {
+			$value = substr( $value, 0, 512 ) . '…';
+		}
+
+		$patterns = [
+			// Emails.
+			'/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/'     => '[email]',
+			// IPv4.
+			'/\b(?:\d{1,3}\.){3}\d{1,3}\b/'                        => '[ip]',
+			// IPv6 — catches both fully-qualified and `::`-compressed forms.
+			'/\b(?:[A-Fa-f0-9]{0,4}:){2,7}[A-Fa-f0-9]{0,4}\b/'     => '[ip]',
+			// Stripe secret-ish tokens (sk_live_…, rk_live_…, sk_test_…, whsec_…).
+			'/\b(?:sk|rk|whsec)_(?:live|test)?_?[A-Za-z0-9]{10,}/' => '[secret]',
+		];
+		foreach ( $patterns as $pattern => $replacement ) {
+			$replaced = preg_replace( $pattern, $replacement, $value );
+			if ( is_string( $replaced ) ) {
+				$value = $replaced;
+			}
+		}
+
+		// URL query strings — keep the path, drop params entirely. URLs with
+		// user identifiers in the query are a common accidental leak source.
+		$replaced = preg_replace_callback(
+			'~(https?://[^\s?]+)\?[^\s]*~',
+			static function ( $m ) {
+				return $m[1] . '?[redacted]';
+			},
+			$value
+		);
+		if ( is_string( $replaced ) ) {
+			$value = $replaced;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Walk a nested array using a dot-path and return the resolved value,
+	 * or null when any segment is missing.
+	 *
+	 * @param array  $source
+	 * @param string $path
+	 * @return mixed|null
+	 */
+	private static function pluck( array $source, string $path ) {
+		$segments = explode( '.', $path );
+		$cursor   = $source;
+		foreach ( $segments as $segment ) {
+			if ( ! is_array( $cursor ) || ! array_key_exists( $segment, $cursor ) ) {
+				return null;
+			}
+			$cursor = $cursor[ $segment ];
+		}
+		return $cursor;
+	}
+
+	/**
+	 * Assign a value into a nested array using a dot-path, creating parent
+	 * arrays as needed.
+	 *
+	 * @param array  $target
+	 * @param string $path
+	 * @param mixed  $value
+	 */
+	private static function assign( array &$target, string $path, $value ): void {
+		$segments = explode( '.', $path );
+		$cursor   = &$target;
+		foreach ( $segments as $i => $segment ) {
+			if ( count( $segments ) - 1 === $i ) {
+				$cursor[ $segment ] = $value;
+				return;
+			}
+			if ( ! isset( $cursor[ $segment ] ) || ! is_array( $cursor[ $segment ] ) ) {
+				$cursor[ $segment ] = [];
+			}
+			$cursor = &$cursor[ $segment ];
+		}
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -155,5 +155,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails
 * Dev - Add wc_stripe_api_response_received action and wc_stripe_localized_data filter to pave the way for the upcoming diagnostics recorder
 * Dev - Add WC_Stripe_Diagnostics_Trace_Store (file-backed trace storage with FIFO eviction and size caps) for the upcoming diagnostics recorder
+* Dev - Add WC_Stripe_Diagnostics_Redactor (allow-list registry + PII scrubbers) for the upcoming diagnostics recorder
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-redactor-test.php
+++ b/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-redactor-test.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * Tests for WC_Stripe_Diagnostics_Redactor.
+ *
+ * @package WooCommerce/Stripe/Diagnostics
+ */
+class WC_Stripe_Diagnostics_Redactor_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var WC_Stripe_Diagnostics_Redactor
+	 */
+	private $redactor;
+
+	public function set_up() {
+		parent::set_up();
+		$this->redactor = new WC_Stripe_Diagnostics_Redactor();
+	}
+
+	public function test_unknown_kind_returns_empty_event() {
+		$this->assertSame(
+			[],
+			$this->redactor->redact(
+				[
+					'kind' => 'nonsense',
+					'foo'  => 'bar',
+				]
+			)
+		);
+		$this->assertSame( [], $this->redactor->redact( [] ) );
+	}
+
+	public function test_fields_outside_allow_list_are_dropped() {
+		$event  = [
+			'kind'           => 'apiResponse',
+			'api'            => 'payment_intents',
+			'method'         => 'POST',
+			'status'         => 200,
+			'request_id'     => 'req_abc',
+			'raw_body'       => 'should not be kept',
+			'customer_email' => 'shopper@example.com',
+			'latency_ms'     => 134,
+		];
+		$result = $this->redactor->redact( $event );
+		$this->assertArrayNotHasKey( 'raw_body', $result );
+		$this->assertArrayNotHasKey( 'customer_email', $result );
+		$this->assertSame( 200, $result['status'] );
+		$this->assertSame( 134, $result['latency_ms'] );
+	}
+
+	public function test_nested_allow_list_paths_are_kept() {
+		$event  = [
+			'kind'     => 'apiRequest',
+			'api'      => 'payment_intents',
+			'method'   => 'POST',
+			'metadata' => [
+				'order_id'           => '42',
+				'wc_diag_session_id' => 'smoke-abc',
+				'customer_email'     => 'leak@example.com',
+			],
+		];
+		$result = $this->redactor->redact( $event );
+		$this->assertSame( '42', $result['metadata']['order_id'] );
+		$this->assertSame( 'smoke-abc', $result['metadata']['wc_diag_session_id'] );
+		$this->assertArrayNotHasKey( 'customer_email', $result['metadata'] );
+	}
+
+	/**
+	 * @dataProvider provide_pii_payloads
+	 */
+	public function test_pii_patterns_are_scrubbed( string $allowed_field, string $raw_value, array $forbidden_substrings ) {
+		// Inject the PII into an allow-listed consoleMessage field.
+		$event                   = [
+			'kind'  => 'consoleMessage',
+			'level' => 'warn',
+		];
+		$event[ $allowed_field ] = $raw_value;
+
+		$result = $this->redactor->redact( $event );
+		$json   = wp_json_encode( $result );
+
+		foreach ( $forbidden_substrings as $needle ) {
+			$this->assertStringNotContainsString( $needle, $json, "PII substring '{$needle}' survived redaction." );
+		}
+	}
+
+	public function provide_pii_payloads(): array {
+		return [
+			'email in message'     => [ 'message_truncated', 'Failed for user shopper@example.com trying again', [ 'shopper@example.com' ] ],
+			'ipv4 in message'      => [ 'message_truncated', 'Blocked from 192.168.1.42 after 3 retries', [ '192.168.1.42' ] ],
+			'ipv6 in message'      => [ 'message_truncated', 'Blocked from 2001:0db8:85a3:0000:0000:8a2e:0370:7334', [ '2001:0db8:85a3:0000:0000:8a2e:0370:7334' ] ],
+			'stripe secret in msg' => [ 'message_truncated', 'Authorization: Bearer sk_live_abcdef1234567890', [ 'sk_live_abcdef1234567890' ] ],
+			'url with query'       => [ 'message_truncated', 'Redirected to https://example.com/pay?email=shopper@example.com&token=xyz', [ 'shopper@example.com', 'token=xyz' ] ],
+		];
+	}
+
+	public function test_redaction_audit_no_pii_survives_for_any_allow_listed_field() {
+		// For every kind / field in the allow list, inject a bundle of PII
+		// patterns and assert none survive into the serialized trace JSON.
+		$pii_payloads = [
+			'foo@bar.com',
+			'user@some-domain.co.uk',
+			'192.168.1.1',
+			'10.0.0.1',
+			'2001:db8::1',
+			'sk_live_supersecretkey12345',
+			'whsec_abcdef1234567890',
+			'https://example.com/checkout?email=leak@example.com',
+		];
+
+		foreach ( WC_Stripe_Diagnostics_Redactor::default_allow_list() as $kind => $fields ) {
+			foreach ( $fields as $path ) {
+				foreach ( $pii_payloads as $payload ) {
+					$event = [ 'kind' => $kind ];
+					$this->assign( $event, $path, $payload );
+					$redacted = $this->redactor->redact( $event );
+					$json     = wp_json_encode( $redacted );
+					$this->assertStringNotContainsString( $payload, $json, "PII '{$payload}' survived in {$kind}.{$path}" );
+				}
+			}
+		}
+	}
+
+	public function test_long_string_is_truncated() {
+		$raw    = str_repeat( 'a', 600 );
+		$event  = [
+			'kind'              => 'consoleMessage',
+			'message_truncated' => $raw,
+		];
+		$result = $this->redactor->redact( $event );
+		$this->assertLessThan( 600, strlen( $result['message_truncated'] ) );
+	}
+
+	/**
+	 * Helper that mirrors the redactor's internal assign().
+	 */
+	private function assign( array &$target, string $path, $value ): void {
+		$segments = explode( '.', $path );
+		$cursor   = &$target;
+		foreach ( $segments as $i => $segment ) {
+			if ( count( $segments ) - 1 === $i ) {
+				$cursor[ $segment ] = $value;
+				return;
+			}
+			if ( ! isset( $cursor[ $segment ] ) || ! is_array( $cursor[ $segment ] ) ) {
+				$cursor[ $segment ] = [];
+			}
+			$cursor = &$cursor[ $segment ];
+		}
+	}
+}

--- a/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-redactor-test.php
+++ b/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-redactor-test.php
@@ -32,7 +32,7 @@ class WC_Stripe_Diagnostics_Redactor_Test extends WP_UnitTestCase {
 
 	public function test_fields_outside_allow_list_are_dropped() {
 		$event  = [
-			'kind'           => 'apiResponse',
+			'kind'           => 'stripe.api.response',
 			'api'            => 'payment_intents',
 			'method'         => 'POST',
 			'status'         => 200,
@@ -50,7 +50,7 @@ class WC_Stripe_Diagnostics_Redactor_Test extends WP_UnitTestCase {
 
 	public function test_nested_allow_list_paths_are_kept() {
 		$event  = [
-			'kind'     => 'apiRequest',
+			'kind'     => 'stripe.api.request',
 			'api'      => 'payment_intents',
 			'method'   => 'POST',
 			'metadata' => [
@@ -69,10 +69,10 @@ class WC_Stripe_Diagnostics_Redactor_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_pii_payloads
 	 */
 	public function test_pii_patterns_are_scrubbed( string $allowed_field, string $raw_value, array $forbidden_substrings ) {
-		// Inject the PII into an allow-listed consoleMessage field.
+		// Inject the PII into an allow-listed console.warn field.
 		$event                   = [
-			'kind'  => 'consoleMessage',
-			'level' => 'warn',
+			'kind'   => 'console.warn',
+			'source' => 'parent_frame',
 		];
 		$event[ $allowed_field ] = $raw_value;
 
@@ -86,11 +86,11 @@ class WC_Stripe_Diagnostics_Redactor_Test extends WP_UnitTestCase {
 
 	public function provide_pii_payloads(): array {
 		return [
-			'email in message'     => [ 'message_truncated', 'Failed for user shopper@example.com trying again', [ 'shopper@example.com' ] ],
-			'ipv4 in message'      => [ 'message_truncated', 'Blocked from 192.168.1.42 after 3 retries', [ '192.168.1.42' ] ],
-			'ipv6 in message'      => [ 'message_truncated', 'Blocked from 2001:0db8:85a3:0000:0000:8a2e:0370:7334', [ '2001:0db8:85a3:0000:0000:8a2e:0370:7334' ] ],
-			'stripe secret in msg' => [ 'message_truncated', 'Authorization: Bearer sk_live_abcdef1234567890', [ 'sk_live_abcdef1234567890' ] ],
-			'url with query'       => [ 'message_truncated', 'Redirected to https://example.com/pay?email=shopper@example.com&token=xyz', [ 'shopper@example.com', 'token=xyz' ] ],
+			'email in message'     => [ 'message', 'Failed for user shopper@example.com trying again', [ 'shopper@example.com' ] ],
+			'ipv4 in message'      => [ 'message', 'Blocked from 192.168.1.42 after 3 retries', [ '192.168.1.42' ] ],
+			'ipv6 in message'      => [ 'message', 'Blocked from 2001:0db8:85a3:0000:0000:8a2e:0370:7334', [ '2001:0db8:85a3:0000:0000:8a2e:0370:7334' ] ],
+			'stripe secret in msg' => [ 'message', 'Authorization: Bearer sk_live_abcdef1234567890', [ 'sk_live_abcdef1234567890' ] ],
+			'url with query'       => [ 'message', 'Redirected to https://example.com/pay?email=shopper@example.com&token=xyz', [ 'shopper@example.com', 'token=xyz' ] ],
 		];
 	}
 
@@ -124,11 +124,11 @@ class WC_Stripe_Diagnostics_Redactor_Test extends WP_UnitTestCase {
 	public function test_long_string_is_truncated() {
 		$raw    = str_repeat( 'a', 600 );
 		$event  = [
-			'kind'              => 'consoleMessage',
-			'message_truncated' => $raw,
+			'kind'    => 'console.warn',
+			'message' => $raw,
 		];
 		$result = $this->redactor->redact( $event );
-		$this->assertLessThan( 600, strlen( $result['message_truncated'] ) );
+		$this->assertLessThan( 600, strlen( $result['message'] ) );
 	}
 
 	/**


### PR DESCRIPTION
Towards RSM-629

## Changes proposed in this Pull Request:

Adds `WC_Stripe_Diagnostics_Redactor`: the pre-store scrubbing layer every diagnostics event passes through before it lands in the trace store. Pure class + tests + changelog. No subscribers or runtime effect yet.

The class lives under `includes/diagnostics/`, which is in composer's classmap (added in #5363), so no `require_once` wiring is needed.

### Two layers, fail-closed

1. **Allow-list registry per event kind.** Known kinds: `apiRequest`, `apiResponse`, `webhookReceived`, `consoleMessage`, `elementEvent`, `sdkCall`, `blocksEvent`, `expressCheckout`, `sessionEnd`. Each kind has an explicit list of allow-listed field paths (dot-notation for nested fields). Any field not on the list is dropped. Unknown kinds return an empty event.

2. **String scrubbers** run on every remaining value:
   - Emails → `[email]`
   - IPv4 and IPv6 (including `::`-compressed forms) → `[ip]`
   - Stripe-shaped secrets (`sk_live_…`, `rk_live_…`, `whsec_…`) → `[secret]`
   - URL query strings stripped (path kept, `?…` replaced with `?[redacted]`)
   - Strings truncated at 512 chars

The bias is intentionally conservative: it is far cheaper to drop a legitimate field than to ship PII in a support bundle.

### Redaction-audit test (per parent issue acceptance criterion)

`test_redaction_audit_no_pii_survives_for_any_allow_listed_field` iterates **every kind × every field × every PII pattern we know about**, injects the PII, and asserts the serialized post-redaction JSON does not contain the payload. This is the gating test for the parent issue's "zero PII patterns survive the recorder boundary" acceptance criterion.

### How can this code break?

- **A new event kind ships without an allow list:** unknown kinds fail closed (empty event), so the worst case is a missing event in a trace, not a leaked field.
- **A future scrubber regex over-matches:** the redaction-audit test catches this for every known PII pattern; new patterns should be added to the parameterized data provider so the same matrix protects them.
- **A nested allow-listed field contains a value type the scrubbers don't expect (e.g. binary):** scrubbers operate only on strings; non-string scalars pass through untouched, which is acceptable because they can't carry PII the regexes target.

## Testing instructions

No runtime effect yet — no subscribers. To verify:

1. Run the new PHPUnit suite:
   ```bash
   npm run test:php -- --filter 'WC_Stripe_Diagnostics_Redactor_Test'
   # → OK (10 tests, 344 assertions)
   ```
2. Smoke-test in a WP shell:
   ```php
   $r = new WC_Stripe_Diagnostics_Redactor();
   $r->redact( [ 'kind' => 'consoleMessage', 'level' => 'warn', 'message_truncated' => 'user shopper@example.com saw error' ] );
   // → ['kind' => 'consoleMessage', 'level' => 'warn', 'message_truncated' => 'user [email] saw error']
   ```
3. `npm run phpstan` → expect `[OK] No errors`
4. `npm run lint:php`

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply) — does not apply (pure PHP function, no UI)

### Changelog entry

* Dev - Add WC_Stripe_Diagnostics_Redactor (allow-list registry + PII scrubbers) for the upcoming diagnostics recorder

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

---

## Stack

- ✅ #5344 (request/response + localized_data filters) — **merged**
- ✅ #5347 (file-backed trace store) — **merged**
- ✅ #5363 (composer-autoload `includes/diagnostics/`) — **merged into `feature/diagnostics`**
- 👉 **This PR** — adds `WC_Stripe_Diagnostics_Redactor`, base `feature/diagnostics`
- 🔄 #5349 (recorder) — open, depends on this
- 🔄 #5350 (REST controller) — open, depends on this and on #5349

## Assumption to flag

The allow list currently lives in `default_allow_list()` and matches `docs/diagnostics-contracts.md §5`. That doc doesn't exist yet — it will land with the recorder PR. For now the allow list reflects the frontend recorder's event shapes in #5330. Reviewers may want to reconcile both once the contracts doc lands.