### PR TITLE
ai-review: subscribe to issue_comment for @claude review re-trigger (QAO-430)

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -1,10 +1,12 @@
 name: AI Code Review
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, ready_for_review, reopened]
+  issue_comment:
+    types: [created]
 
 concurrency:
-  group: ai-review-${{ github.event.pull_request.number }}
+  group: ai-review-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Wires this caller into the QAO-430 comment-trigger flow shipped in [woocommerce/.github#22](https://github.com/woocommerce/.github/pull/22). After merge, `@claude review` or `@claude /review` posted as a PR comment fires a fresh review.