### PR TITLE
Add diagnostics settings toggle

### DIFF
--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -166,6 +166,7 @@ export const useIsShortAccountStatementEnabled = makeSettingsHook(
 	'is_short_statement_descriptor_enabled'
 );
 export const useDebugLog = makeSettingsHook( 'is_debug_log_enabled' );
+export const useDiagnosticsMode = makeSettingsHook( 'is_diagnostics_enabled' );
 export const useIsOCEnabled = makeSettingsHook( 'is_oc_enabled' );
 export const useIsAdaptivePricingEnabled = makeSettingsHook( 'is_ap_enabled' );
 export const useOCLayout = makeSettingsHook( 'oc_layout' );

--- a/client/settings/advanced-settings-section/__tests__/index.test.js
+++ b/client/settings/advanced-settings-section/__tests__/index.test.js
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import AdvancedSettings from '..';
 import {
 	useDebugLog,
+	useDiagnosticsMode,
 	useGetSavingError,
 	useSettings,
 	useIsOCEnabled,
@@ -13,6 +14,7 @@ import {
 
 jest.mock( 'wcstripe/data', () => ( {
 	useDebugLog: jest.fn(),
+	useDiagnosticsMode: jest.fn(),
 	useIsOCEnabled: jest.fn(),
 	useIsAdaptivePricingEnabled: jest.fn(),
 	useOCLayout: jest.fn(),
@@ -32,6 +34,7 @@ describe( 'AdvancedSettings', () => {
 		};
 
 		useDebugLog.mockReturnValue( [ true, jest.fn() ] );
+		useDiagnosticsMode.mockReturnValue( [ false, jest.fn() ] );
 		useIsOCEnabled.mockReturnValue( [ false, jest.fn() ] );
 		useIsAdaptivePricingEnabled.mockReturnValue( [ false, jest.fn() ] );
 		useOCLayout.mockReturnValue( [ 'accordion', jest.fn() ] );
@@ -63,6 +66,29 @@ describe( 'AdvancedSettings', () => {
 		await userEvent.click( debugModeCheckbox );
 
 		expect( setIsLoggingCheckedMock ).toHaveBeenCalledWith( true );
+	} );
+
+	it( 'should enable diagnostics mode when checkbox is clicked', async () => {
+		const setIsDiagnosticsCheckedMock = jest.fn();
+		useDiagnosticsMode.mockReturnValue( [
+			false,
+			setIsDiagnosticsCheckedMock,
+		] );
+
+		render( <AdvancedSettings /> );
+
+		const diagnosticsCheckbox = screen.getByLabelText(
+			'Capture checkout diagnostics'
+		);
+
+		expect(
+			screen.getByText( 'Checkout diagnostics' )
+		).toBeInTheDocument();
+		expect( diagnosticsCheckbox ).not.toBeChecked();
+
+		await userEvent.click( diagnosticsCheckbox );
+
+		expect( setIsDiagnosticsCheckedMock ).toHaveBeenCalledWith( true );
 	} );
 
 	it( 'should not display optimized checkout element setting if the feature flag is disabled', () => {

--- a/client/settings/advanced-settings-section/diagnostics-mode.js
+++ b/client/settings/advanced-settings-section/diagnostics-mode.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { CheckboxControl } from '@wordpress/components';
+import { useDiagnosticsMode } from 'wcstripe/data';
+
+const DiagnosticsMode = () => {
+	const [ isDiagnosticsChecked, setIsDiagnosticsChecked ] =
+		useDiagnosticsMode();
+
+	return (
+		<>
+			<h4>
+				{ __( 'Checkout diagnostics', 'woocommerce-gateway-stripe' ) }
+			</h4>
+			<CheckboxControl
+				data-testid="diagnostics-checkbox"
+				label={ __(
+					'Capture checkout diagnostics',
+					'woocommerce-gateway-stripe'
+				) }
+				help={ __(
+					'When enabled, captures structured traces of checkout sessions for support diagnostics. Disable when not actively troubleshooting.',
+					'woocommerce-gateway-stripe'
+				) }
+				checked={ isDiagnosticsChecked }
+				onChange={ setIsDiagnosticsChecked }
+			/>
+		</>
+	);
+};
+
+export default DiagnosticsMode;

--- a/client/settings/advanced-settings-section/index.js
+++ b/client/settings/advanced-settings-section/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 import SettingsSection from '../settings-section';
 import CardBody from '../card-body';
 import DebugMode from './debug-mode';
+import DiagnosticsMode from './diagnostics-mode';
 import { Card } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import LoadableSettingsSection from 'wcstripe/settings/loadable-settings-section';
@@ -28,6 +29,7 @@ const AdvancedSettings = ( { isOCEnabled, setIsOCEnabled } ) => {
 				<Card>
 					<CardBody>
 						<DebugMode />
+						<DiagnosticsMode />
 						{ isOcAvailable && (
 							<OptimizedCheckoutFeature
 								isOCEnabled={ isOCEnabled }

--- a/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
+++ b/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
@@ -12,7 +12,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 
-	const ENABLED_OPTION = 'wc_stripe_diagnostics_enabled';
+	const SETTINGS_OPTION = 'woocommerce_stripe_settings';
+	const SETTINGS_KEY    = 'diagnostics';
 
 	protected $namespace = 'wc/v3';
 	protected $rest_base = 'wc_stripe/diagnostics';
@@ -115,8 +116,13 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 
 	/**
 	 * Whether the diagnostics feature is currently enabled.
+	 *
+	 * Reads from the gateway's settings group so the merchant-facing toggle
+	 * (`is_diagnostics_enabled` in the settings REST controller) is the
+	 * single source of truth.
 	 */
 	public static function is_enabled(): bool {
-		return 'yes' === get_option( self::ENABLED_OPTION, 'no' );
+		$settings = get_option( self::SETTINGS_OPTION, [] );
+		return is_array( $settings ) && isset( $settings[ self::SETTINGS_KEY ] ) && 'yes' === $settings[ self::SETTINGS_KEY ];
 	}
 }

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -176,6 +176,11 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
+					'is_diagnostics_enabled'                => [
+						'description'       => __( 'When enabled, captures structured client/server traces of checkout sessions for support diagnostics.', 'woocommerce-gateway-stripe' ),
+						'type'              => 'boolean',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
 				],
 			]
 		);
@@ -267,6 +272,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 
 				/* Settings > Advanced settings */
 				'is_debug_log_enabled'                  => 'yes' === $this->gateway->get_option( 'logging' ),
+				'is_diagnostics_enabled'                => 'yes' === $this->gateway->get_option( 'diagnostics' ),
 				'is_upe_enabled'                        => true,
 				'is_oc_enabled'                         => 'yes' === $this->gateway->get_option( 'optimized_checkout_element' ),
 				'is_ap_enabled'                         => 'yes' === $this->gateway->get_option( 'adaptive_pricing' ),
@@ -309,6 +315,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 
 		/* Settings > Advanced settings */
 		$this->update_is_debug_log_enabled( $request );
+		$this->update_is_diagnostics_enabled( $request );
 		$this->update_oc_settings( $request );
 
 		return new WP_REST_Response( [], 200 );
@@ -543,6 +550,23 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		}
 
 		$this->gateway->update_option( 'logging', $is_debug_log_enabled ? 'yes' : 'no' );
+	}
+
+	/**
+	 * Updates whether checkout diagnostics capture is enabled.
+	 *
+	 * @param WP_REST_Request<array<string, mixed>> $request Request object.
+	 *
+	 * @return void
+	 */
+	private function update_is_diagnostics_enabled( WP_REST_Request $request ) {
+		$is_diagnostics_enabled = $request->get_param( 'is_diagnostics_enabled' );
+
+		if ( null === $is_diagnostics_enabled ) {
+			return;
+		}
+
+		$this->gateway->update_option( 'diagnostics', $is_diagnostics_enabled ? 'yes' : 'no' );
 	}
 
 	/**

--- a/tests/phpunit/admin/class-wc-rest-stripe-settings-controller-test.php
+++ b/tests/phpunit/admin/class-wc-rest-stripe-settings-controller-test.php
@@ -588,6 +588,7 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 				'is_short_statement_descriptor_enabled',
 			],
 			'is_debug_log_enabled'                  => [ 'is_debug_log_enabled', 'logging' ],
+			'is_diagnostics_enabled'                => [ 'is_diagnostics_enabled', 'diagnostics' ],
 		];
 	}
 

--- a/tests/phpunit/diagnostics/class-wc-rest-stripe-diagnostics-controller-test.php
+++ b/tests/phpunit/diagnostics/class-wc-rest-stripe-diagnostics-controller-test.php
@@ -23,18 +23,31 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 		parent::set_up();
 		$this->store      = new WC_Stripe_Diagnostics_Trace_Store();
 		$this->controller = new WC_REST_Stripe_Diagnostics_Controller( $this->store );
-		update_option( WC_REST_Stripe_Diagnostics_Controller::ENABLED_OPTION, 'yes' );
+		$this->set_diagnostics_enabled( true );
 		$this->clear_state();
 	}
 
 	public function tear_down() {
 		$this->clear_state();
-		delete_option( WC_REST_Stripe_Diagnostics_Controller::ENABLED_OPTION );
+		$this->set_diagnostics_enabled( false );
 		parent::tear_down();
 	}
 
 	private function clear_state() {
 		$this->store->delete_all();
+	}
+
+	/**
+	 * Toggle the merchant-facing diagnostics setting (lives inside the
+	 * shared `woocommerce_stripe_settings` option group).
+	 */
+	private function set_diagnostics_enabled( bool $enabled ): void {
+		$settings = get_option( WC_REST_Stripe_Diagnostics_Controller::SETTINGS_OPTION, [] );
+		if ( ! is_array( $settings ) ) {
+			$settings = [];
+		}
+		$settings[ WC_REST_Stripe_Diagnostics_Controller::SETTINGS_KEY ] = $enabled ? 'yes' : 'no';
+		update_option( WC_REST_Stripe_Diagnostics_Controller::SETTINGS_OPTION, $settings );
 	}
 
 	private function make_request( array $body ): WP_REST_Request {
@@ -48,7 +61,7 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 	}
 
 	public function test_permission_denied_when_toggle_off() {
-		update_option( WC_REST_Stripe_Diagnostics_Controller::ENABLED_OPTION, 'no' );
+		$this->set_diagnostics_enabled( false );
 		$request = $this->make_request(
 			[
 				'diag_session_id' => 'abc',


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes RSM-1690

## Changes proposed in this Pull Request:

Adds a merchant-facing on/off toggle for Checkout Diagnostics

<img width="2168" height="1114" alt="CleanShot 2026-04-29 at 09 23 18@2x" src="https://github.com/user-attachments/assets/ce744bd5-f400-4a52-a09d-b7d333223824" />


### Out of scope for this PR

- I intentionally left out the auto-shut-off after N orders to keep this simple for now. Merchants need to manually disable diagnostics mode
-  Toggling the option on doesn't yet inject the `wcStripeDiag` global onto checkout pages. Will handle in a follow-up.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

- Go to WooCommerce → Settings → Payments → Stripe → settings.
- Confirm a "Checkout diagnostics" section appears below Debug mode.
- Check the box, save settings, reload - the box should remain checked.
- Uncheck, save, reload - should remain unchecked.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Unreleased WIP feature. We can include a single changelog entry when merging the feature branch to `develop`

</details>

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
