### PR TITLE
[RSM - Diagnostics Mode] Add diagnostics admin toggle + auto-disable at N=20

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ xxxx-xx-xx - version 10.7.0
 * Dev - Add POST /wc/v3/wc_stripe/diagnostics/events REST endpoint that accepts batched client events and appends them to the file-backed trace store
 * Dev - Add WC_Stripe_Diagnostics_Redactor (allow-list registry + PII scrubbers) for the upcoming diagnostics recorder
 * Dev - Add WC_Stripe_Diagnostics_Recorder server-side singleton that injects wc_diag_session_id into Stripe metadata and records redacted request/response/webhook events
+* Dev - Add diagnostics admin toggle (REST endpoints at /wc/v3/wc_stripe/diagnostics/state and /toggle) with per-shopper session id generation and auto-disable at 20 captured traces
 
 2026-04-23 - version 10.6.1
 * Fix - Fix Optimized Checkout Suite bugs that could result in duplicate subscription charges and generic payment methods names

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ xxxx-xx-xx - version 10.7.0
 * Dev - Add WC_Stripe_Diagnostics_Trace_Store (file-backed trace storage with FIFO eviction and size caps) for the upcoming diagnostics recorder
 * Dev - Add POST /wc/v3/wc_stripe/diagnostics/events REST endpoint that accepts batched client events and appends them to the file-backed trace store
 * Dev - Add WC_Stripe_Diagnostics_Redactor (allow-list registry + PII scrubbers) for the upcoming diagnostics recorder
+* Dev - Add WC_Stripe_Diagnostics_Recorder server-side singleton that injects wc_diag_session_id into Stripe metadata and records redacted request/response/webhook events
 
 2026-04-23 - version 10.6.1
 * Fix - Fix Optimized Checkout Suite bugs that could result in duplicate subscription charges and generic payment methods names

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ xxxx-xx-xx - version 10.7.0
 * Dev - Add wc_stripe_api_response_received action and wc_stripe_localized_data filter to pave the way for the upcoming diagnostics recorder
 * Dev - Add WC_Stripe_Diagnostics_Trace_Store (file-backed trace storage with FIFO eviction and size caps) for the upcoming diagnostics recorder
 * Dev - Add POST /wc/v3/wc_stripe/diagnostics/events REST endpoint that accepts batched client events and appends them to the file-backed trace store
+* Dev - Add WC_Stripe_Diagnostics_Redactor (allow-list registry + PII scrubbers) for the upcoming diagnostics recorder
 
 2026-04-23 - version 10.6.1
 * Fix - Fix Optimized Checkout Suite bugs that could result in duplicate subscription charges and generic payment methods names

--- a/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
+++ b/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
@@ -114,9 +114,10 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Whether the diagnostics feature is currently enabled.
+	 * Whether the diagnostics feature is currently enabled. Thin shim over
+	 * the recorder's is_enabled so both classes share one source of truth.
 	 */
 	public static function is_enabled(): bool {
-		return 'yes' === get_option( self::ENABLED_OPTION, 'no' );
+		return WC_Stripe_Diagnostics_Recorder::is_enabled();
 	}
 }

--- a/includes/admin/class-wc-rest-stripe-diagnostics-toggle-controller.php
+++ b/includes/admin/class-wc-rest-stripe-diagnostics-toggle-controller.php
@@ -1,0 +1,98 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Admin REST controller for toggling the diagnostics feature on or off.
+ *
+ * Routes:
+ *   GET  /wc/v3/wc_stripe/diagnostics/state   current toggle state + trace count
+ *   POST /wc/v3/wc_stripe/diagnostics/toggle  flip the toggle
+ */
+class WC_REST_Stripe_Diagnostics_Toggle_Controller extends WP_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Endpoint base path. Shared with WC_REST_Stripe_Diagnostics_Controller
+	 * so all diagnostics routes group under `/wc_stripe/diagnostics`.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'wc_stripe/diagnostics';
+
+	/**
+	 * Register the routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/state',
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'get_state' ],
+				'permission_callback' => [ $this, 'admin_check' ],
+			]
+		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/toggle',
+			[
+				'methods'             => 'POST',
+				'callback'            => [ $this, 'toggle' ],
+				'permission_callback' => [ $this, 'admin_check' ],
+				'args'                => [
+					'enabled' => [
+						'required' => true,
+						'type'     => 'boolean',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Permission callback. Restricted to WooCommerce admins.
+	 *
+	 * @return bool
+	 */
+	public function admin_check() {
+		return current_user_can( 'manage_woocommerce' );
+	}
+
+	/**
+	 * Return `{ enabled, count, limit }`.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_state() {
+		$store = new WC_Stripe_Diagnostics_Trace_Store();
+		return new WP_REST_Response(
+			[
+				'enabled' => WC_Stripe_Diagnostics_Recorder::is_enabled(),
+				'count'   => $store->count(),
+				'limit'   => WC_Stripe_Diagnostics_Recorder::CAPTURE_LIMIT,
+			],
+			200
+		);
+	}
+
+	/**
+	 * Flip the diagnostics toggle.
+	 *
+	 * @param WP_REST_Request<array<string, mixed>> $request
+	 * @return WP_REST_Response
+	 */
+	public function toggle( $request ) {
+		$enabled = (bool) $request->get_param( 'enabled' );
+		update_option( 'wc_stripe_diagnostics_enabled', $enabled ? 'yes' : 'no' );
+		return $this->get_state();
+	}
+}

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -134,6 +134,7 @@ class WC_Stripe {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-database-cache.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-payment-method-configurations.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-database-cache-prefetch.php';
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/diagnostics/class-wc-stripe-diagnostics-redactor.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-api.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-mode.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/compat/class-wc-stripe-subscriptions-helper.php';

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -867,6 +867,10 @@ class WC_Stripe {
 
 		$diagnostics_controller = new WC_REST_Stripe_Diagnostics_Controller();
 		$diagnostics_controller->register_routes();
+
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-diagnostics-toggle-controller.php';
+		$diagnostics_toggle_controller = new WC_REST_Stripe_Diagnostics_Toggle_Controller();
+		$diagnostics_toggle_controller->register_routes();
 	}
 
 	/**

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -135,6 +135,8 @@ class WC_Stripe {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-payment-method-configurations.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-database-cache-prefetch.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/diagnostics/class-wc-stripe-diagnostics-redactor.php';
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/diagnostics/class-wc-stripe-diagnostics-recorder.php';
+		WC_Stripe_Diagnostics_Recorder::get_instance()->init();
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-api.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-mode.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/compat/class-wc-stripe-subscriptions-helper.php';

--- a/includes/diagnostics/class-wc-stripe-diagnostics-recorder.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-recorder.php
@@ -1,0 +1,353 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Server-side diagnostics recorder.
+ *
+ * Subscribes to the plugin's existing request and webhook hooks. When a
+ * diagnostics session is active it:
+ *
+ * - Injects `metadata[wc_diag_session_id]` into outgoing payment-intent,
+ *   setup-intent, and customer create/update requests so webhooks can be
+ *   correlated back to the originating trace.
+ * - Records a redacted event for each Stripe API request/response round trip.
+ * - Records a redacted event for each webhook received.
+ * - Injects a `wcStripeDiag` global alongside the plugin's existing localized
+ *   script params so the frontend recorder can boot.
+ *
+ * The recorder is a singleton so the running session id can be shared across
+ * `wc_stripe_request_body` (request capture) and `wc_stripe_request_response`
+ * (response capture) without threading state through every call site.
+ */
+class WC_Stripe_Diagnostics_Recorder {
+
+	const SESSION_ID_META_KEY   = 'wc_diag_session_id';
+	const SESSION_OPTION        = 'wc_stripe_diag_active_session';
+	const SESSION_TTL           = 30 * MINUTE_IN_SECONDS;
+	const METADATA_ENABLED_APIS = [ 'payment_intents', 'setup_intents', 'customers' ];
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var self|null
+	 */
+	private static $instance;
+
+	/**
+	 * Trace store dependency.
+	 *
+	 * @var WC_Stripe_Diagnostics_Trace_Store
+	 */
+	private $store;
+
+	/**
+	 * Redactor dependency.
+	 *
+	 * @var WC_Stripe_Diagnostics_Redactor
+	 */
+	private $redactor;
+
+	/**
+	 * The current session id for this request, if any.
+	 *
+	 * @var string|null
+	 */
+	private $current_session_id;
+
+	/**
+	 * Track start times for in-flight requests keyed by api:method so the
+	 * response hook can compute latency. The request filter fires before the
+	 * HTTP call and the response filter fires after it, but the api name and
+	 * method are stable identifiers across both.
+	 *
+	 * @var array<string, float>
+	 */
+	private $request_start_times = [];
+
+	public static function get_instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self(
+				new WC_Stripe_Diagnostics_Trace_Store(),
+				new WC_Stripe_Diagnostics_Redactor()
+			);
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Construct with explicit dependencies. Tests inject fakes via this ctor;
+	 * production callers should use {@see self::get_instance()}.
+	 *
+	 * @param WC_Stripe_Diagnostics_Trace_Store $store    Trace store.
+	 * @param WC_Stripe_Diagnostics_Redactor    $redactor Redaction engine.
+	 */
+	public function __construct( WC_Stripe_Diagnostics_Trace_Store $store, WC_Stripe_Diagnostics_Redactor $redactor ) {
+		$this->store    = $store;
+		$this->redactor = $redactor;
+	}
+
+	/**
+	 * Wire up the filter subscriptions. Called once during plugin init.
+	 */
+	public function init(): void {
+		add_filter( 'wc_stripe_request_body', [ $this, 'on_request_body' ], 10, 2 );
+		add_filter( 'wc_stripe_request_response', [ $this, 'on_request_response' ], 10, 4 );
+		add_action( 'wc_stripe_webhook_received', [ $this, 'on_webhook_received' ], 10, 3 );
+		add_filter( 'wc_stripe_localized_data', [ $this, 'on_localized_data' ], 10, 3 );
+	}
+
+	/**
+	 * Start a new diagnostics session. Used by the REST endpoint that takes
+	 * the handoff from the client recorder.
+	 *
+	 * @param string $session_id Client-generated session identifier.
+	 * @return bool True when the session was accepted.
+	 */
+	public function start_session( string $session_id ): bool {
+		$session_id = WC_Stripe_Diagnostics_Trace_Store::sanitize_id( $session_id );
+		if ( '' === $session_id ) {
+			return false;
+		}
+		if ( $this->store->is_full() ) {
+			return false;
+		}
+		$this->current_session_id = $session_id;
+		$this->store->create( $session_id, [ 'started_at' => time() ] );
+		// Persist so later requests within the TTL window can resume.
+		set_transient( self::SESSION_OPTION, $session_id, self::SESSION_TTL );
+		return true;
+	}
+
+	/**
+	 * Return the currently active session id, reading from the persisted
+	 * transient when this request didn't explicitly start one.
+	 */
+	public function current_session_id(): ?string {
+		if ( null !== $this->current_session_id ) {
+			return $this->current_session_id;
+		}
+		$persisted = get_transient( self::SESSION_OPTION );
+		if ( is_string( $persisted ) && '' !== $persisted ) {
+			$this->current_session_id = $persisted;
+			return $persisted;
+		}
+		return null;
+	}
+
+	/**
+	 * Inject session id into outgoing metadata and record the request event.
+	 *
+	 * @param array  $request The request body about to be sent to Stripe.
+	 * @param string $api     The Stripe endpoint.
+	 * @return array
+	 */
+	public function on_request_body( $request, $api ) {
+		if ( ! is_array( $request ) ) {
+			return $request;
+		}
+		$session_id = $this->current_session_id();
+		if ( null === $session_id ) {
+			return $request;
+		}
+
+		if ( in_array( $api, self::METADATA_ENABLED_APIS, true ) ) {
+			if ( ! isset( $request['metadata'] ) || ! is_array( $request['metadata'] ) ) {
+				$request['metadata'] = [];
+			}
+			$request['metadata'][ self::SESSION_ID_META_KEY ] = $session_id;
+		}
+
+		$this->request_start_times[ $this->request_key( $api ) ] = microtime( true );
+
+		$this->store->append_event(
+			$session_id,
+			$this->redactor->redact(
+				[
+					'kind'         => 'apiRequest',
+					'ts'           => time(),
+					'api'          => (string) $api,
+					'method'       => 'POST',
+					'has_metadata' => ! empty( $request['metadata'] ),
+					'metadata'     => $request['metadata'] ?? [],
+					'fields'       => array_keys( $request ),
+				]
+			)
+		);
+
+		return $request;
+	}
+
+	/**
+	 * Record the response event and attach latency.
+	 *
+	 * @param mixed  $response_body The decoded response body.
+	 * @param string $api           The Stripe endpoint.
+	 * @param string $method        HTTP method.
+	 * @param array  $request       The request body.
+	 * @return mixed The unchanged response body.
+	 */
+	public function on_request_response( $response_body, $api, $method, $request ) {
+		$session_id = $this->current_session_id();
+		if ( null === $session_id ) {
+			return $response_body;
+		}
+
+		$start_key = $this->request_key( $api );
+		$latency   = null;
+		if ( isset( $this->request_start_times[ $start_key ] ) ) {
+			$latency = (int) ( ( microtime( true ) - $this->request_start_times[ $start_key ] ) * 1000 );
+			unset( $this->request_start_times[ $start_key ] );
+		}
+
+		$event = [
+			'kind'       => 'apiResponse',
+			'ts'         => time(),
+			'api'        => (string) $api,
+			'method'     => (string) $method,
+			'latency_ms' => $latency,
+			'request_id' => self::extract_request_id( $response_body ),
+			'error'      => self::extract_error( $response_body ),
+		];
+		$this->store->append_event( $session_id, $this->redactor->redact( $event ) );
+
+		return $response_body;
+	}
+
+	/**
+	 * Record a webhook event. Correlation happens via
+	 * `metadata[wc_diag_session_id]` that on_request_body() injected into the
+	 * original PI / SI / Customer request.
+	 *
+	 * @param string $webhook_type  e.g. payment_intent.succeeded.
+	 * @param object $notification  The decoded Stripe webhook payload.
+	 * @param mixed  $resolved_order The order that was resolved for this webhook, if any.
+	 */
+	public function on_webhook_received( $webhook_type, $notification, $resolved_order ): void {
+		$session_id = self::extract_session_id_from_webhook( $notification );
+		if ( null === $session_id ) {
+			return;
+		}
+		$this->store->create( $session_id, [ 'source' => 'webhook' ] );
+
+		$object = self::webhook_object( $notification );
+
+		$this->store->append_event(
+			$session_id,
+			$this->redactor->redact(
+				[
+					'kind'       => 'webhookReceived',
+					'ts'         => time(),
+					'type'       => (string) $webhook_type,
+					'status'     => is_object( $object ) && isset( $object->status ) ? (string) $object->status : null,
+					'intent_id'  => is_object( $object ) && isset( $object->object, $object->id ) && 'payment_intent' === $object->object ? (string) $object->id : null,
+					'charge_id'  => is_object( $object ) && isset( $object->object, $object->id ) && 'charge' === $object->object ? (string) $object->id : null,
+					'order_id'   => is_object( $resolved_order ) && method_exists( $resolved_order, 'get_id' ) ? (int) $resolved_order->get_id() : null,
+					'session_id' => $session_id,
+				]
+			)
+		);
+	}
+
+	/**
+	 * Publish the `wcStripeDiag` global to the frontend recorder whenever a
+	 * Stripe script is being localized. Only runs when a session is active.
+	 *
+	 * @param array  $data          The existing localized data.
+	 * @param string $script_handle The script handle being localized.
+	 * @param string $object_name   The JS variable name.
+	 * @return array
+	 */
+	public function on_localized_data( $data, $script_handle, $object_name ) {
+		$session_id = $this->current_session_id();
+		if ( null === $session_id ) {
+			return $data;
+		}
+
+		wp_localize_script(
+			(string) $script_handle,
+			'wcStripeDiag',
+			[
+				'active'    => true,
+				'sessionId' => $session_id,
+				'nonce'     => wp_create_nonce( 'wc_stripe_diagnostics' ),
+				'endpoint'  => esc_url_raw( rest_url( 'wc/v3/wc_stripe/diagnostics/events' ) ),
+			]
+		);
+
+		return $data;
+	}
+
+	private function request_key( string $api ): string {
+		return $api . ':POST';
+	}
+
+	/**
+	 * Pull Stripe's request_id off a decoded response body.
+	 *
+	 * @param mixed $response Decoded response body.
+	 * @return string|null
+	 */
+	private static function extract_request_id( $response ): ?string {
+		if ( is_object( $response ) && isset( $response->request_id ) && is_string( $response->request_id ) ) {
+			return $response->request_id;
+		}
+		return null;
+	}
+
+	/**
+	 * Extract the Stripe error shape from a decoded response body, if present.
+	 *
+	 * @param mixed $response Decoded response body.
+	 * @return array|null Normalized error fields, or null when the response isn't an error.
+	 */
+	private static function extract_error( $response ): ?array {
+		if ( ! is_object( $response ) || ! isset( $response->error ) || ! is_object( $response->error ) ) {
+			return null;
+		}
+		$err = $response->error;
+		return [
+			'code'         => isset( $err->code ) ? (string) $err->code : null,
+			'type'         => isset( $err->type ) ? (string) $err->type : null,
+			'decline_code' => isset( $err->decline_code ) ? (string) $err->decline_code : null,
+		];
+	}
+
+	/**
+	 * Extract the data.object from a Stripe webhook notification payload.
+	 *
+	 * @param mixed $notification Decoded webhook payload.
+	 * @return object|null
+	 */
+	private static function webhook_object( $notification ): ?object {
+		if ( is_object( $notification ) && isset( $notification->data, $notification->data->object ) ) {
+			return is_object( $notification->data->object ) ? $notification->data->object : null;
+		}
+		return null;
+	}
+
+	/**
+	 * Pull the diagnostics session id out of a webhook's metadata.
+	 *
+	 * @param mixed $notification Decoded webhook payload.
+	 * @return string|null Sanitized session id, or null when absent.
+	 */
+	private static function extract_session_id_from_webhook( $notification ): ?string {
+		$object = self::webhook_object( $notification );
+		if ( ! is_object( $object ) || ! isset( $object->metadata ) ) {
+			return null;
+		}
+		$metadata = $object->metadata;
+		$raw      = null;
+		if ( is_object( $metadata ) && isset( $metadata->{self::SESSION_ID_META_KEY} ) ) {
+			$raw = $metadata->{self::SESSION_ID_META_KEY};
+		} elseif ( is_array( $metadata ) && isset( $metadata[ self::SESSION_ID_META_KEY ] ) ) {
+			$raw = $metadata[ self::SESSION_ID_META_KEY ];
+		}
+		if ( ! is_string( $raw ) ) {
+			return null;
+		}
+		$clean = WC_Stripe_Diagnostics_Trace_Store::sanitize_id( $raw );
+		return '' === $clean ? null : $clean;
+	}
+}

--- a/includes/diagnostics/class-wc-stripe-diagnostics-recorder.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-recorder.php
@@ -28,6 +28,24 @@ class WC_Stripe_Diagnostics_Recorder {
 	const METADATA_ENABLED_APIS = [ 'payment_intents', 'setup_intents', 'customers' ];
 
 	/**
+	 * WC session key under which each shopper's diagnostics session id is
+	 * stored. Per-shopper (not a global transient) so different shoppers
+	 * don't share a trace.
+	 *
+	 * @var string
+	 */
+	const WC_SESSION_KEY = 'wc_stripe_diag_session_id';
+
+	/**
+	 * Number of traces the trace store may hold before the toggle
+	 * auto-disables. Bounds the merchant's exposure and keeps a debugging
+	 * window from running indefinitely if they forget to flip it back off.
+	 *
+	 * @var int
+	 */
+	const CAPTURE_LIMIT = 20;
+
+	/**
 	 * Singleton instance.
 	 *
 	 * @var self|null
@@ -120,12 +138,18 @@ class WC_Stripe_Diagnostics_Recorder {
 	}
 
 	/**
-	 * Return the currently active session id, reading from the persisted
-	 * transient when this request didn't explicitly start one.
+	 * Return the currently active session id for this request, checking (in
+	 * order): in-memory field, the WC session key that the enqueue path
+	 * stores a per-shopper id in, and the admin-initiated transient.
 	 */
 	public function current_session_id(): ?string {
 		if ( null !== $this->current_session_id ) {
 			return $this->current_session_id;
+		}
+		$from_wc = self::read_wc_session();
+		if ( null !== $from_wc ) {
+			$this->current_session_id = $from_wc;
+			return $from_wc;
 		}
 		$persisted = get_transient( self::SESSION_OPTION );
 		if ( is_string( $persisted ) && '' !== $persisted ) {
@@ -133,6 +157,73 @@ class WC_Stripe_Diagnostics_Recorder {
 			return $persisted;
 		}
 		return null;
+	}
+
+	/**
+	 * Ensure this shopper has a diagnostics session id when the feature is
+	 * toggled on. Called from the localized-data filter during script
+	 * enqueue, so every checkout page load gets a fresh id (per shopper,
+	 * not per hit — the id is cached on the WC session).
+	 *
+	 * Auto-disables the toggle when the store already holds
+	 * {@see self::CAPTURE_LIMIT} traces, so merchants don't have to babysit it.
+	 *
+	 * @return string|null The session id to publish to the frontend, or null
+	 *                     when the feature is off / the limit was reached.
+	 */
+	public function ensure_shopper_session(): ?string {
+		if ( ! self::is_enabled() ) {
+			return null;
+		}
+
+		// Budget check runs first — when the merchant has their N traces the
+		// toggle flips off even for shoppers who were already mid-session.
+		if ( $this->store->count() >= self::CAPTURE_LIMIT ) {
+			update_option( 'wc_stripe_diagnostics_enabled', 'no' );
+			return null;
+		}
+
+		$existing = self::read_wc_session();
+		if ( null !== $existing ) {
+			$this->current_session_id = $existing;
+			return $existing;
+		}
+
+		$new_id = WC_Stripe_Diagnostics_Trace_Store::sanitize_id( 'diag-' . wp_generate_password( 12, false, false ) );
+		if ( '' === $new_id ) {
+			return null;
+		}
+		self::write_wc_session( $new_id );
+		$this->current_session_id = $new_id;
+		return $new_id;
+	}
+
+	/**
+	 * Read this shopper's diagnostics session id from WC session, if any.
+	 */
+	private static function read_wc_session(): ?string {
+		if ( ! function_exists( 'WC' ) || null === WC()->session ) {
+			return null;
+		}
+		$value = WC()->session->get( self::WC_SESSION_KEY );
+		return is_string( $value ) && '' !== $value ? $value : null;
+	}
+
+	/**
+	 * Write this shopper's diagnostics session id into WC session.
+	 */
+	private static function write_wc_session( string $session_id ): void {
+		if ( ! function_exists( 'WC' ) || null === WC()->session ) {
+			return;
+		}
+		WC()->session->set( self::WC_SESSION_KEY, $session_id );
+	}
+
+	/**
+	 * Whether the diagnostics feature is currently enabled.
+	 */
+	public static function is_enabled(): bool {
+		return 'yes' === get_option( 'wc_stripe_diagnostics_enabled', 'no' );
 	}
 
 	/**
@@ -259,7 +350,7 @@ class WC_Stripe_Diagnostics_Recorder {
 	 * @return array
 	 */
 	public function on_localized_data( $data, $script_handle, $object_name ) {
-		$session_id = $this->current_session_id();
+		$session_id = $this->current_session_id() ?? $this->ensure_shopper_session();
 		if ( null === $session_id ) {
 			return $data;
 		}

--- a/includes/diagnostics/class-wc-stripe-diagnostics-redactor.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-redactor.php
@@ -1,0 +1,252 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Enforces data scrubbing for diagnostics events.
+ *
+ * Two layers run against every event before it reaches the trace store:
+ *
+ * 1. An **allow-list registry** keyed by event kind (`apiRequest`,
+ *    `apiResponse`, `webhookReceived`, `consoleMessage`, ...). Any field not
+ *    explicitly listed for the event's kind is dropped. Unknown kinds produce
+ *    an empty event (fail-closed).
+ *
+ * 2. A set of **string scrubbers** applied to every remaining value: emails
+ *    become `[email]`, IPv4/IPv6 become `[ip]`, URL query strings are
+ *    truncated, and long opaque tokens / secrets are masked.
+ *
+ * The redactor is deliberately conservative. It is cheaper to drop a legitimate
+ * field than to ship PII.
+ */
+class WC_Stripe_Diagnostics_Redactor {
+
+	/**
+	 * Allow-listed field paths per event kind. Nested fields are declared with
+	 * dot notation (e.g. `meta.order_id`). Array elements share the parent
+	 * allow list.
+	 *
+	 * See docs/diagnostics-contracts.md §5.
+	 *
+	 * @var array<string, string[]>
+	 */
+	private $allow_list;
+
+	/**
+	 * Construct a redactor, optionally overriding the allow list (used in tests).
+	 *
+	 * @param array<string, string[]>|null $allow_list Optional override.
+	 */
+	public function __construct( ?array $allow_list = null ) {
+		$this->allow_list = $allow_list ?? self::default_allow_list();
+	}
+
+	/**
+	 * Redact a single event.
+	 *
+	 * @param array $event The event payload. Must include a `kind` string.
+	 * @return array The redacted event. May be empty for unknown kinds.
+	 */
+	public function redact( array $event ): array {
+		$kind = isset( $event['kind'] ) && is_string( $event['kind'] ) ? $event['kind'] : '';
+		if ( '' === $kind || ! isset( $this->allow_list[ $kind ] ) ) {
+			return [];
+		}
+
+		$allowed = $this->allow_list[ $kind ];
+		$kept    = [ 'kind' => $kind ];
+		if ( isset( $event['ts'] ) && ( is_int( $event['ts'] ) || is_float( $event['ts'] ) ) ) {
+			$kept['ts'] = (int) $event['ts'];
+		}
+
+		foreach ( $allowed as $path ) {
+			$value = self::pluck( $event, $path );
+			if ( null === $value ) {
+				continue;
+			}
+			self::assign( $kept, $path, $this->scrub_value( $value ) );
+		}
+
+		return $kept;
+	}
+
+	/**
+	 * Run the scrubbers on an already-structured value. Recurses into arrays.
+	 *
+	 * @param mixed $value
+	 * @return mixed
+	 */
+	public function scrub_value( $value ) {
+		if ( is_string( $value ) ) {
+			return self::scrub_string( $value );
+		}
+		if ( is_array( $value ) ) {
+			$out = [];
+			foreach ( $value as $k => $v ) {
+				$out[ $k ] = $this->scrub_value( $v );
+			}
+			return $out;
+		}
+		return $value;
+	}
+
+	/**
+	 * The default allow list. Keep this small — adding a field is an explicit
+	 * statement that it's safe to ship to a diagnostics bundle.
+	 *
+	 * @return array<string, string[]>
+	 */
+	public static function default_allow_list(): array {
+		return [
+			'apiRequest'      => [
+				'api',
+				'method',
+				'request_id',
+				'fields',
+				'has_metadata',
+				'metadata.order_id',
+				'metadata.wc_diag_session_id',
+			],
+			'apiResponse'     => [
+				'api',
+				'method',
+				'status',
+				'request_id',
+				'error.code',
+				'error.type',
+				'error.decline_code',
+				'latency_ms',
+			],
+			'webhookReceived' => [
+				'type',
+				'status',
+				'intent_id',
+				'charge_id',
+				'order_id',
+				'session_id',
+			],
+			'consoleMessage'  => [
+				'level',
+				'message_truncated',
+				'source',
+			],
+			'elementEvent'    => [
+				'element',
+				'type',
+				'complete',
+				'empty',
+				'error_code',
+			],
+			'sdkCall'         => [
+				'method',
+				'ok',
+				'latency_ms',
+				'error_code',
+			],
+			'blocksEvent'     => [
+				'phase',
+				'type',
+				'ok',
+				'error_code',
+			],
+			'expressCheckout' => [
+				'phase',
+				'type',
+				'payment_method',
+			],
+			'sessionEnd'      => [
+				'reason',
+			],
+		];
+	}
+
+	/**
+	 * Strip obvious PII patterns from a string. The regexes are intentionally
+	 * broad: false positives in a diagnostics trace are acceptable; PII leaks
+	 * are not.
+	 *
+	 * @param string $value
+	 * @return string
+	 */
+	private static function scrub_string( string $value ): string {
+		// Truncate extremely long strings — the redactor should never amplify them.
+		if ( strlen( $value ) > 512 ) {
+			$value = substr( $value, 0, 512 ) . '…';
+		}
+
+		$patterns = [
+			// Emails.
+			'/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/'     => '[email]',
+			// IPv4.
+			'/\b(?:\d{1,3}\.){3}\d{1,3}\b/'                        => '[ip]',
+			// IPv6 — catches both fully-qualified and `::`-compressed forms.
+			'/\b(?:[A-Fa-f0-9]{0,4}:){2,7}[A-Fa-f0-9]{0,4}\b/'     => '[ip]',
+			// Stripe secret-ish tokens (sk_live_…, rk_live_…, sk_test_…, whsec_…).
+			'/\b(?:sk|rk|whsec)_(?:live|test)?_?[A-Za-z0-9]{10,}/' => '[secret]',
+		];
+		foreach ( $patterns as $pattern => $replacement ) {
+			$replaced = preg_replace( $pattern, $replacement, $value );
+			if ( is_string( $replaced ) ) {
+				$value = $replaced;
+			}
+		}
+
+		// URL query strings — keep the path, drop params entirely. URLs with
+		// user identifiers in the query are a common accidental leak source.
+		$replaced = preg_replace_callback(
+			'~(https?://[^\s?]+)\?[^\s]*~',
+			static function ( $m ) {
+				return $m[1] . '?[redacted]';
+			},
+			$value
+		);
+		if ( is_string( $replaced ) ) {
+			$value = $replaced;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Walk a nested array using a dot-path and return the resolved value,
+	 * or null when any segment is missing.
+	 *
+	 * @param array  $source
+	 * @param string $path
+	 * @return mixed|null
+	 */
+	private static function pluck( array $source, string $path ) {
+		$segments = explode( '.', $path );
+		$cursor   = $source;
+		foreach ( $segments as $segment ) {
+			if ( ! is_array( $cursor ) || ! array_key_exists( $segment, $cursor ) ) {
+				return null;
+			}
+			$cursor = $cursor[ $segment ];
+		}
+		return $cursor;
+	}
+
+	/**
+	 * Assign a value into a nested array using a dot-path, creating parent
+	 * arrays as needed.
+	 *
+	 * @param array  $target
+	 * @param string $path
+	 * @param mixed  $value
+	 */
+	private static function assign( array &$target, string $path, $value ): void {
+		$segments = explode( '.', $path );
+		$cursor   = &$target;
+		foreach ( $segments as $i => $segment ) {
+			if ( count( $segments ) - 1 === $i ) {
+				$cursor[ $segment ] = $value;
+				return;
+			}
+			if ( ! isset( $cursor[ $segment ] ) || ! is_array( $cursor[ $segment ] ) ) {
+				$cursor[ $segment ] = [];
+			}
+			$cursor = &$cursor[ $segment ];
+		}
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -157,5 +157,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Add WC_Stripe_Diagnostics_Trace_Store (file-backed trace storage with FIFO eviction and size caps) for the upcoming diagnostics recorder
 * Dev - Add POST /wc/v3/wc_stripe/diagnostics/events REST endpoint that accepts batched client events and appends them to the file-backed trace store
 * Dev - Add WC_Stripe_Diagnostics_Redactor (allow-list registry + PII scrubbers) for the upcoming diagnostics recorder
+* Dev - Add WC_Stripe_Diagnostics_Recorder server-side singleton that injects wc_diag_session_id into Stripe metadata and records redacted request/response/webhook events
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -156,5 +156,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Add wc_stripe_api_response_received action and wc_stripe_localized_data filter to pave the way for the upcoming diagnostics recorder
 * Dev - Add WC_Stripe_Diagnostics_Trace_Store (file-backed trace storage with FIFO eviction and size caps) for the upcoming diagnostics recorder
 * Dev - Add POST /wc/v3/wc_stripe/diagnostics/events REST endpoint that accepts batched client events and appends them to the file-backed trace store
+* Dev - Add WC_Stripe_Diagnostics_Redactor (allow-list registry + PII scrubbers) for the upcoming diagnostics recorder
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -158,5 +158,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Add POST /wc/v3/wc_stripe/diagnostics/events REST endpoint that accepts batched client events and appends them to the file-backed trace store
 * Dev - Add WC_Stripe_Diagnostics_Redactor (allow-list registry + PII scrubbers) for the upcoming diagnostics recorder
 * Dev - Add WC_Stripe_Diagnostics_Recorder server-side singleton that injects wc_diag_session_id into Stripe metadata and records redacted request/response/webhook events
+* Dev - Add diagnostics admin toggle (REST endpoints at /wc/v3/wc_stripe/diagnostics/state and /toggle) with per-shopper session id generation and auto-disable at 20 captured traces
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/diagnostics/class-wc-rest-stripe-diagnostics-toggle-controller-test.php
+++ b/tests/phpunit/diagnostics/class-wc-rest-stripe-diagnostics-toggle-controller-test.php
@@ -1,0 +1,111 @@
+<?php
+
+require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-diagnostics-toggle-controller.php';
+
+/**
+ * Tests for WC_REST_Stripe_Diagnostics_Toggle_Controller.
+ *
+ * @package WooCommerce/Stripe/Diagnostics
+ */
+class WC_REST_Stripe_Diagnostics_Toggle_Controller_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var WC_REST_Stripe_Diagnostics_Toggle_Controller
+	 */
+	private $controller;
+
+	/**
+	 * @var int
+	 */
+	private $admin_user_id;
+
+	/**
+	 * Build a fresh controller, an administrator account, and reset the
+	 * toggle option + trace store before each test.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->controller    = new WC_REST_Stripe_Diagnostics_Toggle_Controller();
+		$this->admin_user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		delete_option( 'wc_stripe_diagnostics_enabled' );
+		$this->clear_store();
+	}
+
+	/**
+	 * Reset state and the current user so the next test starts clean.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		delete_option( 'wc_stripe_diagnostics_enabled' );
+		$this->clear_store();
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Drop every trace from the underlying store.
+	 *
+	 * @return void
+	 */
+	private function clear_store() {
+		( new WC_Stripe_Diagnostics_Trace_Store() )->delete_all();
+	}
+
+	/**
+	 * `manage_woocommerce` capability passes the admin check.
+	 *
+	 * @return void
+	 */
+	public function test_admin_check_allows_woocommerce_admin() {
+		wp_set_current_user( $this->admin_user_id );
+		$this->assertTrue( $this->controller->admin_check() );
+	}
+
+	/**
+	 * A shopper-level user (subscriber) is denied by the admin check.
+	 *
+	 * @return void
+	 */
+	public function test_admin_check_denies_shopper() {
+		$shopper = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $shopper );
+		$this->assertFalse( $this->controller->admin_check() );
+	}
+
+	/**
+	 * `GET /state` returns `{ enabled: false, count: 0, limit: CAPTURE_LIMIT }`
+	 * on a fresh install.
+	 *
+	 * @return void
+	 */
+	public function test_get_state_reports_defaults() {
+		$response = $this->controller->get_state();
+		$data     = $response->get_data();
+		$this->assertFalse( $data['enabled'] );
+		$this->assertSame( 0, $data['count'] );
+		$this->assertSame( WC_Stripe_Diagnostics_Recorder::CAPTURE_LIMIT, $data['limit'] );
+	}
+
+	/**
+	 * `POST /toggle` flips the option both on and off, and the recorder's
+	 * `is_enabled()` reflects each change.
+	 *
+	 * @return void
+	 */
+	public function test_toggle_flips_the_option() {
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'enabled', true );
+		$response = $this->controller->toggle( $request );
+
+		$this->assertTrue( $response->get_data()['enabled'] );
+		$this->assertTrue( WC_Stripe_Diagnostics_Recorder::is_enabled() );
+
+		$request->set_param( 'enabled', false );
+		$response = $this->controller->toggle( $request );
+		$this->assertFalse( $response->get_data()['enabled'] );
+		$this->assertFalse( WC_Stripe_Diagnostics_Recorder::is_enabled() );
+	}
+}

--- a/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-recorder-test.php
+++ b/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-recorder-test.php
@@ -161,4 +161,29 @@ class WC_Stripe_Diagnostics_Recorder_Test extends WP_UnitTestCase {
 		$recorder = new WC_Stripe_Diagnostics_Recorder( $this->store, new WC_Stripe_Diagnostics_Redactor() );
 		$this->assertSame( 'resumed', $recorder->current_session_id() );
 	}
+
+	public function test_ensure_shopper_session_returns_null_when_disabled() {
+		delete_option( 'wc_stripe_diagnostics_enabled' );
+		$this->assertNull( $this->recorder->ensure_shopper_session() );
+	}
+
+	public function test_ensure_shopper_session_generates_fresh_id_when_enabled() {
+		update_option( 'wc_stripe_diagnostics_enabled', 'yes' );
+		$id = $this->recorder->ensure_shopper_session();
+		$this->assertIsString( $id );
+		$this->assertNotEmpty( $id );
+		// Subsequent calls on the same request return the same id.
+		$this->assertSame( $id, $this->recorder->current_session_id() );
+		delete_option( 'wc_stripe_diagnostics_enabled' );
+	}
+
+	public function test_ensure_shopper_session_auto_disables_at_capture_limit() {
+		update_option( 'wc_stripe_diagnostics_enabled', 'yes' );
+		for ( $i = 0; $i < WC_Stripe_Diagnostics_Recorder::CAPTURE_LIMIT; $i++ ) {
+			$this->store->create( 'cap' . $i );
+		}
+		$this->assertSame( WC_Stripe_Diagnostics_Recorder::CAPTURE_LIMIT, $this->store->count() );
+		$this->assertNull( $this->recorder->ensure_shopper_session() );
+		$this->assertFalse( WC_Stripe_Diagnostics_Recorder::is_enabled() );
+	}
 }

--- a/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-recorder-test.php
+++ b/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-recorder-test.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * Tests for WC_Stripe_Diagnostics_Recorder.
+ *
+ * @package WooCommerce/Stripe/Diagnostics
+ */
+class WC_Stripe_Diagnostics_Recorder_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var WC_Stripe_Diagnostics_Trace_Store
+	 */
+	private $store;
+
+	/**
+	 * @var WC_Stripe_Diagnostics_Recorder
+	 */
+	private $recorder;
+
+	public function set_up() {
+		parent::set_up();
+		$this->store    = new WC_Stripe_Diagnostics_Trace_Store();
+		$this->recorder = new WC_Stripe_Diagnostics_Recorder(
+			$this->store,
+			new WC_Stripe_Diagnostics_Redactor()
+		);
+		$this->clear_state();
+	}
+
+	public function tear_down() {
+		$this->clear_state();
+		parent::tear_down();
+	}
+
+	private function clear_state() {
+		$this->store->delete_all();
+		delete_transient( WC_Stripe_Diagnostics_Recorder::SESSION_OPTION );
+	}
+
+	public function test_request_body_is_untouched_when_no_session_is_active() {
+		$request = [ 'amount' => 1000 ];
+		$this->assertSame( $request, $this->recorder->on_request_body( $request, 'payment_intents' ) );
+	}
+
+	public function test_request_body_injects_session_id_metadata_for_pi() {
+		$this->recorder->start_session( 'smoke-xyz' );
+		$out = $this->recorder->on_request_body( [ 'amount' => 1000 ], 'payment_intents' );
+		$this->assertSame( 'smoke-xyz', $out['metadata']['wc_diag_session_id'] );
+	}
+
+	public function test_request_body_preserves_existing_metadata() {
+		$this->recorder->start_session( 'abc' );
+		$out = $this->recorder->on_request_body(
+			[ 'metadata' => [ 'order_id' => '42' ] ],
+			'setup_intents'
+		);
+		$this->assertSame( '42', $out['metadata']['order_id'] );
+		$this->assertSame( 'abc', $out['metadata']['wc_diag_session_id'] );
+	}
+
+	public function test_request_body_does_not_inject_for_unrelated_apis() {
+		$this->recorder->start_session( 'abc' );
+		$out = $this->recorder->on_request_body( [ 'foo' => 'bar' ], 'balance' );
+		$this->assertArrayNotHasKey( 'metadata', $out );
+	}
+
+	public function test_request_body_records_apiRequest_event() {
+		$this->recorder->start_session( 'rec1' );
+		$this->recorder->on_request_body( [ 'amount' => 100 ], 'payment_intents' );
+		$events = $this->store->get( 'rec1' )['events'];
+		$this->assertCount( 1, $events );
+		$this->assertSame( 'apiRequest', $events[0]['kind'] );
+		$this->assertSame( 'payment_intents', $events[0]['api'] );
+	}
+
+	public function test_request_response_records_apiResponse_event_with_latency() {
+		$this->recorder->start_session( 'rec2' );
+		$this->recorder->on_request_body( [ 'amount' => 100 ], 'payment_intents' );
+
+		$response         = new stdClass();
+		$response->id     = 'pi_123';
+		$response->status = 'succeeded';
+		$this->recorder->on_request_response( $response, 'payment_intents', 'POST', [ 'amount' => 100 ] );
+
+		$events = $this->store->get( 'rec2' )['events'];
+		$this->assertCount( 2, $events );
+		$this->assertSame( 'apiResponse', $events[1]['kind'] );
+		$this->assertSame( 'payment_intents', $events[1]['api'] );
+		$this->assertArrayHasKey( 'latency_ms', $events[1] );
+	}
+
+	public function test_response_with_error_captures_error_shape() {
+		$this->recorder->start_session( 'err1' );
+		$this->recorder->on_request_body( [ 'amount' => 1 ], 'payment_intents' );
+
+		$response                      = new stdClass();
+		$response->error               = new stdClass();
+		$response->error->code         = 'card_declined';
+		$response->error->type         = 'card_error';
+		$response->error->decline_code = 'insufficient_funds';
+		$this->recorder->on_request_response( $response, 'payment_intents', 'POST', [ 'amount' => 1 ] );
+
+		$events = $this->store->get( 'err1' )['events'];
+		$this->assertSame( 'card_declined', $events[1]['error']['code'] );
+		$this->assertSame( 'insufficient_funds', $events[1]['error']['decline_code'] );
+	}
+
+	public function test_webhook_received_correlates_by_metadata_session_id() {
+		$this->store->create( 'webhook-session' );
+
+		$notification               = new stdClass();
+		$notification->data         = new stdClass();
+		$notification->data->object = (object) [
+			'object'   => 'payment_intent',
+			'id'       => 'pi_xyz',
+			'status'   => 'succeeded',
+			'metadata' => (object) [ 'wc_diag_session_id' => 'webhook-session' ],
+		];
+
+		$this->recorder->on_webhook_received( 'payment_intent.succeeded', $notification, null );
+
+		$events = $this->store->get( 'webhook-session' )['events'];
+		$this->assertCount( 1, $events );
+		$this->assertSame( 'webhookReceived', $events[0]['kind'] );
+		$this->assertSame( 'payment_intent.succeeded', $events[0]['type'] );
+		$this->assertSame( 'pi_xyz', $events[0]['intent_id'] );
+	}
+
+	public function test_webhook_received_creates_trace_when_missing() {
+		// Simulate a webhook that arrives before any other activity on this session.
+		$notification               = new stdClass();
+		$notification->data         = new stdClass();
+		$notification->data->object = (object) [
+			'metadata' => (object) [ 'wc_diag_session_id' => 'fresh-from-webhook' ],
+			'status'   => 'processing',
+		];
+		$this->recorder->on_webhook_received( 'payment_intent.processing', $notification, null );
+
+		$this->assertNotNull( $this->store->get( 'fresh-from-webhook' ) );
+	}
+
+	public function test_webhook_without_session_metadata_is_ignored() {
+		$notification               = new stdClass();
+		$notification->data         = new stdClass();
+		$notification->data->object = (object) [ 'metadata' => new stdClass() ];
+		$this->recorder->on_webhook_received( 'payment_intent.succeeded', $notification, null );
+		$this->assertSame( [], $this->store->get_all_ids() );
+	}
+
+	public function test_start_session_fails_when_store_is_full() {
+		// Force the store to saturation using the real store instance.
+		for ( $i = 0; $i < WC_Stripe_Diagnostics_Trace_Store::MAX_TRACES; $i++ ) {
+			$this->store->create( 'f' . $i );
+		}
+		$this->assertFalse( $this->recorder->start_session( 'too-late' ) );
+	}
+
+	public function test_current_session_id_reads_from_transient_between_requests() {
+		set_transient( WC_Stripe_Diagnostics_Recorder::SESSION_OPTION, 'resumed', 60 );
+		// Fresh recorder: no in-memory session.
+		$recorder = new WC_Stripe_Diagnostics_Recorder( $this->store, new WC_Stripe_Diagnostics_Redactor() );
+		$this->assertSame( 'resumed', $recorder->current_session_id() );
+	}
+}

--- a/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-redactor-test.php
+++ b/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-redactor-test.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * Tests for WC_Stripe_Diagnostics_Redactor.
+ *
+ * @package WooCommerce/Stripe/Diagnostics
+ */
+class WC_Stripe_Diagnostics_Redactor_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var WC_Stripe_Diagnostics_Redactor
+	 */
+	private $redactor;
+
+	public function set_up() {
+		parent::set_up();
+		$this->redactor = new WC_Stripe_Diagnostics_Redactor();
+	}
+
+	public function test_unknown_kind_returns_empty_event() {
+		$this->assertSame(
+			[],
+			$this->redactor->redact(
+				[
+					'kind' => 'nonsense',
+					'foo'  => 'bar',
+				]
+			)
+		);
+		$this->assertSame( [], $this->redactor->redact( [] ) );
+	}
+
+	public function test_fields_outside_allow_list_are_dropped() {
+		$event  = [
+			'kind'           => 'apiResponse',
+			'api'            => 'payment_intents',
+			'method'         => 'POST',
+			'status'         => 200,
+			'request_id'     => 'req_abc',
+			'raw_body'       => 'should not be kept',
+			'customer_email' => 'shopper@example.com',
+			'latency_ms'     => 134,
+		];
+		$result = $this->redactor->redact( $event );
+		$this->assertArrayNotHasKey( 'raw_body', $result );
+		$this->assertArrayNotHasKey( 'customer_email', $result );
+		$this->assertSame( 200, $result['status'] );
+		$this->assertSame( 134, $result['latency_ms'] );
+	}
+
+	public function test_nested_allow_list_paths_are_kept() {
+		$event  = [
+			'kind'     => 'apiRequest',
+			'api'      => 'payment_intents',
+			'method'   => 'POST',
+			'metadata' => [
+				'order_id'           => '42',
+				'wc_diag_session_id' => 'smoke-abc',
+				'customer_email'     => 'leak@example.com',
+			],
+		];
+		$result = $this->redactor->redact( $event );
+		$this->assertSame( '42', $result['metadata']['order_id'] );
+		$this->assertSame( 'smoke-abc', $result['metadata']['wc_diag_session_id'] );
+		$this->assertArrayNotHasKey( 'customer_email', $result['metadata'] );
+	}
+
+	/**
+	 * @dataProvider provide_pii_payloads
+	 */
+	public function test_pii_patterns_are_scrubbed( string $allowed_field, string $raw_value, array $forbidden_substrings ) {
+		// Inject the PII into an allow-listed consoleMessage field.
+		$event                   = [
+			'kind'  => 'consoleMessage',
+			'level' => 'warn',
+		];
+		$event[ $allowed_field ] = $raw_value;
+
+		$result = $this->redactor->redact( $event );
+		$json   = wp_json_encode( $result );
+
+		foreach ( $forbidden_substrings as $needle ) {
+			$this->assertStringNotContainsString( $needle, $json, "PII substring '{$needle}' survived redaction." );
+		}
+	}
+
+	public function provide_pii_payloads(): array {
+		return [
+			'email in message'     => [ 'message_truncated', 'Failed for user shopper@example.com trying again', [ 'shopper@example.com' ] ],
+			'ipv4 in message'      => [ 'message_truncated', 'Blocked from 192.168.1.42 after 3 retries', [ '192.168.1.42' ] ],
+			'ipv6 in message'      => [ 'message_truncated', 'Blocked from 2001:0db8:85a3:0000:0000:8a2e:0370:7334', [ '2001:0db8:85a3:0000:0000:8a2e:0370:7334' ] ],
+			'stripe secret in msg' => [ 'message_truncated', 'Authorization: Bearer sk_live_abcdef1234567890', [ 'sk_live_abcdef1234567890' ] ],
+			'url with query'       => [ 'message_truncated', 'Redirected to https://example.com/pay?email=shopper@example.com&token=xyz', [ 'shopper@example.com', 'token=xyz' ] ],
+		];
+	}
+
+	public function test_redaction_audit_no_pii_survives_for_any_allow_listed_field() {
+		// For every kind / field in the allow list, inject a bundle of PII
+		// patterns and assert none survive into the serialized trace JSON.
+		$pii_payloads = [
+			'foo@bar.com',
+			'user@some-domain.co.uk',
+			'192.168.1.1',
+			'10.0.0.1',
+			'2001:db8::1',
+			'sk_live_supersecretkey12345',
+			'whsec_abcdef1234567890',
+			'https://example.com/checkout?email=leak@example.com',
+		];
+
+		foreach ( WC_Stripe_Diagnostics_Redactor::default_allow_list() as $kind => $fields ) {
+			foreach ( $fields as $path ) {
+				foreach ( $pii_payloads as $payload ) {
+					$event = [ 'kind' => $kind ];
+					$this->assign( $event, $path, $payload );
+					$redacted = $this->redactor->redact( $event );
+					$json     = wp_json_encode( $redacted );
+					$this->assertStringNotContainsString( $payload, $json, "PII '{$payload}' survived in {$kind}.{$path}" );
+				}
+			}
+		}
+	}
+
+	public function test_long_string_is_truncated() {
+		$raw    = str_repeat( 'a', 600 );
+		$event  = [
+			'kind'              => 'consoleMessage',
+			'message_truncated' => $raw,
+		];
+		$result = $this->redactor->redact( $event );
+		$this->assertLessThan( 600, strlen( $result['message_truncated'] ) );
+	}
+
+	/**
+	 * Helper that mirrors the redactor's internal assign().
+	 */
+	private function assign( array &$target, string $path, $value ): void {
+		$segments = explode( '.', $path );
+		$cursor   = &$target;
+		foreach ( $segments as $i => $segment ) {
+			if ( count( $segments ) - 1 === $i ) {
+				$cursor[ $segment ] = $value;
+				return;
+			}
+			if ( ! isset( $cursor[ $segment ] ) || ! is_array( $cursor[ $segment ] ) ) {
+				$cursor[ $segment ] = [];
+			}
+			$cursor = &$cursor[ $segment ];
+		}
+	}
+}


### PR DESCRIPTION
Part of RSM-629 — completes the backend work.

> ⚠️ Stacked on #5348 (Redactor) and #5349 (Recorder backend). The diff shrinks to just this PR's additions once those merge.

## Changes proposed in this Pull Request:

Final piece that turns the recorder + REST endpoint + store + redactor into a user-facing feature: an admin toggle with a 20-trace capture budget that auto-disables when spent.

### Admin REST endpoints

| Route | Auth | Body | Response |
|---|---|---|---|
| `GET /wc/v3/wc_stripe/diagnostics/state` | `manage_woocommerce` | — | `{ enabled, count, limit }` |
| `POST /wc/v3/wc_stripe/diagnostics/toggle` | `manage_woocommerce` | `{ enabled: bool }` | same as /state |

### Per-shopper session id generation

`WC_Stripe_Diagnostics_Recorder::ensure_shopper_session()` is called from the `wc_stripe_localized_data` filter. When the toggle is on and the budget isn't spent, it:

1. Returns the shopper's existing session id from WC session if present.
2. Otherwise generates `diag-<12-char-random>`, stores it in WC session, and returns it.

Per-shopper storage uses `WC()->session` (not a global transient) so different shoppers don't share a trace. When WC session isn't available (rare edge cases outside checkout), the method returns null — no harm done.

### Auto-disable at N=20

When the trace store already holds `CAPTURE_LIMIT` (20) traces, `ensure_shopper_session()`:
1. Flips `wc_stripe_diagnostics_enabled` to `no`.
2. Returns null — no further shoppers instrument.

The check runs **before** reading the existing WC session id, so mid-flight shoppers still stop instrumenting the moment the budget is spent — no "one extra trace" from an already-started session.

### Why the recorder owns `is_enabled()`

The events controller from #5350 previously owned `is_enabled()`. Moving it onto the recorder makes the recorder the single source of truth for "is the feature live?" — both controllers and the `ensure_shopper_session()` path now read from one method. The events controller keeps a thin shim so its public API is unchanged.

## Testing instructions

1. **Unit tests:**
   - `./bin/run-tests.sh --filter 'WC_REST_Stripe_Diagnostics_Toggle_Controller_Test'` — 4 tests
   - `./bin/run-tests.sh --filter 'WC_Stripe_Diagnostics_Recorder_Test'` — 15 tests
   - Full diagnostics suite: 48 tests, 635 assertions.

2. **End-to-end smoke test** (with the frontend #5330 cherry-picked):
   ```bash
   # Enable via REST
   NONCE=$(wp eval 'echo wp_create_nonce("wp_rest");')
   curl -X POST http://localhost:8072/wp-json/wc/v3/wc_stripe/diagnostics/toggle \
        -H "X-WP-Nonce: $NONCE" -H "Content-Type: application/json" \
        -d '{"enabled":true}' --cookie-jar /tmp/wpc.txt --cookie /tmp/wpc.txt
   ```
   Then load the storefront checkout: `wcStripeDiag` should be set to `{ active: true, sessionId: 'diag-xxxxx', ... }`. Complete a checkout. Repeat 20 times — on the 21st page load the toggle should have auto-flipped to off and `wcStripeDiag` should no longer be injected.

### Test coverage

- Admin-only access (administrator allowed, subscriber denied).
- State response shape and defaults.
- Toggle flips the option in both directions.
- Recorder returns null when disabled.
- Recorder generates a fresh id when enabled.
- Recorder auto-disables at the capture limit and returns null.

Local checks: `npm run lint:php` ✅ · `npm run phpstan` ✅ · full diagnostics suite ✅

## Known follow-ups (explicitly not in this PR)

- **Admin UI:** the toggle is wired as REST only. A visible UI in WooCommerce → Settings → Payments → Stripe → Diagnostics is a follow-up, since the parent issue didn't call it out. Merchants would flip it via the REST endpoint or a future admin screen.
- **Trace browser:** merchants have no way to see captured traces yet. That's the next track (the AI root-cause UI from the project description).
- **Filter-backed per-shopper id rotation:** right now the id lives in WC session for the whole session, which is fine for one checkout but stretches across multi-checkout visits. If needed, a timeout rotation can be added.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)