### PR TITLE
Add an option to copy trace(s) for support

### DIFF
--- a/client/settings/advanced-settings-section/__tests__/diagnostics-traces.test.js
+++ b/client/settings/advanced-settings-section/__tests__/diagnostics-traces.test.js
@@ -1,0 +1,197 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DiagnosticsTraces from '../diagnostics-traces';
+import apiFetch from '@wordpress/api-fetch';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+// Stub @wordpress/components: the component only relies on label text, the
+// disabled flag, the click handler, and the dismissible notice surface.
+// Pulling in the real components inflates test boot time without adding
+// coverage.
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( { children, disabled, onClick } ) => (
+		<button type="button" disabled={ disabled } onClick={ onClick }>
+			{ children }
+		</button>
+	),
+	Notice: ( { children, status } ) => (
+		<div data-status={ status }>{ children }</div>
+	),
+} ) );
+
+const summaryFixture = ( overrides = {} ) => ( {
+	counts: {
+		pending: 0,
+		failed: 2,
+		completed: 1,
+		abandoned: 1,
+		...( overrides.counts || {} ),
+	},
+	total: overrides.total ?? 4,
+} );
+
+const tracesFixture = ( count = 2 ) => ( {
+	traces: Array.from( { length: count }, ( _, i ) => ( {
+		id: `t${ i }`,
+		status: 'failed',
+		events: [],
+	} ) ),
+	count,
+} );
+
+describe( 'DiagnosticsTraces', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		Object.assign( navigator, {
+			clipboard: { writeText: jest.fn().mockResolvedValue() },
+		} );
+	} );
+
+	it( 'renders nothing when there are no captured traces', async () => {
+		apiFetch.mockResolvedValueOnce( { counts: {}, total: 0 } );
+		const { container } = render( <DiagnosticsTraces /> );
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalled() );
+		expect( container.firstChild ).toBeNull();
+	} );
+
+	// Breakdown row rendering. Encodes the three behaviors the user can
+	// see — non-zero bucket suppression, mixed counts, and singular
+	// pluralization — in one parameterized test.
+	it.each( [
+		[
+			'omits zero-count buckets',
+			summaryFixture(), // pending=0, the rest non-zero
+			'4 traces captured (2 failed, 1 abandoned, 1 succeeded)',
+		],
+		[
+			'mixed counts with one zero bucket (abandoned)',
+			summaryFixture( {
+				counts: {
+					pending: 5,
+					failed: 1,
+					completed: 1,
+					abandoned: 0,
+				},
+				total: 7,
+			} ),
+			'7 traces captured (1 failed, 1 succeeded, 5 pending)',
+		],
+		[
+			'singularizes when there is exactly one trace',
+			summaryFixture( {
+				counts: { pending: 0, failed: 1, completed: 0, abandoned: 0 },
+				total: 1,
+			} ),
+			'1 trace captured (1 failed)',
+		],
+	] )( 'renders breakdown line: %s', async ( _label, summary, expected ) => {
+		apiFetch.mockResolvedValueOnce( summary );
+		render( <DiagnosticsTraces /> );
+		expect( await screen.findByText( expected ) ).toBeInTheDocument();
+	} );
+
+	it( 'disables the primary button when no failed or abandoned traces exist', async () => {
+		apiFetch.mockResolvedValueOnce(
+			summaryFixture( {
+				counts: { pending: 0, failed: 0, completed: 3, abandoned: 0 },
+				total: 3,
+			} )
+		);
+		render( <DiagnosticsTraces /> );
+
+		const button = await screen.findByText(
+			'Copy failed traces for support (0)'
+		);
+		expect( button ).toBeDisabled();
+	} );
+
+	// Click → fetch → clipboard → notice. Both buttons go through the same
+	// pipeline; only the path filter and the rendered count differ.
+	it.each( [
+		[
+			'primary button sends status=failed,abandoned',
+			'Copy failed traces for support (3)',
+			( path ) =>
+				path.includes( 'status[]=failed' ) &&
+				path.includes( 'status[]=abandoned' ),
+			'Copied 3 traces to clipboard.',
+		],
+		[
+			'secondary link sends no status filter',
+			'Copy all instead',
+			( path ) => ! path.includes( 'status[]' ),
+			'Copied 4 traces to clipboard.',
+		],
+	] )(
+		'click → fetch → clipboard → notice: %s',
+		async ( _label, buttonText, pathMatches, expectedNotice ) => {
+			const tracesCount = expectedNotice.includes( '4' ) ? 4 : 3;
+			apiFetch
+				.mockResolvedValueOnce( summaryFixture() )
+				.mockResolvedValueOnce( tracesFixture( tracesCount ) )
+				.mockResolvedValueOnce( summaryFixture() );
+
+			render( <DiagnosticsTraces /> );
+			await userEvent.click( await screen.findByText( buttonText ) );
+
+			await waitFor( () =>
+				expect( navigator.clipboard.writeText ).toHaveBeenCalled()
+			);
+			expect( pathMatches( apiFetch.mock.calls[ 1 ][ 0 ].path ) ).toBe(
+				true
+			);
+			await screen.findByText( expectedNotice );
+		}
+	);
+
+	it( 'shows an error notice when the traces fetch fails', async () => {
+		apiFetch
+			.mockResolvedValueOnce( summaryFixture() )
+			.mockRejectedValueOnce( new Error( 'boom' ) );
+
+		render( <DiagnosticsTraces /> );
+		await userEvent.click(
+			await screen.findByText( 'Copy failed traces for support (3)' )
+		);
+
+		const notice = await screen.findByText( /Could not copy traces/ );
+		expect( notice.dataset.status ).toBe( 'error' );
+	} );
+
+	it( 'falls back to a file download when the trace bundle exceeds the clipboard threshold', async () => {
+		// Force a > 1MB JSON payload by inflating events.
+		const bigEvent = { kind: 'pad', data: 'x'.repeat( 600 * 1024 ) };
+		const bigTraces = {
+			traces: [
+				{ id: 'big1', status: 'failed', events: [ bigEvent ] },
+				{ id: 'big2', status: 'failed', events: [ bigEvent ] },
+			],
+			count: 2,
+		};
+		apiFetch
+			.mockResolvedValueOnce( summaryFixture() )
+			.mockResolvedValueOnce( bigTraces )
+			.mockResolvedValueOnce( summaryFixture() );
+
+		const createObjectURL = jest.fn().mockReturnValue( 'blob:fake' );
+		Object.defineProperty( global.URL, 'createObjectURL', {
+			value: createObjectURL,
+			writable: true,
+		} );
+		Object.defineProperty( global.URL, 'revokeObjectURL', {
+			value: jest.fn(),
+			writable: true,
+		} );
+
+		render( <DiagnosticsTraces /> );
+		await userEvent.click(
+			await screen.findByText( 'Copy failed traces for support (3)' )
+		);
+
+		await screen.findByText( /downloaded as a file instead/ );
+		expect( createObjectURL ).toHaveBeenCalled();
+		expect( navigator.clipboard.writeText ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/settings/advanced-settings-section/__tests__/index.test.js
+++ b/client/settings/advanced-settings-section/__tests__/index.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import AdvancedSettings from '..';
+import apiFetch from '@wordpress/api-fetch';
 import {
 	useDebugLog,
 	useDiagnosticsMode,
@@ -26,12 +27,21 @@ jest.mock( '@woocommerce/navigation', () => ( {
 	getQuery: jest.fn().mockReturnValue( {} ),
 } ) );
 
+// DiagnosticsTraces (rendered by DiagnosticsMode) fires a /summary fetch on
+// mount. Stub it out at this layer so the existing AdvancedSettings tests
+// don't trigger an unwrapped state update warning. The component's own
+// behavior is covered by diagnostics-traces.test.js.
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
 describe( 'AdvancedSettings', () => {
 	beforeEach( () => {
 		global.wc_stripe_settings_params = {
 			is_cs_available: false,
 			is_oc_available: false,
 		};
+
+		// Default: no traces stored, so DiagnosticsTraces collapses to null.
+		apiFetch.mockResolvedValue( { counts: {}, total: 0 } );
 
 		useDebugLog.mockReturnValue( [ true, jest.fn() ] );
 		useDiagnosticsMode.mockReturnValue( [ false, jest.fn() ] );

--- a/client/settings/advanced-settings-section/diagnostics-mode.js
+++ b/client/settings/advanced-settings-section/diagnostics-mode.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import DiagnosticsTraces from './diagnostics-traces';
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '@wordpress/components';
 import { useDiagnosticsMode } from 'wcstripe/data';
@@ -25,6 +26,7 @@ const DiagnosticsMode = () => {
 				checked={ isDiagnosticsChecked }
 				onChange={ setIsDiagnosticsChecked }
 			/>
+			<DiagnosticsTraces />
 		</>
 	);
 };

--- a/client/settings/advanced-settings-section/diagnostics-traces.js
+++ b/client/settings/advanced-settings-section/diagnostics-traces.js
@@ -1,0 +1,194 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { Button, Notice } from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+import { NAMESPACE } from 'wcstripe/data/constants';
+
+// Clipboard writes silently truncate or fail above a few MB on most
+// browsers, and ticket forms strip large pastes long before that. Falling
+// back to a file download above this size is cheap insurance.
+const CLIPBOARD_BYTE_THRESHOLD = 1024 * 1024;
+
+// Status filter used by the primary "Copy failed traces for support"
+// button. Mirrors the spec's "what support actually needs" — failures plus
+// the shopper-walked-away signal that finalizes via `express.cancel`.
+const SUPPORT_STATUSES = [ 'failed', 'abandoned' ];
+
+const buildTracesPath = ( statuses ) => {
+	if ( ! statuses ) {
+		return `${ NAMESPACE }/diagnostics/traces`;
+	}
+	const query = statuses
+		.map( ( s ) => `status[]=${ encodeURIComponent( s ) }` )
+		.join( '&' );
+	return `${ NAMESPACE }/diagnostics/traces?${ query }`;
+};
+
+const downloadAsFile = ( contents ) => {
+	const blob = new Blob( [ contents ], { type: 'application/json' } );
+	const url = URL.createObjectURL( blob );
+	const link = document.createElement( 'a' );
+	const stamp = new Date().toISOString().replace( /[:.]/g, '-' );
+	link.href = url;
+	link.download = `wc-stripe-diagnostics-${ stamp }.json`;
+	document.body.appendChild( link );
+	link.click();
+	document.body.removeChild( link );
+	URL.revokeObjectURL( url );
+};
+
+const DiagnosticsTraces = () => {
+	const [ summary, setSummary ] = useState( null );
+	const [ isCopying, setIsCopying ] = useState( false );
+	const [ feedback, setFeedback ] = useState( null );
+
+	const refreshSummary = useCallback( () => {
+		apiFetch( { path: `${ NAMESPACE }/diagnostics/summary` } )
+			.then( setSummary )
+			.catch( () => setSummary( { counts: {}, total: 0 } ) );
+	}, [] );
+
+	useEffect( () => {
+		refreshSummary();
+	}, [ refreshSummary ] );
+
+	if ( ! summary || ! summary.total ) {
+		return null;
+	}
+
+	const counts = summary.counts || {};
+	const failed = counts.failed || 0;
+	const abandoned = counts.abandoned || 0;
+	const completed = counts.completed || 0;
+	const pending = counts.pending || 0;
+	const supportCount = failed + abandoned;
+
+	// Build the breakdown list dynamically so empty buckets disappear
+	// rather than showing a noisy "0 abandoned" segment.
+	const breakdownSegments = [
+		failed > 0 &&
+			sprintf(
+				/* translators: %d: number of failed traces */
+				__( '%d failed', 'woocommerce-gateway-stripe' ),
+				failed
+			),
+		abandoned > 0 &&
+			sprintf(
+				/* translators: %d: number of abandoned traces */
+				__( '%d abandoned', 'woocommerce-gateway-stripe' ),
+				abandoned
+			),
+		completed > 0 &&
+			sprintf(
+				/* translators: %d: number of succeeded traces */
+				__( '%d succeeded', 'woocommerce-gateway-stripe' ),
+				completed
+			),
+		pending > 0 &&
+			sprintf(
+				/* translators: %d: number of pending traces */
+				__( '%d pending', 'woocommerce-gateway-stripe' ),
+				pending
+			),
+	].filter( Boolean );
+
+	const handleCopy = async ( statuses ) => {
+		setIsCopying( true );
+		setFeedback( null );
+		try {
+			const response = await apiFetch( {
+				path: buildTracesPath( statuses ),
+			} );
+			const json = JSON.stringify( response.traces, null, 2 );
+			const bytes = new Blob( [ json ] ).size;
+
+			if ( bytes > CLIPBOARD_BYTE_THRESHOLD ) {
+				downloadAsFile( json );
+				setFeedback( {
+					status: 'success',
+					message: __(
+						'Trace bundle was too large to copy — downloaded as a file instead.',
+						'woocommerce-gateway-stripe'
+					),
+				} );
+			} else {
+				await navigator.clipboard.writeText( json );
+				setFeedback( {
+					status: 'success',
+					message: sprintf(
+						/* translators: %d: number of traces */
+						_n(
+							'Copied %d trace to clipboard.',
+							'Copied %d traces to clipboard.',
+							response.count,
+							'woocommerce-gateway-stripe'
+						),
+						response.count
+					),
+				} );
+			}
+			refreshSummary();
+		} catch ( err ) {
+			setFeedback( {
+				status: 'error',
+				message: __(
+					'Could not copy traces. Try again, or check the browser console for details.',
+					'woocommerce-gateway-stripe'
+				),
+			} );
+		} finally {
+			setIsCopying( false );
+		}
+	};
+
+	return (
+		<div className="wc-stripe-diagnostics-traces">
+			<p>
+				{ sprintf(
+					/* translators: 1: total trace count, 2: comma-separated breakdown of non-zero status counts */
+					_n(
+						'%1$d trace captured (%2$s)',
+						'%1$d traces captured (%2$s)',
+						summary.total,
+						'woocommerce-gateway-stripe'
+					),
+					summary.total,
+					breakdownSegments.join( ', ' )
+				) }
+			</p>
+			<Button
+				variant="primary"
+				isBusy={ isCopying }
+				disabled={ isCopying || supportCount === 0 }
+				onClick={ () => handleCopy( SUPPORT_STATUSES ) }
+			>
+				{ sprintf(
+					/* translators: %d: count of failed + abandoned traces */
+					__(
+						'Copy failed traces for support (%d)',
+						'woocommerce-gateway-stripe'
+					),
+					supportCount
+				) }
+			</Button>{ ' ' }
+			<Button
+				variant="link"
+				disabled={ isCopying }
+				onClick={ () => handleCopy( null ) }
+			>
+				{ __( 'Copy all instead', 'woocommerce-gateway-stripe' ) }
+			</Button>
+			{ feedback && (
+				<Notice
+					status={ feedback.status }
+					isDismissible
+					onRemove={ () => setFeedback( null ) }
+				>
+					{ feedback.message }
+				</Notice>
+			) }
+		</div>
+	);
+};
+
+export default DiagnosticsTraces;

--- a/client/settings/advanced-settings-section/diagnostics-traces.js
+++ b/client/settings/advanced-settings-section/diagnostics-traces.js
@@ -34,7 +34,9 @@ const downloadAsFile = ( contents ) => {
 	document.body.appendChild( link );
 	link.click();
 	document.body.removeChild( link );
-	URL.revokeObjectURL( url );
+	// Defer the revoke to give Safari/iOS time to start the download —
+	// synchronous revoke can produce a 0-byte file there.
+	setTimeout( () => URL.revokeObjectURL( url ), 0 );
 };
 
 const DiagnosticsTraces = () => {
@@ -132,7 +134,7 @@ const DiagnosticsTraces = () => {
 			setFeedback( {
 				status: 'error',
 				message: __(
-					'Could not copy traces. Try again, or check the browser console for details.',
+					'Could not copy traces. Try again.',
 					'woocommerce-gateway-stripe'
 				),
 			} );

--- a/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
+++ b/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
@@ -3,12 +3,12 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * REST controller for the diagnostics events ingest endpoint.
+ * REST controller for the diagnostics endpoints.
  *
- * Takes the frontend recorder's batched events and writes them to the
- * trace store.
- *
- * Route: POST /wc/v3/wc_stripe/diagnostics/events
+ * Routes:
+ * - POST /wc/v3/wc_stripe/diagnostics/events  (shopper-facing event ingest)
+ * - GET  /wc/v3/wc_stripe/diagnostics/summary (admin: per-status counts)
+ * - GET  /wc/v3/wc_stripe/diagnostics/traces  (admin: full trace JSON, filtered)
  */
 class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 
@@ -25,8 +25,22 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 	 */
 	private $store;
 
-	public function __construct( ?WC_Stripe_Diagnostics_Trace_Store $store = null ) {
-		$this->store = $store ?? new WC_Stripe_Diagnostics_Trace_Store();
+	/**
+	 * Outcome promoter — keeps the trace's stored status field in sync as
+	 * client events come in (createPaymentMethod errors, blocks setup
+	 * failures, express cancels) so the merchant-facing "Copy failed
+	 * traces" filter has the right answer to read from.
+	 *
+	 * @var WC_Stripe_Diagnostics_Outcome_Promoter
+	 */
+	private $promoter;
+
+	public function __construct(
+		?WC_Stripe_Diagnostics_Trace_Store $store = null,
+		?WC_Stripe_Diagnostics_Outcome_Promoter $promoter = null
+	) {
+		$this->store    = $store ?? new WC_Stripe_Diagnostics_Trace_Store();
+		$this->promoter = $promoter ?? new WC_Stripe_Diagnostics_Outcome_Promoter( $this->store );
 	}
 
 	/**
@@ -51,6 +65,103 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 					],
 				],
 			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/summary',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_summary' ],
+				'permission_callback' => [ $this, 'admin_permissions_check' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/traces',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_traces' ],
+				'permission_callback' => [ $this, 'admin_permissions_check' ],
+				'args'                => [
+					'status' => [
+						'required' => false,
+						'type'     => 'array',
+						'items'    => [ 'type' => 'string' ],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Permission callback for the admin endpoints (summary, traces). The
+	 * shopper-facing /events endpoint uses {@see self::permissions_check()}
+	 * instead.
+	 *
+	 * Intentionally does NOT gate on the diagnostics-enabled toggle — a
+	 * merchant who disables capture must still be able to copy or clear
+	 * traces that were captured while the toggle was on.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function admin_permissions_check() {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return new WP_Error(
+				'wc_stripe_diagnostics_forbidden',
+				'Insufficient permissions.',
+				[ 'status' => rest_authorization_required_code() ]
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Return per-status counts for the admin breakdown row
+	 * ("X traces (Y failed, Z abandoned, W succeeded, K pending)"). Always
+	 * includes every status as a key — zero-counted buckets render alongside
+	 * populated ones without conditional plumbing.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_summary() {
+		$counts = $this->store->count_by_status();
+		return new WP_REST_Response(
+			[
+				'counts' => $counts,
+				'total'  => array_sum( $counts ),
+			],
+			200
+		);
+	}
+
+	/**
+	 * Return full trace JSON for the requested statuses. Powers the
+	 * "Copy failed traces for support" button (status=failed,abandoned)
+	 * and the "Copy all instead" link (no status filter).
+	 *
+	 * @param WP_REST_Request<array<string, mixed>> $request
+	 * @return WP_REST_Response
+	 */
+	public function get_traces( $request ) {
+		$statuses = $request->get_param( 'status' );
+		if ( ! is_array( $statuses ) || empty( $statuses ) ) {
+			// "Copy all" path — no filter, every status included.
+			$statuses = [
+				WC_Stripe_Diagnostics_Trace_Store::STATUS_PENDING,
+				WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED,
+				WC_Stripe_Diagnostics_Trace_Store::STATUS_COMPLETED,
+				WC_Stripe_Diagnostics_Trace_Store::STATUS_ABANDONED,
+			];
+		}
+		$traces = $this->store->get_by_status( $statuses );
+		return new WP_REST_Response(
+			[
+				'traces' => $traces,
+				'count'  => count( $traces ),
+			],
+			200
 		);
 	}
 
@@ -108,6 +219,7 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 			}
 			if ( $this->store->append_event( $session_id, $raw ) ) {
 				++$written;
+				$this->promoter->maybe_promote( $session_id, $raw );
 			}
 		}
 

--- a/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
+++ b/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
@@ -35,12 +35,24 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 	 */
 	private $promoter;
 
+	/**
+	 * Redactor used to scrub client-supplied event payloads before they
+	 * land in the trace store. Without this, the un-trusted `data` blob
+	 * a shopper's browser POSTs would flow into trace files that the
+	 * merchant copies into support tickets.
+	 *
+	 * @var WC_Stripe_Diagnostics_Redactor
+	 */
+	private $redactor;
+
 	public function __construct(
 		?WC_Stripe_Diagnostics_Trace_Store $store = null,
-		?WC_Stripe_Diagnostics_Outcome_Promoter $promoter = null
+		?WC_Stripe_Diagnostics_Outcome_Promoter $promoter = null,
+		?WC_Stripe_Diagnostics_Redactor $redactor = null
 	) {
 		$this->store    = $store ?? new WC_Stripe_Diagnostics_Trace_Store();
 		$this->promoter = $promoter ?? new WC_Stripe_Diagnostics_Outcome_Promoter( $this->store );
+		$this->redactor = $redactor ?? new WC_Stripe_Diagnostics_Redactor();
 	}
 
 	/**
@@ -217,9 +229,18 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 			if ( ! is_array( $raw ) ) {
 				continue;
 			}
-			if ( $this->store->append_event( $session_id, $raw ) ) {
+			// Scrub PII patterns (PAN/CVV/email/IP) from string values
+			// before storing. We use scrub_value() rather than the full
+			// redact() allow-list because the client SDK event shape
+			// uses nested `data.*` fields the current allow-list doesn't
+			// describe — full allow-list compliance is a follow-up.
+			$scrubbed = $this->redactor->scrub_value( $raw );
+			if ( ! is_array( $scrubbed ) ) {
+				continue;
+			}
+			if ( $this->store->append_event( $session_id, $scrubbed ) ) {
 				++$written;
-				$this->promoter->maybe_promote( $session_id, $raw );
+				$this->promoter->maybe_promote( $session_id, $scrubbed );
 			}
 		}
 

--- a/includes/diagnostics/class-wc-stripe-diagnostics-outcome-promoter.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-outcome-promoter.php
@@ -81,6 +81,13 @@ class WC_Stripe_Diagnostics_Outcome_Promoter {
 			return null;
 		}
 
+		// Stripe.js wrapped-call rejections, emitted by aroundStripeCall()
+		// as `stripe.<method>.throw` for any thrown error (network drop, JS
+		// exception). Treat as failure regardless of which method threw.
+		if ( 0 === strncmp( $kind, 'stripe.', 7 ) && str_ends_with( $kind, '.throw' ) ) {
+			return WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED;
+		}
+
 		switch ( $kind ) {
 			case 'stripe.api.response':
 				if ( isset( $event['error'] ) && ! empty( $event['error'] ) ) {
@@ -96,7 +103,11 @@ class WC_Stripe_Diagnostics_Outcome_Promoter {
 				if ( str_ends_with( $type, '.payment_failed' ) ) {
 					return WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED;
 				}
-				if ( str_ends_with( $type, '.succeeded' ) ) {
+				// Explicit allowlist — `setup_intent.succeeded` etc. fire
+				// for save-card flows that never charge, so a generic
+				// `.succeeded` match would mislabel those as completed
+				// checkouts.
+				if ( in_array( $type, [ 'payment_intent.succeeded', 'charge.succeeded' ], true ) ) {
 					return WC_Stripe_Diagnostics_Trace_Store::STATUS_COMPLETED;
 				}
 				return null;

--- a/includes/diagnostics/class-wc-stripe-diagnostics-outcome-promoter.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-outcome-promoter.php
@@ -1,0 +1,126 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Promotes a diagnostics trace to a terminal status based on the events
+ * flowing through it.
+ *
+ * Both the server-side recorder and the client-event REST controller call
+ * {@see self::maybe_promote()} after appending each event. That keeps the
+ * status field correct regardless of which side captured the failure
+ * (frontend createPaymentMethod errors, server-side Stripe API errors,
+ * webhook results) and lets the merchant-facing "Copy failed traces" filter
+ * work off a single stored field instead of re-walking events at copy time.
+ *
+ * Precedence rules:
+ * - `failed` and `completed` are last-write-wins, so a 3DS retry that errors
+ *   then succeeds correctly ends as `completed`.
+ * - `abandoned` only promotes from `pending`. A late `express.cancel` after
+ *   a confirmed failure or success must not downgrade the trace.
+ */
+class WC_Stripe_Diagnostics_Outcome_Promoter {
+
+	/**
+	 * Trace store that holds the status field being mutated.
+	 *
+	 * @var WC_Stripe_Diagnostics_Trace_Store
+	 */
+	private $store;
+
+	/**
+	 * Construct with the trace store the promoter mutates.
+	 *
+	 * @param WC_Stripe_Diagnostics_Trace_Store $store Trace store.
+	 */
+	public function __construct( WC_Stripe_Diagnostics_Trace_Store $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * Apply the precedence rules and write the new status to the trace
+	 * store, when the event carries a recognized signal.
+	 *
+	 * @param string $session_id Trace identifier.
+	 * @param array  $event      The event just appended to the trace.
+	 */
+	public function maybe_promote( string $session_id, array $event ): void {
+		$signal = self::classify_event( $event );
+		if ( null === $signal ) {
+			return;
+		}
+
+		// `abandoned` only promotes from `pending`; never downgrade a
+		// known failure or success when a late wallet-cancel arrives.
+		if ( WC_Stripe_Diagnostics_Trace_Store::STATUS_ABANDONED === $signal ) {
+			$trace = $this->store->get( $session_id );
+			if ( null === $trace ) {
+				return;
+			}
+			$current = isset( $trace['status'] ) ? (string) $trace['status'] : WC_Stripe_Diagnostics_Trace_Store::STATUS_PENDING;
+			if ( WC_Stripe_Diagnostics_Trace_Store::STATUS_PENDING !== $current ) {
+				return;
+			}
+		}
+
+		$this->store->set_status( $session_id, $signal );
+	}
+
+	/**
+	 * Map an event to the status it implies, or null when the event
+	 * carries no terminal signal. Pure function — exposed (and tested)
+	 * separately from {@see self::maybe_promote()} so the classification
+	 * matrix is verifiable without touching the trace store.
+	 *
+	 * @param array $event Event payload.
+	 * @return string|null One of the WC_Stripe_Diagnostics_Trace_Store::STATUS_* constants, or null.
+	 */
+	public static function classify_event( array $event ): ?string {
+		$kind = isset( $event['kind'] ) ? (string) $event['kind'] : '';
+		if ( '' === $kind ) {
+			return null;
+		}
+
+		switch ( $kind ) {
+			case 'stripe.api.response':
+				if ( isset( $event['error'] ) && ! empty( $event['error'] ) ) {
+					return WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED;
+				}
+				return null;
+
+			case 'webhook.received':
+				$type = isset( $event['type'] ) ? (string) $event['type'] : '';
+				if ( '' === $type ) {
+					return null;
+				}
+				if ( str_ends_with( $type, '.payment_failed' ) ) {
+					return WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED;
+				}
+				if ( str_ends_with( $type, '.succeeded' ) ) {
+					return WC_Stripe_Diagnostics_Trace_Store::STATUS_COMPLETED;
+				}
+				return null;
+
+			case 'stripe.createPaymentMethod.resolve':
+			case 'stripe.confirmPayment.resolve':
+				$data = isset( $event['data'] ) && is_array( $event['data'] ) ? $event['data'] : [];
+				if ( ! empty( $data['has_error'] ) ) {
+					return WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED;
+				}
+				return null;
+
+			case 'blocks.payment_setup.end':
+				$data   = isset( $event['data'] ) && is_array( $event['data'] ) ? $event['data'] : [];
+				$result = isset( $data['result_type'] ) ? (string) $data['result_type'] : '';
+				if ( in_array( $result, [ 'failure', 'error' ], true ) ) {
+					return WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED;
+				}
+				return null;
+
+			case 'express.cancel':
+				return WC_Stripe_Diagnostics_Trace_Store::STATUS_ABANDONED;
+		}
+
+		return null;
+	}
+}

--- a/includes/diagnostics/class-wc-stripe-diagnostics-recorder.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-recorder.php
@@ -50,6 +50,15 @@ class WC_Stripe_Diagnostics_Recorder {
 	private $redactor;
 
 	/**
+	 * Outcome promoter — keeps the trace's stored status field in sync with
+	 * the events as they're recorded so the merchant-facing "Copy failed
+	 * traces" filter can read a single field instead of re-walking events.
+	 *
+	 * @var WC_Stripe_Diagnostics_Outcome_Promoter
+	 */
+	private $promoter;
+
+	/**
 	 * The current session id for this request, if any.
 	 *
 	 * @var string|null
@@ -77,9 +86,11 @@ class WC_Stripe_Diagnostics_Recorder {
 	 */
 	public static function get_instance(): self {
 		if ( null === self::$instance ) {
+			$store          = new WC_Stripe_Diagnostics_Trace_Store();
 			self::$instance = new self(
-				new WC_Stripe_Diagnostics_Trace_Store(),
-				new WC_Stripe_Diagnostics_Redactor()
+				$store,
+				new WC_Stripe_Diagnostics_Redactor(),
+				new WC_Stripe_Diagnostics_Outcome_Promoter( $store )
 			);
 		}
 		return self::$instance;
@@ -89,12 +100,18 @@ class WC_Stripe_Diagnostics_Recorder {
 	 * Construct with explicit dependencies. Tests inject fakes via this ctor;
 	 * production callers should use {@see self::get_instance()}.
 	 *
-	 * @param WC_Stripe_Diagnostics_Trace_Store $store    Trace store.
-	 * @param WC_Stripe_Diagnostics_Redactor    $redactor Redaction engine.
+	 * @param WC_Stripe_Diagnostics_Trace_Store           $store    Trace store.
+	 * @param WC_Stripe_Diagnostics_Redactor              $redactor Redaction engine.
+	 * @param WC_Stripe_Diagnostics_Outcome_Promoter|null $promoter Optional outcome promoter; defaults to one wrapping $store.
 	 */
-	public function __construct( WC_Stripe_Diagnostics_Trace_Store $store, WC_Stripe_Diagnostics_Redactor $redactor ) {
+	public function __construct(
+		WC_Stripe_Diagnostics_Trace_Store $store,
+		WC_Stripe_Diagnostics_Redactor $redactor,
+		?WC_Stripe_Diagnostics_Outcome_Promoter $promoter = null
+	) {
 		$this->store    = $store;
 		$this->redactor = $redactor;
+		$this->promoter = $promoter ?? new WC_Stripe_Diagnostics_Outcome_Promoter( $store );
 	}
 
 	/**
@@ -225,7 +242,7 @@ class WC_Stripe_Diagnostics_Recorder {
 			unset( $this->request_start_times[ $start_key ] );
 		}
 
-		$event = [
+		$event    = [
 			'kind'       => 'stripe.api.response',
 			'ts'         => time(),
 			'api'        => (string) $api,
@@ -234,7 +251,9 @@ class WC_Stripe_Diagnostics_Recorder {
 			'request_id' => self::extract_request_id( $response_body ),
 			'error'      => self::extract_error( $response_body ),
 		];
-		$this->store->append_event( $session_id, $this->redactor->redact( $event ) );
+		$redacted = $this->redactor->redact( $event );
+		$this->store->append_event( $session_id, $redacted );
+		$this->promoter->maybe_promote( $session_id, $redacted );
 	}
 
 	/**
@@ -255,21 +274,20 @@ class WC_Stripe_Diagnostics_Recorder {
 
 		$object = self::webhook_object( $notification );
 
-		$this->store->append_event(
-			$session_id,
-			$this->redactor->redact(
-				[
-					'kind'       => 'webhook.received',
-					'ts'         => time(),
-					'type'       => (string) $webhook_type,
-					'status'     => is_object( $object ) && isset( $object->status ) ? (string) $object->status : null,
-					'intent_id'  => is_object( $object ) && isset( $object->object, $object->id ) && 'payment_intent' === $object->object ? (string) $object->id : null,
-					'charge_id'  => is_object( $object ) && isset( $object->object, $object->id ) && 'charge' === $object->object ? (string) $object->id : null,
-					'order_id'   => is_object( $resolved_order ) && method_exists( $resolved_order, 'get_id' ) ? (int) $resolved_order->get_id() : null,
-					'session_id' => $session_id,
-				]
-			)
+		$redacted = $this->redactor->redact(
+			[
+				'kind'       => 'webhook.received',
+				'ts'         => time(),
+				'type'       => (string) $webhook_type,
+				'status'     => is_object( $object ) && isset( $object->status ) ? (string) $object->status : null,
+				'intent_id'  => is_object( $object ) && isset( $object->object, $object->id ) && 'payment_intent' === $object->object ? (string) $object->id : null,
+				'charge_id'  => is_object( $object ) && isset( $object->object, $object->id ) && 'charge' === $object->object ? (string) $object->id : null,
+				'order_id'   => is_object( $resolved_order ) && method_exists( $resolved_order, 'get_id' ) ? (int) $resolved_order->get_id() : null,
+				'session_id' => $session_id,
+			]
 		);
+		$this->store->append_event( $session_id, $redacted );
+		$this->promoter->maybe_promote( $session_id, $redacted );
 	}
 
 	/**

--- a/includes/diagnostics/class-wc-stripe-diagnostics-trace-store.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-trace-store.php
@@ -122,10 +122,10 @@ class WC_Stripe_Diagnostics_Trace_Store {
 	}
 
 	/**
-	 * Promote a trace to a terminal status (completed | abandoned).
+	 * Promote a trace to a terminal status (completed | abandoned | failed).
 	 *
 	 * @param string $session_id Session identifier.
-	 * @param string $status     One of STATUS_COMPLETED, STATUS_ABANDONED.
+	 * @param string $status     One of STATUS_COMPLETED, STATUS_ABANDONED, STATUS_FAILED.
 	 * @return bool True if status was updated.
 	 */
 	public function set_status( $session_id, $status ) {

--- a/includes/diagnostics/class-wc-stripe-diagnostics-trace-store.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-trace-store.php
@@ -35,6 +35,7 @@ class WC_Stripe_Diagnostics_Trace_Store {
 	const STATUS_PENDING   = 'pending';
 	const STATUS_COMPLETED = 'completed';
 	const STATUS_ABANDONED = 'abandoned';
+	const STATUS_FAILED    = 'failed';
 
 	/**
 	 * Cached absolute path (with trailing slash) to the trace storage dir.
@@ -132,7 +133,7 @@ class WC_Stripe_Diagnostics_Trace_Store {
 		if ( '' === $session_id ) {
 			return false;
 		}
-		if ( ! in_array( $status, [ self::STATUS_COMPLETED, self::STATUS_ABANDONED ], true ) ) {
+		if ( ! in_array( $status, [ self::STATUS_COMPLETED, self::STATUS_ABANDONED, self::STATUS_FAILED ], true ) ) {
 			return false;
 		}
 		if ( ! $this->ensure_storage_dir() ) {
@@ -235,6 +236,71 @@ class WC_Stripe_Diagnostics_Trace_Store {
 	 */
 	public function is_full() {
 		return $this->count() >= self::MAX_TRACES;
+	}
+
+	/**
+	 * Group stored traces by status. Always returns every defined status as
+	 * a key (zero-counted when no traces match), so the merchant-facing
+	 * breakdown UI can render every bucket without conditional plumbing.
+	 *
+	 * @return array<string, int>
+	 */
+	public function count_by_status(): array {
+		$counts = [
+			self::STATUS_PENDING   => 0,
+			self::STATUS_FAILED    => 0,
+			self::STATUS_COMPLETED => 0,
+			self::STATUS_ABANDONED => 0,
+		];
+		foreach ( $this->read_index() as $id ) {
+			$trace = $this->read_trace( (string) $id );
+			if ( null === $trace ) {
+				continue;
+			}
+			$status = isset( $trace['status'] ) ? (string) $trace['status'] : self::STATUS_PENDING;
+			if ( isset( $counts[ $status ] ) ) {
+				++$counts[ $status ];
+			}
+		}
+		return $counts;
+	}
+
+	/**
+	 * Return decoded traces whose stored status matches one of the given
+	 * statuses. Unknown status values are silently dropped from the filter
+	 * so a careless caller can't widen it accidentally.
+	 *
+	 * @param string[] $statuses Statuses to include.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function get_by_status( array $statuses ): array {
+		$statuses = array_values(
+			array_intersect(
+				$statuses,
+				[
+					self::STATUS_PENDING,
+					self::STATUS_FAILED,
+					self::STATUS_COMPLETED,
+					self::STATUS_ABANDONED,
+				]
+			)
+		);
+		if ( empty( $statuses ) ) {
+			return [];
+		}
+
+		$matches = [];
+		foreach ( $this->read_index() as $id ) {
+			$trace = $this->read_trace( (string) $id );
+			if ( null === $trace ) {
+				continue;
+			}
+			$status = isset( $trace['status'] ) ? (string) $trace['status'] : self::STATUS_PENDING;
+			if ( in_array( $status, $statuses, true ) ) {
+				$matches[] = $trace;
+			}
+		}
+		return $matches;
 	}
 
 	/**

--- a/tests/phpunit/diagnostics/class-wc-rest-stripe-diagnostics-controller-test.php
+++ b/tests/phpunit/diagnostics/class-wc-rest-stripe-diagnostics-controller-test.php
@@ -148,6 +148,101 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 		$this->assertSame( 200, count( $this->store->get( 'big' )['events'] ) );
 	}
 
+	/**
+	 * Admin endpoints require `manage_woocommerce` regardless of whether
+	 * the diagnostics toggle is on or off (a merchant who disabled capture
+	 * must still be able to copy traces from when it was on).
+	 *
+	 * @dataProvider admin_permission_matrix
+	 */
+	public function test_admin_permissions_check( bool $is_admin, bool $toggle_on, bool $expect_allowed ) {
+		$this->set_diagnostics_enabled( $toggle_on );
+		if ( $is_admin ) {
+			wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+		} else {
+			wp_set_current_user( 0 );
+		}
+
+		$result = $this->controller->admin_permissions_check();
+
+		if ( $expect_allowed ) {
+			$this->assertTrue( $result );
+		} else {
+			$this->assertInstanceOf( WP_Error::class, $result );
+			$this->assertSame( 'wc_stripe_diagnostics_forbidden', $result->get_error_code() );
+		}
+	}
+
+	public function admin_permission_matrix(): array {
+		return [
+			'anon user, toggle on  → denied' => [ false, true, false ],
+			'anon user, toggle off → denied' => [ false, false, false ],
+			'admin user, toggle on  → allow' => [ true, true, true ],
+			'admin user, toggle off → allow' => [ true, false, true ],
+		];
+	}
+
+	/**
+	 * Summary always returns every status bucket as a key (zero-counted
+	 * included) plus a total — the frontend renders the breakdown row from
+	 * this shape directly.
+	 */
+	public function test_get_summary_returns_per_status_counts_and_total() {
+		$this->store->create( 'p1' );
+		$this->store->create( 'f1' );
+		$this->store->set_status( 'f1', WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED );
+		$this->store->create( 'c1' );
+		$this->store->set_status( 'c1', WC_Stripe_Diagnostics_Trace_Store::STATUS_COMPLETED );
+
+		$data = $this->controller->get_summary()->get_data();
+
+		$this->assertSame( 1, $data['counts'][ WC_Stripe_Diagnostics_Trace_Store::STATUS_PENDING ] );
+		$this->assertSame( 1, $data['counts'][ WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED ] );
+		$this->assertSame( 1, $data['counts'][ WC_Stripe_Diagnostics_Trace_Store::STATUS_COMPLETED ] );
+		$this->assertSame( 0, $data['counts'][ WC_Stripe_Diagnostics_Trace_Store::STATUS_ABANDONED ] );
+		$this->assertSame( 3, $data['total'] );
+	}
+
+	/**
+	 * Filter behavior of GET /traces. Single fixture (one trace per
+	 * terminal status) exercised from each call site:
+	 *   - "Copy failed traces" (status=failed,abandoned)
+	 *   - "Copy all instead"   (no status param)
+	 *   - empty filter result  (status=completed when no completed exists)
+	 *
+	 * @dataProvider get_traces_filter_matrix
+	 */
+	public function test_get_traces_filter_behavior( ?array $statuses, array $expected_ids, int $expected_count ) {
+		$this->store->create( 'p' );
+		$this->store->create( 'f' );
+		$this->store->set_status( 'f', WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED );
+		$this->store->create( 'a' );
+		$this->store->set_status( 'a', WC_Stripe_Diagnostics_Trace_Store::STATUS_ABANDONED );
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/wc_stripe/diagnostics/traces' );
+		if ( null !== $statuses ) {
+			$request->set_query_params( [ 'status' => $statuses ] );
+		}
+		$data = $this->controller->get_traces( $request )->get_data();
+		$ids  = array_column( $data['traces'], 'id' );
+		sort( $ids );
+
+		$this->assertSame( $expected_ids, $ids );
+		$this->assertSame( $expected_count, $data['count'] );
+	}
+
+	public function get_traces_filter_matrix(): array {
+		$failed    = WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED;
+		$abandoned = WC_Stripe_Diagnostics_Trace_Store::STATUS_ABANDONED;
+		$completed = WC_Stripe_Diagnostics_Trace_Store::STATUS_COMPLETED;
+
+		return [
+			'Copy failed (failed+abandoned filter)' => [ [ $failed, $abandoned ], [ 'a', 'f' ], 2 ],
+			'Copy all (no filter → all 3 traces)'   => [ null, [ 'a', 'f', 'p' ], 3 ],
+			'no matches → empty list'               => [ [ $completed ], [], 0 ],
+		];
+	}
+
 	public function test_ingest_evicts_oldest_trace_when_store_is_full() {
 		for ( $i = 0; $i < WC_Stripe_Diagnostics_Trace_Store::MAX_TRACES; $i++ ) {
 			$this->store->create( 'full' . $i );

--- a/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-outcome-promoter-test.php
+++ b/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-outcome-promoter-test.php
@@ -1,0 +1,206 @@
+<?php
+
+/**
+ * Tests for WC_Stripe_Diagnostics_Outcome_Promoter.
+ *
+ * @package WooCommerce/Stripe/Diagnostics
+ */
+class WC_Stripe_Diagnostics_Outcome_Promoter_Test extends WP_UnitTestCase {
+
+	/**
+	 * Trace store fixture.
+	 *
+	 * @var WC_Stripe_Diagnostics_Trace_Store
+	 */
+	private $store;
+
+	/**
+	 * Promoter under test.
+	 *
+	 * @var WC_Stripe_Diagnostics_Outcome_Promoter
+	 */
+	private $promoter;
+
+	public function set_up() {
+		parent::set_up();
+		$this->store    = new WC_Stripe_Diagnostics_Trace_Store();
+		$this->promoter = new WC_Stripe_Diagnostics_Outcome_Promoter( $this->store );
+		$this->store->delete_all();
+	}
+
+	public function tear_down() {
+		$this->store->delete_all();
+		parent::tear_down();
+	}
+
+	/**
+	 * Full classification matrix — single test, one data row per recognized
+	 * (or pointedly-not-recognized) signal. The label key on each row points
+	 * at the specific shape under test when something fails.
+	 *
+	 * @dataProvider event_classification_matrix
+	 *
+	 * @param array       $event    Event payload to classify.
+	 * @param string|null $expected Expected status, or null for no signal.
+	 */
+	public function test_classify_event( array $event, ?string $expected ) {
+		$this->assertSame( $expected, WC_Stripe_Diagnostics_Outcome_Promoter::classify_event( $event ) );
+	}
+
+	public function event_classification_matrix(): array {
+		$failed    = WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED;
+		$completed = WC_Stripe_Diagnostics_Trace_Store::STATUS_COMPLETED;
+		$abandoned = WC_Stripe_Diagnostics_Trace_Store::STATUS_ABANDONED;
+
+		return [
+			'api_response_with_error_failed'           => [
+				[
+					'kind'  => 'stripe.api.response',
+					'error' => [ 'code' => 'card_declined' ],
+				],
+				$failed,
+			],
+			'api_response_without_error_null'          => [
+				[
+					'kind' => 'stripe.api.response',
+					'id'   => 'pi_123',
+				],
+				null,
+			],
+			'webhook_payment_failed_failed'            => [
+				[
+					'kind' => 'webhook.received',
+					'type' => 'payment_intent.payment_failed',
+				],
+				$failed,
+			],
+			'webhook_succeeded_completed'              => [
+				[
+					'kind' => 'webhook.received',
+					'type' => 'payment_intent.succeeded',
+				],
+				$completed,
+			],
+			'create_payment_method_error_failed'       => [
+				[
+					'kind' => 'stripe.createPaymentMethod.resolve',
+					'data' => [ 'has_error' => true ],
+				],
+				$failed,
+			],
+			'confirm_payment_error_failed'             => [
+				[
+					'kind' => 'stripe.confirmPayment.resolve',
+					'data' => [ 'has_error' => true ],
+				],
+				$failed,
+			],
+			'blocks_payment_setup_result_failure'      => [
+				[
+					'kind' => 'blocks.payment_setup.end',
+					'data' => [ 'result_type' => 'failure' ],
+				],
+				$failed,
+			],
+			'blocks_payment_setup_result_error'        => [
+				[
+					'kind' => 'blocks.payment_setup.end',
+					'data' => [ 'result_type' => 'error' ],
+				],
+				$failed,
+			],
+			'blocks_payment_setup_result_success_null' => [
+				[
+					'kind' => 'blocks.payment_setup.end',
+					'data' => [ 'result_type' => 'success' ],
+				],
+				null,
+			],
+			'express_cancel_abandoned'                 => [
+				[ 'kind' => 'express.cancel' ],
+				$abandoned,
+			],
+			'unrelated_event_kind_null'                => [
+				[
+					'kind' => 'element.change',
+					'data' => [ 'complete' => true ],
+				],
+				null,
+			],
+			'event_without_kind_null'                  => [
+				[],
+				null,
+			],
+		];
+	}
+
+	/**
+	 * Precedence matrix for {@see WC_Stripe_Diagnostics_Outcome_Promoter::maybe_promote()}.
+	 *
+	 * Encodes the rules:
+	 *   - failed/completed are last-write-wins (so 3DS retry promotes
+	 *     failed → completed)
+	 *   - abandoned only promotes from pending (a late wallet-cancel
+	 *     never downgrades a confirmed terminal status)
+	 *   - unrecognized events are no-ops
+	 *
+	 * @dataProvider promotion_precedence_matrix
+	 *
+	 * @param string|null $starting_status Status to seed before firing the event, or null for fresh.
+	 * @param array       $event           Event to promote.
+	 * @param string      $expected_after  Expected status after promotion.
+	 */
+	public function test_maybe_promote_applies_precedence_rules( ?string $starting_status, array $event, string $expected_after ) {
+		$this->store->create( 'precedence' );
+		if ( null !== $starting_status ) {
+			$this->store->set_status( 'precedence', $starting_status );
+		}
+
+		$this->promoter->maybe_promote( 'precedence', $event );
+
+		$this->assertSame( $expected_after, $this->store->get( 'precedence' )['status'] );
+	}
+
+	public function promotion_precedence_matrix(): array {
+		$failed    = WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED;
+		$completed = WC_Stripe_Diagnostics_Trace_Store::STATUS_COMPLETED;
+		$abandoned = WC_Stripe_Diagnostics_Trace_Store::STATUS_ABANDONED;
+
+		$failure_signal     = [
+			'kind'  => 'stripe.api.response',
+			'error' => [ 'code' => 'card_declined' ],
+		];
+		$success_signal     = [
+			'kind' => 'webhook.received',
+			'type' => 'payment_intent.succeeded',
+		];
+		$abandoned_signal   = [ 'kind' => 'express.cancel' ];
+		$unrecognized_event = [ 'kind' => 'element.change' ];
+
+		return [
+			'pending_to_failed'              => [ null, $failure_signal, $failed ],
+			'failed_to_completed_3ds_retry'  => [ $failed, $success_signal, $completed ],
+			'completed_to_failed_last_write' => [ $completed, $failure_signal, $failed ],
+			'pending_to_abandoned_express'   => [ null, $abandoned_signal, $abandoned ],
+			'failed_blocks_abandoned'        => [ $failed, $abandoned_signal, $failed ],
+			'completed_blocks_abandoned'     => [ $completed, $abandoned_signal, $completed ],
+			'unrecognized_event_is_noop'     => [ $failed, $unrecognized_event, $failed ],
+		];
+	}
+
+	/**
+	 * Missing trace must be a silent no-op — the recorder may fire events
+	 * for sessions that haven't been created yet (e.g. lazy webhook
+	 * creation paths).
+	 */
+	public function test_maybe_promote_is_noop_when_trace_is_missing() {
+		$this->promoter->maybe_promote(
+			'ghost',
+			[
+				'kind' => 'webhook.received',
+				'type' => 'payment_intent.succeeded',
+			]
+		);
+		$this->assertNull( $this->store->get( 'ghost' ) );
+	}
+}

--- a/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-outcome-promoter-test.php
+++ b/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-outcome-promoter-test.php
@@ -81,6 +81,22 @@ class WC_Stripe_Diagnostics_Outcome_Promoter_Test extends WP_UnitTestCase {
 				],
 				$completed,
 			],
+			'webhook_charge_succeeded_completed'       => [
+				[
+					'kind' => 'webhook.received',
+					'type' => 'charge.succeeded',
+				],
+				$completed,
+			],
+			'webhook_setup_intent_succeeded_null'      => [
+				// Save-card flow never charges; must NOT mark a checkout
+				// as completed via the generic `.succeeded` suffix.
+				[
+					'kind' => 'webhook.received',
+					'type' => 'setup_intent.succeeded',
+				],
+				null,
+			],
 			'create_payment_method_error_failed'       => [
 				[
 					'kind' => 'stripe.createPaymentMethod.resolve',
@@ -119,6 +135,13 @@ class WC_Stripe_Diagnostics_Outcome_Promoter_Test extends WP_UnitTestCase {
 			'express_cancel_abandoned'                 => [
 				[ 'kind' => 'express.cancel' ],
 				$abandoned,
+			],
+			'stripe_call_throw_failed'                 => [
+				// aroundStripeCall() emits stripe.<method>.throw on Promise
+				// rejection (network drop, JS exception). Caught by the
+				// prefix/suffix check, not the case list.
+				[ 'kind' => 'stripe.confirmPayment.throw' ],
+				$failed,
 			],
 			'unrelated_event_kind_null'                => [
 				[

--- a/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-trace-store-test.php
+++ b/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-trace-store-test.php
@@ -74,6 +74,79 @@ class WC_Stripe_Diagnostics_Trace_Store_Test extends WP_UnitTestCase {
 		$this->assertFalse( $this->store->set_status( 'promote', 'nonsense' ) );
 	}
 
+	/**
+	 * STATUS_FAILED was added alongside the outcome promoter; covered here
+	 * to lock in that set_status accepts it (the existing
+	 * test_set_status_promotes_and_rejects_unknown_status only exercises
+	 * COMPLETED).
+	 */
+	public function test_set_status_accepts_failed() {
+		$this->store->create( 'failable' );
+		$this->assertTrue( $this->store->set_status( 'failable', WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED ) );
+		$this->assertSame(
+			WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED,
+			$this->store->get( 'failable' )['status']
+		);
+	}
+
+	/**
+	 * Powers the merchant-facing breakdown row. Single fixture covers both
+	 * "groups by status" and "zero-counts surface as keys" — UI relies on
+	 * the keys always being present so it can omit empty buckets cleanly.
+	 */
+	public function test_count_by_status_groups_traces_and_includes_zero_buckets() {
+		$this->store->create( 'p1' );
+		$this->store->create( 'p2' );
+		$this->store->create( 'f1' );
+		$this->store->set_status( 'f1', WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED );
+		$this->store->create( 'c1' );
+		$this->store->set_status( 'c1', WC_Stripe_Diagnostics_Trace_Store::STATUS_COMPLETED );
+		// Note: no abandoned trace created — must still show as 0, not missing.
+
+		$counts = $this->store->count_by_status();
+
+		$this->assertSame( 2, $counts[ WC_Stripe_Diagnostics_Trace_Store::STATUS_PENDING ] );
+		$this->assertSame( 1, $counts[ WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED ] );
+		$this->assertSame( 1, $counts[ WC_Stripe_Diagnostics_Trace_Store::STATUS_COMPLETED ] );
+		$this->assertSame( 0, $counts[ WC_Stripe_Diagnostics_Trace_Store::STATUS_ABANDONED ] );
+	}
+
+	/**
+	 * Filter behavior of get_by_status: single status, multi-status, empty
+	 * result, and silent drop of unknown values. Each row's key documents
+	 * the case under test so failures point at the specific scenario.
+	 *
+	 * @dataProvider get_by_status_filter_matrix
+	 */
+	public function test_get_by_status_filter_behavior( array $statuses, array $expected_ids ) {
+		// Shared fixture: one of each terminal status.
+		$this->store->create( 'p' );
+		$this->store->create( 'f1' );
+		$this->store->set_status( 'f1', WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED );
+		$this->store->create( 'f2' );
+		$this->store->set_status( 'f2', WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED );
+		$this->store->create( 'a' );
+		$this->store->set_status( 'a', WC_Stripe_Diagnostics_Trace_Store::STATUS_ABANDONED );
+
+		$ids = array_column( $this->store->get_by_status( $statuses ), 'id' );
+		sort( $ids );
+		$this->assertSame( $expected_ids, $ids );
+	}
+
+	public function get_by_status_filter_matrix(): array {
+		$failed    = WC_Stripe_Diagnostics_Trace_Store::STATUS_FAILED;
+		$abandoned = WC_Stripe_Diagnostics_Trace_Store::STATUS_ABANDONED;
+		$completed = WC_Stripe_Diagnostics_Trace_Store::STATUS_COMPLETED;
+
+		return [
+			'single status returns only matching traces' => [ [ $failed ], [ 'f1', 'f2' ] ],
+			'multiple statuses union-match'              => [ [ $failed, $abandoned ], [ 'a', 'f1', 'f2' ] ],
+			'no matches returns empty list'              => [ [ $completed ], [] ],
+			'unknown status values are dropped'          => [ [ 'nonsense', $failed ], [ 'f1', 'f2' ] ],
+			'all-unknown status drops to empty filter'   => [ [ 'nonsense' ], [] ],
+		];
+	}
+
 	public function test_fifo_eviction_at_trace_cap() {
 		$cap      = WC_Stripe_Diagnostics_Trace_Store::MAX_TRACES;
 		$overflow = 3;


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes RSM-1905

## Changes proposed in this Pull Request:

Adds a **Copy failed traces for support** action to the Checkout diagnostics panel

The action renders below the existing toggle, but only when traces exist. It shows a per-status count breakdown, a primary button that copies `failed + abandoned` traces to the clipboard, and a secondary *Copy all instead* link. Bundles larger than ~1MB fall back to a `.json` file download.

To make the filter accurate the trace's stored status needs to be current, so this PR also adds an **outcome promoter** that classifies events to a status with simple precedence (`failed`/`completed` last-write-wins; `abandoned` only promotes from `pending`):

| Source | Signal | New status |
|---|---|---|
| Server | `stripe.api.response` with `error` | `failed` |
| Server | `webhook.received` matching `*.payment_failed` / `*.succeeded` | `failed` / `completed` |
| Client | `stripe.createPaymentMethod.resolve` / `confirmPayment.resolve` `has_error` | `failed` |
| Client | `blocks.payment_setup.end` `result_type ∈ {failure, error}` | `failed` |
| Client | `express.cancel` | `abandoned` |

<img width="2246" height="1276" alt="CleanShot 2026-04-30 at 14 16 45@2x" src="https://github.com/user-attachments/assets/fc9fb987-cb03-4d75-aeaf-d2280749a096" />


<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. Enable **Capture checkout diagnostics** in WooCommerce → Settings → Payments → Stripe → Advanced.
2. Run a couple of test checkouts — one with `4242424242424242` (succeeds) and one with `4000000000000002` (declined).
3. Reload the Advanced settings page. Below the diagnostics toggle you should see:
   - a count breakdown line, e.g. *"2 traces captured (1 failed, 1 succeeded)"*
   - a **Copy failed traces for support (1)** primary button
   - a *Copy all instead* link
4. Click the button and paste anywhere; clipboard contains a JSON array with just the failed trace.
5. Click *Copy all instead*, clipboard now contains both traces.
6. Disable the toggle and reload. The breakdown + buttons should still appear (so existing data stays accessible).
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Unreleased feature

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
