### PR TITLE
[RSM - Diagnostics Mode] Add diagnostics frontend loader

### DIFF
--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -106,6 +106,8 @@ class WC_Stripe {
 		$this->init();
 
 		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+
+		( new WC_Stripe_Diagnostics_Frontend_Loader() )->init();
 	}
 
 	/**

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -106,8 +106,6 @@ class WC_Stripe {
 		$this->init();
 
 		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
-
-		( new WC_Stripe_Diagnostics_Frontend_Loader() )->init();
 	}
 
 	/**
@@ -293,6 +291,8 @@ class WC_Stripe {
 
 		add_action( 'init', [ $this, 'initialize_apple_pay_registration' ] );
 
+		add_action( 'init', [ $this, 'initialize_diagnostics_frontend_loader' ] );
+
 		// Initialize Agentic Commerce integration.
 		add_action( 'woocommerce_init', [ $this, 'initialize_agentic_commerce' ] );
 
@@ -316,6 +316,13 @@ class WC_Stripe {
 	 */
 	public function initialize_apple_pay_registration() {
 		new WC_Stripe_Apple_Pay_Registration();
+	}
+
+	/**
+	 * Initialize the diagnostics frontend loader.
+	 */
+	public function initialize_diagnostics_frontend_loader() {
+		( new WC_Stripe_Diagnostics_Frontend_Loader() )->init();
 	}
 
 	/**

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -321,7 +321,7 @@ class WC_Stripe {
 	/**
 	 * Initialize the diagnostics frontend loader.
 	 */
-	public function initialize_diagnostics_frontend_loader() {
+	public function initialize_diagnostics_frontend_loader(): void {
 		( new WC_Stripe_Diagnostics_Frontend_Loader() )->init();
 	}
 

--- a/includes/diagnostics/class-wc-stripe-diagnostics-frontend-loader.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-frontend-loader.php
@@ -64,11 +64,11 @@ class WC_Stripe_Diagnostics_Frontend_Loader {
 		if ( ! WC_REST_Stripe_Diagnostics_Controller::is_enabled() ) {
 			return false;
 		}
-		$session = WC()->session ?? null;
-		if ( ! $session instanceof WC_Session ) {
-			return false;
+		if ( is_user_logged_in() ) {
+			return true;
 		}
-		return $session->has_session() || is_user_logged_in();
+		$session = WC()->session;
+		return $session instanceof WC_Session_Handler && $session->has_session();
 	}
 
 	/**
@@ -99,11 +99,8 @@ class WC_Stripe_Diagnostics_Frontend_Loader {
 	 * session lives.
 	 */
 	public function get_or_create_session_id(): string {
-		$session = WC()->session ?? null;
-		if ( ! $session instanceof WC_Session ) {
-			return wp_generate_uuid4();
-		}
-		$id = $session->get( self::SESSION_KEY );
+		$session = WC()->session;
+		$id      = $session->get( self::SESSION_KEY );
 		if ( ! is_string( $id ) || ! self::looks_like_uuid( $id ) ) {
 			$id = wp_generate_uuid4();
 			$session->set( self::SESSION_KEY, $id );

--- a/includes/diagnostics/class-wc-stripe-diagnostics-frontend-loader.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-frontend-loader.php
@@ -25,6 +25,13 @@ class WC_Stripe_Diagnostics_Frontend_Loader {
 	 */
 	const SESSION_KEY = 'wc_stripe_diag_session_id';
 
+	/**
+	 * Cached inline-config string for this request.
+	 *
+	 * @var string|null
+	 */
+	private $cached = null;
+
 	public function init(): void {
 		add_action( 'wp_footer', [ $this, 'maybe_localize' ], 11 );
 	}
@@ -40,6 +47,9 @@ class WC_Stripe_Diagnostics_Frontend_Loader {
 			return;
 		}
 		$inline = $this->build_inline_config();
+		if ( null === $inline ) {
+			return;
+		}
 		foreach ( self::SCRIPT_HANDLES as $handle ) {
 			if ( wp_script_is( $handle, 'enqueued' ) || wp_script_is( $handle, 'registered' ) ) {
 				wp_add_inline_script( $handle, $inline, 'before' );
@@ -51,9 +61,11 @@ class WC_Stripe_Diagnostics_Frontend_Loader {
 	 * Whether the loader should emit `wcStripeDiag` for this request.
 	 *
 	 * Skipped when the toggle is off, or when the request has no
-	 * established WC session and no logged-in user — writing to the WC
-	 * session in that state would set a session cookie and break
-	 * full-page caching for first-time visitors.
+	 * established WC session — writing to the WC session in that state
+	 * would set a session cookie and break full-page caching for
+	 * first-time visitors. Logged-in users are covered by the same
+	 * check because WC_Session_Handler::has_session() returns true for
+	 * them.
 	 */
 	public function should_localize(): bool {
 		if ( ! WC_REST_Stripe_Diagnostics_Controller::is_enabled() ) {
@@ -68,10 +80,9 @@ class WC_Stripe_Diagnostics_Frontend_Loader {
 	 * page that has multiple recorder-host handles enqueued sees the
 	 * same sessionId/nonce.
 	 */
-	private function build_inline_config(): string {
-		static $cached = null;
-		if ( null !== $cached ) {
-			return $cached;
+	private function build_inline_config(): ?string {
+		if ( null !== $this->cached ) {
+			return $this->cached;
 		}
 
 		$config = [
@@ -81,8 +92,13 @@ class WC_Stripe_Diagnostics_Frontend_Loader {
 			'nonce'     => wp_create_nonce( 'wp_rest' ),
 		];
 
-		$cached = 'window.wcStripeDiag = ' . wp_json_encode( $config ) . ';';
-		return $cached;
+		$encoded = wp_json_encode( $config );
+		if ( false === $encoded ) {
+			return null;
+		}
+
+		$this->cached = 'window.wcStripeDiag = ' . $encoded . ';';
+		return $this->cached;
 	}
 
 	/**

--- a/includes/diagnostics/class-wc-stripe-diagnostics-frontend-loader.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-frontend-loader.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Localizes window.wcStripeDiag on pages that load the Stripe checkout
+ * bundles, so client/diagnostics/recorder.js can boot.
+ *
+ * Bound to the merchant-facing diagnostics toggle. Only activates on
+ * requests that already have a WC session (or a logged-in user), so the
+ * localization itself never triggers a Set-Cookie that would expand the
+ * no-cache surface for first-time visitors.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+class WC_Stripe_Diagnostics_Frontend_Loader {
+
+	/**
+	 * Script handles the recorder is bundled into. The loader attaches an
+	 * inline `wcStripeDiag` global to whichever of these is enqueued on
+	 * the current page.
+	 */
+	const SCRIPT_HANDLES = [
+		'wc-stripe-upe-classic',
+		'wc-stripe-blocks-integration',
+	];
+
+	/**
+	 * Key under which the diag session id is stored in the WC session.
+	 * Tying the id to the WC session keeps it stable across pageviews
+	 * (including 3DS redirects) for the same shopper.
+	 */
+	const SESSION_KEY = 'wc_stripe_diag_session_id';
+
+	public function init(): void {
+		add_action( 'wp_footer', [ $this, 'maybe_localize' ], 11 );
+	}
+
+	/**
+	 * Inline-attach the recorder config to whichever recorder-host
+	 * script is on the page. Hooked at wp_footer priority 11 so the
+	 * gateway's own payment_scripts() callback (priority 10) has
+	 * already enqueued/registered its handle.
+	 */
+	public function maybe_localize(): void {
+		if ( ! $this->should_localize() ) {
+			return;
+		}
+		$inline = $this->build_inline_config();
+		foreach ( self::SCRIPT_HANDLES as $handle ) {
+			if ( wp_script_is( $handle, 'enqueued' ) || wp_script_is( $handle, 'registered' ) ) {
+				wp_add_inline_script( $handle, $inline, 'before' );
+			}
+		}
+	}
+
+	/**
+	 * Whether the loader should emit `wcStripeDiag` for this request.
+	 *
+	 * Skipped when the toggle is off, or when the request has no
+	 * established WC session and no logged-in user — writing to the WC
+	 * session in that state would set a session cookie and break
+	 * full-page caching for first-time visitors.
+	 */
+	public function should_localize(): bool {
+		if ( ! WC_REST_Stripe_Diagnostics_Controller::is_enabled() ) {
+			return false;
+		}
+		$session = WC()->session ?? null;
+		if ( ! $session instanceof WC_Session ) {
+			return false;
+		}
+		return $session->has_session() || is_user_logged_in();
+	}
+
+	/**
+	 * Build the inline `window.wcStripeDiag = …;` snippet, cached so a
+	 * page that has multiple recorder-host handles enqueued sees the
+	 * same sessionId/nonce.
+	 */
+	private function build_inline_config(): string {
+		static $cached = null;
+		if ( null !== $cached ) {
+			return $cached;
+		}
+
+		$config = [
+			'active'    => true,
+			'sessionId' => $this->get_or_create_session_id(),
+			'endpoint'  => rest_url( 'wc/v3/wc_stripe/diagnostics/events' ),
+			'nonce'     => wp_create_nonce( 'wp_rest' ),
+		];
+
+		$cached = 'window.wcStripeDiag = ' . wp_json_encode( $config ) . ';';
+		return $cached;
+	}
+
+	/**
+	 * Read the diag session id from the WC session, generating and
+	 * persisting one if missing. Stable across pageviews while the WC
+	 * session lives.
+	 */
+	public function get_or_create_session_id(): string {
+		$session = WC()->session ?? null;
+		if ( ! $session instanceof WC_Session ) {
+			return wp_generate_uuid4();
+		}
+		$id = $session->get( self::SESSION_KEY );
+		if ( ! is_string( $id ) || ! self::looks_like_uuid( $id ) ) {
+			$id = wp_generate_uuid4();
+			$session->set( self::SESSION_KEY, $id );
+		}
+		return $id;
+	}
+
+	private static function looks_like_uuid( string $candidate ): bool {
+		return 1 === preg_match( '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i', $candidate );
+	}
+}

--- a/includes/diagnostics/class-wc-stripe-diagnostics-frontend-loader.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-frontend-loader.php
@@ -59,9 +59,6 @@ class WC_Stripe_Diagnostics_Frontend_Loader {
 		if ( ! WC_REST_Stripe_Diagnostics_Controller::is_enabled() ) {
 			return false;
 		}
-		if ( is_user_logged_in() ) {
-			return true;
-		}
 		$session = WC()->session;
 		return $session instanceof WC_Session_Handler && $session->has_session();
 	}

--- a/includes/diagnostics/class-wc-stripe-diagnostics-frontend-loader.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-frontend-loader.php
@@ -2,11 +2,6 @@
 /**
  * Localizes window.wcStripeDiag on pages that load the Stripe checkout
  * bundles, so client/diagnostics/recorder.js can boot.
- *
- * Bound to the merchant-facing diagnostics toggle. Only activates on
- * requests that already have a WC session (or a logged-in user), so the
- * localization itself never triggers a Set-Cookie that would expand the
- * no-cache surface for first-time visitors.
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-frontend-loader-test.php
+++ b/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-frontend-loader-test.php
@@ -24,9 +24,7 @@ class WC_Stripe_Diagnostics_Frontend_Loader_Test extends WP_UnitTestCase {
 
 	public function tear_down() {
 		$this->set_diagnostics_enabled( false );
-		if ( WC()->session instanceof WC_Session ) {
-			WC()->session->set( WC_Stripe_Diagnostics_Frontend_Loader::SESSION_KEY, null );
-		}
+		WC()->session->set( WC_Stripe_Diagnostics_Frontend_Loader::SESSION_KEY, null );
 		wp_set_current_user( 0 );
 		parent::tear_down();
 	}

--- a/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-frontend-loader-test.php
+++ b/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-frontend-loader-test.php
@@ -30,12 +30,10 @@ class WC_Stripe_Diagnostics_Frontend_Loader_Test extends WP_UnitTestCase {
 	}
 
 	private function set_diagnostics_enabled( bool $enabled ): void {
-		$settings = get_option( WC_REST_Stripe_Diagnostics_Controller::SETTINGS_OPTION, [] );
-		if ( ! is_array( $settings ) ) {
-			$settings = [];
-		}
-		$settings[ WC_REST_Stripe_Diagnostics_Controller::SETTINGS_KEY ] = $enabled ? 'yes' : 'no';
-		update_option( WC_REST_Stripe_Diagnostics_Controller::SETTINGS_OPTION, $settings );
+		update_option(
+			WC_REST_Stripe_Diagnostics_Controller::ENABLED_OPTION,
+			$enabled ? 'yes' : 'no'
+		);
 	}
 
 	public function test_should_not_localize_when_toggle_off() {

--- a/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-frontend-loader-test.php
+++ b/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-frontend-loader-test.php
@@ -1,0 +1,104 @@
+<?php
+
+require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-diagnostics-controller.php';
+require_once WC_STRIPE_PLUGIN_PATH . '/includes/diagnostics/class-wc-stripe-diagnostics-frontend-loader.php';
+
+/**
+ * Tests for WC_Stripe_Diagnostics_Frontend_Loader.
+ *
+ * @package WooCommerce/Stripe/Diagnostics
+ */
+class WC_Stripe_Diagnostics_Frontend_Loader_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var WC_Stripe_Diagnostics_Frontend_Loader
+	 */
+	private $loader;
+
+	public function set_up() {
+		parent::set_up();
+		$this->loader = new WC_Stripe_Diagnostics_Frontend_Loader();
+		$this->set_diagnostics_enabled( true );
+		WC()->initialize_session();
+	}
+
+	public function tear_down() {
+		$this->set_diagnostics_enabled( false );
+		if ( WC()->session instanceof WC_Session ) {
+			WC()->session->set( WC_Stripe_Diagnostics_Frontend_Loader::SESSION_KEY, null );
+		}
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	private function set_diagnostics_enabled( bool $enabled ): void {
+		$settings = get_option( WC_REST_Stripe_Diagnostics_Controller::SETTINGS_OPTION, [] );
+		if ( ! is_array( $settings ) ) {
+			$settings = [];
+		}
+		$settings[ WC_REST_Stripe_Diagnostics_Controller::SETTINGS_KEY ] = $enabled ? 'yes' : 'no';
+		update_option( WC_REST_Stripe_Diagnostics_Controller::SETTINGS_OPTION, $settings );
+	}
+
+	public function test_should_not_localize_when_toggle_off() {
+		$this->set_diagnostics_enabled( false );
+		WC()->session->set_customer_session_cookie( true );
+		$this->assertFalse( $this->loader->should_localize() );
+	}
+
+	public function test_should_not_localize_when_no_session_and_logged_out() {
+		// No customer session cookie set, and no logged-in user. This is the
+		// product-page-first-visit case where writing a session would set a
+		// cookie and break full-page caching.
+		$this->assertFalse( $this->loader->should_localize() );
+	}
+
+	public function test_should_localize_when_session_exists() {
+		WC()->session->set_customer_session_cookie( true );
+		$this->assertTrue( $this->loader->should_localize() );
+	}
+
+	public function test_should_localize_when_user_logged_in_even_without_session_cookie() {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+		$this->assertTrue( $this->loader->should_localize() );
+	}
+
+	public function test_session_id_is_generated_and_stable_across_calls() {
+		WC()->session->set_customer_session_cookie( true );
+
+		$first  = $this->loader->get_or_create_session_id();
+		$second = $this->loader->get_or_create_session_id();
+
+		$this->assertSame( $first, $second );
+		$this->assertMatchesRegularExpression(
+			'/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i',
+			$first
+		);
+	}
+
+	public function test_session_id_persists_in_wc_session() {
+		WC()->session->set_customer_session_cookie( true );
+		$id = $this->loader->get_or_create_session_id();
+		$this->assertSame(
+			$id,
+			WC()->session->get( WC_Stripe_Diagnostics_Frontend_Loader::SESSION_KEY )
+		);
+	}
+
+	public function test_session_id_regenerates_when_stored_value_is_invalid() {
+		WC()->session->set_customer_session_cookie( true );
+		WC()->session->set(
+			WC_Stripe_Diagnostics_Frontend_Loader::SESSION_KEY,
+			'not-a-uuid'
+		);
+
+		$id = $this->loader->get_or_create_session_id();
+
+		$this->assertNotSame( 'not-a-uuid', $id );
+		$this->assertMatchesRegularExpression(
+			'/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i',
+			$id
+		);
+	}
+}

--- a/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-frontend-loader-test.php
+++ b/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-frontend-loader-test.php
@@ -30,10 +30,12 @@ class WC_Stripe_Diagnostics_Frontend_Loader_Test extends WP_UnitTestCase {
 	}
 
 	private function set_diagnostics_enabled( bool $enabled ): void {
-		update_option(
-			WC_REST_Stripe_Diagnostics_Controller::ENABLED_OPTION,
-			$enabled ? 'yes' : 'no'
-		);
+		$settings = get_option( WC_REST_Stripe_Diagnostics_Controller::SETTINGS_OPTION, [] );
+		if ( ! is_array( $settings ) ) {
+			$settings = [];
+		}
+		$settings[ WC_REST_Stripe_Diagnostics_Controller::SETTINGS_KEY ] = $enabled ? 'yes' : 'no';
+		update_option( WC_REST_Stripe_Diagnostics_Controller::SETTINGS_OPTION, $settings );
 	}
 
 	public function test_should_not_localize_when_toggle_off() {

--- a/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-frontend-loader-test.php
+++ b/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-frontend-loader-test.php
@@ -25,8 +25,19 @@ class WC_Stripe_Diagnostics_Frontend_Loader_Test extends WP_UnitTestCase {
 	public function tear_down() {
 		$this->set_diagnostics_enabled( false );
 		WC()->session->set( WC_Stripe_Diagnostics_Frontend_Loader::SESSION_KEY, null );
+		unset( $_COOKIE[ 'wp_woocommerce_session_' . COOKIEHASH ] );
 		wp_set_current_user( 0 );
 		parent::tear_down();
+	}
+
+	/**
+	 * Make WC_Session_Handler::has_session() return true without going
+	 * through set_customer_session_cookie(), which calls wc_setcookie()
+	 * and triggers a "headers already sent" notice in the PHPUnit CLI
+	 * environment. has_session() is satisfied by isset($_COOKIE[...]).
+	 */
+	private function simulate_active_wc_session(): void {
+		$_COOKIE[ 'wp_woocommerce_session_' . COOKIEHASH ] = 'test-session';
 	}
 
 	private function set_diagnostics_enabled( bool $enabled ): void {
@@ -40,7 +51,7 @@ class WC_Stripe_Diagnostics_Frontend_Loader_Test extends WP_UnitTestCase {
 
 	public function test_should_not_localize_when_toggle_off() {
 		$this->set_diagnostics_enabled( false );
-		WC()->session->set_customer_session_cookie( true );
+		$this->simulate_active_wc_session();
 		$this->assertFalse( $this->loader->should_localize() );
 	}
 
@@ -52,7 +63,7 @@ class WC_Stripe_Diagnostics_Frontend_Loader_Test extends WP_UnitTestCase {
 	}
 
 	public function test_should_localize_when_session_exists() {
-		WC()->session->set_customer_session_cookie( true );
+		$this->simulate_active_wc_session();
 		$this->assertTrue( $this->loader->should_localize() );
 	}
 
@@ -63,7 +74,7 @@ class WC_Stripe_Diagnostics_Frontend_Loader_Test extends WP_UnitTestCase {
 	}
 
 	public function test_session_id_is_generated_and_stable_across_calls() {
-		WC()->session->set_customer_session_cookie( true );
+		$this->simulate_active_wc_session();
 
 		$first  = $this->loader->get_or_create_session_id();
 		$second = $this->loader->get_or_create_session_id();
@@ -76,7 +87,7 @@ class WC_Stripe_Diagnostics_Frontend_Loader_Test extends WP_UnitTestCase {
 	}
 
 	public function test_session_id_persists_in_wc_session() {
-		WC()->session->set_customer_session_cookie( true );
+		$this->simulate_active_wc_session();
 		$id = $this->loader->get_or_create_session_id();
 		$this->assertSame(
 			$id,
@@ -85,7 +96,7 @@ class WC_Stripe_Diagnostics_Frontend_Loader_Test extends WP_UnitTestCase {
 	}
 
 	public function test_session_id_regenerates_when_stored_value_is_invalid() {
-		WC()->session->set_customer_session_cookie( true );
+		$this->simulate_active_wc_session();
 		WC()->session->set(
 			WC_Stripe_Diagnostics_Frontend_Loader::SESSION_KEY,
 			'not-a-uuid'


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes RSM-1706

## Changes proposed in this Pull Request:

Wires the frontend recorder (#5330) to the diagnostics toggle so the feature works end-to-end when a merchant enables it.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. Enable the diagnostics toggle in Stripe settings.
2. As a guest (not logged in) with items in the cart, open the classic checkout.
3. In DevTools console, confirm `window.wcStripeDiag` is present:
   `{ active: true, sessionId: <UUID>, endpoint, nonce }`.
4. Reload. `window.wcStripeDiag.sessionId` should be unchanged
5. Place an order and notice trace JSONs with above session ID are created in `wp-content/uploads/wc-stripe-diagnostics/`
6. Switch to Blocks checkout. Repeat steps 2–4 and confirm `window.wcStripeDiag` is present there too.
7. Disable the toggle. Reload checkout. Confirm `window.wcStripeDiag` is undefined.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This is an unreleased feature

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
