### PR TITLE
Explore: deprecate WC_Stripe_API in favor of the official stripe/stripe-php SDK

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.7.0
+* Add - Add stripe/stripe-php as a runtime dependency exposed via WC_Stripe_Client; deprecate WC_Stripe_API::request() and ::retrieve() in favor of the official SDK
 * Add - Filter wc_stripe_optimized_checkout_title to override the Optimized Checkout payment method title at checkout
 * Fix - Fix compatibility with WooCommerce 10.8 payment handling, where created-via is required for orders
 * Update - Enable Optimized Checkout Suite by default for new installs

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
             "composer/installers": true
         }
     },
+    "require": {
+        "stripe/stripe-php": "^17.6"
+    },
     "require-dev": {
         "composer/installers": "1.9.0",
         "php-stubs/woocommerce-stubs": "^10.4",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "includes/admin/class-wc-stripe-rest-base-controller.php",
         "includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php",
         "includes/admin/class-wc-rest-stripe-exit-survey-controller.php",
-        "includes/admin/class-wc-stripe-plugins-page-controller.php"
+        "includes/admin/class-wc-stripe-plugins-page-controller.php",
+        "includes/class-wc-stripe-client.php"
       ]
     },
     "autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,68 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5b902fe9fbd5436e6c65600b25f6b8bd",
-    "packages": [],
+    "content-hash": "2da4fefb438b1d19440f1135a4ba9075",
+    "packages": [
+        {
+            "name": "stripe/stripe-php",
+            "version": "v17.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stripe/stripe-php.git",
+                "reference": "a6219df5df1324a0d3f1da25fb5e4b8a3307ea16"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/a6219df5df1324a0d3f1da25fb5e4b8a3307ea16",
+                "reference": "a6219df5df1324a0d3f1da25fb5e4b8a3307ea16",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "3.72.0",
+                "phpstan/phpstan": "^1.2",
+                "phpunit/phpunit": "^5.7 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Stripe\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stripe and contributors",
+                    "homepage": "https://github.com/stripe/stripe-php/contributors"
+                }
+            ],
+            "description": "Stripe PHP Library",
+            "homepage": "https://stripe.com/",
+            "keywords": [
+                "api",
+                "payment processing",
+                "stripe"
+            ],
+            "support": {
+                "issues": "https://github.com/stripe/stripe-php/issues",
+                "source": "https://github.com/stripe/stripe-php/tree/v17.6.0"
+            },
+            "time": "2025-08-27T19:32:42+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "brianium/paratest",

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -201,6 +201,8 @@ class WC_Stripe_API {
 	/**
 	 * Send the request to Stripe's API
 	 *
+	 * @deprecated 10.7.0 Use the Stripe PHP SDK via `WC_Stripe_Client::get()` instead.
+	 *
 	 * @since 3.1.0
 	 * @version 4.0.6
 	 * @param array  $request
@@ -293,6 +295,8 @@ class WC_Stripe_API {
 
 	/**
 	 * Retrieve API endpoint.
+	 *
+	 * @deprecated 10.7.0 Use the Stripe PHP SDK via `WC_Stripe_Client::get()` instead.
 	 *
 	 * @since 4.0.0
 	 * @version 4.0.0

--- a/includes/class-wc-stripe-client.php
+++ b/includes/class-wc-stripe-client.php
@@ -1,0 +1,74 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Factory for the official Stripe PHP SDK client.
+ *
+ * Returns a `\Stripe\StripeClient` configured with the active secret key, the
+ * pinned API version, and the partner / app info Stripe uses to identify this
+ * plugin in dashboards and traffic analytics.
+ *
+ * @since 10.7.0
+ */
+class WC_Stripe_Client {
+
+	/**
+	 * The Stripe partner ID assigned to the WooCommerce Stripe Gateway plugin.
+	 */
+	const PARTNER_ID = 'pp_partner_EYuSt9peR0WTMg';
+
+	/**
+	 * Cached SDK client.
+	 *
+	 * @var \Stripe\StripeClient|null
+	 */
+	private static $client = null;
+
+	/**
+	 * The secret key the cached client was built with. Lets us rebuild the
+	 * client when the key changes (mode toggle, OAuth reconnect, tests).
+	 *
+	 * @var string
+	 */
+	private static $cached_secret_key = '';
+
+	/**
+	 * Returns a configured `\Stripe\StripeClient`.
+	 *
+	 * Lazily constructs the client and caches it per-secret-key.
+	 */
+	public static function get(): \Stripe\StripeClient {
+		$secret_key = WC_Stripe_API::get_secret_key();
+
+		if ( null === self::$client || self::$cached_secret_key !== $secret_key ) {
+			\Stripe\Stripe::setAppInfo(
+				'WooCommerce Stripe Gateway',
+				WC_STRIPE_VERSION,
+				'https://woocommerce.com/products/stripe/',
+				self::PARTNER_ID
+			);
+
+			self::$client = new \Stripe\StripeClient(
+				[
+					'api_key'        => $secret_key,
+					'stripe_version' => WC_Stripe_API::STRIPE_API_VERSION,
+				]
+			);
+
+			self::$cached_secret_key = $secret_key;
+		}
+
+		return self::$client;
+	}
+
+	/**
+	 * Resets the cached client. Mainly intended for tests and for callers that
+	 * mutate the secret key out-of-band.
+	 */
+	public static function reset(): void {
+		self::$client            = null;
+		self::$cached_secret_key = '';
+	}
+}

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -434,19 +434,21 @@ class WC_Stripe_Customer {
 			return $customer_id;
 		}
 
-		$response = WC_Stripe_API::retrieve( 'customers/' . $this->get_id() );
-
-		if ( ! empty( $response->error ) ) {
-			if ( $this->is_no_such_customer_error( $response->error ) ) {
-				// This can happen when switching the main Stripe account or importing users from another site.
-				// Recreate the customer in this case.
+		try {
+			$customer = WC_Stripe_Client::get()->customers->retrieve( $this->get_id() );
+		} catch ( \Stripe\Exception\InvalidRequestException $e ) {
+			// `resource_missing` means the customer no longer exists in this Stripe account
+			// (mode swap, account swap, or imported users from another site). Recreate it.
+			if ( 'resource_missing' === $e->getStripeCode() ) {
 				return $this->recreate_customer();
 			}
 
-			throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
+			throw new WC_Stripe_Exception( $e->getMessage(), $e->getMessage() );
+		} catch ( \Stripe\Exception\ApiErrorException $e ) {
+			throw new WC_Stripe_Exception( $e->getMessage(), $e->getMessage() );
 		}
 
-		return $response->id;
+		return $customer->id;
 	}
 
 	/**

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -135,6 +135,7 @@ class WC_Stripe {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-payment-method-configurations.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-database-cache-prefetch.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-api.php';
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-client.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-mode.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/compat/class-wc-stripe-subscriptions-helper.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/compat/trait-wc-stripe-subscriptions-utilities.php';

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -135,7 +135,6 @@ class WC_Stripe {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-payment-method-configurations.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-database-cache-prefetch.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-api.php';
-		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-client.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-mode.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/compat/class-wc-stripe-subscriptions-helper.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/compat/trait-wc-stripe-subscriptions-utilities.php';

--- a/readme.txt
+++ b/readme.txt
@@ -152,6 +152,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.7.0 - xxxx-xx-xx =
+* Add - Add stripe/stripe-php as a runtime dependency exposed via WC_Stripe_Client; deprecate WC_Stripe_API::request() and ::retrieve() in favor of the official SDK
 * Add - Filter wc_stripe_optimized_checkout_title to override the Optimized Checkout payment method title at checkout
 * Fix - Fix compatibility with WooCommerce 10.8 checkout-evidence guard (required created-via in orders)
 * Update - Enable Optimized Checkout Suite by default for new installs


### PR DESCRIPTION
## Changes proposed in this Pull Request:

**Status: draft / exploratory.** Posting to surface the shape and migration cost; not for merge as-is.

`WC_Stripe_API` is a hand-rolled HTTP client built on `wp_safe_remote_post` / `wp_safe_remote_get` that has accumulated several responsibilities: secret key lookup, custom user agent + partner_id, idempotency-key generation, request-body / headers filters, request/response logging, level-3 data injection, 401 invalid-key tracking, and `WC_Stripe_Exception` wrapping. The official `stripe/stripe-php` SDK covers most of those out of the box — and Stripe maintains it against the API version we already pin (\`2025-09-30.clover\`). The plugin currently has **zero runtime composer dependencies**; this would be the first.

This PR explores the move:

- **Adds `stripe/stripe-php: ^17.6` to `composer.json` `require`.** First runtime dep; vendor is gitignored, so distribution build needs `composer install --no-dev` (CI / release script change).
- **New `WC_Stripe_Client` factory** (`includes/class-wc-stripe-client.php`): returns a lazily-cached `\Stripe\StripeClient` configured with the active secret key, `WC_Stripe_API::STRIPE_API_VERSION`, and `Stripe::setAppInfo()` carrying the existing partner_id `pp_partner_EYuSt9peR0WTMg`. Rebuilds the client when the secret key changes (mode toggle, OAuth reconnect).
- **Marks `WC_Stripe_API::request()` and `WC_Stripe_API::retrieve()` `@deprecated 10.7.0`** in PHPDoc only — no `_deprecated_function` notice yet, since 63 in-repo callsites would emit on every request.
- **One representative migration** to demonstrate the new shape:
  - `WC_Stripe_Customer::maybe_create_customer()` now calls `WC_Stripe_Client::get()->customers->retrieve($id)`, catches `\Stripe\Exception\InvalidRequestException`, and uses `getStripeCode() === 'resource_missing'` to drive the recreate-customer branch (replacing the existing `is_no_such_customer_error` check on `$response->error`).

### Why bother

- Stripe maintains it. Future API features land in the SDK without us updating our HTTP path.
- Built-in retries on 5xx + connection errors (we currently don't retry).
- Typed objects (`\Stripe\Customer`, `\Stripe\PaymentIntent`, …) instead of `stdClass` from `json_decode`. PHPStan can actually see them.
- Built-in idempotency-key option, app-info, partner_id, automatic pagination — we wouldn't reinvent those.
- Catchable, typed exception hierarchy (`InvalidRequestException`, `AuthenticationException`, `RateLimitException`, …) instead of one `WC_Stripe_Exception` for everything.

### Cost / risk

- **63 production callsites** to migrate (`WC_Stripe_API::request()` / `::retrieve()` / `::request_with_level3_data()`). Each one moves from `(array $args, string $api, string $method)` to a typed `$client->resource->verb(...)` call.
- **Response shape changes.** Callers do `$response->error->message`, `is_array($response)`, `$response->id`, etc. Those become `try { ... } catch (\Stripe\Exception\ApiErrorException $e)` / `$customer->id`. Every callsite needs review.
- **Custom behavior not covered by the SDK** has to be ported as a thin wrapper:
  - `WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_*` 401 tracking and bail-out.
  - `wc_stripe_request_headers` / `wc_stripe_request_body` / `wc_stripe_idempotency_key` filters. Unclear how many third-party integrations rely on them; deprecating these is a public-API concern.
  - `WC_Stripe_API::request_with_level3_data()`'s country-specific level-3 injection.
  - The `AGENTIC_COMMERCE_API_VERSION` per-call override.
  - `WC_Stripe_Logger::debug()` request/response logging. The SDK has request hooks but the format won't match what we log today.
- **Bundle size.** `stripe/stripe-php` is ~10–15 MB unzipped (with deps). Has to be in the released artifact via `composer install --no-dev`.
- **PHP version.** `stripe-php ^17` supports PHP 7.4 (which matches the platform pin). Newer majors (`^18+`) require PHP 8+; if we want those, that's a separate platform bump.

### Verification

- `npm run phpstan` — clean.
- `npm run lint:php` — clean.
- `npm run test:php -- --filter='WC_Stripe_Customer_Test'` — 20 tests / 39 assertions pass.
- The full suite is unaffected at this stage because only one callsite was migrated.

### Suggested phasing if we pursue this

1. Land this PR (or a tightened version of it): SDK dep + `WC_Stripe_Client`.
2. Port the cross-cutting behavior (`wc_stripe_request_headers/body` filters, 401 tracking, custom logging) into a small wrapper around the SDK calls — say `WC_Stripe_Client::request(...)` — so the call sites get a single consistent interface.
3. Migrate callsites in waves, grouped by resource (`customers`, `payment_intents`, `setup_intents`, `charges`, `refunds`, `webhook_endpoints`, …). Keep `WC_Stripe_API` working until all sites are off it.
4. Once the helpers are gone, switch `WC_Stripe_API::request()` / `::retrieve()` to emit `_deprecated_function` and finally remove them.

## Testing instructions

This is a refactor with no user-visible behavior change. Smoke test:

1. With Stripe credentials configured, place a test order through classic / Blocks checkout and confirm the customer flow still works end-to-end.
2. In a Stripe test account, delete the saved customer ID associated with a logged-in WooCommerce user, then place another order: `maybe_create_customer()` should hit the `resource_missing` branch and recreate.
3. `npm run test:php` — full suite.
4. `npm run phpstan`.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply) — refactor only.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Internal refactor / dep addition; no user-visible behavior change. If we ship a full migration, the changelog entry should call out the new `stripe/stripe-php` runtime dependency.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)