### PR TITLE
Pass Stripe auth headers through Playground CORS proxy

### DIFF
--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -16,6 +16,7 @@ on:
             - '.github/**'
             - '!.github/workflows/pr-build-live-branch.yml'
             - '!.github/workflows/scripts/generate-playground-blueprint.js'
+            - '!.github/workflows/scripts/playground-mu-plugins/**'
             - '**/tests/**'
             - 'docker/**'
             - '*.md'

--- a/.github/workflows/scripts/generate-playground-blueprint.js
+++ b/.github/workflows/scripts/generate-playground-blueprint.js
@@ -121,7 +121,7 @@ The changes in this pull request can be previewed and tested using a [WordPress 
 
 [Test this pull request with WordPress Playground](${ url }).
 
-**Scope:** Playground runs PHP in a browser WASM sandbox. Outbound calls to \`api.stripe.com\` are routed through Playground's CORS proxy, which the bundled mu-plugin opts the Stripe \`Authorization\` header through — so account connect, payment-method listing, and checkout requests should work. Webhook delivery still won't (no inbound HTTP into the sandbox); for anything webhook-driven, use a real local environment (\`npm run up\`).
+**Scope:** Playground runs PHP in a browser WASM sandbox. Stripe REST API calls do **not** work end-to-end in this preview — Playground's service worker strips JS-set \`Authorization\` headers on direct fetches before falling back to its CORS proxy ([WordPress/wordpress-playground#3559](https://github.com/WordPress/wordpress-playground/issues/3559)), so account connect, payment-method listing, checkout-against-Stripe, and webhook delivery all fail. Use this preview to review admin UI, settings shape, and install/activation flow only; use a real local environment (\`npm run up\`) for anything that talks to Stripe.
 
 Note that this URL is valid for 30 days from when this comment was last updated. You can update it by closing/reopening the PR or pushing a new commit.
 `;

--- a/.github/workflows/scripts/generate-playground-blueprint.js
+++ b/.github/workflows/scripts/generate-playground-blueprint.js
@@ -1,5 +1,21 @@
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+const stripeCorsMuPlugin = fs.readFileSync(
+	path.join( __dirname, 'playground-mu-plugins/stripe-cors-headers.php' ),
+	'utf8'
+);
+
 const generatePlaygroundBlueprint = ( runId, prNumber, devToolsAvailable ) => {
 	const steps = [
+		{
+			/* Playground's CORS proxy strips Authorization headers by default.
+			This mu-plugin opts Stripe's auth headers through the proxy so
+			account retrieval and payment-method listing work in the sandbox. */
+			step: 'writeFile',
+			path: '/wordpress/wp-content/mu-plugins/stripe-cors-headers.php',
+			data: stripeCorsMuPlugin,
+		},
 		{
 			step: 'installPlugin',
 			pluginData: {
@@ -98,7 +114,7 @@ The changes in this pull request can be previewed and tested using a [WordPress 
 
 [Test this pull request with WordPress Playground](${ url }).
 
-**Scope:** Playground runs PHP in a browser WASM sandbox, so outbound calls to \`api.stripe.com\` are subject to browser CORS. In practice, account connection, payment-method listing, checkout against Stripe, and webhook delivery will not work end-to-end here. Use the preview to review admin UI, settings shape, and install/activation flow; use a real local environment (\`npm run up\`) for anything that needs to talk to Stripe.
+**Scope:** Playground runs PHP in a browser WASM sandbox. Outbound calls to \`api.stripe.com\` are routed through Playground's CORS proxy, which the bundled mu-plugin opts the Stripe \`Authorization\` header through — so account connect, payment-method listing, and checkout requests should work. Webhook delivery still won't (no inbound HTTP into the sandbox); for anything webhook-driven, use a real local environment (\`npm run up\`).
 
 Note that this URL is valid for 30 days from when this comment was last updated. You can update it by closing/reopening the PR or pushing a new commit.
 `;

--- a/.github/workflows/scripts/generate-playground-blueprint.js
+++ b/.github/workflows/scripts/generate-playground-blueprint.js
@@ -105,9 +105,16 @@ async function run( { github, context, core } ) {
 		devToolsAvailable
 	);
 
-	const url = `https://playground.wordpress.net/#${ JSON.stringify(
-		blueprint
-	) }`;
+	// Base64-encode the blueprint so paren-, bracket-, and quote-containing
+	// payloads (e.g. PHP source written via the writeFile step) don't break
+	// the [text](url) Markdown link in the sticky PR comment. Playground's
+	// fragment parser accepts both raw JSON and base64; base64 is the
+	// recommended encoding when payloads contain special characters.
+	const blueprintBase64 = Buffer.from(
+		JSON.stringify( blueprint ),
+		'utf8'
+	).toString( 'base64' );
+	const url = `https://playground.wordpress.net/#${ blueprintBase64 }`;
 
 	const body = `## Test using WordPress Playground
 The changes in this pull request can be previewed and tested using a [WordPress Playground](https://developer.wordpress.org/playground/) instance.

--- a/.github/workflows/scripts/playground-mu-plugins/stripe-cors-headers.php
+++ b/.github/workflows/scripts/playground-mu-plugins/stripe-cors-headers.php
@@ -10,6 +10,14 @@
  * UI as "test API keys are no longer valid." Setting
  * X-Cors-Proxy-Allowed-Request-Headers explicitly opts the listed headers
  * through.
+ *
+ * Header value MUST be lowercase. The proxy's PHP filter lowercases before
+ * comparing, but Playground's service-worker layer
+ * (fetch-with-cors-proxy.ts) does a case-sensitive
+ * `.includes('authorization')` to decide whether to set
+ * `credentials: 'include'` on the proxy retry. Without that flag the browser
+ * drops the JS-set Authorization header before it ever leaves the sandbox,
+ * and Stripe responds "you did not provide an API key."
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -25,7 +33,7 @@ add_filter(
 			$args['headers'] = array();
 		}
 
-		$args['headers']['X-Cors-Proxy-Allowed-Request-Headers'] = 'Authorization, Idempotency-Key, Stripe-Version, Stripe-Account';
+		$args['headers']['X-Cors-Proxy-Allowed-Request-Headers'] = 'authorization, idempotency-key, stripe-version, stripe-account';
 
 		return $args;
 	},

--- a/.github/workflows/scripts/playground-mu-plugins/stripe-cors-headers.php
+++ b/.github/workflows/scripts/playground-mu-plugins/stripe-cors-headers.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Plugin Name: Stripe CORS Header Pass-through (Playground only)
+ * Description: Opts the Stripe Authorization header through Playground's CORS proxy. Loaded only inside the Playground sandbox; never shipped with the plugin.
+ *
+ * Playground's CORS proxy (cors.wordpress.net/proxy.php) strips Authorization
+ * headers by default. Stripe REST endpoints require Authorization: Bearer ...,
+ * so without this filter every wp_safe_remote_post() to api.stripe.com hits
+ * the proxy, loses its auth header, and returns 401 — surfaced in the plugin
+ * UI as "test API keys are no longer valid." Setting
+ * X-Cors-Proxy-Allowed-Request-Headers explicitly opts the listed headers
+ * through.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_filter(
+	'http_request_args',
+	function ( $args, $url ) {
+		if ( 0 !== strpos( $url, 'https://api.stripe.com/' ) ) {
+			return $args;
+		}
+
+		if ( ! isset( $args['headers'] ) || ! is_array( $args['headers'] ) ) {
+			$args['headers'] = array();
+		}
+
+		$args['headers']['X-Cors-Proxy-Allowed-Request-Headers'] = 'Authorization, Idempotency-Key, Stripe-Version, Stripe-Account';
+
+		return $args;
+	},
+	10,
+	2
+);


### PR DESCRIPTION
> ⏸️ **Parked pending upstream Playground fix** — [WordPress/wordpress-playground#3559](https://github.com/WordPress/wordpress-playground/issues/3559).
>
> The mu-plugin in this PR is correct in isolation, but Playground's service-worker `fetchWithCorsProxy` only retries through the CORS proxy when the direct fetch *throws*. Stripe's permissive CORS makes the direct fetch resolve with status 401 (the browser strips JS-set `Authorization` because the request isn't `credentials: 'include'`), so the proxy retry never fires and the mu-plugin's opt-in header has no effect. Until upstream lands one of the three fixes proposed in the linked issue, account-bound Stripe flows can't work in Playground previews. End-to-end debugging trail in [#5368 (comment)](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5368#issuecomment-4339110774).

Fixes _N/A — follow-up to #5074 addressing the Playground CORS limitation surfaced in [#5074 (comment)](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5074#issuecomment-4309094827)._

## Changes proposed in this Pull Request:

Stacked on #5074. Lets the Stripe REST API actually work inside the Playground PR preview, so reviewers can exercise account connect / payment-method listing / checkout-against-Stripe instead of only admin UI shape.

**Root cause.** Playground runs PHP in a browser WASM sandbox; PHP HTTP calls (`wp_safe_remote_post`, cURL) are tunneled through the browser's `fetch()`. `api.stripe.com` doesn't return CORS headers permitting `playground.wordpress.net`, so the direct fetch fails. Since [WP/wp-playground#2076](https://github.com/WordPress/wordpress-playground/pull/2076) Playground retries through its CORS proxy at `cors.wordpress.net/proxy.php` — but [the proxy strips `Authorization` headers in both directions by default](https://github.com/WordPress/wordpress-playground/tree/trunk/packages/playground/php-cors-proxy) ("authentication headers are blocked in both directions … refuses to pass authentication credentials"). Stripe receives an unauthenticated request, returns 401, and the plugin surfaces it as *"test API keys we've saved for you are no longer valid"*. Payment methods don't list because `WC_Stripe_UPE_Payment_Gateway` gates method availability on `accounts/retrieve` capabilities, and that call has just been 401'd.

**Fix.** A Playground-only must-use plugin, written into the sandbox via a blueprint `writeFile` step (never shipped with the released plugin zip), hooks `http_request_args` for `api.stripe.com` URLs and adds the proxy's documented per-request opt-in:

```
X-Cors-Proxy-Allowed-Request-Headers: Authorization, Idempotency-Key, Stripe-Version, Stripe-Account
```

Webhook delivery still won't work in the sandbox (no inbound HTTP into the WASM runtime); the sticky comment is updated to reflect the new scope.

- New `.github/workflows/scripts/playground-mu-plugins/stripe-cors-headers.php`: the mu-plugin itself, URL-prefix-gated on `https://api.stripe.com/`.
- `.github/workflows/scripts/generate-playground-blueprint.js`: read the mu-plugin source at workflow runtime (`fs.readFileSync` + `__dirname`), prepend a `writeFile` step that drops it at `/wordpress/wp-content/mu-plugins/`, and update the sticky-comment scope copy.
- `.github/workflows/pr-build-live-branch.yml`: un-ignore `scripts/playground-mu-plugins/**` so edits to the mu-plugin retrigger the workflow.

**How can this code break?**
- Playground's CORS proxy could change its allowlist behavior or rename the opt-in header. Symptom is a regression to "test API keys are no longer valid" inside the preview — caught by the testing steps below.
- A future Stripe-side change adding new authentication-class headers would silently get stripped. The mu-plugin's allowlist is conservative; we extend it as new headers appear rather than allow-all (which would re-introduce abuse risk for the shared proxy).
- The mu-plugin runs on every Playground sandbox boot for this repo. Malformed PHP would break preview boot — caught by phpcs/PHPStan in CI plus the testing steps.

**What are we doing to make sure this code doesn't break?**
- The `http_request_args` filter is URL-prefix-gated on `https://api.stripe.com/` so it cannot affect non-Stripe outbound traffic in the sandbox.
- The mu-plugin lives only in `.github/workflows/scripts/` and is never copied into the released plugin zip — released-plugin behavior is unchanged.
- The blueprint generator reads the mu-plugin via `fs.readFileSync` at workflow runtime, so the file is reviewable and lintable as PHP rather than embedded as a JS string blob.
- Path-filter un-ignore on `scripts/playground-mu-plugins/**` ensures future edits trigger a rebuild instead of silently shipping a stale Playground bundle.

## Testing instructions

1. After this PR's CI run completes, click the freshly-updated Playground sticky comment link and let the sandbox boot.
2. Paste valid Stripe **test** keys into the Stripe Dev Tools settings screen.
3. Confirm the connection step succeeds (the connected-account block replaces the "test API keys we've saved for you are no longer valid" warning).
4. Navigate to **WooCommerce → Settings → Payments → Stripe** and confirm payment methods populate (Cards plus whatever methods the test account has capabilities for).
5. Open browser devtools → Network. Trigger any settings save or checkout that hits Stripe and confirm:
   - Requests are routed via `cors.wordpress.net/proxy.php?…api.stripe.com/…`
   - The request includes header `X-Cors-Proxy-Allowed-Request-Headers: Authorization, Idempotency-Key, Stripe-Version, Stripe-Account`
   - The proxy returns **200** (not 401)
   - The matching request appears in the Stripe dashboard logs for that test account
6. Add a product to cart, proceed to checkout, and confirm a `4242…` test card produces a successful Stripe `payment_intent` (visible in Stripe dashboard).
7. Edit `.github/workflows/scripts/playground-mu-plugins/stripe-cors-headers.php` (e.g., add a comment), push, and confirm the workflow re-runs (the path-filter un-ignore is what makes that work).
8. Negative case: spin up `npm run up` locally and confirm `wp-content/mu-plugins/stripe-cors-headers.php` is **not** present — the mu-plugin must only exist inside the Playground sandbox.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️) — CI/preview tooling change; coverage is the manual Playground walkthrough above.
-   [x] Tested on mobile (or does not apply) — preview tooling, no user-facing UI.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Internal CI/preview tooling only. The mu-plugin is written into the Playground sandbox via a blueprint step at workflow runtime and never ships in the released plugin zip, so there is no user-visible change.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply) — does not apply (CI tooling).
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply) — does not apply.
-   [ ] Included this PR in the Release Thread scope (or does not apply) — does not apply.

