### PR TITLE
Enable OCS and Adaptive Pricing for new installs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,8 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.7.0
+* Update - Enable Optimized Checkout Suite by default for new installs
+* Update - Enable Adaptive Pricing by default for new installs
 * Fix - Surface PHP Throwables from the Agentic Commerce checkout.session.completed flow so fatals are logged, the order rollback runs, and Action Scheduler marks the job failed
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -367,18 +367,9 @@ class WC_Stripe {
 
 		$is_new_install = false === $previous_version;
 
-		/*
-		 * Pause defaulting on Optimized Checkout for the time being, as we want to make UX improvements.
-		 * @see https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4979
-		 *
-		 * // Mark optimized checkout as default on for new installs.
-		 * if ( false === get_option( 'wc_stripe_version' ) && false === get_option( 'wc_stripe_optimized_checkout_default_on' ) ) {
-		 *   update_option( 'wc_stripe_optimized_checkout_default_on', true );
-		 * }
-		 */
-
 		if ( $is_new_install ) {
 			update_option( 'wc_stripe_amazon_pay_default_on', 'yes' );
+			update_option( 'wc_stripe_optimized_checkout_default_on', 'yes' );
 		}
 
 		add_woocommerce_inbox_variant();

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -282,6 +282,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			delete_option( 'wc_stripe_optimized_checkout_default_on' );
 			if ( 'connect' === $type && $should_default_optimized_checkout_on ) {
 				$options['optimized_checkout_element'] = 'yes';
+				$options['adaptive_pricing']           = 'yes';
 			}
 			if ( 'app' === $type ) {
 				$options[ $prefix . 'refresh_token' ] = $result->refreshToken; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,9 @@ Stripe is available for store owners and merchants in [46 countries worldwide](h
 
 The following items note specific versions that include important changes, features, or deprecations.
 
+* 10.7.0
+   - Optimized Checkout Suite re-enabled by default for new installs
+   - Adaptive Pricing enabled by default for new installs
 * 10.6.0
    - Adaptive Pricing available
 * 10.4.0
@@ -148,6 +151,8 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.7.0 - xxxx-xx-xx =
+* Update - Enable Optimized Checkout Suite by default for new installs
+* Update - Enable Adaptive Pricing by default for new installs
 * Add - Add Agentic Commerce admin dashboard for monitoring product feed sync status, history, errors, and triggering manual syncs
 * Dev - Use paratest in CI workflow for faster PHP test execution
 * Fix - Surface PHP Throwables from the Agentic Commerce checkout.session.completed flow so fatals are logged, the order rollback runs, and Action Scheduler marks the job failed

--- a/tests/phpunit/class-wc-stripe-connect-test.php
+++ b/tests/phpunit/class-wc-stripe-connect-test.php
@@ -54,7 +54,7 @@ class WC_Stripe_Connect_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 */
 	public function test_save_stripe_keys_defaults_ocs_and_adaptive_pricing_for_new_installs( bool $marker_set, string $type, string $expected_oc, string $expected_ap ): void {
 		if ( $marker_set ) {
-			update_option( 'wc_stripe_optimized_checkout_default_on', true );
+			update_option( 'wc_stripe_optimized_checkout_default_on', 'yes' );
 		}
 
 		$result                 = new stdClass();

--- a/tests/phpunit/class-wc-stripe-connect-test.php
+++ b/tests/phpunit/class-wc-stripe-connect-test.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * Tests for the WC_Stripe_Connect class.
+ *
+ * @package WooCommerce/Stripe/WC_Stripe_Connect
+ */
+class WC_Stripe_Connect_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
+
+	/**
+	 * @var WC_Stripe_Connect
+	 */
+	private $connect;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// The settings-update filter merges defaults when saving settings, which would
+		// inject `optimized_checkout_element` / `adaptive_pricing` defaults and obscure
+		// the Connect consumer's explicit writes.
+		remove_filter( 'pre_update_option_woocommerce_stripe_settings', [ WC_Stripe::get_instance(), 'gateway_settings_update' ] );
+
+		$api_mock      = $this->getMockBuilder( WC_Stripe_Connect_API::class )->disableOriginalConstructor()->getMock();
+		$this->connect = new WC_Stripe_Connect( $api_mock );
+
+		delete_option( 'wc_stripe_optimized_checkout_default_on' );
+		WC_Stripe_Helper::update_main_stripe_settings( [] );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function tear_down() {
+		delete_option( 'wc_stripe_optimized_checkout_default_on' );
+		WC_Stripe_Helper::update_main_stripe_settings( [] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Asserts that the OCS install marker is consumed during Connect OAuth: when the
+	 * marker is present and the connection type is 'connect', both Optimized Checkout
+	 * and Adaptive Pricing are defaulted to 'yes'. The marker is always cleaned up.
+	 *
+	 * @param bool   $marker_set       Whether the OCS install marker is set before save.
+	 * @param string $type             Connection type ('connect' or 'app').
+	 * @param string $expected_oc      Expected value of optimized_checkout_element after save.
+	 * @param string $expected_ap      Expected value of adaptive_pricing after save.
+	 *
+	 * @dataProvider provide_save_stripe_keys_defaults_ocs_for_new_installs
+	 */
+	public function test_save_stripe_keys_defaults_ocs_and_adaptive_pricing_for_new_installs( bool $marker_set, string $type, string $expected_oc, string $expected_ap ): void {
+		if ( $marker_set ) {
+			update_option( 'wc_stripe_optimized_checkout_default_on', true );
+		}
+
+		$result                 = new stdClass();
+		$result->publishableKey = 'pk_test_123'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$result->secretKey      = 'sk_test_123'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		if ( 'app' === $type ) {
+			$result->refreshToken = 'rt_test_123'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		}
+
+		$method = new ReflectionMethod( WC_Stripe_Connect::class, 'save_stripe_keys' );
+		$method->setAccessible( true );
+		$method->invoke( $this->connect, $result, $type, 'test' );
+
+		$settings = WC_Stripe_Helper::get_stripe_settings();
+
+		$this->assertSame( $expected_oc, $settings['optimized_checkout_element'] ?? '' );
+		$this->assertSame( $expected_ap, $settings['adaptive_pricing'] ?? '' );
+
+		// Marker is always consumed, even when not applied.
+		$this->assertEquals( false, get_option( 'wc_stripe_optimized_checkout_default_on' ) );
+	}
+
+	/**
+	 * @return array
+	 */
+	public function provide_save_stripe_keys_defaults_ocs_for_new_installs(): array {
+		return [
+			'marker set + connect type defaults both OCS and Adaptive Pricing' => [
+				'marker_set'  => true,
+				'type'        => 'connect',
+				'expected_oc' => 'yes',
+				'expected_ap' => 'yes',
+			],
+			'marker set + app type leaves both unset'                          => [
+				'marker_set'  => true,
+				'type'        => 'app',
+				'expected_oc' => '',
+				'expected_ap' => '',
+			],
+			'no marker + connect type leaves both unset'                       => [
+				'marker_set'  => false,
+				'type'        => 'connect',
+				'expected_oc' => '',
+				'expected_ap' => '',
+			],
+		];
+	}
+}

--- a/tests/phpunit/class-wc-stripe-connect-test.php
+++ b/tests/phpunit/class-wc-stripe-connect-test.php
@@ -55,6 +55,8 @@ class WC_Stripe_Connect_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	public function test_save_stripe_keys_defaults_ocs_and_adaptive_pricing_for_new_installs( bool $marker_set, string $type, string $expected_oc, string $expected_ap ): void {
 		if ( $marker_set ) {
 			update_option( 'wc_stripe_optimized_checkout_default_on', 'yes' );
+		} else {
+			delete_option( 'wc_stripe_optimized_checkout_default_on' );
 		}
 
 		$result                 = new stdClass();

--- a/tests/phpunit/class-wc-stripe-test.php
+++ b/tests/phpunit/class-wc-stripe-test.php
@@ -249,10 +249,7 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 
 		$wc_stripe->install();
 
-		// Test that we are NOT setting the flag for now.
-		// @see https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4979
-		$this->assertEquals( false, get_option( 'wc_stripe_optimized_checkout_default_on' ) );
-
+		$this->assertNotEmpty( get_option( 'wc_stripe_optimized_checkout_default_on' ) );
 		$this->assertEquals( 'yes', get_option( 'wc_stripe_amazon_pay_default_on' ) );
 	}
 

--- a/tests/phpunit/class-wc-stripe-test.php
+++ b/tests/phpunit/class-wc-stripe-test.php
@@ -249,7 +249,7 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 
 		$wc_stripe->install();
 
-		$this->assertNotEmpty( get_option( 'wc_stripe_optimized_checkout_default_on' ) );
+		$this->assertEquals( 'yes', get_option( 'wc_stripe_optimized_checkout_default_on' ) );
 		$this->assertEquals( 'yes', get_option( 'wc_stripe_amazon_pay_default_on' ) );
 	}
 


### PR DESCRIPTION
Fixes STRIPE-<linear_issue_id>
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:

Re-enables the Optimized Checkout Suite (OCS) default-on flow for new installs (originally added in [#4811](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4811), reverted in [#4981](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4981) pending UX work tracked in [#4979](https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4979)) and bundles Adaptive Pricing into the same flow.

The existing two-step pattern is reused:

1. `WC_Stripe::install()` writes the `wc_stripe_optimized_checkout_default_on` marker option when `wc_stripe_version` is not yet set.
2. On the next OAuth Connect (`type=connect`) completion in `WC_Stripe_Connect::save_stripe_keys()`, the marker is consumed and **both** `optimized_checkout_element` and `adaptive_pricing` are written to `woocommerce_stripe_settings` as `'yes'`. The marker is deleted regardless of whether it was applied.

- The default is intentionally scoped to **fresh installs that connect via WooCommerce Connect OAuth**. Existing merchants (`wc_stripe_version` already populated) are untouched, and merchants connecting via Stripe App or manual API keys (`type=app`) are not affected.
- Adaptive Pricing is coupled to OCS because its UI is gated behind `WC_Stripe_Helper::is_adaptive_pricing_supported()`, which already requires Checkout Sessions / OCS and applies the existing region/currency restrictions (India/EEA exclusions still apply at runtime).


## Testing instructions

1. From a clean state (no `wc_stripe_version` option), activate the plugin. Confirm `wc_stripe_optimized_checkout_default_on` is set in `wp_options`.
2. Run the WooCommerce Connect OAuth flow (Stripe settings → **Connect or create a new test account**) and complete it.
3. **Expected** `woocommerce_stripe_settings['optimized_checkout_element'] = 'yes'` and `['adaptive_pricing'] = 'yes'`. The `wc_stripe_optimized_checkout_default_on` option is gone.
4. In **Stripe → Settings**, confirm both **Optimized Checkout Suite** and **Adaptive Pricing** checkboxes are enabled.
5. Verify the Optimized Checkout renders on classic checkout, Blocks checkout, and the Optimized Checkout view, and the Adaptive Pricing currency selector appears for supported regions.
6. **Negative case (upgrade)**: the easiest way is to create a JN site with version `10.6.1` and then upload a zip built from this branch. Then confirm the marker is **not** written and existing `woocommerce_stripe_settings` are unchanged.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
