### PR TITLE
Explore: inline WC_Stripe_Settings_Controller into WC_Stripe

### DIFF
--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -1,312 +1,77 @@
 <?php
-
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 /**
- * Controls whether we're on the settings page and enqueues the JS code.
+ * Backwards-compatibility shim for the now-inlined Stripe settings page logic.
  *
- * @since 5.4.1
+ * The hooks and methods previously registered here now live on `WC_Stripe`. This
+ * class is retained only so external code that instantiated it continues to load,
+ * and so the public `hide_gateways_on_settings_page` static keeps working when
+ * called directly. Each entry point delegates to `WC_Stripe` and emits a
+ * deprecation notice.
+ *
+ * @deprecated 10.7.0 Use the equivalent methods on `WC_Stripe`.
  */
 class WC_Stripe_Settings_Controller {
 	/**
-	 * The Stripe account instance.
+	 * Constructor (deprecation shim).
 	 *
-	 * @var WC_Stripe_Account
-	 */
-	private $account;
-
-	/**
-	 * The Stripe gateway instance.
-	 *
-	 * @var WC_Stripe_Payment_Gateway|null
-	 */
-	private $gateway;
-
-	/**
-	 * Constructor
-	 *
-	 * @param WC_Stripe_Account $account Stripe account
-	 * @param WC_Stripe_Payment_Gateway|null $gateway Stripe gateway
+	 * @param WC_Stripe_Account              $account Stripe account (unused — kept for signature compatibility).
+	 * @param WC_Stripe_Payment_Gateway|null $gateway Stripe gateway (unused — kept for signature compatibility).
 	 */
 	public function __construct( WC_Stripe_Account $account, ?WC_Stripe_Payment_Gateway $gateway = null ) {
-		$this->account = $account;
-		$this->gateway = $gateway;
-
-		add_action( 'admin_enqueue_scripts', [ $this, 'admin_scripts' ] );
-		add_action( 'wc_stripe_gateway_admin_options_wrapper', [ $this, 'admin_options' ] );
-		add_action( 'woocommerce_order_item_add_action_buttons', [ $this, 'hide_refund_button_for_uncaptured_orders' ] );
-
-		// Priority 5 so we can manipulate the registered gateways before they are shown.
-		add_action( 'woocommerce_admin_field_payment_gateways', [ $this, 'hide_gateways_on_settings_page' ], 5 );
-
-		// Add AJAX handler for OAuth URL generation
-		add_action( 'wp_ajax_wc_stripe_get_oauth_url', [ $this, 'ajax_get_oauth_url' ] );
+		_deprecated_function( __CLASS__, '10.7.0', 'WC_Stripe' );
 	}
 
 	/**
-	 * Fetches the Stripe gateway instance.
-	 */
-	private function get_gateway() {
-		if ( ! $this->gateway ) {
-			$this->gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
-		}
-
-		return $this->gateway;
-	}
-
-	/**
-	* This replaces the refund button with a disabled 'Refunding unavailable' button in the same place for orders that have been authorized but not captured.
-	*
-	* A help tooltip explains that refunds are not available for orders which have not been captured yet.
-	*
-	* @param WC_Order $order The order that is being viewed.
-	*/
-	public function hide_refund_button_for_uncaptured_orders( $order ) {
-		try {
-			$intent = $this->get_gateway()->get_intent_from_order( $order );
-
-			if ( $intent && WC_Stripe_Intent_Status::REQUIRES_CAPTURE === $intent->status ) {
-				$no_refunds_button  = __( 'Refunding unavailable', 'woocommerce-gateway-stripe' );
-				$no_refunds_tooltip = __( 'Refunding via Stripe is unavailable because funds have not been captured for this order. Process order to take payment, or cancel to remove the pre-authorization.', 'woocommerce-gateway-stripe' );
-				echo '<style>.button.refund-items { display: none; }</style>';
-				echo '<span class="button button-disabled">' . esc_html( $no_refunds_button ) . wp_kses_post( wc_help_tip( $no_refunds_tooltip ) ) . '</span>';
-			}
-		} catch ( Exception $e ) {
-			WC_Stripe_Logger::error( 'Error getting intent from order: ' . $order->get_id(), [ 'error_message' => $e->getMessage() ] );
-		}
-	}
-
-	/**
-	 * Prints the admin options for the gateway.
-	 * Remove this action once we're fully migrated to UPE and move the wrapper in the `admin_options` method of the UPE gateway.
+	 * Delegates to the equivalent method on `WC_Stripe`.
 	 *
-	 * @param WC_Stripe_Payment_Gateway $gateway the Stripe gateway.
+	 * @deprecated 10.7.0 Use `WC_Stripe::hide_refund_button_for_uncaptured_orders()`.
+	 */
+	public function hide_refund_button_for_uncaptured_orders( $order ) {
+		_deprecated_function( __METHOD__, '10.7.0', 'WC_Stripe::hide_refund_button_for_uncaptured_orders' );
+		WC_Stripe::get_instance()->hide_refund_button_for_uncaptured_orders( $order );
+	}
+
+	/**
+	 * Delegates to the equivalent method on `WC_Stripe`.
+	 *
+	 * @deprecated 10.7.0 Use `WC_Stripe::render_settings_admin_options()`.
 	 */
 	public function admin_options( WC_Stripe_Payment_Gateway $gateway ) {
-		global $hide_save_button;
-
-		$hide_save_button = true;
-		$return_url       = admin_url( 'admin.php?page=wc-settings&tab=checkout' );
-		$header           = $gateway->get_method_title();
-		$return_text      = __( 'Return to payments', 'woocommerce-gateway-stripe' );
-
-		WC_Stripe_Helper::render_admin_header( $header, $return_text, $return_url );
-
-		$settings = WC_Stripe_Helper::get_stripe_settings();
-
-		$account_data_exists = ( ! empty( $settings['publishable_key'] ) && ! empty( $settings['secret_key'] ) ) || ( ! empty( $settings['test_publishable_key'] ) && ! empty( $settings['test_secret_key'] ) );
-		echo $account_data_exists ? '<div id="wc-stripe-account-settings-container"></div>' : '<div id="wc-stripe-new-account-container"></div>';
+		_deprecated_function( __METHOD__, '10.7.0', 'WC_Stripe::render_settings_admin_options' );
+		WC_Stripe::get_instance()->render_settings_admin_options( $gateway );
 	}
 
 	/**
-	 * Determines if the payments task is completed in WooCommerce onboarding flow.
+	 * Delegates to the equivalent method on `WC_Stripe`.
 	 *
-	 * @return bool True if the payments task is completed, false otherwise.
-	 */
-	private function is_payments_onboarding_task_completed(): bool {
-		$task_list = TaskLists::get_list( 'setup' );
-		if ( empty( $task_list ) ) {
-			return false;
-		}
-
-		$payments_task = $task_list->get_task( 'payments' );
-		if ( empty( $payments_task ) ) {
-			return false;
-		}
-
-		return $payments_task->is_complete();
-	}
-
-	/**
-	 * AJAX handler to generate OAuth URL on-demand
+	 * @deprecated 10.7.0 Use `WC_Stripe::ajax_get_oauth_url()`.
 	 */
 	public function ajax_get_oauth_url() {
-		// Check nonce and capabilities
-		if ( ! check_ajax_referer( 'wc_stripe_get_oauth_url', 'nonce', false ) ||
-			! current_user_can( 'manage_woocommerce' ) ) {
-			wp_send_json_error( [ 'message' => __( 'You do not have permission to do this.', 'woocommerce-gateway-stripe' ) ] );
-			return;
-		}
-
-		$mode = isset( $_POST['mode'] ) ? sanitize_text_field( wp_unslash( $_POST['mode'] ) ) : 'test';
-		if ( ! in_array( $mode, [ 'live', 'test' ], true ) ) {
-			$mode = 'test';
-		}
-
-		$oauth_url = woocommerce_gateway_stripe()->connect->get_oauth_url( '', $mode );
-
-		if ( is_wp_error( $oauth_url ) ) {
-			wp_send_json_error( [ 'message' => $oauth_url->get_error_message() ] );
-			return;
-		}
-
-		wp_send_json_success( [ 'oauth_url' => $oauth_url ] );
+		_deprecated_function( __METHOD__, '10.7.0', 'WC_Stripe::ajax_get_oauth_url' );
+		WC_Stripe::get_instance()->ajax_get_oauth_url();
 	}
 
 	/**
-	 * Load admin scripts.
+	 * Delegates to the equivalent method on `WC_Stripe`.
+	 *
+	 * @deprecated 10.7.0 Use `WC_Stripe::enqueue_settings_admin_scripts()`.
 	 */
 	public function admin_scripts( $hook_suffix ) {
-		if ( 'woocommerce_page_wc-settings' !== $hook_suffix ) {
-			return;
-		}
-
-		// TODO: refactor this to a regex approach, we will need to touch `should_enqueue_in_current_tab_section` to support it
-		if ( ! ( WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe' )
-			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_sepa' )
-			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_giropay' )
-			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_ideal' )
-			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_bancontact' )
-			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_eps' )
-			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_sofort' )
-			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_p24' )
-			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_alipay' )
-			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_multibanco' )
-			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_oxxo' )
-			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_boleto' ) ) ) {
-			return;
-		}
-
-		// Webpack generates an assets file containing a dependencies array for our built JS file.
-		$script_asset_path = WC_STRIPE_PLUGIN_PATH . '/build/upe-settings.asset.php';
-		$script_asset      = file_exists( $script_asset_path )
-			? require $script_asset_path
-			: [
-				'dependencies' => [],
-				'version'      => WC_STRIPE_VERSION,
-			];
-
-		wp_register_script(
-			'woocommerce_stripe_admin',
-			plugins_url( 'build/upe-settings.js', WC_STRIPE_MAIN_FILE ),
-			$script_asset['dependencies'],
-			$script_asset['version'],
-			true
-		);
-		wp_register_style(
-			'woocommerce_stripe_admin',
-			plugins_url( 'build/upe-settings.css', WC_STRIPE_MAIN_FILE ),
-			[ 'wc-components' ],
-			$script_asset['version']
-		);
-
-		$message = sprintf(
-		/* translators: 1) Html strong opening tag 2) Html strong closing tag */
-			esc_html__( '%1$sWarning:%2$s your site\'s time does not match the time on your browser and may be incorrect. Some payment methods depend on webhook verification and verifying webhooks with a signing secret depends on your site\'s time being correct, so please check your site\'s time before setting a webhook secret. You may need to contact your site\'s hosting provider to correct the site\'s time.', 'woocommerce-gateway-stripe' ),
-			'<strong>',
-			'</strong>'
-		);
-
-		$enabled_payment_methods    = $this->get_gateway()->get_upe_enabled_payment_method_ids();
-		$show_bnpl_promotion_banner = get_option( 'wc_stripe_show_bnpl_promotion_banner', 'yes' ) === 'yes'
-			// Show the BNPL promotional banner only if no BNPL payment methods are enabled.
-			&& ! array_intersect( WC_Stripe_Payment_Methods::BNPL_PAYMENT_METHODS, $enabled_payment_methods );
-
-		$is_oc_enabled = $this->get_gateway()->is_oc_enabled();
-
-		$show_oc_promotion_banner = get_option( 'wc_stripe_show_oc_promotion_banner', 'yes' ) === 'yes'
-			// Show the OC promotional banner only if OC is disabled
-			&& ! $is_oc_enabled;
-
-		$show_stripe_tax_banner = get_option( 'wc_stripe_show_stripe_tax_banner', 'yes' ) === 'yes'
-			// Show the Stripe Tax banner only if OC is enabled
-			&& $is_oc_enabled;
-
-		$is_ap_available_for_account = WC_Stripe_Helper::is_adaptive_pricing_available_for_account();
-
-		$params = [
-			'time'                                  => time(),
-			'i18n_out_of_sync'                      => $message,
-			'is_upe_checkout_enabled'               => true,
-			'show_customization_notice'             => get_option( 'wc_stripe_show_customization_notice', 'yes' ) === 'yes' ? true : false,
-			'show_optimized_checkout_notice'        => get_option( 'wc_stripe_show_optimized_checkout_notice', 'yes' ) === 'yes' ? true : false,
-			'show_bnpl_promotional_banner'          => $show_bnpl_promotion_banner,
-			'show_oc_promotional_banner'            => $show_oc_promotion_banner,
-			'show_stripe_tax_banner'                => $show_stripe_tax_banner,
-			'is_test_mode'                          => $this->get_gateway()->is_in_test_mode(),
-			'plugin_version'                        => WC_STRIPE_VERSION,
-			'account_country'                       => $this->account->get_account_country(),
-			'are_apms_deprecated'                   => false,
-			'is_amazon_pay_available'               => WC_Stripe_Feature_Flags::is_amazon_pay_available(),
-			'is_oc_available'                       => WC_Stripe_Feature_Flags::is_oc_available(),
-			'is_oc_enabled'                         => $is_oc_enabled,
-			'is_cs_available'                       => WC_Stripe_Feature_Flags::is_checkout_sessions_available() && $is_ap_available_for_account,
-			'oc_layout'                             => $this->get_gateway()->get_validated_option( 'optimized_checkout_layout' ),
-			'oauth_nonce'                           => wp_create_nonce( 'wc_stripe_get_oauth_url' ),
-			'is_sepa_tokens_for_ideal_enabled'      => 'yes' === $this->gateway->get_option( 'sepa_tokens_for_ideal', 'no' ),
-			'is_sepa_tokens_for_bancontact_enabled' => 'yes' === $this->gateway->get_option( 'sepa_tokens_for_bancontact', 'no' ),
-			'has_affirm_gateway_plugin'             => WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM ),
-			'has_klarna_gateway_plugin'             => WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA ),
-			'has_other_bnpl_plugins'                => WC_Stripe_Helper::has_other_bnpl_plugins_active(),
-			'is_payments_onboarding_task_completed' => $this->is_payments_onboarding_task_completed(),
-			'taxes_based_on_billing'                => wc_tax_enabled() && 'billing' === get_option( 'woocommerce_tax_based_on' ),
-			'is_card_method_enabled'                => in_array( WC_Stripe_Payment_Methods::CARD, $enabled_payment_methods, true ),
-			'is_agentic_commerce_enabled'           => WC_Stripe_Feature_Flags::is_agentic_commerce_enabled(),
-			'agentic_commerce_import_sets_url'      => $this->get_gateway()->is_in_test_mode()
-				? 'https://dashboard.stripe.com/test/data-management/import-sets'
-				: 'https://dashboard.stripe.com/data-management/import-sets',
-			'agentic_commerce_logs_url'             => $this->get_agentic_commerce_logs_url(),
-			'show_stripe_first_method_notice'       => WC_Stripe_Helper::should_show_stripe_first_method_notice(),
-		];
-		$params = array_merge( $params, WC_Stripe_Helper::get_exit_survey_params( $this->account ) );
-		wp_localize_script(
-			'woocommerce_stripe_admin',
-			'wc_stripe_settings_params',
-			$params
-		);
-		wp_set_script_translations(
-			'woocommerce_stripe_admin',
-			'woocommerce-gateway-stripe'
-		);
-
-		wp_enqueue_script( 'woocommerce_stripe_admin' );
-		wp_enqueue_style( 'woocommerce_stripe_admin' );
+		_deprecated_function( __METHOD__, '10.7.0', 'WC_Stripe::enqueue_settings_admin_scripts' );
+		WC_Stripe::get_instance()->enqueue_settings_admin_scripts( $hook_suffix );
 	}
 
 	/**
-	 * Build a URL to the WooCommerce logs page pre-filtered to the Stripe log source.
+	 * Delegates to the equivalent method on `WC_Stripe`.
 	 *
-	 * The `source` query argument is supported by WooCommerce's logs screen for
-	 * both the database and file log handlers, so merchants land directly on the
-	 * Stripe log entries rather than the unfiltered log index.
-	 *
-	 * @since 10.7.0
-	 * @return string
-	 */
-	private function get_agentic_commerce_logs_url(): string {
-		return admin_url(
-			'admin.php?page=wc-status&tab=logs&source=' . rawurlencode( WC_Stripe_Logger::WC_LOG_FILENAME )
-		);
-	}
-
-	/**
-	 * Removes all Stripe alternative payment methods (eg Bancontact, giropay) on the WooCommerce Settings page.
-	 *
-	 * Note: This function is hooked onto `woocommerce_admin_field_payment_gateways` which is the hook used
-	 * to display the payment gateways on the WooCommerce Settings page.
+	 * @deprecated 10.7.0 Use `WC_Stripe::hide_payment_gateways_on_settings_page()`.
 	 */
 	public static function hide_gateways_on_settings_page() {
-		// Prevent hiding gateways in the new payments settings experience (React-based UI).
-		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) && \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'reactify-classic-payments-settings' ) ) {
-			return;
-		}
-
-		$gateways_to_hide = [
-			// Hide all UPE payment methods.
-			WC_Stripe_UPE_Payment_Method::class,
-		];
-
-		foreach ( WC()->payment_gateways->payment_gateways as $index => $payment_gateway ) {
-			foreach ( $gateways_to_hide as $gateway_to_hide ) {
-				if ( $payment_gateway instanceof $gateway_to_hide ) {
-					unset( WC()->payment_gateways->payment_gateways[ $index ] );
-					break; // Break the inner loop as we've already found a match and removed the gateway
-				}
-			}
-		}
+		_deprecated_function( __METHOD__, '10.7.0', 'WC_Stripe::hide_payment_gateways_on_settings_page' );
+		WC_Stripe::hide_payment_gateways_on_settings_page();
 	}
 }

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -239,6 +241,7 @@ class WC_Stripe {
 			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-admin-notices.php';
 			new WC_Stripe_Admin_Notices();
 
+			// Kept loadable so the deprecated `WC_Stripe_Settings_Controller` shim is reachable for external code.
 			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-settings-controller.php';
 
 			if ( isset( $_GET['area'] ) && in_array( $_GET['area'], [ 'express_checkout', 'payment_requests' ], true ) ) {
@@ -248,7 +251,7 @@ class WC_Stripe {
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-amazon-pay-controller.php';
 				new WC_Stripe_Amazon_Pay_Controller();
 			} else {
-				new WC_Stripe_Settings_Controller( $this->account );
+				$this->register_settings_admin_hooks();
 			}
 
 			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-payment-gateways-controller.php';
@@ -1080,5 +1083,261 @@ class WC_Stripe {
 
 		// Disable Amazon Pay.
 		return [ WC_Stripe_Payment_Methods::AMAZON_PAY ];
+	}
+
+	/**
+	 * Registers the admin hooks that drive the Stripe settings page UI.
+	 *
+	 * Inlined from the deprecated `WC_Stripe_Settings_Controller`.
+	 */
+	private function register_settings_admin_hooks() {
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_settings_admin_scripts' ] );
+		add_action( 'wc_stripe_gateway_admin_options_wrapper', [ $this, 'render_settings_admin_options' ] );
+		add_action( 'woocommerce_order_item_add_action_buttons', [ $this, 'hide_refund_button_for_uncaptured_orders' ] );
+
+		// Priority 5 so we can manipulate the registered gateways before they are shown.
+		add_action( 'woocommerce_admin_field_payment_gateways', [ self::class, 'hide_payment_gateways_on_settings_page' ], 5 );
+
+		add_action( 'wp_ajax_wc_stripe_get_oauth_url', [ $this, 'ajax_get_oauth_url' ] );
+	}
+
+	/**
+	 * Replaces the refund button with a disabled "Refunding unavailable" button
+	 * for orders that have been authorized but not captured.
+	 *
+	 * @param WC_Order $order The order being viewed.
+	 */
+	public function hide_refund_button_for_uncaptured_orders( $order ) {
+		try {
+			$intent = $this->get_main_stripe_gateway()->get_intent_from_order( $order );
+
+			if ( $intent && WC_Stripe_Intent_Status::REQUIRES_CAPTURE === $intent->status ) {
+				$no_refunds_button  = __( 'Refunding unavailable', 'woocommerce-gateway-stripe' );
+				$no_refunds_tooltip = __( 'Refunding via Stripe is unavailable because funds have not been captured for this order. Process order to take payment, or cancel to remove the pre-authorization.', 'woocommerce-gateway-stripe' );
+				echo '<style>.button.refund-items { display: none; }</style>';
+				echo '<span class="button button-disabled">' . esc_html( $no_refunds_button ) . wp_kses_post( wc_help_tip( $no_refunds_tooltip ) ) . '</span>';
+			}
+		} catch ( Exception $e ) {
+			WC_Stripe_Logger::error( 'Error getting intent from order: ' . $order->get_id(), [ 'error_message' => $e->getMessage() ] );
+		}
+	}
+
+	/**
+	 * Prints the admin options wrapper for the Stripe settings page.
+	 *
+	 * @param WC_Stripe_Payment_Gateway $gateway The Stripe gateway.
+	 */
+	public function render_settings_admin_options( WC_Stripe_Payment_Gateway $gateway ) {
+		global $hide_save_button;
+
+		$hide_save_button = true;
+		$return_url       = admin_url( 'admin.php?page=wc-settings&tab=checkout' );
+		$header           = $gateway->get_method_title();
+		$return_text      = __( 'Return to payments', 'woocommerce-gateway-stripe' );
+
+		WC_Stripe_Helper::render_admin_header( $header, $return_text, $return_url );
+
+		$settings = WC_Stripe_Helper::get_stripe_settings();
+
+		$account_data_exists = ( ! empty( $settings['publishable_key'] ) && ! empty( $settings['secret_key'] ) ) || ( ! empty( $settings['test_publishable_key'] ) && ! empty( $settings['test_secret_key'] ) );
+		echo $account_data_exists ? '<div id="wc-stripe-account-settings-container"></div>' : '<div id="wc-stripe-new-account-container"></div>';
+	}
+
+	/**
+	 * Determines whether the WooCommerce onboarding "payments" task has been completed.
+	 */
+	private function is_payments_onboarding_task_completed(): bool {
+		$task_list = TaskLists::get_list( 'setup' );
+		if ( empty( $task_list ) ) {
+			return false;
+		}
+
+		$payments_task = $task_list->get_task( 'payments' );
+		if ( empty( $payments_task ) ) {
+			return false;
+		}
+
+		return $payments_task->is_complete();
+	}
+
+	/**
+	 * AJAX handler that generates a Stripe Connect OAuth URL on demand.
+	 */
+	public function ajax_get_oauth_url() {
+		if ( ! check_ajax_referer( 'wc_stripe_get_oauth_url', 'nonce', false ) ||
+			! current_user_can( 'manage_woocommerce' ) ) {
+			wp_send_json_error( [ 'message' => __( 'You do not have permission to do this.', 'woocommerce-gateway-stripe' ) ] );
+			return;
+		}
+
+		$mode = isset( $_POST['mode'] ) ? sanitize_text_field( wp_unslash( $_POST['mode'] ) ) : 'test';
+		if ( ! in_array( $mode, [ 'live', 'test' ], true ) ) {
+			$mode = 'test';
+		}
+
+		$oauth_url = $this->connect->get_oauth_url( '', $mode );
+
+		if ( is_wp_error( $oauth_url ) ) {
+			wp_send_json_error( [ 'message' => $oauth_url->get_error_message() ] );
+			return;
+		}
+
+		wp_send_json_success( [ 'oauth_url' => $oauth_url ] );
+	}
+
+	/**
+	 * Loads the Stripe settings page assets.
+	 */
+	public function enqueue_settings_admin_scripts( $hook_suffix ) {
+		if ( 'woocommerce_page_wc-settings' !== $hook_suffix ) {
+			return;
+		}
+
+		// TODO: refactor this to a regex approach, we will need to touch `should_enqueue_in_current_tab_section` to support it
+		if ( ! ( WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe' )
+			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_sepa' )
+			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_giropay' )
+			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_ideal' )
+			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_bancontact' )
+			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_eps' )
+			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_sofort' )
+			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_p24' )
+			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_alipay' )
+			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_multibanco' )
+			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_oxxo' )
+			|| WC_Stripe_Helper::should_enqueue_in_current_tab_section( 'checkout', 'stripe_boleto' ) ) ) {
+			return;
+		}
+
+		$gateway = $this->get_main_stripe_gateway();
+
+		// Webpack generates an assets file containing a dependencies array for our built JS file.
+		$script_asset_path = WC_STRIPE_PLUGIN_PATH . '/build/upe-settings.asset.php';
+		$script_asset      = file_exists( $script_asset_path )
+			? require $script_asset_path
+			: [
+				'dependencies' => [],
+				'version'      => WC_STRIPE_VERSION,
+			];
+
+		wp_register_script(
+			'woocommerce_stripe_admin',
+			plugins_url( 'build/upe-settings.js', WC_STRIPE_MAIN_FILE ),
+			$script_asset['dependencies'],
+			$script_asset['version'],
+			true
+		);
+		wp_register_style(
+			'woocommerce_stripe_admin',
+			plugins_url( 'build/upe-settings.css', WC_STRIPE_MAIN_FILE ),
+			[ 'wc-components' ],
+			$script_asset['version']
+		);
+
+		$message = sprintf(
+			/* translators: 1) Html strong opening tag 2) Html strong closing tag */
+			esc_html__( '%1$sWarning:%2$s your site\'s time does not match the time on your browser and may be incorrect. Some payment methods depend on webhook verification and verifying webhooks with a signing secret depends on your site\'s time being correct, so please check your site\'s time before setting a webhook secret. You may need to contact your site\'s hosting provider to correct the site\'s time.', 'woocommerce-gateway-stripe' ),
+			'<strong>',
+			'</strong>'
+		);
+
+		$enabled_payment_methods    = $gateway->get_upe_enabled_payment_method_ids();
+		$show_bnpl_promotion_banner = get_option( 'wc_stripe_show_bnpl_promotion_banner', 'yes' ) === 'yes'
+			// Show the BNPL promotional banner only if no BNPL payment methods are enabled.
+			&& ! array_intersect( WC_Stripe_Payment_Methods::BNPL_PAYMENT_METHODS, $enabled_payment_methods );
+
+		$is_oc_enabled = $gateway->is_oc_enabled();
+
+		$show_oc_promotion_banner = get_option( 'wc_stripe_show_oc_promotion_banner', 'yes' ) === 'yes'
+			// Show the OC promotional banner only if OC is disabled
+			&& ! $is_oc_enabled;
+
+		$show_stripe_tax_banner = get_option( 'wc_stripe_show_stripe_tax_banner', 'yes' ) === 'yes'
+			// Show the Stripe Tax banner only if OC is enabled
+			&& $is_oc_enabled;
+
+		$is_ap_available_for_account = WC_Stripe_Helper::is_adaptive_pricing_available_for_account();
+
+		$params = [
+			'time'                                  => time(),
+			'i18n_out_of_sync'                      => $message,
+			'is_upe_checkout_enabled'               => true,
+			'show_customization_notice'             => get_option( 'wc_stripe_show_customization_notice', 'yes' ) === 'yes' ? true : false,
+			'show_optimized_checkout_notice'        => get_option( 'wc_stripe_show_optimized_checkout_notice', 'yes' ) === 'yes' ? true : false,
+			'show_bnpl_promotional_banner'          => $show_bnpl_promotion_banner,
+			'show_oc_promotional_banner'            => $show_oc_promotion_banner,
+			'show_stripe_tax_banner'                => $show_stripe_tax_banner,
+			'is_test_mode'                          => $gateway->is_in_test_mode(),
+			'plugin_version'                        => WC_STRIPE_VERSION,
+			'account_country'                       => $this->account->get_account_country(),
+			'are_apms_deprecated'                   => false,
+			'is_amazon_pay_available'               => WC_Stripe_Feature_Flags::is_amazon_pay_available(),
+			'is_oc_available'                       => WC_Stripe_Feature_Flags::is_oc_available(),
+			'is_oc_enabled'                         => $is_oc_enabled,
+			'is_cs_available'                       => WC_Stripe_Feature_Flags::is_checkout_sessions_available() && $is_ap_available_for_account,
+			'oc_layout'                             => $gateway->get_validated_option( 'optimized_checkout_layout' ),
+			'oauth_nonce'                           => wp_create_nonce( 'wc_stripe_get_oauth_url' ),
+			'is_sepa_tokens_for_ideal_enabled'      => 'yes' === $gateway->get_option( 'sepa_tokens_for_ideal', 'no' ),
+			'is_sepa_tokens_for_bancontact_enabled' => 'yes' === $gateway->get_option( 'sepa_tokens_for_bancontact', 'no' ),
+			'has_affirm_gateway_plugin'             => WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM ),
+			'has_klarna_gateway_plugin'             => WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA ),
+			'has_other_bnpl_plugins'                => WC_Stripe_Helper::has_other_bnpl_plugins_active(),
+			'is_payments_onboarding_task_completed' => $this->is_payments_onboarding_task_completed(),
+			'taxes_based_on_billing'                => wc_tax_enabled() && 'billing' === get_option( 'woocommerce_tax_based_on' ),
+			'is_card_method_enabled'                => in_array( WC_Stripe_Payment_Methods::CARD, $enabled_payment_methods, true ),
+			'is_agentic_commerce_enabled'           => WC_Stripe_Feature_Flags::is_agentic_commerce_enabled(),
+			'agentic_commerce_import_sets_url'      => $gateway->is_in_test_mode()
+				? 'https://dashboard.stripe.com/test/data-management/import-sets'
+				: 'https://dashboard.stripe.com/data-management/import-sets',
+			'agentic_commerce_logs_url'             => $this->get_agentic_commerce_logs_url(),
+			'show_stripe_first_method_notice'       => WC_Stripe_Helper::should_show_stripe_first_method_notice(),
+		];
+		$params = array_merge( $params, WC_Stripe_Helper::get_exit_survey_params( $this->account ) );
+		wp_localize_script(
+			'woocommerce_stripe_admin',
+			'wc_stripe_settings_params',
+			$params
+		);
+		wp_set_script_translations(
+			'woocommerce_stripe_admin',
+			'woocommerce-gateway-stripe'
+		);
+
+		wp_enqueue_script( 'woocommerce_stripe_admin' );
+		wp_enqueue_style( 'woocommerce_stripe_admin' );
+	}
+
+	/**
+	 * Build a URL to the WooCommerce logs page pre-filtered to the Stripe log source.
+	 */
+	private function get_agentic_commerce_logs_url(): string {
+		return admin_url(
+			'admin.php?page=wc-status&tab=logs&source=' . rawurlencode( WC_Stripe_Logger::WC_LOG_FILENAME )
+		);
+	}
+
+	/**
+	 * Removes Stripe alternative payment methods from the WooCommerce Settings page gateway list.
+	 *
+	 * Hooked to `woocommerce_admin_field_payment_gateways`.
+	 */
+	public static function hide_payment_gateways_on_settings_page() {
+		// Skip in the new payments settings experience (React-based UI).
+		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) && \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'reactify-classic-payments-settings' ) ) {
+			return;
+		}
+
+		$gateways_to_hide = [
+			WC_Stripe_UPE_Payment_Method::class,
+		];
+
+		foreach ( WC()->payment_gateways->payment_gateways as $index => $payment_gateway ) {
+			foreach ( $gateways_to_hide as $gateway_to_hide ) {
+				if ( $payment_gateway instanceof $gateway_to_hide ) {
+					unset( WC()->payment_gateways->payment_gateways[ $index ] );
+					break;
+				}
+			}
+		}
 	}
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1189,12 +1189,6 @@ parameters:
 			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
 
 		-
-			message: '#^Method WC_REST_Stripe_Agentic_Commerce_Controller\:\:update_agentic_settings\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
-
-		-
 			message: '#^Method WC_REST_Stripe_Account_Keys_Controller\:\:test_account_keys\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1
@@ -1229,6 +1223,12 @@ parameters:
 			identifier: missingType.generics
 			count: 1
 			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
+
+		-
+			message: '#^Method WC_REST_Stripe_Agentic_Commerce_Controller\:\:update_agentic_settings\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
+			identifier: missingType.generics
+			count: 1
+			path: includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
 
 		-
 			message: '#^Method WC_REST_Stripe_Connection_Tokens_Controller\:\:create_token\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
@@ -1621,15 +1621,15 @@ parameters:
 			path: includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php
 
 		-
-			message: '#^Access to an undefined property WooCommerce\:\:\$payment_gateways\.$#'
-			identifier: property.notFound
+			message: '#^Constructor of class WC_Stripe_Settings_Controller has an unused parameter \$account\.$#'
+			identifier: constructor.unusedParameter
 			count: 1
 			path: includes/admin/class-wc-stripe-settings-controller.php
 
 		-
-			message: '#^Cannot call method get_option\(\) on WC_Stripe_Payment_Gateway\|null\.$#'
-			identifier: method.nonObject
-			count: 2
+			message: '#^Constructor of class WC_Stripe_Settings_Controller has an unused parameter \$gateway\.$#'
+			identifier: constructor.unusedParameter
+			count: 1
 			path: includes/admin/class-wc-stripe-settings-controller.php
 
 		-
@@ -1657,12 +1657,6 @@ parameters:
 			path: includes/admin/class-wc-stripe-settings-controller.php
 
 		-
-			message: '#^Method WC_Stripe_Settings_Controller\:\:get_gateway\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/admin/class-wc-stripe-settings-controller.php
-
-		-
 			message: '#^Method WC_Stripe_Settings_Controller\:\:hide_gateways_on_settings_page\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -1675,9 +1669,9 @@ parameters:
 			path: includes/admin/class-wc-stripe-settings-controller.php
 
 		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
-			count: 2
+			message: '#^Method WC_Stripe_Settings_Controller\:\:hide_refund_button_for_uncaptured_orders\(\) has parameter \$order with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
 			path: includes/admin/class-wc-stripe-settings-controller.php
 
 		-
@@ -3463,6 +3457,18 @@ parameters:
 			path: includes/class-wc-stripe-webhook-state.php
 
 		-
+			message: '#^Access to an undefined property WooCommerce\:\:\$payment_gateways\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/class-wc-stripe.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$status\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/class-wc-stripe.php
+
+		-
 			message: '#^Call to an undefined method WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens\:\:init\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -3477,6 +3483,12 @@ parameters:
 		-
 			message: '#^Method WC_Stripe\:\:add_gateways\(\) has parameter \$methods with no type specified\.$#'
 			identifier: missingType.parameter
+			count: 1
+			path: includes/class-wc-stripe.php
+
+		-
+			message: '#^Method WC_Stripe\:\:ajax_get_oauth_url\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: includes/class-wc-stripe.php
 
@@ -3505,6 +3517,18 @@ parameters:
 			path: includes/class-wc-stripe.php
 
 		-
+			message: '#^Method WC_Stripe\:\:enqueue_settings_admin_scripts\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: includes/class-wc-stripe.php
+
+		-
+			message: '#^Method WC_Stripe\:\:enqueue_settings_admin_scripts\(\) has parameter \$hook_suffix with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: includes/class-wc-stripe.php
+
+		-
 			message: '#^Method WC_Stripe\:\:filter_gateway_order_admin\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -3519,6 +3543,18 @@ parameters:
 		-
 			message: '#^Method WC_Stripe\:\:get_main_stripe_gateway\(\) should return WC_Stripe_UPE_Payment_Gateway but returns WC_Stripe_Payment_Gateway\.$#'
 			identifier: return.type
+			count: 1
+			path: includes/class-wc-stripe.php
+
+		-
+			message: '#^Method WC_Stripe\:\:hide_payment_gateways_on_settings_page\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: includes/class-wc-stripe.php
+
+		-
+			message: '#^Method WC_Stripe\:\:hide_refund_button_for_uncaptured_orders\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: includes/class-wc-stripe.php
 
@@ -3583,6 +3619,18 @@ parameters:
 			path: includes/class-wc-stripe.php
 
 		-
+			message: '#^Method WC_Stripe\:\:register_settings_admin_hooks\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: includes/class-wc-stripe.php
+
+		-
+			message: '#^Method WC_Stripe\:\:render_settings_admin_options\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: includes/class-wc-stripe.php
+
+		-
 			message: '#^Method WC_Stripe\:\:update_plugin_version\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -3598,6 +3646,12 @@ parameters:
 			message: '#^Parameter \#2 \$old_settings of method WC_Stripe\:\:maybe_reset_stripe_in_memory_key\(\) expects array, array\|true given\.$#'
 			identifier: argument.type
 			count: 1
+			path: includes/class-wc-stripe.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 2
 			path: includes/class-wc-stripe.php
 
 		-

--- a/tests/phpunit/admin/class-wc-stripe-settings-controller-test.php
+++ b/tests/phpunit/admin/class-wc-stripe-settings-controller-test.php
@@ -31,7 +31,10 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 									->getMock();
 
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-settings-controller.php';
-		$this->gateway    = new WC_Stripe_UPE_Payment_Gateway();
+		$this->gateway = new WC_Stripe_UPE_Payment_Gateway();
+
+		// The controller is now a deprecation shim; instantiating it triggers a deprecation notice.
+		$this->setExpectedDeprecated( 'WC_Stripe_Settings_Controller' );
 		$this->controller = new WC_Stripe_Settings_Controller( $this->account, $this->gateway );
 	}
 
@@ -52,6 +55,8 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		$stripe_settings['test_secret_key']      = 'sk_test_key';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
+		$this->setExpectedDeprecated( 'WC_Stripe_Settings_Controller::admin_options' );
+
 		ob_start();
 		$this->controller->admin_options( $this->gateway );
 		$output = ob_get_clean();
@@ -70,6 +75,8 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		$stripe_settings['publishable_key']      = '';
 		$stripe_settings['secret_key']           = '';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		$this->setExpectedDeprecated( 'WC_Stripe_Settings_Controller::admin_options' );
 
 		ob_start();
 		$this->controller->admin_options( $this->gateway );
@@ -103,12 +110,26 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 			->with( $order )
 			->willReturn( $intent );
 
-		$controller = new WC_Stripe_Settings_Controller( $this->account, $gateway );
+		$this->setExpectedDeprecated( 'WC_Stripe_Settings_Controller' );
+		$this->setExpectedDeprecated( 'WC_Stripe_Settings_Controller::hide_refund_button_for_uncaptured_orders' );
 
-		ob_start();
-		$controller->hide_refund_button_for_uncaptured_orders( $order );
-		$output = ob_get_clean();
-		$this->assertStringMatchesFormat( '%aclass="button button-disabled"%a', $output );
+		// Inject the mock gateway into the singleton so the inlined method picks it up.
+		$singleton  = WC_Stripe::get_instance();
+		$reflection = new ReflectionProperty( $singleton, 'stripe_gateway' );
+		$reflection->setAccessible( true );
+		$original_gateway = $reflection->getValue( $singleton );
+		$reflection->setValue( $singleton, $gateway );
+
+		try {
+			$controller = new WC_Stripe_Settings_Controller( $this->account, $gateway );
+
+			ob_start();
+			$controller->hide_refund_button_for_uncaptured_orders( $order );
+			$output = ob_get_clean();
+			$this->assertStringMatchesFormat( '%aclass="button button-disabled"%a', $output );
+		} finally {
+			$reflection->setValue( $singleton, $original_gateway );
+		}
 	}
 
 	/**
@@ -167,6 +188,16 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 			$gateway->method( 'get_validated_option' )->with( 'optimized_checkout_layout' )->willReturn( 'accordion' );
 			$gateway->method( 'get_option' )->willReturn( 'no' );
 
+			// Inject the mock gateway into the singleton so the inlined method picks it up.
+			$singleton          = WC_Stripe::get_instance();
+			$gateway_reflection = new ReflectionProperty( $singleton, 'stripe_gateway' );
+			$gateway_reflection->setAccessible( true );
+			$original_main_gateway = $gateway_reflection->getValue( $singleton );
+			$gateway_reflection->setValue( $singleton, $gateway );
+
+			$this->setExpectedDeprecated( 'WC_Stripe_Settings_Controller' );
+			$this->setExpectedDeprecated( 'WC_Stripe_Settings_Controller::admin_scripts' );
+
 			$controller = new WC_Stripe_Settings_Controller( $account, $gateway );
 
 			add_filter( 'wc_stripe_is_checkout_sessions_available', $feature_filter );
@@ -189,6 +220,9 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		} finally {
 			if ( isset( $stripe_singleton_account_backup ) ) {
 				WC_Stripe::get_instance()->account = $stripe_singleton_account_backup;
+			}
+			if ( isset( $gateway_reflection, $original_main_gateway ) ) {
+				$gateway_reflection->setValue( WC_Stripe::get_instance(), $original_main_gateway );
 			}
 			$GLOBALS['wp_scripts'] = $wp_scripts_backup;
 			remove_filter( 'wc_stripe_is_checkout_sessions_available', $feature_filter );


### PR DESCRIPTION
## Changes proposed in this Pull Request:

**Status: draft / exploratory.** Opening this to surface the diff and shape, not to merge as-is.

The Stripe settings page controller currently sits in its own class (`WC_Stripe_Settings_Controller`, ~310 lines) but it's mostly hooks and one-shot callbacks for the admin Stripe settings tab. Before #1713 (Aug 2021) all of this logic lived directly on the gateway class — the extraction was justified by the UPE settings flag refactor at the time, and that flag is long gone.

This PR explores collapsing it back into `WC_Stripe`:

- **Methods moved verbatim** to `WC_Stripe`:
  - `enqueue_settings_admin_scripts` (was `admin_scripts`)
  - `render_settings_admin_options` (was `admin_options`)
  - `hide_refund_button_for_uncaptured_orders`
  - `hide_payment_gateways_on_settings_page` (was the static `hide_gateways_on_settings_page`)
  - `ajax_get_oauth_url`
  - private helpers: `is_payments_onboarding_task_completed`, `get_agentic_commerce_logs_url`
- **Hook registration** moved into a private `register_settings_admin_hooks()` called from `WC_Stripe::init()` in the same conditional branch where the controller was previously instantiated.
- **`WC_Stripe_Settings_Controller` kept as a deprecation shim** — same public surface, each method delegates to `WC_Stripe` and emits `_deprecated_function`. External plugins that instantiated the class continue to load.
- **PHPStan baseline regenerated** because every existing baseline entry on the controller had to follow the methods to `WC_Stripe`. No new errors were silenced; the count is unchanged in spirit.

### Design questions worth a second opinion

- **Right destination.** I picked `WC_Stripe` (the singleton orchestrator) because the controller already takes `$account` from there, and several of its hooks (OAuth AJAX, the gateway-list filter) are not gateway-specific. The historical home was the gateway (`WC_Gateway_Stripe` → now `WC_Stripe_UPE_Payment_Gateway`). The gateway is arguably more cohesive for `admin_options` + `admin_scripts` since those *are* gateway concerns; the orchestrator is more cohesive for the cross-cutting bits. Worth discussing which target survives the merge.
- **Keep the shim or delete it?** Nothing in this repo (or in the search I ran across `client/`) instantiates `WC_Stripe_Settings_Controller` outside of `WC_Stripe::init()` and the test file. If we're confident no external integrations rely on it, we can drop the shim file in a follow-up.
- **Test ergonomics.** The existing tests instantiated the controller with a mock gateway. Now they reach into `WC_Stripe::stripe_gateway` via reflection because the inlined methods rely on `$this->get_main_stripe_gateway()`. A clean follow-up would either expose a setter or rewrite the tests around `WC_Stripe` directly.

## Testing instructions

1. Visit **WP Admin → WooCommerce → Settings → Payments → Stripe**: the React settings UI should render exactly as before (header + return link + `<div id="wc-stripe-account-settings-container">` or `wc-stripe-new-account-container`).
2. With pending capture on an order, open **WooCommerce → Orders → [order]**: confirm the **Refunding unavailable** disabled button + tooltip still appears in place of the refund button.
3. From the settings page, trigger a Connect / OAuth flow (re-connect banner): the AJAX call to `wc_stripe_get_oauth_url` should still return a URL.
4. `npm run test:php -- --filter=WC_Stripe_Settings_Controller_Test` (7 tests, 31 assertions, all pass).
5. `npm run phpstan` (clean).

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply) — admin-only refactor.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Internal refactor with no user-visible behavior change. If we end up shipping this, we can decide whether the deprecation notice itself warrants an entry.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)