### PR TITLE
Explore: route Stripe SDK calls through WordPress' HTTP API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php",
         "includes/admin/class-wc-rest-stripe-exit-survey-controller.php",
         "includes/admin/class-wc-stripe-plugins-page-controller.php",
-        "includes/class-wc-stripe-client.php"
+        "includes/class-wc-stripe-client.php",
+        "includes/class-wc-stripe-sdk-wp-http-client.php"
       ]
     },
     "autoload-dev": {

--- a/includes/class-wc-stripe-client.php
+++ b/includes/class-wc-stripe-client.php
@@ -50,6 +50,11 @@ class WC_Stripe_Client {
 				self::PARTNER_ID
 			);
 
+			// Route SDK traffic through `wp_safe_remote_request` so existing
+			// `pre_http_request` mocks, third-party WP HTTP filters, and the
+			// `wp_safe_remote_*` allowlist all continue to apply.
+			\Stripe\ApiRequestor::setHttpClient( new WC_Stripe_SDK_WP_Http_Client() );
+
 			self::$client = new \Stripe\StripeClient(
 				[
 					'api_key'        => $secret_key,

--- a/includes/class-wc-stripe-sdk-wp-http-client.php
+++ b/includes/class-wc-stripe-sdk-wp-http-client.php
@@ -1,0 +1,156 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Stripe PHP SDK HTTP transport that routes through WordPress' HTTP API.
+ *
+ * The default `\Stripe\HttpClient\CurlClient` uses curl directly. That bypasses
+ * `wp_safe_remote_*`, the `pre_http_request` filter the WP test framework relies
+ * on, and any third-party rewrites added to the WP HTTP layer. This adapter
+ * implements `\Stripe\HttpClient\ClientInterface` on top of `wp_safe_remote_request`
+ * so SDK calls behave like every other HTTP call the plugin makes.
+ *
+ * Registered globally via `\Stripe\ApiRequestor::setHttpClient()` from
+ * {@see WC_Stripe_Client::get()}.
+ *
+ * @since 10.7.0
+ */
+class WC_Stripe_SDK_WP_Http_Client implements \Stripe\HttpClient\ClientInterface {
+
+	/**
+	 * Default request timeout (seconds). Matches `WC_Stripe_API::request()`.
+	 */
+	private const REQUEST_TIMEOUT = 70;
+
+	/**
+	 * Performs an HTTP request on behalf of the Stripe SDK.
+	 *
+	 * @param 'delete'|'get'|'post' $method  HTTP method (lowercase, per SDK contract).
+	 * @param string                $absUrl  Fully qualified request URL.
+	 * @param array<int,string>     $headers Headers as full "Header: value" strings.
+	 * @param array<string,mixed>   $params  Request parameters.
+	 * @param bool                  $hasFile Whether `$params` references a file upload.
+	 * @param 'v1'|'v2'             $apiMode Stripe API mode — affects POST body encoding.
+	 * @param null|int              $maxNetworkRetries Honored by the SDK at a higher layer; we don't retry here (matches `WC_Stripe_API::request()`).
+	 *
+	 * @return array{0:string,1:int,2:array<string,string>} `[ body, status, headers ]`.
+	 *
+	 * @throws \Stripe\Exception\ApiConnectionException When the request never reaches Stripe.
+	 * @throws \Stripe\Exception\UnexpectedValueException When asked to upload a file (not yet supported by this adapter).
+	 */
+	// phpcs:disable WordPress.NamingConventions.ValidVariableName -- Argument names must match \Stripe\HttpClient\ClientInterface::request().
+	public function request( $method, $absUrl, $headers, $params, $hasFile, $apiMode = 'v1', $maxNetworkRetries = null ) {
+		if ( $hasFile ) {
+			throw new \Stripe\Exception\UnexpectedValueException( 'WC_Stripe_SDK_WP_Http_Client does not support file uploads.' );
+		}
+
+		$method = strtolower( $method );
+
+		[ $url, $body, $extra_headers ] = $this->build_url_and_body( $method, $absUrl, $params, $apiMode );
+
+		$args = [
+			'method'    => strtoupper( $method ),
+			'headers'   => array_merge( $this->normalize_headers( $headers ), $extra_headers ),
+			'timeout'   => self::REQUEST_TIMEOUT,
+			'sslverify' => true,
+		];
+
+		if ( null !== $body ) {
+			$args['body'] = $body;
+		}
+
+		$response = wp_safe_remote_request( $url, $args );
+
+		if ( is_wp_error( $response ) ) {
+			throw new \Stripe\Exception\ApiConnectionException(
+				sprintf( 'Stripe request failed via WordPress HTTP: %s', $response->get_error_message() )
+			);
+		}
+
+		$status   = (int) wp_remote_retrieve_response_code( $response );
+		$body_str = (string) wp_remote_retrieve_body( $response );
+
+		return [ $body_str, $status, $this->collapse_headers( $response ) ];
+	}
+	// phpcs:enable WordPress.NamingConventions.ValidVariableName
+
+	/**
+	 * Mirrors `\Stripe\HttpClient\CurlClient::constructUrlAndBody()` for the
+	 * combinations we care about: form-encoded POST/DELETE bodies for v1,
+	 * JSON for v2, and query-string params for GET.
+	 *
+	 * @param array<string,mixed> $params
+	 * @return array{0:string,1:null|string|array<string,mixed>,2:array<string,string>}
+	 */
+	private function build_url_and_body( string $method, string $abs_url, array $params, string $api_mode ): array {
+		$params = \Stripe\Util\Util::objectsToIds( $params );
+
+		if ( 'post' === $method ) {
+			if ( 'v2' === $api_mode ) {
+				$body = empty( $params ) ? null : (string) wp_json_encode( $params );
+				return [ $abs_url, $body, [ 'Content-Type' => 'application/json' ] ];
+			}
+
+			return [ $abs_url, $params, [] ];
+		}
+
+		// GET / DELETE — params go on the query string.
+		if ( ! empty( $params ) ) {
+			$encoded = \Stripe\Util\Util::encodeParameters( $params, $api_mode );
+			$abs_url = $abs_url . ( false === strpos( $abs_url, '?' ) ? '?' : '&' ) . $encoded;
+		}
+
+		return [ $abs_url, null, [] ];
+	}
+
+	/**
+	 * Converts the SDK's `[ "Header: value", … ]` array into the assoc form
+	 * `wp_safe_remote_request()` expects.
+	 *
+	 * @param array<int,string> $headers
+	 * @return array<string,string>
+	 */
+	private function normalize_headers( array $headers ): array {
+		$normalized = [];
+		foreach ( $headers as $line ) {
+			$colon = strpos( $line, ':' );
+			if ( false === $colon ) {
+				continue;
+			}
+			$name  = trim( substr( $line, 0, $colon ) );
+			$value = trim( substr( $line, $colon + 1 ) );
+			if ( '' !== $name ) {
+				$normalized[ $name ] = $value;
+			}
+		}
+		return $normalized;
+	}
+
+	/**
+	 * Collapses WP's response headers into the assoc form the SDK expects.
+	 *
+	 * `wp_remote_retrieve_headers()` returns a `Requests_Utility_CaseInsensitiveDictionary`
+	 * (or `WpOrg\Requests\Utility\CaseInsensitiveDictionary`); both expose
+	 * `getAll()`.
+	 *
+	 * @param array|\WP_Error $response Whatever `wp_safe_remote_request()` returned.
+	 * @return array<string,string>
+	 */
+	private function collapse_headers( $response ): array {
+		$headers = wp_remote_retrieve_headers( $response );
+		if ( is_object( $headers ) && method_exists( $headers, 'getAll' ) ) {
+			$headers = $headers->getAll();
+		}
+		if ( ! is_array( $headers ) ) {
+			return [];
+		}
+
+		$out = [];
+		foreach ( $headers as $name => $value ) {
+			$out[ (string) $name ] = is_array( $value ) ? implode( ', ', $value ) : (string) $value;
+		}
+		return $out;
+	}
+}

--- a/tests/phpunit/class-wc-stripe-sdk-wp-http-client-test.php
+++ b/tests/phpunit/class-wc-stripe-sdk-wp-http-client-test.php
@@ -1,0 +1,182 @@
+<?php
+
+/**
+ * Tests for the Stripe SDK <-> WordPress HTTP API transport adapter.
+ *
+ * Drives the adapter directly so that:
+ *   1. POST/GET/DELETE requests reach `wp_safe_remote_request` with the
+ *      headers, body, and URL the SDK contract requires.
+ *   2. `pre_http_request`-based mocks (which power the rest of the test suite)
+ *      keep working when SDK calls are routed through the adapter.
+ *   3. WP HTTP errors surface as `\Stripe\Exception\ApiConnectionException`.
+ *   4. The adapter rejects file uploads, which it does not (yet) support.
+ *
+ * @package WooCommerce_Stripe/Tests/WC_Stripe_SDK_WP_Http_Client
+ */
+class WC_Stripe_SDK_WP_Http_Client_Test extends WP_UnitTestCase {
+
+	/**
+	 * Captured args from the most recent `wp_safe_remote_request` call.
+	 *
+	 * @var array{url: string, args: array<string, mixed>}|null
+	 */
+	private $captured = null;
+
+	/**
+	 * Return value for the next intercepted HTTP call.
+	 *
+	 * @var array|WP_Error
+	 */
+	private $next_response = [
+		'response' => [ 'code' => 200 ],
+		'body'     => '{}',
+		'headers'  => [],
+	];
+
+	public function set_up() {
+		parent::set_up();
+		add_filter( 'pre_http_request', [ $this, 'capture_request' ], 10, 3 );
+	}
+
+	public function tear_down() {
+		remove_filter( 'pre_http_request', [ $this, 'capture_request' ], 10 );
+		$this->captured      = null;
+		$this->next_response = [
+			'response' => [ 'code' => 200 ],
+			'body'     => '{}',
+			'headers'  => [],
+		];
+		parent::tear_down();
+	}
+
+	/**
+	 * Captures the request and returns the canned response. Hooked to
+	 * `pre_http_request` so we can intercept without ever touching the network.
+	 */
+	public function capture_request( $preempt, $args, $url ) {
+		$this->captured = [
+			'url'  => $url,
+			'args' => $args,
+		];
+		return $this->next_response;
+	}
+
+	/**
+	 * v1 POST requests should send a form-encoded body (whatever WP would do
+	 * with an array `body` arg) and propagate the SDK headers verbatim.
+	 *
+	 * @return void
+	 */
+	public function test_post_v1_sends_form_body_and_headers() {
+		$client = new WC_Stripe_SDK_WP_Http_Client();
+
+		$result = $client->request(
+			'post',
+			'https://api.stripe.com/v1/customers',
+			[ 'Authorization: Bearer sk_test_xyz', 'Stripe-Version: 2025-09-30.clover' ],
+			[ 'email' => 'shop@example.test' ],
+			false
+		);
+
+		$this->assertSame( 'POST', $this->captured['args']['method'] );
+		$this->assertSame( 'https://api.stripe.com/v1/customers', $this->captured['url'] );
+		$this->assertSame( [ 'email' => 'shop@example.test' ], $this->captured['args']['body'] );
+		$this->assertSame( 'Bearer sk_test_xyz', $this->captured['args']['headers']['Authorization'] );
+		$this->assertSame( '2025-09-30.clover', $this->captured['args']['headers']['Stripe-Version'] );
+
+		$this->assertSame( '{}', $result[0] );
+		$this->assertSame( 200, $result[1] );
+		$this->assertIsArray( $result[2] );
+	}
+
+	/**
+	 * v2 POST requests need to be JSON-encoded and carry an `application/json`
+	 * Content-Type header so Stripe parses them correctly.
+	 *
+	 * @return void
+	 */
+	public function test_post_v2_sends_json_body() {
+		$client = new WC_Stripe_SDK_WP_Http_Client();
+
+		$client->request(
+			'post',
+			'https://api.stripe.com/v2/billing/meter_event_session',
+			[ 'Authorization: Bearer sk_test_xyz' ],
+			[ 'identifier' => 'evt_123' ],
+			false,
+			'v2'
+		);
+
+		$this->assertSame( wp_json_encode( [ 'identifier' => 'evt_123' ] ), $this->captured['args']['body'] );
+		$this->assertSame( 'application/json', $this->captured['args']['headers']['Content-Type'] );
+	}
+
+	/**
+	 * GET (and DELETE) requests must move params onto the URL query string —
+	 * `wp_safe_remote_request` will not put a body on a GET that Stripe would
+	 * accept.
+	 *
+	 * @return void
+	 */
+	public function test_get_appends_params_as_query_string() {
+		$client = new WC_Stripe_SDK_WP_Http_Client();
+
+		$client->request(
+			'get',
+			'https://api.stripe.com/v1/customers',
+			[ 'Authorization: Bearer sk_test_xyz' ],
+			[ 'limit' => 10 ],
+			false
+		);
+
+		$this->assertSame( 'GET', $this->captured['args']['method'] );
+		$this->assertStringContainsString( 'limit=10', $this->captured['url'] );
+		// WP merges in `body => null` as a default — the assertion is that we
+		// don't send a real body, not that the key is absent from the args array.
+		$this->assertEmpty( $this->captured['args']['body'] ?? null );
+	}
+
+	/**
+	 * Connection failures from `wp_safe_remote_request` should surface as the
+	 * SDK's `ApiConnectionException` so callers can catch them with the same
+	 * exception hierarchy they already use for the SDK.
+	 *
+	 * @return void
+	 */
+	public function test_wp_error_response_throws_api_connection_exception() {
+		$this->next_response = new WP_Error( 'http_request_failed', 'cURL error 7: Failed to connect' );
+		$client              = new WC_Stripe_SDK_WP_Http_Client();
+
+		$this->expectException( \Stripe\Exception\ApiConnectionException::class );
+		$this->expectExceptionMessageMatches( '/Failed to connect/' );
+
+		$client->request(
+			'get',
+			'https://api.stripe.com/v1/customers',
+			[ 'Authorization: Bearer sk_test_xyz' ],
+			[],
+			false
+		);
+	}
+
+	/**
+	 * Multipart file uploads aren't wired into this adapter yet — confirm we
+	 * fail fast with the SDK's `UnexpectedValueException` instead of silently
+	 * dropping the file.
+	 *
+	 * @return void
+	 */
+	public function test_file_upload_is_rejected() {
+		$client = new WC_Stripe_SDK_WP_Http_Client();
+
+		$this->expectException( \Stripe\Exception\UnexpectedValueException::class );
+
+		$client->request(
+			'post',
+			'https://files.stripe.com/v1/files',
+			[ 'Authorization: Bearer sk_test_xyz' ],
+			[ 'file' => 'somefile' ],
+			true
+		);
+	}
+}


### PR DESCRIPTION
## Changes proposed in this Pull Request:

**Status: draft / exploratory.** Foundation for the upcoming `WC_Stripe_API` → SDK migration. Stacked on #5403 — merge that first.

The Stripe PHP SDK ships its own curl-based HTTP transport. That's normally fine, but in this codebase it gets in the way:

- The PHPUnit suite mocks Stripe responses by hooking `pre_http_request`. Curl requests bypass that filter entirely, so any test that exercises an SDK callsite either hits the live network or fails with `api_key cannot be the empty string`.
- WP's `wp_safe_remote_*` allowlist + any host-level HTTP filters (proxies, debug capture, third-party plugins) don't see SDK traffic.
- The bulk migration we attempted on top of #5403 produced **430 failures + 23 errors** for exactly this reason.

This PR introduces `WC_Stripe_SDK_WP_Http_Client` — an implementation of `\Stripe\HttpClient\ClientInterface` on top of `wp_safe_remote_request` — and registers it as the SDK's global HTTP client from `WC_Stripe_Client::get()` via `\Stripe\ApiRequestor::setHttpClient()`. After this lands, every SDK call goes through the WP HTTP API and inherits the same mock seam, allowlist, and filter chain the rest of the plugin uses.

### What the adapter does

- Maps the SDK's `(method, $absUrl, $headers, $params, $hasFile, $apiMode, $maxNetworkRetries)` contract onto `wp_safe_remote_request()`.
- POST + v1: passes `$params` as a form-encoded array body (WP handles encoding).
- POST + v2: JSON-encodes the body and adds `Content-Type: application/json`.
- GET / DELETE: appends params to the URL as a query string (mirrors `Stripe\HttpClient\CurlClient::constructUrlAndBody()`).
- Translates the SDK's `[ "Header: value", … ]` array into the assoc form WP expects, and back again on the response.
- Returns `[ body, status, headers ]` — the exact tuple the SDK contract requires.
- Surfaces `WP_Error` as `\Stripe\Exception\ApiConnectionException`.
- Throws `\Stripe\Exception\UnexpectedValueException` for file uploads (no callsite in this codebase needs them today; the next PR can wire that up if/when it does).
- Uses the same 70-second timeout `WC_Stripe_API::request()` carries.

### What it deliberately doesn't do

- **No retries.** `WC_Stripe_API::request()` doesn't retry today either, so we keep parity. Adding retries is a separate, scoped change with its own opinions about idempotency.
- **No request/response logging.** `WC_Stripe_Client::request()` (in #5403's follow-up scope) handles that at the wrapper layer; the adapter is a pure transport.

### Why this unblocks the migration

With the adapter in place, the bulk `WC_Stripe_API::` → `WC_Stripe_Client::` rename can land without rewriting tests: every existing `pre_http_request` mock keeps intercepting Stripe traffic. The follow-up PRs (per-resource migration → final cleanup that turns `WC_Stripe_API::request()` / `::retrieve()` / `::request_with_level3_data()` into thin shims) all build on this.

### Verification

- `npm run test:php` — full suite, **1922 tests / 4431 assertions, all green**.
- `npm run phpstan` — clean.
- `npm run lint:php` — clean.
- New file `tests/phpunit/class-wc-stripe-sdk-wp-http-client-test.php` covers 5 cases on the adapter directly: form-encoded v1 POST, JSON v2 POST, GET query-string handling, `WP_Error` → `ApiConnectionException`, and file-upload rejection.

## Testing instructions

This is foundation infrastructure with no user-visible behavior change. Smoke test:

1. Visit **WP Admin → WooCommerce → Settings → Payments → Stripe** and confirm the React UI still loads and the Stripe account banner is correct (this exercises a number of SDK / `WC_Stripe_API` paths).
2. Place a test order through classic + Blocks checkout — the customer-create flow already runs through the SDK after #5403.
3. `npm run test:php` (full suite).
4. `npm run phpstan`.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply) — refactor only, admin/checkout-side.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Internal refactor / dep wiring; no user-visible behavior change. The user-visible entry already lives on #5403 (the parent PR introducing `stripe/stripe-php` and `WC_Stripe_Client`).

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)