### PR TITLE
[RSM - Diagnostics Mode] Autoload WC_Stripe_Diagnostics_Trace_Store via composer classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
       "classmap": [
         "includes/ajax-handlers/",
         "includes/agentic-commerce/",
+        "includes/diagnostics/",
         "includes/admin/class-wc-rest-stripe-exit-survey-controller.php",
         "includes/admin/class-wc-stripe-plugins-page-controller.php"
       ]

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -134,7 +134,6 @@ class WC_Stripe {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-database-cache.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-payment-method-configurations.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-database-cache-prefetch.php';
-		require_once WC_STRIPE_PLUGIN_PATH . '/includes/diagnostics/class-wc-stripe-diagnostics-trace-store.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-api.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-mode.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/compat/class-wc-stripe-subscriptions-helper.php';


### PR DESCRIPTION
Towards RSM-629

## Changes proposed in this Pull Request:

`WC_Stripe_Diagnostics_Trace_Store` (added in #5347) is currently loaded with a `require_once` line in `WC_Stripe::init()`. The plugin's other modular subsystems — `includes/agentic-commerce/`, `includes/ajax-handlers/` — are picked up through composer's classmap instead.

This PR brings diagnostics in line with that pattern:

- Add `includes/diagnostics/` to the `autoload.classmap` array in `composer.json`.
- Drop the matching `require_once` for the trace store from `WC_Stripe::init()`.

That's a 1-line addition + 1-line removal. The follow-up child PRs in this stack (#5348 redactor, #5349 recorder, #5350 controller) all add more classes under `includes/diagnostics/`, so landing the directory entry here means those PRs only need to remove their own `require_once` lines instead of each touching `composer.json` and racing for the same line.

### How can this code break?

- **Composer autoloader not registered yet at `init()` time?** It is: `woocommerce-gateway-stripe.php` line 87 requires `vendor/autoload.php` before any plugin class loads. Verified by running the full diagnostics test suite — every `new WC_Stripe_Diagnostics_Trace_Store()` (12 tests, 235 assertions) resolves cleanly.
- **A consumer that relied on the file being included as a side effect?** No — the only call site was the `require_once` we just removed; everything else uses the class through `new`.

## Testing instructions

1. `composer dump-autoload --classmap-authoritative`
2. `npm run test:php -- --filter 'WC_Stripe_Diagnostics_Trace_Store_Test'` → expect `OK (12 tests, 235 assertions)`
3. `npm run phpstan` → expect `[OK] No errors`
4. Smoke check that `WC_Stripe_Diagnostics_Trace_Store::sanitize_id( 'abc' )` works from any code path with no manual `require` in front of it.

---

-   [x] Covered with tests (existing trace store tests exercise the autoloaded class)
-   [x] Tested on mobile (or does not apply) — does not apply (loader-only refactor)

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Loader-only refactor with no observable behavior change. The trace store class itself is already covered by #5347's changelog entry; how it gets loaded is an implementation detail.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)