### PR TITLE
[RSM - Diagnostics Mode] Instrument diagnostics mode usage

### DIFF
--- a/client/settings/advanced-settings-section/diagnostics-traces.js
+++ b/client/settings/advanced-settings-section/diagnostics-traces.js
@@ -3,6 +3,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { Button, Notice } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { NAMESPACE } from 'wcstripe/data/constants';
+import { recordEvent } from 'wcstripe/tracking';
 
 // Clipboard writes silently truncate or fail above a few MB on most
 // browsers, and ticket forms strip large pastes long before that. Falling
@@ -95,6 +96,8 @@ const DiagnosticsTraces = () => {
 	].filter( Boolean );
 
 	const handleCopy = async ( statuses ) => {
+		// 'support' when filtering to SUPPORT_STATUSES (failed + abandoned), 'all' otherwise.
+		const scope = statuses ? 'support' : 'all';
 		setIsCopying( true );
 		setFeedback( null );
 		try {
@@ -106,6 +109,11 @@ const DiagnosticsTraces = () => {
 
 			if ( bytes > CLIPBOARD_BYTE_THRESHOLD ) {
 				downloadAsFile( json );
+				recordEvent( 'wcstripe_diagnostics_copy_traces', {
+					scope,
+					result: 'download',
+					count: response.count,
+				} );
 				setFeedback( {
 					status: 'success',
 					message: __(
@@ -115,6 +123,11 @@ const DiagnosticsTraces = () => {
 				} );
 			} else {
 				await navigator.clipboard.writeText( json );
+				recordEvent( 'wcstripe_diagnostics_copy_traces', {
+					scope,
+					result: 'clipboard',
+					count: response.count,
+				} );
 				setFeedback( {
 					status: 'success',
 					message: sprintf(
@@ -131,6 +144,11 @@ const DiagnosticsTraces = () => {
 			}
 			refreshSummary();
 		} catch ( err ) {
+			recordEvent( 'wcstripe_diagnostics_copy_traces', {
+				scope,
+				result: 'error',
+				count: 0,
+			} );
 			setFeedback( {
 				status: 'error',
 				message: __(

--- a/client/settings/advanced-settings-section/diagnostics-traces.js
+++ b/client/settings/advanced-settings-section/diagnostics-traces.js
@@ -147,7 +147,7 @@ const DiagnosticsTraces = () => {
 			recordEvent( 'wcstripe_diagnostics_copy_traces', {
 				scope,
 				result: 'error',
-				count: 0,
+				count: null,
 			} );
 			setFeedback( {
 				status: 'error',

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -566,7 +566,20 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			return;
 		}
 
-		$this->gateway->update_option( 'diagnostics', $is_diagnostics_enabled ? 'yes' : 'no' );
+		$previous = 'yes' === $this->gateway->get_option( 'diagnostics' );
+		$next     = (bool) $is_diagnostics_enabled;
+
+		$this->gateway->update_option( 'diagnostics', $next ? 'yes' : 'no' );
+
+		if ( $previous !== $next && function_exists( 'wc_admin_record_tracks_event' ) ) {
+			wc_admin_record_tracks_event(
+				'wcstripe_diagnostics_mode_toggled',
+				[
+					'enabled'   => $next ? 'yes' : 'no',
+					'test_mode' => WC_Stripe_Mode::is_test() ? 1 : 0,
+				]
+			);
+		}
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -575,7 +575,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			wc_admin_record_tracks_event(
 				'wcstripe_diagnostics_mode_toggled',
 				[
-					'enabled'   => $next ? 'yes' : 'no',
+					'enabled'   => $next ? 1 : 0,
 					'test_mode' => WC_Stripe_Mode::is_test() ? 1 : 0,
 				]
 			);


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes RSM-2093

## Changes proposed in this Pull Request:

Adds Tracks instrumentation for Diagnostics Mode so we can measure adoption .

- `wcadmin_wcstripe_diagnostics_mode_toggled`: Fired from the server when the diagnostic mode checkbox is saved.
- `wcadmin_wcstripe_diagnostics_copy_traces`: Fired from the client when the diagnostic traces are copied.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. Make sure Usage tracking is enabled for the site.
2. Enable/Disable Diagnostics mode in Stripe Settings page.
3. In ~5 minutes, go to MC -> Tracks Live tracking page
4. Ensure there's an `wcstripe_diagnostics_mode_toggled` event with the correct `enabled` prop values
5. Click the "Copy failed traces for support" button.
6. In MC, there should be an `wcstripe_diagnostics_copy_traces` with correct props.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This is an unreleased feature

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
