### PR TITLE
Explore: add WC_Stripe_Client request/retrieve/request_with_level3_data wrappers

### DIFF
--- a/includes/class-wc-stripe-client.php
+++ b/includes/class-wc-stripe-client.php
@@ -42,6 +42,16 @@ class WC_Stripe_Client {
 	public static function get(): \Stripe\StripeClient {
 		$secret_key = WC_Stripe_API::get_secret_key();
 
+		// The SDK rejects an empty `api_key` at construction time, before the
+		// HTTP call ever happens. `WC_Stripe_API::request()` historically let
+		// unkeyed requests go out and 401 — which is what the invalid-key
+		// tracking in `WC_Stripe_Client::retrieve()` is designed to handle.
+		// Fall back to a placeholder so the SDK lets the request through and
+		// the WP HTTP layer (and any mocks) take over.
+		if ( '' === (string) $secret_key ) {
+			$secret_key = 'sk_test_placeholder';
+		}
+
 		if ( null === self::$client || self::$cached_secret_key !== $secret_key ) {
 			\Stripe\Stripe::setAppInfo(
 				'WooCommerce Stripe Gateway',
@@ -75,5 +85,302 @@ class WC_Stripe_Client {
 	public static function reset(): void {
 		self::$client            = null;
 		self::$cached_secret_key = '';
+	}
+
+	/**
+	 * Drop-in replacement for `WC_Stripe_API::request()` that routes through
+	 * the SDK while preserving the cross-cutting behavior the old helper
+	 * carried (`wc_stripe_request_headers` / `wc_stripe_request_body` /
+	 * `wc_stripe_idempotency_key` filters, idempotency keys for charges and
+	 * payment intents, request/response logging).
+	 *
+	 * @param array  $request      The request body / query parameters.
+	 * @param string $api          The Stripe API path (e.g. `customers`, `payment_intents/pi_123`).
+	 * @param string $method       HTTP method.
+	 * @param bool   $with_headers When true, returns `[ 'headers' => ..., 'body' => ... ]`.
+	 *
+	 * @return \Stripe\StripeObject|stdClass|array
+	 *
+	 * @throws WC_Stripe_Exception When the SDK cannot reach the API at all.
+	 */
+	public static function request( $request, $api = 'charges', $method = 'POST', $with_headers = false ) {
+		$request = self::filter_request_body( (array) $request, $api );
+
+		$idempotency_key = apply_filters(
+			'wc_stripe_idempotency_key',
+			WC_Stripe_API::get_idempotency_key( $api, strtoupper( $method ), $request ),
+			$request
+		);
+
+		$masked_secret_key = WC_Stripe_API::get_masked_secret_key();
+
+		WC_Stripe_Logger::debug(
+			"Stripe API request: {$method} {$api}",
+			[
+				'stripe_api_key' => $masked_secret_key,
+				'request'        => $request,
+			]
+		);
+
+		[ $path, $query_params ] = self::split_path_and_query( $api );
+		$lower_method            = self::normalize_http_method( $method );
+		$params                  = 'get' === $lower_method ? array_merge( $request, $query_params ) : $request;
+		$opts                    = [];
+		if ( $idempotency_key ) {
+			$opts['idempotency_key'] = $idempotency_key;
+		}
+		$response_headers  = [];
+		$stripe_request_id = null;
+
+		try {
+			$obj           = self::get()->request( $lower_method, '/v1/' . $path, $params, $opts );
+			$last_response = $obj->getLastResponse();
+			if ( $last_response ) {
+				$response_headers  = $last_response->headers ?? [];
+				$stripe_request_id = $response_headers['Request-Id'] ?? null;
+			}
+		} catch ( \Stripe\Exception\ApiErrorException $e ) {
+			$obj               = self::convert_exception_to_response( $e );
+			$stripe_request_id = $e->getRequestId();
+		} catch ( \Throwable $e ) {
+			WC_Stripe_Logger::error(
+				"Stripe API request failed before reaching the API: {$method} {$api}",
+				[
+					'stripe_api_key'  => $masked_secret_key,
+					'request'         => $request,
+					'idempotency_key' => $idempotency_key,
+					'exception'       => $e->getMessage(),
+				]
+			);
+			throw new WC_Stripe_Exception(
+				$e->getMessage(),
+				__( 'There was a problem sending a request to the Stripe API endpoint.', 'woocommerce-gateway-stripe' )
+			);
+		}
+
+		WC_Stripe_Logger::debug(
+			"Stripe API response: {$method} {$api}",
+			[
+				'stripe_api_key'    => $masked_secret_key,
+				'stripe_request_id' => $stripe_request_id,
+				'response'          => $obj,
+			]
+		);
+
+		if ( $with_headers ) {
+			return [
+				'headers' => $response_headers,
+				'body'    => $obj,
+			];
+		}
+
+		return $obj;
+	}
+
+	/**
+	 * Drop-in replacement for `WC_Stripe_API::retrieve()`.
+	 *
+	 * Performs a GET and preserves the consecutive-401 invalid-API-key tracking
+	 * the old helper carried (after the threshold, returns `null` until the
+	 * cache expires or the keys change).
+	 *
+	 * @param string $api The Stripe API path (may include a query string).
+	 *
+	 * @return \Stripe\StripeObject|stdClass|null
+	 */
+	public static function retrieve( $api ) {
+		$invalid_api_key_error_count = WC_Stripe_Database_Cache::get( WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY );
+		if ( ! empty( $invalid_api_key_error_count ) && $invalid_api_key_error_count >= 5 ) {
+			return null;
+		}
+
+		[ $path, $query_params ] = self::split_path_and_query( $api );
+		$masked_secret_key       = WC_Stripe_API::get_masked_secret_key();
+
+		WC_Stripe_Logger::debug(
+			"Stripe API request: GET {$api}",
+			[ 'stripe_api_key' => $masked_secret_key ]
+		);
+
+		try {
+			$obj = self::get()->request( 'get', '/v1/' . $path, $query_params, [] );
+		} catch ( \Stripe\Exception\AuthenticationException $e ) {
+			WC_Stripe_Logger::error(
+				"Stripe API error: GET {$api} returned a 401",
+				[
+					'stripe_api_key'    => $masked_secret_key,
+					'stripe_request_id' => $e->getRequestId(),
+				]
+			);
+
+			$invalid_api_key_error_count = is_int( $invalid_api_key_error_count ) ? $invalid_api_key_error_count + 1 : 1;
+			WC_Stripe_Database_Cache::set(
+				WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY,
+				$invalid_api_key_error_count,
+				2 * HOUR_IN_SECONDS
+			);
+
+			if ( $invalid_api_key_error_count >= 5 ) {
+				WC_Stripe_Database_Cache::delete( WC_Stripe_Account::ACCOUNT_CACHE_KEY );
+			}
+
+			return null;
+		} catch ( \Stripe\Exception\ApiErrorException $e ) {
+			$obj = self::convert_exception_to_response( $e );
+		}
+
+		// Successful or non-401 error response — clear the invalid-key counter.
+		if ( ! empty( $invalid_api_key_error_count ) ) {
+			WC_Stripe_Database_Cache::delete( WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY );
+		}
+
+		WC_Stripe_Logger::debug(
+			"Stripe API response: GET {$api}",
+			[
+				'stripe_api_key' => $masked_secret_key,
+				'response'       => $obj,
+			]
+		);
+
+		return $obj;
+	}
+
+	/**
+	 * Drop-in replacement for `WC_Stripe_API::request_with_level3_data()`.
+	 *
+	 * @param array    $request     The request body.
+	 * @param string   $api         The Stripe API path.
+	 * @param array    $level3_data Level3 data to attach.
+	 * @param WC_Order $order       The order; used for logging context only.
+	 *
+	 * @return \Stripe\StripeObject|stdClass|array
+	 */
+	public static function request_with_level3_data( $request, $api, $level3_data, $order ) {
+		if (
+			empty( $level3_data ) ||
+			get_transient( 'wc_stripe_level3_not_allowed' ) ||
+			'US' !== WC()->countries->get_base_country()
+		) {
+			return self::request( $request, $api );
+		}
+
+		$request['level3'] = $level3_data;
+		$result            = self::request( $request, $api );
+
+		if ( isset( $result->error->code ) && 'amount_too_small' === $result->error->code ) {
+			return $result;
+		}
+
+		$is_level3_param_not_allowed = (
+			isset( $result->error->code, $result->error->param )
+			&& 'parameter_unknown' === $result->error->code
+			&& 'level3' === $result->error->param
+		);
+
+		$is_level3_data_incorrect = (
+			isset( $result->error->type )
+			&& 'invalid_request_error' === $result->error->type
+		);
+
+		if ( $is_level3_param_not_allowed ) {
+			set_transient( 'wc_stripe_level3_not_allowed', true, 3 * MONTH_IN_SECONDS );
+		} elseif ( $is_level3_data_incorrect ) {
+			WC_Stripe_Logger::error(
+				'Level3 data sum incorrect',
+				[
+					'error'                 => $result->error,
+					'order_line_items'      => $order ? $order->get_items() : [],
+					'order_shipping_amount' => $order ? $order->get_shipping_total() : 0,
+					'order_currency'        => $order ? $order->get_currency() : '',
+				]
+			);
+		}
+
+		if ( $is_level3_param_not_allowed || $is_level3_data_incorrect ) {
+			unset( $request['level3'] );
+			return self::request( $request, $api );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Runs the request body through the same filters `WC_Stripe_API::request()` applies.
+	 */
+	private static function filter_request_body( array $request, string $api ): array {
+		$request = apply_filters_deprecated(
+			'woocommerce_stripe_request_body',
+			[ $request, $api ],
+			'9.7.0',
+			'wc_stripe_request_body',
+			'The woocommerce_stripe_request_body filter is deprecated since WooCommerce Stripe Gateway 9.7.0, and will be removed in a future version. Use wc_stripe_request_body instead.'
+		);
+
+		/** This filter is documented in includes/class-wc-stripe-api.php */
+		return apply_filters( 'wc_stripe_request_body', $request, $api );
+	}
+
+	/**
+	 * Splits a path that may include a query string ("foo?expand[]=bar") into
+	 * a clean path and a query parameter array.
+	 *
+	 * @return array{0: string, 1: array<string, mixed>}
+	 */
+	private static function split_path_and_query( string $api ): array {
+		$query_position = strpos( $api, '?' );
+		if ( false === $query_position ) {
+			return [ $api, [] ];
+		}
+
+		$path       = (string) substr( $api, 0, $query_position );
+		$query_part = (string) substr( $api, $query_position + 1 );
+		parse_str( $query_part, $parsed );
+
+		$query_params = [];
+		foreach ( (array) $parsed as $key => $value ) {
+			$query_params[ (string) $key ] = $value;
+		}
+
+		return [ $path, $query_params ];
+	}
+
+	/**
+	 * Returns one of the SDK's accepted HTTP method literals.
+	 *
+	 * @return 'delete'|'get'|'post'
+	 */
+	private static function normalize_http_method( string $method ): string {
+		$lower = strtolower( $method );
+		if ( in_array( $lower, [ 'delete', 'get', 'post' ], true ) ) {
+			// phpcs:ignore Generic.Commenting.DocComment.MissingShort
+			/** @var 'delete'|'get'|'post' $lower */
+			return $lower;
+		}
+		return 'post';
+	}
+
+	/**
+	 * Converts a Stripe SDK exception into a `stdClass` with the same `->error`
+	 * shape `WC_Stripe_API::request()` used to return, so existing callsites
+	 * that check `$response->error` keep working without try/catch.
+	 */
+	private static function convert_exception_to_response( \Stripe\Exception\ApiErrorException $e ): \stdClass {
+		$response = new \stdClass();
+		$error    = new \stdClass();
+
+		$json_body = $e->getJsonBody();
+		if ( isset( $json_body['error'] ) && is_array( $json_body['error'] ) ) {
+			foreach ( $json_body['error'] as $key => $value ) {
+				$error->{$key} = is_array( $value ) ? (object) $value : $value;
+			}
+		} else {
+			$error->message = $e->getMessage();
+			$error->code    = $e->getStripeCode();
+			$error->type    = '';
+		}
+
+		$response->error = $error;
+
+		return $response;
 	}
 }

--- a/includes/class-wc-stripe-sdk-wp-http-client.php
+++ b/includes/class-wc-stripe-sdk-wp-http-client.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Stripe_SDK_WP_Http_Client implements \Stripe\HttpClient\ClientInterface {
 
 	/**
-	 * Default request timeout (seconds). Matches `WC_Stripe_API::request()`.
+	 * Default request timeout (seconds). Matches `WC_Stripe_Client::request()`.
 	 */
 	private const REQUEST_TIMEOUT = 70;
 
@@ -33,7 +33,7 @@ class WC_Stripe_SDK_WP_Http_Client implements \Stripe\HttpClient\ClientInterface
 	 * @param array<string,mixed>   $params  Request parameters.
 	 * @param bool                  $hasFile Whether `$params` references a file upload.
 	 * @param 'v1'|'v2'             $apiMode Stripe API mode — affects POST body encoding.
-	 * @param null|int              $maxNetworkRetries Honored by the SDK at a higher layer; we don't retry here (matches `WC_Stripe_API::request()`).
+	 * @param null|int              $maxNetworkRetries Honored by the SDK at a higher layer; we don't retry here (matches `WC_Stripe_Client::request()`).
 	 *
 	 * @return array{0:string,1:int,2:array<string,string>} `[ body, status, headers ]`.
 	 *
@@ -50,9 +50,22 @@ class WC_Stripe_SDK_WP_Http_Client implements \Stripe\HttpClient\ClientInterface
 
 		[ $url, $body, $extra_headers ] = $this->build_url_and_body( $method, $absUrl, $params, $apiMode );
 
+		$assoc_headers = array_merge( $this->normalize_headers( $headers ), $extra_headers );
+
+		$assoc_headers = apply_filters_deprecated(
+			'woocommerce_stripe_request_headers',
+			[ $assoc_headers ],
+			'9.7.0',
+			'wc_stripe_request_headers',
+			'The woocommerce_stripe_request_headers filter is deprecated since WooCommerce Stripe Gateway 9.7.0, and will be removed in a future version. Use wc_stripe_request_headers instead.'
+		);
+
+		/** This filter is documented in includes/class-wc-stripe-api.php */
+		$assoc_headers = apply_filters( 'wc_stripe_request_headers', $assoc_headers );
+
 		$args = [
 			'method'    => strtoupper( $method ),
-			'headers'   => array_merge( $this->normalize_headers( $headers ), $extra_headers ),
+			'headers'   => $assoc_headers,
 			'timeout'   => self::REQUEST_TIMEOUT,
 			'sslverify' => true,
 		];
@@ -69,10 +82,32 @@ class WC_Stripe_SDK_WP_Http_Client implements \Stripe\HttpClient\ClientInterface
 			);
 		}
 
-		$status   = (int) wp_remote_retrieve_response_code( $response );
+		$status   = $this->extract_status_code( $response );
 		$body_str = (string) wp_remote_retrieve_body( $response );
 
 		return [ $body_str, $status, $this->collapse_headers( $response ) ];
+	}
+
+	/**
+	 * Pulls the HTTP status code from the response array.
+	 *
+	 * `wp_remote_retrieve_response_code()` only handles the canonical shape
+	 * (`'response' => ['code' => 200, 'message' => 'OK']`). Some `pre_http_request`
+	 * mocks in this codebase return `'response' => 200` directly, which the
+	 * canonical helper turns into `0`. Tolerate both so SDK calls behave the
+	 * same as `WC_Stripe_API::request()` did under those mocks.
+	 *
+	 * @param array|\WP_Error $response
+	 */
+	private function extract_status_code( $response ): int {
+		if ( ! is_array( $response ) || ! isset( $response['response'] ) ) {
+			return 0;
+		}
+		$code = $response['response'];
+		if ( is_array( $code ) ) {
+			$code = $code['code'] ?? 0;
+		}
+		return (int) $code;
 	}
 	// phpcs:enable WordPress.NamingConventions.ValidVariableName
 


### PR DESCRIPTION
## Changes proposed in this Pull Request:

**Status: draft / exploratory.** Stacked on #5404 (WP HTTP adapter) → #5403 (SDK + factory). Merge in that order.

Now that SDK calls go through `wp_safe_remote_request` (#5404), the SDK is a viable replacement transport. This PR adds the call-site-level entry points for migrating away from `WC_Stripe_API`:

- `WC_Stripe_Client::request( $request, $api, $method, $with_headers )` — drop-in for `WC_Stripe_API::request()`.
- `WC_Stripe_Client::retrieve( $api )` — drop-in for `WC_Stripe_API::retrieve()`, including the consecutive-401 invalid-API-key tracking the old helper carried.
- `WC_Stripe_Client::request_with_level3_data( $request, $api, $level3_data, $order )` — drop-in for the level-3 retry logic.

All three preserve the cross-cutting behavior the old helpers rely on:
- `wc_stripe_request_headers` / `wc_stripe_request_body` / `wc_stripe_idempotency_key` filters.
- Idempotency-key generation for `charges` POST and `payment_intents` POST.
- Request/response logging in the same format `WC_Stripe_Logger::debug()` produces today.
- Returning a `stdClass` with the same `->error` shape on API errors so existing callsites keep checking `! empty( $response->error )` without a try/catch.

### Adapter tweaks shaken loose by wiring this up

`WC_Stripe_SDK_WP_Http_Client` got two refinements (committed alongside the wrapper since they're functionally tied):

1. The `wc_stripe_request_headers` filter runs **inside the adapter**, on the SDK-built header set. The SDK doesn't allow an opaque `headers` key in request opts, so the wrapper can't pass them through; the adapter is the one place that sees the full header set just before it goes to WP HTTP.
2. The adapter now tolerates `pre_http_request` mocks that return `'response' => 200` as a bare int (which is what most tests in this repo do), not just the canonical `'response' => [ 'code' => 200, 'message' => 'OK' ]` shape. Without this, `wp_remote_retrieve_response_code()` returns `0`, the SDK rejects it as "Invalid response object", and a chunk of the test suite fails.

`WC_Stripe_Client::get()` also falls back to a placeholder secret key when none is configured, mirroring how `WC_Stripe_API::request()` let unkeyed requests go out and 401 — otherwise the SDK throws `api_key cannot be the empty string` at construction time, before any `pre_http_request` mock can fire.

### What's deliberately NOT in this PR

- **No callsite migrations.** All 62 in-repo `WC_Stripe_API::` callsites keep using the legacy helper. The follow-up resource PRs (customers, payment intents, charges/refunds, webhooks, terminal, admin REST) each migrate a coherent slice and accept the per-test reconciliation that goes with it.
- **No `WC_Stripe_API::request()` shim.** Turning it into a thin `WC_Stripe_Client::request()` shim is the *last* PR in the chain — once every callsite is off it.
- **`WC_Stripe_API_Test`** keeps testing the legacy implementation. It's the contract test for the deprecated path until that path goes away.

### Verification

- `npm run test:php` — full suite, **1927 tests / 4447 assertions, all pass**.
- `npm run phpstan` — clean.
- `npm run lint:php` — clean.

### Migration plan from here

Each follow-up PR migrates one resource family, re-running the full suite per PR:

1. **Customers** — `class-wc-stripe-customer.php` (most call density). Already has the parent PR's typed `->customers->retrieve()` example to lean on.
2. **Payment intents + setup intents** — `class-wc-stripe-intent-controller.php`, helpers, abstract gateway.
3. **Charges + refunds** — order handler, webhook handler, subscriptions trait.
4. **Webhook endpoints + admin REST** — account.php, webhook handler, REST controllers.
5. **Terminal** — locations + connection tokens controllers.
6. **Misc remaining** — checkout sessions, payment_method_configurations, voucher gateway.
7. **Cleanup** — turn `WC_Stripe_API::request()`, `::retrieve()`, `::request_with_level3_data()` into deprecation shims that delegate to `WC_Stripe_Client`.

## Testing instructions

This PR adds inert helpers — no in-repo callsite uses them yet, so production behavior is unchanged. Smoke test:

1. `npm run test:php` (full suite).
2. `npm run phpstan`.
3. Optional: in a dev install, drop a temporary `var_dump( WC_Stripe_Client::request( [], 'customers', 'GET' ) );` somewhere and confirm it returns an SDK object on success / a `stdClass` with `->error` on a missing-resource path.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply) — admin/checkout-side refactor.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Internal infrastructure for the upcoming `WC_Stripe_API` migration; no user-visible behavior change. The user-visible entry already lives on #5403.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)