### PR TITLE
Use adjacent-sibling selector for agentic dashboard Card spacing

### DIFF
--- a/client/settings/agentic-commerce/styled.js
+++ b/client/settings/agentic-commerce/styled.js
@@ -5,7 +5,10 @@ export const Card = styled.div`
 	border: 1px solid #c3c4c7;
 	border-radius: 4px;
 	padding: 20px 24px;
-	margin-bottom: 20px;
+
+	& + & {
+		margin-top: 20px;
+	}
 `;
 
 export const CardTitle = styled.h2`


### PR DESCRIPTION
Addresses Dale's [follow-up review](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5176#discussion_r3144666285) on #5176.

## Changes proposed in this Pull Request:

The agentic dashboard's local \`Card\` styled component sits in \`client/settings/agentic-commerce/styled.js\` and used \`margin-bottom: 20px\`, which leaves a phantom gap after the last card and means every consumer of \`Card\` has to think about its outer margin.

Switch to emotion's self-adjacent selector so spacing is applied between sibling cards only:

\`\`\`js
& + & {
    margin-top: 20px;
}
\`\`\`

Mirrors the \`&:last-child { margin-bottom: 0 }\` pattern \`SettingsSection\` already uses elsewhere under \`client/settings/\`. Other Dale-flagged items from that review either already landed (\`get_agentic_commerce_logs_url()\` helper now uses \`WC_Stripe_Logger::WC_LOG_FILENAME\`) or are tracked in his own #5364, so this PR only addresses the spacing one.

### How can this code break?

- The two-card stack on the dashboard (Status + History) renders identically — the new selector emits \`margin-top\` on the second card, which equals the old \`margin-bottom\` on the first card. Visual is unchanged.
- Any future consumer that relies on the old trailing \`margin-bottom\` would lose that gap. There is no such consumer in tree (\`grep\` for \`<Card\` from this module returns only the dashboard usages).

## Testing instructions

1. \`npm run test:js -- --testPathPattern='client/settings/agentic-commerce'\` — 30 tests pass.
2. \`npm run lint:js\` — clean for files this PR touches.
3. Open the agentic-commerce dashboard and confirm:
   - The Status card and the History card still have a visible 20px gap between them.
   - There is **no** trailing 20px gap below the last card.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️) — no behavior change; existing tests cover the dashboard render path.
-   [x] Tested on mobile (or does not apply) — admin-only.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

CSS-only refactor with no observable behavior change for merchants.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)