### PR TITLE
Explore: migrate WC_Stripe_Customer to typed Stripe SDK calls

### DIFF
--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -456,13 +456,14 @@ class WC_Stripe_Customer {
 	 *
 	 * @param string $email Customer email.
 	 * @param string $name  Customer name.
-	 * @return array
+	 * @return array|\Stripe\Customer The first matched customer, or `[]` if none / on error.
 	 */
 	public function get_existing_customer( $email, $name ) {
-		$search_query    = [ 'query' => 'name:\'' . $name . '\' AND email:\'' . $email . '\'' ];
-		$search_response = WC_Stripe_API::request( $search_query, 'customers/search', 'GET' );
-
-		if ( ! empty( $search_response->error ) ) {
+		try {
+			$search_response = WC_Stripe_Client::get()->customers->search(
+				[ 'query' => 'name:\'' . $name . '\' AND email:\'' . $email . '\'' ]
+			);
+		} catch ( \Stripe\Exception\ApiErrorException $e ) {
 			return [];
 		}
 
@@ -491,29 +492,27 @@ class WC_Stripe_Customer {
 		// $current_context was initially introduced as a boolean flag, so check for old callers.
 		$current_context = $this->normalize_current_context( $current_context );
 
-		if ( empty( $response ) ) {
-			/**
-			 * Filters the arguments used to create a customer.
-			 *
-			 * @since 4.0.0
-			 *
-			 * @param array $args The arguments used to create a customer.
-			 */
-			$create_customer_args = apply_filters( 'wc_stripe_create_customer_args', $args );
+		try {
+			if ( empty( $response ) ) {
+				/**
+				 * Filters the arguments used to create a customer.
+				 *
+				 * @since 4.0.0
+				 *
+				 * @param array $args The arguments used to create a customer.
+				 */
+				$create_customer_args = apply_filters( 'wc_stripe_create_customer_args', $args );
 
-			$this->validate_create_customer_request( $create_customer_args, $current_context );
+				$this->validate_create_customer_request( $create_customer_args, $current_context );
 
-			$response = WC_Stripe_API::request( $create_customer_args, 'customers' );
-		} else {
-			/**
-			 * This filter is documented in includes/class-wc-stripe-customer.php.
-			 */
-			$update_customer_args = apply_filters( 'wc_stripe_update_customer_args', $args );
-			$response             = WC_Stripe_API::request( $update_customer_args, 'customers/' . $response->id );
-		}
-
-		if ( ! empty( $response->error ) ) {
-			throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
+				$response = WC_Stripe_Client::get()->customers->create( $create_customer_args );
+			} else {
+				/** This filter is documented in includes/class-wc-stripe-customer.php. */
+				$update_customer_args = apply_filters( 'wc_stripe_update_customer_args', $args );
+				$response             = WC_Stripe_Client::get()->customers->update( $response->id, $update_customer_args );
+			}
+		} catch ( \Stripe\Exception\ApiErrorException $e ) {
+			throw new WC_Stripe_Exception( $e->getMessage(), $e->getMessage() );
 		}
 
 		$this->set_id( $response->id );
@@ -554,18 +553,21 @@ class WC_Stripe_Customer {
 		 *
 		 * @param array $args The arguments used to update a customer.
 		 */
-		$args     = apply_filters( 'wc_stripe_update_customer_args', $args );
-		$response = WC_Stripe_API::request( $args, 'customers/' . $this->get_id() );
+		$args = apply_filters( 'wc_stripe_update_customer_args', $args );
 
-		if ( ! empty( $response->error ) ) {
-			if ( $this->is_no_such_customer_error( $response->error ) && ! $is_retry ) {
+		try {
+			$response = WC_Stripe_Client::get()->customers->update( $this->get_id(), $args );
+		} catch ( \Stripe\Exception\InvalidRequestException $e ) {
+			if ( 'resource_missing' === $e->getStripeCode() && ! $is_retry ) {
 				// This can happen when switching the main Stripe account or importing users from another site.
 				// If not already retrying, recreate the customer and then try updating it again.
 				$this->recreate_customer();
 				return $this->update_customer( $args, true );
 			}
 
-			throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
+			throw new WC_Stripe_Exception( $e->getMessage(), $e->getMessage() );
+		} catch ( \Stripe\Exception\ApiErrorException $e ) {
+			throw new WC_Stripe_Exception( $e->getMessage(), $e->getMessage() );
 		}
 
 		$this->clear_cache();
@@ -761,15 +763,12 @@ class WC_Stripe_Customer {
 		$sources = get_transient( 'stripe_sources_' . $this->get_id() );
 
 		if ( false === $sources ) {
-			$response = WC_Stripe_API::request(
-				[
-					'limit' => 100,
-				],
-				'customers/' . $this->get_id() . '/payment_methods',
-				'GET'
-			);
-
-			if ( ! empty( $response->error ) ) {
+			try {
+				$response = WC_Stripe_Client::get()->customers->allPaymentMethods(
+					$this->get_id(),
+					[ 'limit' => 100 ]
+				);
+			} catch ( \Stripe\Exception\ApiErrorException $e ) {
 				return [];
 			}
 
@@ -798,27 +797,27 @@ class WC_Stripe_Customer {
 		$payment_methods = get_transient( self::PAYMENT_METHODS_TRANSIENT_KEY . $payment_method_type . $this->get_id() );
 
 		if ( false === $payment_methods ) {
-			$params   = WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID === $payment_method_type ? '?expand[]=data.sepa_debit.generated_from.charge&expand[]=data.sepa_debit.generated_from.setup_attempt' : '';
-			$response = WC_Stripe_API::request(
-				[
-					'customer' => $this->get_id(),
-					'type'     => $payment_method_type,
-					'limit'    => self::PAYMENT_METHODS_API_LIMIT,
-				],
-				'payment_methods' . $params,
-				'GET'
-			);
+			$params = [
+				'customer' => $this->get_id(),
+				'type'     => $payment_method_type,
+				'limit'    => self::PAYMENT_METHODS_API_LIMIT,
+			];
+			if ( WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID === $payment_method_type ) {
+				$params['expand'] = [
+					'data.sepa_debit.generated_from.charge',
+					'data.sepa_debit.generated_from.setup_attempt',
+				];
+			}
 
-			if ( ! empty( $response->error ) ) {
-				if (
-					isset( $response->error->code, $response->error->param, $response->error->type )
-					&& 'customer' === $response->error->param
-					&& 'resource_missing' === $response->error->code
-					&& 'invalid_request_error' === $response->error->type
-				) {
+			try {
+				$response = WC_Stripe_Client::get()->paymentMethods->all( $params );
+			} catch ( \Stripe\Exception\InvalidRequestException $e ) {
+				if ( 'resource_missing' === $e->getStripeCode() && 'customer' === $e->getStripeParam() ) {
 					// If the customer doesn't exist, cache an empty array as a result.
 					set_transient( self::PAYMENT_METHODS_TRANSIENT_KEY . $payment_method_type . $this->get_id(), [], DAY_IN_SECONDS );
 				}
+				return [];
+			} catch ( \Stripe\Exception\ApiErrorException $e ) {
 				return [];
 			}
 
@@ -855,23 +854,25 @@ class WC_Stripe_Customer {
 				$request_params = [
 					'customer' => $this->get_id(),
 					'limit'    => self::PAYMENT_METHODS_API_LIMIT,
+					'expand'   => [
+						'data.sepa_debit.generated_from.charge',
+						'data.sepa_debit.generated_from.setup_attempt',
+					],
 				];
 
 				if ( $last_payment_method_id ) {
 					$request_params['starting_after'] = $last_payment_method_id;
 				}
 
-				$response = WC_Stripe_API::request( $request_params, 'payment_methods?expand[]=data.sepa_debit.generated_from.charge&expand[]=data.sepa_debit.generated_from.setup_attempt', 'GET' );
-
-				if ( ! empty( $response->error ) ) {
-					if (
-						isset( $response->error->param, $response->error->code )
-						&& 'customer' === $response->error->param
-						&& 'resource_missing' === $response->error->code
-					) {
+				try {
+					$response = WC_Stripe_Client::get()->paymentMethods->all( $request_params );
+				} catch ( \Stripe\Exception\InvalidRequestException $e ) {
+					if ( 'resource_missing' === $e->getStripeCode() && 'customer' === $e->getStripeParam() ) {
 						// If the customer doesn't exist, cache an empty array.
 						set_transient( $cache_key, [], DAY_IN_SECONDS );
 					}
+					return [];
+				} catch ( \Stripe\Exception\ApiErrorException $e ) {
 					return [];
 				}
 
@@ -971,24 +972,25 @@ class WC_Stripe_Customer {
 	 * @throws WC_Stripe_Exception
 	 */
 	public function set_default_source( $source_id ): bool {
-		$response = WC_Stripe_API::request(
-			[
-				'default_source' => sanitize_text_field( $source_id ),
-			],
-			'customers/' . $this->get_id(),
-			'POST'
-		);
-
-		if ( empty( $response->error ) ) {
-			// Clear cache so that the payment methods list from Stripe is refreshed to have the correct default payment method.
-			$this->clear_cache();
-
-			do_action( 'wc_stripe_set_default_source', $this->get_id(), $response );
-
-			return true;
+		if ( ! $this->get_id() ) {
+			return false;
 		}
 
-		return false;
+		try {
+			$response = WC_Stripe_Client::get()->customers->update(
+				$this->get_id(),
+				[ 'default_source' => sanitize_text_field( $source_id ) ]
+			);
+		} catch ( \Stripe\Exception\ApiErrorException $e ) {
+			return false;
+		}
+
+		// Clear cache so that the payment methods list from Stripe is refreshed to have the correct default payment method.
+		$this->clear_cache();
+
+		do_action( 'wc_stripe_set_default_source', $this->get_id(), $response );
+
+		return true;
 	}
 
 	/**
@@ -999,26 +1001,29 @@ class WC_Stripe_Customer {
 	 * @throws WC_Stripe_Exception
 	 */
 	public function set_default_payment_method( $payment_method_id ): bool {
-		$response = WC_Stripe_API::request(
-			[
-				'invoice_settings' => [
-					'default_payment_method' => sanitize_text_field( $payment_method_id ),
-				],
-			],
-			'customers/' . $this->get_id(),
-			'POST'
-		);
-
-		if ( empty( $response->error ) ) {
-			// Clear cache so that the payment methods list from Stripe is refreshed to have the correct default payment method.
-			$this->clear_cache();
-
-			do_action( 'wc_stripe_set_default_payment_method', $this->get_id(), $response );
-
-			return true;
+		if ( ! $this->get_id() ) {
+			return false;
 		}
 
-		return false;
+		try {
+			$response = WC_Stripe_Client::get()->customers->update(
+				$this->get_id(),
+				[
+					'invoice_settings' => [
+						'default_payment_method' => sanitize_text_field( $payment_method_id ),
+					],
+				]
+			);
+		} catch ( \Stripe\Exception\ApiErrorException $e ) {
+			return false;
+		}
+
+		// Clear cache so that the payment methods list from Stripe is refreshed to have the correct default payment method.
+		$this->clear_cache();
+
+		do_action( 'wc_stripe_set_default_payment_method', $this->get_id(), $response );
+
+		return true;
 	}
 
 	/**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1189,12 +1189,6 @@ parameters:
 			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
 
 		-
-			message: '#^Method WC_REST_Stripe_Agentic_Commerce_Controller\:\:update_agentic_settings\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
-
-		-
 			message: '#^Method WC_REST_Stripe_Account_Keys_Controller\:\:test_account_keys\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1
@@ -1229,6 +1223,12 @@ parameters:
 			identifier: missingType.generics
 			count: 1
 			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
+
+		-
+			message: '#^Method WC_REST_Stripe_Agentic_Commerce_Controller\:\:update_agentic_settings\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
+			identifier: missingType.generics
+			count: 1
+			path: includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
 
 		-
 			message: '#^Method WC_REST_Stripe_Connection_Tokens_Controller\:\:create_token\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
@@ -1951,21 +1951,9 @@ parameters:
 			path: includes/class-wc-stripe-customer.php
 
 		-
-			message: '#^Cannot access property \$data on array\|stdClass\.$#'
-			identifier: property.nonObject
-			count: 7
-			path: includes/class-wc-stripe-customer.php
-
-		-
-			message: '#^Cannot access property \$id on array\.$#'
+			message: '#^Cannot access property \$id on array\|Stripe\\Customer\.$#'
 			identifier: property.nonObject
 			count: 1
-			path: includes/class-wc-stripe-customer.php
-
-		-
-			message: '#^Cannot access property \$id on array\|stdClass\.$#'
-			identifier: property.nonObject
-			count: 3
 			path: includes/class-wc-stripe-customer.php
 
 		-

--- a/tests/phpunit/class-wc-stripe-customer-test.php
+++ b/tests/phpunit/class-wc-stripe-customer-test.php
@@ -313,7 +313,10 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 					'headers'  => [ 'Content-Type' => 'application/json' ],
 					'body'     => json_encode(
 						[
-							'data' => [],
+							'object'   => 'search_result',
+							'url'      => '/v1/customers/search',
+							'has_more' => false,
+							'data'     => [],
 						]
 					),
 				];
@@ -528,7 +531,14 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 				return [
 					'response' => 200,
 					'headers'  => [ 'Content-Type' => 'application/json' ],
-					'body'     => json_encode( [ 'data' => [] ] ),
+					'body'     => json_encode(
+						[
+							'object'   => 'search_result',
+							'url'      => '/v1/customers/search',
+							'has_more' => false,
+							'data'     => [],
+						]
+					),
 				];
 			}
 			return $return_value;

--- a/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
+++ b/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
@@ -663,9 +663,12 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 		// Mock the Stripe API to return the CashApp payment method (prevents the token being
 		// treated as orphaned and deleted during the sync step).
 		$stripe_api_response = [
+			'object'   => 'list',
+			'url'      => '/v1/payment_methods',
 			'data'     => [
 				[
 					'id'      => $cashapp_pm_id,
+					'object'  => 'payment_method',
 					'type'    => WC_Stripe_Payment_Methods::CASHAPP_PAY,
 					'cashapp' => [ 'cashtag' => '$testcashtag' ],
 				],


### PR DESCRIPTION
## Changes proposed in this Pull Request:

**Status: draft / exploratory.** First resource PR in the WC_Stripe_API → SDK migration. Stacked on #5405 → #5404 → #5403.

Replaces every `WC_Stripe_API::request()` call inside `WC_Stripe_Customer` with the equivalent typed Stripe SDK method, plus per-callsite exception handling.

| Method | Before | After |
| --- | --- | --- |
| `get_existing_customer()` | `WC_Stripe_API::request( …, 'customers/search', 'GET' )` | `WC_Stripe_Client::get()->customers->search( … )` |
| `create_customer()` (new) | `WC_Stripe_API::request( …, 'customers' )` | `…->customers->create( … )` |
| `create_customer()` (existing match) | `WC_Stripe_API::request( …, 'customers/' . $id )` | `…->customers->update( $id, … )` |
| `update_customer()` | `WC_Stripe_API::request( …, 'customers/' . $id )` | `…->customers->update( $id, … )` (with recreate-on-missing retry) |
| `get_sources()` | `WC_Stripe_API::request( …, 'customers/' . $id . '/payment_methods', 'GET' )` | `…->customers->allPaymentMethods( $id, … )` |
| `get_payment_methods()` | `WC_Stripe_API::request( …, 'payment_methods?expand[]=…', 'GET' )` | `…->paymentMethods->all( … )` with typed `expand[]` |
| `get_all_payment_methods()` | same as above (paginated) | same |
| `set_default_source()` | `WC_Stripe_API::request( [ 'default_source' => … ], 'customers/' . $id )` | `…->customers->update( $id, [ 'default_source' => … ] )` |
| `set_default_payment_method()` | `WC_Stripe_API::request( [ 'invoice_settings' => … ], 'customers/' . $id )` | `…->customers->update( $id, [ 'invoice_settings' => … ] )` |

The `is_no_such_customer_error( $response->error )` checks that gated the recreate-customer retries are now `\Stripe\Exception\InvalidRequestException` + `getStripeCode() === 'resource_missing'` (with `getStripeParam()` for the per-method-listing paths).

### Behavior change worth a second look

Two `! get_id()` short-circuits added at the top of `set_default_source()` and `set_default_payment_method()`:

```php
if ( ! $this->get_id() ) {
    return false;
}
```

Without the guards, the SDK throws `InvalidArgumentException: The resource ID cannot be null or whitespace.` at construction time before the HTTP layer ever runs. The old `WC_Stripe_API::request()` happily POSTed to `customers/` (with an empty id), Stripe 404'd, the helper returned a `WP_Error`-shaped `stdClass`, and these methods returned `false`. Net behavior is identical (`false` either way) — just enforced one layer earlier.

### Test mock updates that came with it

Three mocks needed the canonical Stripe envelope to satisfy the SDK's typed responses:

- `tests/phpunit/class-wc-stripe-customer-test.php` — both `customers/search` mocks now return `{ object: 'search_result', url, has_more, data: [] }`. Without `object: 'search_result'`, the SDK throws "Expected to receive `Stripe\\SearchResult` object".
- `tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php` — the `payment_methods` list mock now returns `{ object: 'list', url, data, has_more }` for the same reason against `Stripe\\Collection`.

### What's NOT touched

- `WC_Stripe_API::get_payment_method()` and `WC_Stripe_API::attach_payment_method_to_customer()` are still called from this class (and elsewhere). They're separate helpers — not part of the `request()` / `retrieve()` deprecation set — so they stay until later cleanup.
- `is_no_such_customer_error()` is kept; other not-yet-migrated files (`order-handler`, `webhook-handler`, abstract gateway) still call it. The customer.php call site no longer needs it but the helper survives until those files migrate.

### Verification

- `npm run test:php` — full suite, **1927 tests / 4447 assertions, all pass**.
- `npm run phpstan` — clean (baseline regenerated; **2 ignored patterns dropped**, no new errors silenced).
- `npm run lint:php` — clean.

## Testing instructions

This is a refactor with no user-visible behavior change. Smoke test:

1. **Guest checkout with new Stripe account flag**: register a Stripe account, place a guest order with a previously-used email. Confirm the existing customer is reused (search path) instead of duplicating.
2. **Logged-in checkout, first payment**: `customers->create()` runs, customer ID is stored in user meta, payment goes through.
3. **Logged-in checkout, repeat payment**: `customers->update()` runs (no recreate), payment goes through.
4. **Saved payment methods page**: list renders correctly (`get_all_payment_methods()` paginates if needed).
5. **Set default payment method from Saved methods**: confirm the gear icon works (`set_default_payment_method()`).
6. **Recreate-on-missing flow**: invalidate the stored Stripe customer ID by switching to a different Stripe account, then trigger an order — `update_customer()` should detect `resource_missing` and recreate.
7. `npm run test:php` and `npm run phpstan`.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply) — checkout + my-account paths.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Internal refactor / SDK migration; no user-visible behavior change. The user-visible entry already lives on #5403.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)