### PR TITLE
[RSM - Diagnostics Mode] Wire frontend recorder with backend endpoint

### DIFF
--- a/client/diagnostics/__tests__/recorder.test.js
+++ b/client/diagnostics/__tests__/recorder.test.js
@@ -10,11 +10,6 @@ describe( 'Recorder', () => {
 		return recorder;
 	}
 
-	// sendBeacon is now invoked with a Blob (so the request goes out as
-	// application/json). Tests previously read mock.calls[i][1] as a string;
-	// route those reads through this helper instead. Uses FileReader since
-	// the older jsdom in this repo's Jest config exposes neither
-	// `Blob.prototype.text()` nor `Response`.
 	function readBeaconBody( call ) {
 		const blob = call[ 1 ];
 		return new Promise( ( resolve, reject ) => {

--- a/client/diagnostics/__tests__/recorder.test.js
+++ b/client/diagnostics/__tests__/recorder.test.js
@@ -232,6 +232,32 @@ describe( 'Recorder', () => {
 			expect( body.events ).toHaveLength( 2 );
 		} );
 
+		it( 'auto-flushes the buffer when it reaches the server batch cap, so the controller never silently truncates', async () => {
+			const recorder = makeRecorder();
+			recorder.boot();
+
+			// Fill to 199 — no flush yet.
+			for ( let i = 0; i < 199; i++ ) {
+				recorder.record( 'element.change', { element_type: 'card' } );
+			}
+			expect( sendBeaconSpy ).not.toHaveBeenCalled();
+
+			// 200th event triggers an immediate flush.
+			recorder.record( 'element.change', { element_type: 'card' } );
+			expect( sendBeaconSpy ).toHaveBeenCalledTimes( 1 );
+
+			const body = await readBeaconBody( sendBeaconSpy.mock.calls[ 0 ] );
+			expect( body.events ).toHaveLength( 200 );
+
+			// Buffer is empty after the size-triggered flush, so subsequent
+			// events start a fresh batch.
+			recorder.record( 'element.change', { element_type: 'card' } );
+			recorder.flush();
+			expect( sendBeaconSpy ).toHaveBeenCalledTimes( 2 );
+			const next = await readBeaconBody( sendBeaconSpy.mock.calls[ 1 ] );
+			expect( next.events ).toHaveLength( 1 );
+		} );
+
 		it( 'auto-flushes the buffer when the pagehide event fires', () => {
 			const recorder = makeRecorder();
 			recorder.boot();

--- a/client/diagnostics/__tests__/recorder.test.js
+++ b/client/diagnostics/__tests__/recorder.test.js
@@ -10,6 +10,21 @@ describe( 'Recorder', () => {
 		return recorder;
 	}
 
+	// sendBeacon is now invoked with a Blob (so the request goes out as
+	// application/json). Tests previously read mock.calls[i][1] as a string;
+	// route those reads through this helper instead. Uses FileReader since
+	// the older jsdom in this repo's Jest config exposes neither
+	// `Blob.prototype.text()` nor `Response`.
+	function readBeaconBody( call ) {
+		const blob = call[ 1 ];
+		return new Promise( ( resolve, reject ) => {
+			const reader = new FileReader();
+			reader.onload = () => resolve( JSON.parse( reader.result ) );
+			reader.onerror = () => reject( reader.error );
+			reader.readAsText( blob );
+		} );
+	}
+
 	beforeEach( () => {
 		sendBeaconSpy = jest.fn().mockReturnValue( true );
 		Object.defineProperty( navigator, 'sendBeacon', {
@@ -84,13 +99,13 @@ describe( 'Recorder', () => {
 			);
 		} );
 
-		it( 'sends a body with diag_session_id and events shaped per contract', () => {
+		it( 'sends a body with diag_session_id and events shaped per contract', async () => {
 			const recorder = makeRecorder();
 			recorder.boot();
 			recorder.record( 'element.ready', { element_type: 'card' } );
 			recorder.flush();
 
-			const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+			const body = await readBeaconBody( sendBeaconSpy.mock.calls[ 0 ] );
 			expect( body ).toEqual( {
 				diag_session_id: '550e8400-e29b-41d4-a716-446655440000',
 				events: [
@@ -104,7 +119,18 @@ describe( 'Recorder', () => {
 			expect( body.events[ 0 ].t ).toBeGreaterThanOrEqual( 0 );
 		} );
 
-		it( 'preserves the buffer when sendBeacon refuses the request (returns false), so the next flush retries instead of dropping events', () => {
+		it( 'uses a Blob with type application/json so WP auto-parses the body', () => {
+			const recorder = makeRecorder();
+			recorder.boot();
+			recorder.record( 'element.ready', { element_type: 'card' } );
+			recorder.flush();
+
+			const sentBody = sendBeaconSpy.mock.calls[ 0 ][ 1 ];
+			expect( sentBody ).toBeInstanceOf( Blob );
+			expect( sentBody.type ).toBe( 'application/json' );
+		} );
+
+		it( 'preserves the buffer when sendBeacon refuses the request (returns false), so the next flush retries instead of dropping events', async () => {
 			sendBeaconSpy.mockReturnValueOnce( false );
 
 			const recorder = makeRecorder();
@@ -118,13 +144,15 @@ describe( 'Recorder', () => {
 			recorder.flush();
 
 			expect( sendBeaconSpy ).toHaveBeenCalledTimes( 2 );
-			const retryBody = JSON.parse( sendBeaconSpy.mock.calls[ 1 ][ 1 ] );
+			const retryBody = await readBeaconBody(
+				sendBeaconSpy.mock.calls[ 1 ]
+			);
 			expect( retryBody.events.map( ( e ) => e.kind ) ).toEqual( [
 				'element.ready',
 			] );
 		} );
 
-		it( 'anchors t to a trace-start timestamp persisted across recorder boots within the same session', () => {
+		it( 'anchors t to a trace-start timestamp persisted across recorder boots within the same session', async () => {
 			let mockTime = 1000;
 			const clock = () => mockTime;
 
@@ -143,8 +171,8 @@ describe( 'Recorder', () => {
 			r2.record( 'element.change', { element_type: 'card' } );
 			r2.flush();
 
-			const body1 = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
-			const body2 = JSON.parse( sendBeaconSpy.mock.calls[ 1 ][ 1 ] );
+			const body1 = await readBeaconBody( sendBeaconSpy.mock.calls[ 0 ] );
+			const body2 = await readBeaconBody( sendBeaconSpy.mock.calls[ 1 ] );
 
 			// First event sits at the trace start.
 			expect( body1.events[ 0 ].t ).toBe( 0 );
@@ -179,7 +207,7 @@ describe( 'Recorder', () => {
 			expect( sendBeaconSpy ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		it( 'resets the idle timer each time record() is called', () => {
+		it( 'resets the idle timer each time record() is called', async () => {
 			const cleared = [];
 			let nextId = 1;
 			let scheduledFn = null;
@@ -205,7 +233,7 @@ describe( 'Recorder', () => {
 			scheduledFn();
 
 			expect( sendBeaconSpy ).toHaveBeenCalledTimes( 1 );
-			const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+			const body = await readBeaconBody( sendBeaconSpy.mock.calls[ 0 ] );
 			expect( body.events ).toHaveLength( 2 );
 		} );
 
@@ -219,7 +247,7 @@ describe( 'Recorder', () => {
 			expect( sendBeaconSpy ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		it( 'assigns monotonically non-decreasing t to recorded events', () => {
+		it( 'assigns monotonically non-decreasing t to recorded events', async () => {
 			const recorder = makeRecorder();
 			recorder.boot();
 			recorder.record( 'element.ready', { element_type: 'card' } );
@@ -227,7 +255,7 @@ describe( 'Recorder', () => {
 			recorder.record( 'element.focus', { element_type: 'card' } );
 			recorder.flush();
 
-			const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+			const body = await readBeaconBody( sendBeaconSpy.mock.calls[ 0 ] );
 			expect( body.events ).toHaveLength( 3 );
 			expect( body.events[ 0 ].t ).toBeLessThanOrEqual(
 				body.events[ 1 ].t
@@ -248,7 +276,7 @@ describe( 'Recorder', () => {
 				};
 			}
 
-			it( 'records element.ready with element_type when the Stripe Element fires ready', () => {
+			it( 'records element.ready with element_type when the Stripe Element fires ready', async () => {
 				const recorder = makeRecorder();
 				recorder.boot();
 				const element = makeFakeElement();
@@ -257,7 +285,9 @@ describe( 'Recorder', () => {
 				element.emit( 'ready' );
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				expect( body.events ).toEqual( [
 					expect.objectContaining( {
 						kind: 'element.ready',
@@ -266,7 +296,7 @@ describe( 'Recorder', () => {
 				] );
 			} );
 
-			it( 'attachAfterReady records a synthetic element.ready (the underlying ready event has already fired)', () => {
+			it( 'attachAfterReady records a synthetic element.ready (the underlying ready event has already fired)', async () => {
 				const recorder = makeRecorder();
 				recorder.boot();
 				const element = makeFakeElement();
@@ -276,14 +306,16 @@ describe( 'Recorder', () => {
 				// point is that Stripe has already fired ready before we attach.
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				expect( body.events[ 0 ] ).toMatchObject( {
 					kind: 'element.ready',
 					data: { element_type: 'payment' },
 				} );
 			} );
 
-			it( 'attachAfterReady still subscribes to lifecycle events that fire later (focus/blur/change/loaderror)', () => {
+			it( 'attachAfterReady still subscribes to lifecycle events that fire later (focus/blur/change/loaderror)', async () => {
 				const recorder = makeRecorder();
 				recorder.boot();
 				const element = makeFakeElement();
@@ -293,7 +325,9 @@ describe( 'Recorder', () => {
 				element.emit( 'blur' );
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				expect( body.events.map( ( e ) => e.kind ) ).toEqual( [
 					'element.ready', // synthetic
 					'element.focus',
@@ -301,7 +335,7 @@ describe( 'Recorder', () => {
 				] );
 			} );
 
-			it( 'records element.focus and element.blur with element_type', () => {
+			it( 'records element.focus and element.blur with element_type', async () => {
 				const recorder = makeRecorder();
 				recorder.boot();
 				const element = makeFakeElement();
@@ -311,7 +345,9 @@ describe( 'Recorder', () => {
 				element.emit( 'blur' );
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				expect( body.events.map( ( e ) => e.kind ) ).toEqual( [
 					'element.focus',
 					'element.blur',
@@ -324,7 +360,7 @@ describe( 'Recorder', () => {
 				} );
 			} );
 
-			it( 'records element.loaderror with element_type and the projected error fields', () => {
+			it( 'records element.loaderror with element_type and the projected error fields', async () => {
 				const recorder = makeRecorder();
 				recorder.boot();
 				const element = makeFakeElement();
@@ -340,7 +376,9 @@ describe( 'Recorder', () => {
 				} );
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				expect( body.events[ 0 ] ).toMatchObject( {
 					kind: 'element.loaderror',
 					data: {
@@ -352,7 +390,7 @@ describe( 'Recorder', () => {
 				} );
 			} );
 
-			it( 'records element.change with the contract-allowed projection of the Stripe payload', () => {
+			it( 'records element.change with the contract-allowed projection of the Stripe payload', async () => {
 				const recorder = makeRecorder();
 				recorder.boot();
 				const element = makeFakeElement();
@@ -375,7 +413,9 @@ describe( 'Recorder', () => {
 				} );
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				expect( body.events ).toHaveLength( 1 );
 				expect( body.events[ 0 ].kind ).toBe( 'element.change' );
 				expect( body.events[ 0 ].data ).toEqual( {
@@ -391,7 +431,7 @@ describe( 'Recorder', () => {
 		} );
 
 		describe( 'recordBlocksPaymentSetupStart / End', () => {
-			it( 'records start and end events with site, duration_ms, and result_type for a successful payment setup', () => {
+			it( 'records start and end events with site, duration_ms, and result_type for a successful payment setup', async () => {
 				let mockTime = 1000;
 				const clock = () => mockTime;
 				const recorder = makeRecorder( { now: clock } );
@@ -407,7 +447,9 @@ describe( 'Recorder', () => {
 				} );
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				expect( body.events.map( ( e ) => e.kind ) ).toEqual( [
 					'blocks.payment_setup.start',
 					'blocks.payment_setup.end',
@@ -423,7 +465,7 @@ describe( 'Recorder', () => {
 				} );
 			} );
 
-			it( 'records error_message on end when the result carries one', () => {
+			it( 'records error_message on end when the result carries one', async () => {
 				let mockTime = 0;
 				const clock = () => mockTime;
 				const recorder = makeRecorder( { now: clock } );
@@ -440,7 +482,9 @@ describe( 'Recorder', () => {
 				} );
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				const endEvent = body.events.find(
 					( e ) => e.kind === 'blocks.payment_setup.end'
 				);
@@ -464,7 +508,7 @@ describe( 'Recorder', () => {
 				};
 			}
 
-			it( 'records paymentmethod with wallet_type and payment_method_type', () => {
+			it( 'records paymentmethod with wallet_type and payment_method_type', async () => {
 				const recorder = makeRecorder();
 				recorder.boot();
 				const eceButton = makeFakeEce();
@@ -483,7 +527,9 @@ describe( 'Recorder', () => {
 				} );
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				expect( body.events[ 0 ].kind ).toBe( 'express.paymentmethod' );
 				expect( body.events[ 0 ].data ).toEqual( {
 					wallet_type: 'link',
@@ -491,7 +537,7 @@ describe( 'Recorder', () => {
 				} );
 			} );
 
-			it( 'records shippingaddresschange with wallet_type and country (drops other address fields)', () => {
+			it( 'records shippingaddresschange with wallet_type and country (drops other address fields)', async () => {
 				const recorder = makeRecorder();
 				recorder.boot();
 				const eceButton = makeFakeEce();
@@ -508,7 +554,9 @@ describe( 'Recorder', () => {
 				} );
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				expect( body.events[ 0 ].kind ).toBe(
 					'express.shippingaddresschange'
 				);
@@ -518,7 +566,7 @@ describe( 'Recorder', () => {
 				} );
 			} );
 
-			it( 'records click, confirm, cancel, and shippingratechange with wallet_type', () => {
+			it( 'records click, confirm, cancel, and shippingratechange with wallet_type', async () => {
 				const recorder = makeRecorder();
 				recorder.boot();
 				const eceButton = makeFakeEce();
@@ -536,7 +584,9 @@ describe( 'Recorder', () => {
 				} );
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				expect( body.events.map( ( e ) => e.kind ) ).toEqual( [
 					'express.click',
 					'express.confirm',
@@ -550,7 +600,7 @@ describe( 'Recorder', () => {
 		} );
 
 		describe( 'recordExpressEvent() — call-site capture for the Blocks ECE React component', () => {
-			it( 'records click, cancel, and shippingratechange with wallet_type', () => {
+			it( 'records click, cancel, and shippingratechange with wallet_type', async () => {
 				const recorder = makeRecorder();
 				recorder.boot();
 
@@ -565,7 +615,9 @@ describe( 'Recorder', () => {
 				} );
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				expect( body.events.map( ( e ) => e.kind ) ).toEqual( [
 					'express.click',
 					'express.cancel',
@@ -576,7 +628,7 @@ describe( 'Recorder', () => {
 				} );
 			} );
 
-			it( 'records shippingaddresschange with wallet_type and country, dropping other address fields', () => {
+			it( 'records shippingaddresschange with wallet_type and country, dropping other address fields', async () => {
 				const recorder = makeRecorder();
 				recorder.boot();
 
@@ -591,7 +643,9 @@ describe( 'Recorder', () => {
 				} );
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				expect( body.events[ 0 ].kind ).toBe(
 					'express.shippingaddresschange'
 				);
@@ -601,7 +655,7 @@ describe( 'Recorder', () => {
 				} );
 			} );
 
-			it( 'records confirm with wallet_type and payment_method_type when paymentMethod is present (Blocks merges paymentmethod into onConfirm)', () => {
+			it( 'records confirm with wallet_type and payment_method_type when paymentMethod is present (Blocks merges paymentmethod into onConfirm)', async () => {
 				const recorder = makeRecorder();
 				recorder.boot();
 
@@ -614,7 +668,9 @@ describe( 'Recorder', () => {
 				} );
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				expect( body.events[ 0 ].kind ).toBe( 'express.confirm' );
 				expect( body.events[ 0 ].data ).toEqual( {
 					wallet_type: 'link',
@@ -622,7 +678,7 @@ describe( 'Recorder', () => {
 				} );
 			} );
 
-			it( 'records confirm with only wallet_type when paymentMethod is absent', () => {
+			it( 'records confirm with only wallet_type when paymentMethod is absent', async () => {
 				const recorder = makeRecorder();
 				recorder.boot();
 
@@ -631,20 +687,24 @@ describe( 'Recorder', () => {
 				} );
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				expect( body.events[ 0 ].data ).toEqual( {
 					wallet_type: 'apple_pay',
 				} );
 			} );
 
-			it( 'tolerates an undefined payload (no event payload from React)', () => {
+			it( 'tolerates an undefined payload (no event payload from React)', async () => {
 				const recorder = makeRecorder();
 				recorder.boot();
 
 				recorder.recordExpressEvent( 'click' );
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				expect( body.events[ 0 ].kind ).toBe( 'express.click' );
 				expect( body.events[ 0 ].data ).toEqual( {
 					wallet_type: undefined,
@@ -668,7 +728,9 @@ describe( 'Recorder', () => {
 
 				expect( result ).toBe( stripeResponse );
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				const kinds = body.events.map( ( e ) => e.kind );
 				expect( kinds ).toEqual( [
 					'stripe.createPaymentMethod.invoke',
@@ -700,7 +762,9 @@ describe( 'Recorder', () => {
 				);
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				const resolve = body.events.find(
 					( e ) => e.kind === 'stripe.createPaymentMethod.resolve'
 				);
@@ -724,7 +788,9 @@ describe( 'Recorder', () => {
 
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				const thrown = body.events.find(
 					( e ) => e.kind === 'stripe.createPaymentMethod.throw'
 				);
@@ -739,7 +805,7 @@ describe( 'Recorder', () => {
 		// intentional, exercising the recorder's console-interception behavior.
 		/* eslint-disable no-console */
 		describe( 'parent-frame console interception', () => {
-			it( 'records console.warn calls as console.warn events with the message', () => {
+			it( 'records console.warn calls as console.warn events with the message', async () => {
 				const recorder = makeRecorder();
 				recorder.boot();
 
@@ -748,7 +814,9 @@ describe( 'Recorder', () => {
 				);
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				expect( body.events[ 0 ].kind ).toBe( 'console.warn' );
 				expect( body.events[ 0 ].data ).toEqual( {
 					message:
@@ -757,21 +825,23 @@ describe( 'Recorder', () => {
 				} );
 			} );
 
-			it( 'records console.error calls as console.error events', () => {
+			it( 'records console.error calls as console.error events', async () => {
 				const recorder = makeRecorder();
 				recorder.boot();
 
 				console.error( 'something exploded' );
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				expect( body.events[ 0 ].kind ).toBe( 'console.error' );
 				expect( body.events[ 0 ].data.message ).toBe(
 					'something exploded'
 				);
 			} );
 
-			it( 'truncates messages to 500 chars', () => {
+			it( 'truncates messages to 500 chars', async () => {
 				const recorder = makeRecorder();
 				recorder.boot();
 
@@ -779,7 +849,9 @@ describe( 'Recorder', () => {
 				console.warn( longMessage );
 				recorder.flush();
 
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				expect( body.events[ 0 ].data.message ).toHaveLength( 500 );
 			} );
 
@@ -845,7 +917,7 @@ describe( 'Recorder', () => {
 				expect( sendBeaconSpy ).toHaveBeenCalledTimes( 1 );
 			} );
 
-			it( 'replays buffered events from sessionStorage on boot (return from 3DS)', () => {
+			it( 'replays buffered events from sessionStorage on boot (return from 3DS)', async () => {
 				window.sessionStorage.setItem(
 					STORAGE_KEY,
 					JSON.stringify( {
@@ -864,7 +936,9 @@ describe( 'Recorder', () => {
 				recorder.boot();
 
 				expect( sendBeaconSpy ).toHaveBeenCalledTimes( 1 );
-				const body = JSON.parse( sendBeaconSpy.mock.calls[ 0 ][ 1 ] );
+				const body = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 0 ]
+				);
 				expect( body.events ).toEqual( [
 					{
 						t: 100,

--- a/client/diagnostics/recorder.js
+++ b/client/diagnostics/recorder.js
@@ -38,7 +38,7 @@ export class Recorder {
 		// Replay any buffer left over from a prior pageload (e.g. 3DS redirect)
 		// then clear it from sessionStorage to prevent a second replay on the next boot.
 		if ( persisted?.bufferedEvents?.length ) {
-			const payload = JSON.stringify( {
+			const payload = buildIngestBlob( {
 				diag_session_id: this.config.sessionId,
 				events: persisted.bufferedEvents,
 			} );
@@ -255,7 +255,7 @@ export class Recorder {
 		if ( ! this.config?.active || this.buffer.length === 0 ) {
 			return;
 		}
-		const payload = JSON.stringify( {
+		const payload = buildIngestBlob( {
 			diag_session_id: this.config.sessionId,
 			events: this.buffer,
 		} );
@@ -312,6 +312,15 @@ export function getRecorder() {
 		_singleton.boot();
 	}
 	return _singleton;
+}
+
+// Wrap the JSON payload in a Blob so sendBeacon sets Content-Type to
+// application/json. Without this, sendBeacon defaults to text/plain and
+// WP's REST server skips JSON body parsing.
+function buildIngestBlob( payload ) {
+	return new Blob( [ JSON.stringify( payload ) ], {
+		type: 'application/json',
+	} );
 }
 
 function buildIngestUrl( config ) {

--- a/client/diagnostics/recorder.js
+++ b/client/diagnostics/recorder.js
@@ -1,5 +1,9 @@
 const STORAGE_KEY_PREFIX = 'wc_stripe_diag_';
 const IDLE_FLUSH_MS = 5000;
+// Server caps a batch at 200 events; flush early so a noisy checkout
+// (e.g., intercepted console.warn/error) can't push past the cap and
+// have the controller silently truncate.
+const MAX_BUFFER_BEFORE_FLUSH = 200;
 const CONSOLE_MESSAGE_MAX_CHARS = 500;
 const CONSOLE_LEVELS = [ 'warn', 'error' ];
 
@@ -248,6 +252,10 @@ export class Recorder {
 			kind,
 			data,
 		} );
+		if ( this.buffer.length >= MAX_BUFFER_BEFORE_FLUSH ) {
+			this.flush();
+			return;
+		}
 		this._resetIdleTimer();
 	}
 

--- a/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
+++ b/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
@@ -57,8 +57,11 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 	 * Permission callback.
 	 *
 	 * The endpoint is intentionally shopper-facing and unauthenticated.
-	 * Abuse mitigation comes from the `is_enabled()` toggle and the
-	 * trace store's caps (200 events/trace, FIFO trace-count eviction).
+	 * Abuse mitigation relies on the bounded debug window — the
+	 * `is_enabled()` toggle is meant to be on only briefly while a
+	 * merchant is actively debugging. Don't default it on: with the
+	 * toggle on, anyone can rotate `diag_session_id` to evict
+	 * legitimate traces from the FIFO trace store.
 	 *
 	 * @param WP_REST_Request<array<string, mixed>> $request
 	 * @return bool|WP_Error

--- a/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
+++ b/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
@@ -39,12 +39,26 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 				'methods'             => 'POST',
 				'callback'            => [ $this, 'ingest_events' ],
 				'permission_callback' => [ $this, 'permissions_check' ],
+				'args'                => [
+					'diag_session_id' => [
+						'required' => true,
+						'type'     => 'string',
+					],
+					'events'          => [
+						'required' => true,
+						'type'     => 'array',
+					],
+				],
 			]
 		);
 	}
 
 	/**
 	 * Permission callback.
+	 *
+	 * The endpoint is intentionally shopper-facing and unauthenticated.
+	 * Abuse mitigation comes from the `is_enabled()` toggle and the
+	 * trace store's caps (200 events/trace, FIFO trace-count eviction).
 	 *
 	 * @param WP_REST_Request<array<string, mixed>> $request
 	 * @return bool|WP_Error

--- a/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
+++ b/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
@@ -13,7 +13,6 @@ defined( 'ABSPATH' ) || exit;
 class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 
 	const ENABLED_OPTION = 'wc_stripe_diagnostics_enabled';
-	const NONCE_ACTION   = 'wc_stripe_diagnostics';
 
 	protected $namespace = 'wc/v3';
 	protected $rest_base = 'wc_stripe/diagnostics';
@@ -40,24 +39,12 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 				'methods'             => 'POST',
 				'callback'            => [ $this, 'ingest_events' ],
 				'permission_callback' => [ $this, 'permissions_check' ],
-				'args'                => [
-					'sessionId' => [
-						'required' => true,
-						'type'     => 'string',
-					],
-					'events'    => [
-						'required' => true,
-						'type'     => 'array',
-					],
-				],
 			]
 		);
 	}
 
 	/**
-	 * Permission callback. Requires:
-	 * 1. The diagnostics feature is enabled.
-	 * 2. A valid `wc_stripe_diagnostics` nonce in either an HTTP header or the body.
+	 * Permission callback.
 	 *
 	 * @param WP_REST_Request<array<string, mixed>> $request
 	 * @return bool|WP_Error
@@ -66,15 +53,6 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 		if ( ! self::is_enabled() ) {
 			return new WP_Error( 'wc_stripe_diagnostics_disabled', 'Diagnostics mode is not enabled.', [ 'status' => 403 ] );
 		}
-
-		$nonce = $request->get_header( 'x_wp_nonce' );
-		if ( ! is_string( $nonce ) || '' === $nonce ) {
-			$nonce = (string) $request->get_param( 'nonce' );
-		}
-		if ( ! wp_verify_nonce( $nonce, self::NONCE_ACTION ) ) {
-			return new WP_Error( 'wc_stripe_diagnostics_bad_nonce', 'Invalid diagnostics nonce.', [ 'status' => 403 ] );
-		}
-
 		return true;
 	}
 
@@ -85,9 +63,9 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function ingest_events( $request ) {
-		$session_id = WC_Stripe_Diagnostics_Trace_Store::sanitize_id( (string) $request->get_param( 'sessionId' ) );
+		$session_id = WC_Stripe_Diagnostics_Trace_Store::sanitize_id( (string) $request->get_param( 'diag_session_id' ) );
 		if ( '' === $session_id ) {
-			return new WP_Error( 'wc_stripe_diagnostics_bad_session', 'Invalid sessionId.', [ 'status' => 400 ] );
+			return new WP_Error( 'wc_stripe_diagnostics_bad_session', 'Invalid diag_session_id.', [ 'status' => 400 ] );
 		}
 
 		$raw_events = $request->get_param( 'events' );

--- a/tests/phpunit/diagnostics/class-wc-rest-stripe-diagnostics-controller-test.php
+++ b/tests/phpunit/diagnostics/class-wc-rest-stripe-diagnostics-controller-test.php
@@ -37,13 +37,13 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 		$this->store->delete_all();
 	}
 
-	private function make_request( array $body, ?string $nonce = null ): WP_REST_Request {
-		$nonce   = $nonce ?? wp_create_nonce( WC_REST_Stripe_Diagnostics_Controller::NONCE_ACTION );
+	private function make_request( array $body ): WP_REST_Request {
 		$request = new WP_REST_Request( 'POST', '/wc/v3/wc_stripe/diagnostics/events' );
-		$request->set_header( 'X-WP-Nonce', $nonce );
-		foreach ( $body as $k => $v ) {
-			$request->set_param( $k, $v );
-		}
+		// The recorder posts via sendBeacon with a Blob typed as
+		// `application/json`, so WP auto-decodes the body. Mirror that here
+		// to exercise the same parameter-parsing path in tests.
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $body ) );
 		return $request;
 	}
 
@@ -51,8 +51,8 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 		update_option( WC_REST_Stripe_Diagnostics_Controller::ENABLED_OPTION, 'no' );
 		$request = $this->make_request(
 			[
-				'sessionId' => 'abc',
-				'events'    => [],
+				'diag_session_id' => 'abc',
+				'events'          => [],
 			]
 		);
 		$result  = $this->controller->permissions_check( $request );
@@ -60,24 +60,11 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 		$this->assertSame( 'wc_stripe_diagnostics_disabled', $result->get_error_code() );
 	}
 
-	public function test_permission_denied_when_nonce_invalid() {
+	public function test_permission_granted_when_toggle_on() {
 		$request = $this->make_request(
 			[
-				'sessionId' => 'abc',
-				'events'    => [],
-			],
-			'not-a-nonce'
-		);
-		$result  = $this->controller->permissions_check( $request );
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'wc_stripe_diagnostics_bad_nonce', $result->get_error_code() );
-	}
-
-	public function test_permission_granted_with_valid_nonce_and_toggle_on() {
-		$request = $this->make_request(
-			[
-				'sessionId' => 'abc',
-				'events'    => [],
+				'diag_session_id' => 'abc',
+				'events'          => [],
 			]
 		);
 		$this->assertTrue( $this->controller->permissions_check( $request ) );
@@ -86,8 +73,8 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 	public function test_ingest_rejects_invalid_session_id() {
 		$request = $this->make_request(
 			[
-				'sessionId' => '@@@',
-				'events'    => [],
+				'diag_session_id' => '@@@',
+				'events'          => [],
 			]
 		);
 		$result  = $this->controller->ingest_events( $request );
@@ -98,8 +85,8 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 	public function test_ingest_rejects_non_array_events() {
 		$request = $this->make_request(
 			[
-				'sessionId' => 'abc',
-				'events'    => 'nope',
+				'diag_session_id' => 'abc',
+				'events'          => 'nope',
 			]
 		);
 		$result  = $this->controller->ingest_events( $request );
@@ -110,8 +97,8 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 	public function test_ingest_creates_trace_on_first_event() {
 		$request = $this->make_request(
 			[
-				'sessionId' => 'first-event',
-				'events'    => [
+				'diag_session_id' => 'first-event',
+				'events'          => [
 					[
 						'kind'              => 'consoleMessage',
 						'level'             => 'warn',
@@ -138,8 +125,8 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 		}
 		$request = $this->make_request(
 			[
-				'sessionId' => 'big',
-				'events'    => $events,
+				'diag_session_id' => 'big',
+				'events'          => $events,
 			]
 		);
 		$result  = $this->controller->ingest_events( $request );
@@ -154,8 +141,8 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 		}
 		$request = $this->make_request(
 			[
-				'sessionId' => 'overflow',
-				'events'    => [
+				'diag_session_id' => 'overflow',
+				'events'          => [
 					[
 						'kind'   => 'sdkCall',
 						'method' => 'x',


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

This PR fixes a couple of issues that was preventing the events from the frontend recorder #5330 from being persisted via the endpoint in #5350 

1. The recorder posts via `navigator.sendBeacon` with a plain string, which sets Content-Type to `text/plain;charset=UTF-8`. WP's REST server only auto-decodes JSON bodies tagged `application/json`, so the controller's parameter lookup were failing. To fix that, this PR wraps the JSON payload in a `Blob` typed `application/json` before ahding to `sendBeacon`. 
2.  The controller's `args` required `sessionId`, but the recorder sends `diag_session_id`. The controller also did its own `wp_verify_nonce` against a custom `wc_stripe_diagnostics` action read from neither location the recorder actually populates, and a custom action that conflicts with WP's cookie-auth layer (which validates the same `_wpnonce` against `wp_rest`). This PR drops the controller's nonce check and trusts WP's cookie-auth layer for nonce validation. It's worth noting that the endpoint is unauthenticated by design. It's Abuse mitigation comes from the `is_enabled()` toggle and the trace store's caps (200 events/trace, FIFO trace-count eviction).

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
Since we don't yet have the merchant toggle to enable diagnostics, testing this requires a code snippet.

- Create `includes/diagnostics/class-wc-stripe-diagnostics-stub.php` with the following content: 3b18d-pb/#php
- Update `includes/class-wc-stripe.php` to import the above file in line 106 with `( new WC_Stripe_Diagnostics_Stub() )->init();`

1. Navigate to checkout and place an order.
2. In dev tools -> Network, notice POST requests to the `/events` endpoint
3. Confirm the response is `200 { written: <n> }` with `n` matching the number of events sent.
4. Confirm a trace file appears in `wp-content/uploads/wc-stripe-diagnostics/`.
5. Repeat as a logged-out shopper to confirm cookie-auth still gates guest traffic correctly.


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Fixes issues in an unreleased feature.
</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)