### PR TITLE
Fix readme changelog merge error

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -149,101 +149,14 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 10.7.0 - xxxx-xx-xx =
 * Add - Display a bank authorization notice for Pre-Authorized Debit (ACSS) payments on checkout
-* Add - Add Agentic Commerce settings UI with feature introduction, onboarding guide, enable/disable toggle, and webhook secret management
-* Add - Add Agentic Commerce admin dashboard for monitoring product feed sync status, history, errors, and triggering manual syncs
-* Dev - Use paratest in CI workflow for faster PHP test execution
 * Fix - Detect Agentic Commerce sessions via payment_intent.agent_details so their checkout.session.completed webhooks aren't skipped
+* Add - Add Agentic Commerce settings UI with feature introduction, onboarding guide, enable/disable toggle, and webhook secret management
 * Fix - Surface PHP Throwables from the Agentic Commerce checkout.session.completed flow so fatals are logged, the order rollback runs, and Action Scheduler marks the job failed
 * Fix - Look up products by SKU in Agentic Commerce manual approval and tax calculation flows
 * Dev - Rename payment request references to express checkout
+* Add - Add Agentic Commerce admin dashboard for monitoring product feed sync status, history, errors, and triggering manual syncs
 * Fix - Store Stripe Terminal IPP channel metadata on orders so WooCommerce can identify POS payments and suppress standard transactional emails
 * Dev - Reduce PR PHP test matrix from 30 to 12 jobs (PHP 7.4, 8.2, 8.5; WC/WP at L and L-2) for faster CI feedback
-* Dev - Use paratest in CI workflow for faster PHP test execution
-* Remove - Remove EU adaptive pricing disclosure component from classic and Blocks checkout as it is shown natively within the Stripe currency selector element
-* Dev - Add paratest for parallel PHP unit test execution
-* Fix - Accept regional language names for Spanish provinces (e.g., Basque "Gipuzkoa") in Apple Pay and express checkout address validation
-* Fix - Restore missing saved payment tokens when Optimized Checkout Suite is enabled
-* Add - Add exit survey to capture merchant feedback on plugin deactivation and gateway disablement
-* Update - Defer checkout sessions webhook processing via Action Scheduler to prevent race conditions when webhook events arrive before order metadata is stored
-* Fix - Hide duplicate store-level save checkbox when Stripe Link is enabled on checkout
-* Dev - Autoload all Agentic Commerce classes via Composer classmap, removing manual require_once calls
-* Update - Show "Payment Options" as the Optimized Checkout title on classic checkout and "Payment Methods" on Blocks checkout instead of "Stripe"
-* Dev - Separate Agentic Commerce merchant-controlled is_enabled setting from the developer feature flag
-* Fix - Move test mode instructions above the Adaptive Pricing currency selector in classic checkout
-* Fix - Render the Adaptive Pricing currency selector immediately above the payment element in classic checkout
-* Update - Show Express Checkout on block checkout when Adaptive Pricing is enabled
-* Fix - Fix checkout session creation for guest users
-* Add - Allow payment methods for other currencies to be enabled when Adaptive Pricing is enabled
-* Fix - Re-compute Stripe PE appearance after web fonts load to prevent fallback font rendering
-* Fix - Better background color detection for block themes and allow fonts from fonts.bunny.net
-* Update - Shorten test mode messaging, add Test Mode badge on Blocks checkout, and add copy-to-clipboard for test card numbers
-* Fix - Prevent brief display of wrong title on classic checkout when Optimized Checkout is enabled
-* Fix - Update Stripe Fee and Stripe Payout values correctly after partial capture by replacing authorization-phase values instead of adding to them
-* Fix - Add defensive checks before running renewal meta cleanup when renewal/subscription objects are missing or invalid
-* Dev - Add metadata accessor methods for subscription objects to WC_Stripe_Order_Helper, centralizing subscription-specific metadata handling
-* Add - Include specific information on converted currency for adaptive pricing in order confirmation emails
-* Fix - Use the order currency instead of the global store currency when creating a payment intent, resolving incorrect charges in multicurrency setups
-* Dev - Rename and move the new Checkout Sessions ajax handler class to be autoloaded
-* Add - Process payment with adaptive pricing in the classic checkout
-* Dev - Add WC_Stripe_Country_Code constants class and replace hardcoded country code strings
-* Dev - Update WC_Stripe_Currency_Code constants class with zero-decimal and three-decimal currency lists and replace legacy no_decimal_currencies() usage
-* Fix - Resolve intermittent "Missing required customer field: address->line1" error during checkout with auto-account creation
-* Update - Add deprecation notices to methods and properties that were deprecated without them in older versions
-* Add - New promotional banner to highlight the Stripe Tax extension for OCS-enabled merchants
-* Add - Include specific information on converted currency for adaptive pricing in the order received page and order details page
-* Add - Support express checkout for free trial subscription products that require shipping
-* Fix - Normalize express checkout button spacing on the block cart page in Safari
-* Fix - Re-block UI during express checkout post-modal processing so shoppers see a loading state while the checkout API call completes
-* Dev - Add product deletion tracking to Agentic Commerce inventory sync: product deletes and trash events are batched and uploaded to Stripe as a product_catalog_feed with delete:true
-* Dev - Rename PHPUnit test files and directories to match the WordPress kebab-case naming convention used in includes/
-* Add - Process payment with adaptive pricing in the blocks checkout
-* Update - Express Checkout button logging will only occur when verbose debug mode is enabled
-* Update - Disable the Optimized Checkout Suite in the "Add Payment Method" and "Change Subscription Payment Method" screens
-* Dev - Remove unused frontend code: legacy blocks payment request API helpers, related normalize utilities, and unused Stripe icon component
-* Add - Allow additional font domains to be included in Stripe fonts
-* Dev - Add incremental inventory sync for Agentic Commerce: tracks stock changes via WooCommerce hooks and uploads a minimal inventory_feed CSV to Stripe one minute after the first change
-* Dev - Add Agentic Commerce admin dashboard for monitoring product feed sync status, history, errors, and triggering manual syncs
-* Update - Move Agentic Commerce settings from a separate tab to an inline section in the Settings tab, use sentence case, and integrate save into the global Save changes button
-* Dev - Skip registering Stripe email classes when WooCommerce email class is not loaded
-* Fix - Add order and payment method validation to prevent errors
-* Dev - Remove @woocommerce/currency dev dependency to resolve locutus CVE-2026-32304 (GHSA-vh9h-29pq-r5m8)
-* Tweak - Hide pay and cancel actions for pending orders processed via Checkout Session in order received page and My Account orders list
-* Fix - Improve default layout when Optimized Checkout is disabled
-* Fix - Ensure that we enqueue all needed scripts on payment pages
-* Fix - Use floating labels and correct field spacing on Blocks checkout to match WooPayments
-* Fix - Improve performance of CSS style lookups
-* Fix - Wrap express checkout add-to-cart in try/catch to prevent errors
-* Fix - Treat customer-initiated Klarna (and other redirect BNPL) cancellations as recoverable so the order stays retryable and shoppers can complete checkout with another payment method
-* Add - Initial implementation of always-expanded Optimized Checkout Suite in shortcode checkout
-* Dev - Collapse PHPUnit tests using data providers to reduce duplication and improve test isolation
-* Fix - Fix UPE style transition keys for font smoothing properties
-* Add - Handle Checkout Session failure webhook events for expired and async failed payments
-* Add - Process Checkout Session async payment success webhooks
-* Dev - Hide Stripe's testing assistant on checkout page
-* Dev - Treat misaligned statements as errors in PHPCS ruleset
-* Fix - Put subscription on hold when Stripe Radar blocks a renewal payment to prevent WC Subscriptions from scheduling further retry attempts
-* Fix - Fall back to split Stripe payment methods when Optimized Checkout is enabled but Stripe is not the first available gateway
-* Dev - Remove checkout sessions feature flag and make the feature available by default
-* Fix - Prevent TypeError when processing deferred webhooks using Action Scheduler
-* Update - Hide Adaptive Pricing option for Stripe accounts based in India and European Economic Area countries
-* Fix - Prevent JavaScript error in `elements.update` when using checkout sessions with adaptive pricing
-* Fix - Keep adaptive pricing amount in sync on classic checkout after order total changes
-* Fix - Keep adaptive pricing amount in sync on block checkout after order total changes
-* Fix - Use a single Checkout Session line item priced at the full payable cart total so adaptive pricing sessions match checkout totals
-* Add - Add Ajax endpoint to update line items in a checkout session
-* Tweak - Hide the Adaptive Pricing currency selector from classic checkout when a saved payment method is selected
-* Add - Allow customers to save payment methods during checkout with adaptive pricing
-* Fix - Only collect and send payer phone in Checkout Sessions when the WooCommerce phone field is required
-* Fix - Restrict Checkout Session saved payment method options to logged-in customers so guest checkout session creation succeeds
-* Add - Add an admin notice and one-click action to move Stripe payment methods to the top of WooCommerce payment gateway order for Optimized Checkout
-* Update - Allow Adaptive Pricing for merchant accounts based in EEA countries                                                                                                                               
-* Add - Show ECB interbank rate conversion fee notice to EEA-based shoppers on the order received page and in customer order confirmation emails
-* Fix - Confirm checkout session with user data in classic checkout for guest user
-* Add - Handle redirect payment flow in classic checkout for Checkout Sessions
-* Dev - Add automatic changelog entry suggestions to bin/changelog.js
-* Fix: Improve UX for the "Stripe first method" notice for Optimized Checkout
-* Fix - Change Checkout Sessions (Adaptive Pricing) redirect-based flow to match the existing PaymentIntent flow (redirect to checkout page)
-* Fix - Ensure currency selector appears after saved payment methods in classic checkout
 * Dev - Bump transitive minimatch dev dependency to resolve ReDoS CVE-2026-27903 (GHSA-7r86-cg39-jmmj)
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Cleans up the `10.7.0` changelog block in `readme.txt`, removing the accumulated duplicate entries after recent merges.

## Testing instructions

Check that the `readme.txt` only has entries for the upcoming `10.7.0` version, and that they match what's in the `changelog.txt` file.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment 

The PR fixes the changelog entries, no need to add one.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
