### PR TITLE
[RSM - Diagnostics Mode] Use existing toast component for traces

### DIFF
--- a/client/settings/advanced-settings-section/__tests__/diagnostics-traces.test.js
+++ b/client/settings/advanced-settings-section/__tests__/diagnostics-traces.test.js
@@ -26,6 +26,7 @@ jest.mock( '@wordpress/components', () => ( {
 
 let createSuccessNotice;
 let createErrorNotice;
+let removeNotice;
 
 const summaryFixture = ( overrides = {} ) => ( {
 	counts: {
@@ -55,10 +56,12 @@ describe( 'DiagnosticsTraces', () => {
 		} );
 		createSuccessNotice = jest.fn();
 		createErrorNotice = jest.fn();
-		useDispatch.mockReturnValue( {
-			createSuccessNotice,
-			createErrorNotice,
-		} );
+		removeNotice = jest.fn();
+		useDispatch.mockImplementation( ( storeName ) =>
+			storeName === 'core/notices'
+				? { createSuccessNotice, createErrorNotice, removeNotice }
+				: {}
+		);
 	} );
 
 	it( 'renders nothing when there are no captured traces', async () => {
@@ -147,6 +150,11 @@ describe( 'DiagnosticsTraces', () => {
 
 			render( <DiagnosticsTraces /> );
 			await userEvent.click( await screen.findByText( buttonText ) );
+
+			// Stale notice from a prior click is cleared up front so the
+			// previous "Copied N traces" toast doesn't linger during the
+			// next round-trip.
+			expect( removeNotice ).toHaveBeenCalledWith( NOTICE_ID );
 
 			await waitFor( () =>
 				expect( navigator.clipboard.writeText ).toHaveBeenCalled()

--- a/client/settings/advanced-settings-section/__tests__/diagnostics-traces.test.js
+++ b/client/settings/advanced-settings-section/__tests__/diagnostics-traces.test.js
@@ -2,24 +2,30 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DiagnosticsTraces from '../diagnostics-traces';
+import { useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
+
+const NOTICE_ID = 'wc-stripe/diagnostics-copy-traces';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+} ) );
+
 // Stub @wordpress/components: the component only relies on label text, the
-// disabled flag, the click handler, and the dismissible notice surface.
-// Pulling in the real components inflates test boot time without adding
-// coverage.
+// disabled flag, and the click handler. Pulling in the real components
+// inflates test boot time without adding coverage.
 jest.mock( '@wordpress/components', () => ( {
 	Button: ( { children, disabled, onClick } ) => (
 		<button type="button" disabled={ disabled } onClick={ onClick }>
 			{ children }
 		</button>
 	),
-	Notice: ( { children, status } ) => (
-		<div data-status={ status }>{ children }</div>
-	),
 } ) );
+
+let createSuccessNotice;
+let createErrorNotice;
 
 const summaryFixture = ( overrides = {} ) => ( {
 	counts: {
@@ -46,6 +52,12 @@ describe( 'DiagnosticsTraces', () => {
 		jest.clearAllMocks();
 		Object.assign( navigator, {
 			clipboard: { writeText: jest.fn().mockResolvedValue() },
+		} );
+		createSuccessNotice = jest.fn();
+		createErrorNotice = jest.fn();
+		useDispatch.mockReturnValue( {
+			createSuccessNotice,
+			createErrorNotice,
 		} );
 	} );
 
@@ -142,7 +154,12 @@ describe( 'DiagnosticsTraces', () => {
 			expect( pathMatches( apiFetch.mock.calls[ 1 ][ 0 ].path ) ).toBe(
 				true
 			);
-			await screen.findByText( expectedNotice );
+			await waitFor( () =>
+				expect( createSuccessNotice ).toHaveBeenCalledWith(
+					expectedNotice,
+					{ id: NOTICE_ID }
+				)
+			);
 		}
 	);
 
@@ -156,8 +173,13 @@ describe( 'DiagnosticsTraces', () => {
 			await screen.findByText( 'Copy failed traces for support (3)' )
 		);
 
-		const notice = await screen.findByText( /Could not copy traces/ );
-		expect( notice.dataset.status ).toBe( 'error' );
+		await waitFor( () =>
+			expect( createErrorNotice ).toHaveBeenCalledWith(
+				'Could not copy traces. Try again.',
+				{ id: NOTICE_ID }
+			)
+		);
+		expect( createSuccessNotice ).not.toHaveBeenCalled();
 	} );
 
 	it( 'falls back to a file download when the trace bundle exceeds the clipboard threshold', async () => {
@@ -190,7 +212,12 @@ describe( 'DiagnosticsTraces', () => {
 			await screen.findByText( 'Copy failed traces for support (3)' )
 		);
 
-		await screen.findByText( /downloaded as a file instead/ );
+		await waitFor( () =>
+			expect( createSuccessNotice ).toHaveBeenCalledWith(
+				'Trace bundle was too large to copy — downloaded as a file instead.',
+				{ id: NOTICE_ID }
+			)
+		);
 		expect( createObjectURL ).toHaveBeenCalled();
 		expect( navigator.clipboard.writeText ).not.toHaveBeenCalled();
 	} );

--- a/client/settings/advanced-settings-section/diagnostics-traces.js
+++ b/client/settings/advanced-settings-section/diagnostics-traces.js
@@ -1,8 +1,12 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Button, Notice } from '@wordpress/components';
+import { Button } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 import { NAMESPACE } from 'wcstripe/data/constants';
+
+// Stable id so repeated clicks replace the previous notice rather than stack.
+const NOTICE_ID = 'wc-stripe/diagnostics-copy-traces';
 
 // Clipboard writes silently truncate or fail above a few MB on most
 // browsers, and ticket forms strip large pastes long before that. Falling
@@ -42,7 +46,8 @@ const downloadAsFile = ( contents ) => {
 const DiagnosticsTraces = () => {
 	const [ summary, setSummary ] = useState( null );
 	const [ isCopying, setIsCopying ] = useState( false );
-	const [ feedback, setFeedback ] = useState( null );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( 'core/notices' );
 
 	const refreshSummary = useCallback( () => {
 		apiFetch( { path: `${ NAMESPACE }/diagnostics/summary` } )
@@ -96,7 +101,6 @@ const DiagnosticsTraces = () => {
 
 	const handleCopy = async ( statuses ) => {
 		setIsCopying( true );
-		setFeedback( null );
 		try {
 			const response = await apiFetch( {
 				path: buildTracesPath( statuses ),
@@ -106,18 +110,17 @@ const DiagnosticsTraces = () => {
 
 			if ( bytes > CLIPBOARD_BYTE_THRESHOLD ) {
 				downloadAsFile( json );
-				setFeedback( {
-					status: 'success',
-					message: __(
+				createSuccessNotice(
+					__(
 						'Trace bundle was too large to copy — downloaded as a file instead.',
 						'woocommerce-gateway-stripe'
 					),
-				} );
+					{ id: NOTICE_ID }
+				);
 			} else {
 				await navigator.clipboard.writeText( json );
-				setFeedback( {
-					status: 'success',
-					message: sprintf(
+				createSuccessNotice(
+					sprintf(
 						/* translators: %d: number of traces */
 						_n(
 							'Copied %d trace to clipboard.',
@@ -127,17 +130,18 @@ const DiagnosticsTraces = () => {
 						),
 						response.count
 					),
-				} );
+					{ id: NOTICE_ID }
+				);
 			}
 			refreshSummary();
 		} catch ( err ) {
-			setFeedback( {
-				status: 'error',
-				message: __(
+			createErrorNotice(
+				__(
 					'Could not copy traces. Try again.',
 					'woocommerce-gateway-stripe'
 				),
-			} );
+				{ id: NOTICE_ID }
+			);
 		} finally {
 			setIsCopying( false );
 		}
@@ -180,15 +184,6 @@ const DiagnosticsTraces = () => {
 			>
 				{ __( 'Copy all instead', 'woocommerce-gateway-stripe' ) }
 			</Button>
-			{ feedback && (
-				<Notice
-					status={ feedback.status }
-					isDismissible
-					onRemove={ () => setFeedback( null ) }
-				>
-					{ feedback.message }
-				</Notice>
-			) }
 		</div>
 	);
 };

--- a/client/settings/advanced-settings-section/diagnostics-traces.js
+++ b/client/settings/advanced-settings-section/diagnostics-traces.js
@@ -46,7 +46,7 @@ const downloadAsFile = ( contents ) => {
 const DiagnosticsTraces = () => {
 	const [ summary, setSummary ] = useState( null );
 	const [ isCopying, setIsCopying ] = useState( false );
-	const { createSuccessNotice, createErrorNotice } =
+	const { createSuccessNotice, createErrorNotice, removeNotice } =
 		useDispatch( 'core/notices' );
 
 	const refreshSummary = useCallback( () => {
@@ -101,6 +101,7 @@ const DiagnosticsTraces = () => {
 
 	const handleCopy = async ( statuses ) => {
 		setIsCopying( true );
+		removeNotice( NOTICE_ID );
 		try {
 			const response = await apiFetch( {
 				path: buildTracesPath( statuses ),


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->


## Changes proposed in this Pull Request:

This PR updates the toast notifications that show up when copying diagnostics traces to use the existing components instead of a custom notification

<img width="498" height="150" alt="CleanShot 2026-05-04 at 10 10 24@2x" src="https://github.com/user-attachments/assets/63161e70-fada-4737-a518-ab2542df4849" />

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Go to Stripe settings
2. Click Copy failed traces for support
3. Ensure that toast notification matches the one that shows up when saving settings


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
