### PR TITLE
Honor per-method save toggles when OCS is enabled (STRIPE-1139)

### DIFF
--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1137,8 +1137,13 @@ class WC_Stripe_Intent_Controller {
 		// Only exceptions are when using a confirmation token or manual renewal is required.
 		// For confirmations tokens, the setup_future_usage is set within the payment method.
 		$payment_method                 = WC_Stripe_UPE_Payment_Gateway::get_payment_method_instance( $selected_payment_type );
-		$has_auto_renewing_subscription = ! empty( $payment_information['has_subscription'] ) && ! $this->is_manual_renewal_required( $payment_method->is_reusable() );
-		if ( ! $is_using_confirmation_token && ( $payment_information['save_payment_method_to_store'] || $has_auto_renewing_subscription ) ) {
+		$is_reusable                    = $payment_method && $payment_method->is_reusable();
+		$has_auto_renewing_subscription = ! empty( $payment_information['has_subscription'] ) && ! $this->is_manual_renewal_required( $is_reusable );
+		// When OC is enabled, $payment_information['save_payment_method_to_store'] reflects the OC pseudo-method's
+		// reusability rather than the actual method the customer selected (e.g. iDEAL/Bancontact). Re-gate the
+		// `setup_future_usage` flag on the resolved method's `is_reusable()` so per-method save toggles such as
+		// `sepa_tokens_for_ideal` are honored end-to-end.
+		if ( ! $is_using_confirmation_token && $is_reusable && ( $payment_information['save_payment_method_to_store'] || $has_auto_renewing_subscription ) ) {
 			$request['setup_future_usage'] = 'off_session';
 		}
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1654,6 +1654,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			}
 
 			// Save payment method to store if the customer requested it during checkout.
+			// The reusability of the actual payment method (e.g. iDEAL/Bancontact when OC is enabled)
+			// is enforced inside handle_saving_payment_method().
 			if ( $order_helper->get_should_save_stripe_payment_method( $order ) && ! empty( $payment_method_id ) ) {
 				$upe_gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3591,6 +3591,14 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			$payment_method_instance = $this->payment_methods[ $payment_method_type ];
 		}
 
+		// When OC is enabled, upstream save signals are computed against the OC pseudo-method, which is
+		// always reusable. Honor the resolved method's per-method save toggle (e.g. `sepa_tokens_for_ideal`)
+		// here so non-reusable methods like iDEAL/Wero are never tokenized regardless of which call path
+		// reached this function. STRIPE-1139.
+		if ( ! $payment_method_instance || ! $payment_method_instance->is_reusable() ) {
+			return;
+		}
+
 		// Searches for an existing duplicate token to update.
 		$found_token = WC_Stripe_Payment_Tokens::get_duplicate_token( $payment_method_object, $customer->get_user_id(), $this->id );
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2377,12 +2377,6 @@ parameters:
 			path: includes/class-wc-stripe-intent-controller.php
 
 		-
-			message: '#^Cannot call method is_reusable\(\) on WC_Stripe_UPE_Payment_Method\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
 			message: '#^Cannot call method needs_payment\(\) on WC_Order\|WC_Order_Refund\|true\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -4519,12 +4513,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
 		-
-			message: '#^Cannot call method create_payment_token_for_user\(\) on WC_Stripe_UPE_Payment_Method\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
 			message: '#^Cannot call method get_billing_country\(\) on bool\|WC_Order\|WC_Order_Refund\.$#'
 			identifier: method.nonObject
 			count: 2
@@ -4574,12 +4562,6 @@ parameters:
 
 		-
 			message: '#^Cannot call method save\(\) on bool\|WC_Order\|WC_Order_Refund\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Cannot call method update_payment_token\(\) on WC_Stripe_UPE_Payment_Method\|null\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -5121,7 +5103,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$payment_method of method WC_Stripe_UPE_Payment_Gateway\:\:get_upe_gateway_id_for_order\(\) expects WC_Stripe_UPE_Payment_Method, WC_Stripe_UPE_Payment_Method\|null given\.$#'
 			identifier: argument.type
-			count: 3
+			count: 2
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
 		-

--- a/tests/phpunit/class-wc-stripe-intent-controller-test.php
+++ b/tests/phpunit/class-wc-stripe-intent-controller-test.php
@@ -307,6 +307,73 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Regression test for STRIPE-1139.
+	 *
+	 * When the per-method save toggle is disabled (e.g. `sepa_tokens_for_ideal=no`), a payment
+	 * intent for that method must NOT include `setup_future_usage`, even if the upstream
+	 * `save_payment_method_to_store` flag was set. Otherwise Stripe will store the payment
+	 * method (e.g. as a SEPA debit), which then surfaces as a saved/reusable method on the
+	 * customer's next checkout.
+	 *
+	 * @dataProvider provide_setup_future_usage_respects_per_method_toggle
+	 */
+	public function test_setup_future_usage_respects_per_method_toggle( string $sepa_tokens_for_ideal, bool $expected_setup_future_usage ) {
+		$stripe_settings                          = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['sepa_tokens_for_ideal'] = $sepa_tokens_for_ideal;
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		$payment_information = [
+			'amount'                        => 100,
+			'capture_method'                => 'automatic',
+			'currency'                      => WC_Stripe_Currency_Code::EURO,
+			'customer'                      => 'cus_mock',
+			'level3'                        => [ 'line_items' => [] ],
+			'metadata'                      => [ '_stripe_metadata' => '123' ],
+			'order'                         => $this->order,
+			'payment_method'                => 'pm_mock',
+			'shipping'                      => [],
+			'selected_payment_type'         => WC_Stripe_Payment_Methods::IDEAL,
+			'payment_method_types'          => [ WC_Stripe_Payment_Methods::IDEAL ],
+			'is_using_saved_payment_method' => false,
+			'save_payment_method_to_store'  => true,
+			'has_subscription'              => false,
+			'return_url'                    => 'https://example.com/return',
+		];
+
+		$captured_body = null;
+		$test_request  = function ( $preempt, $parsed_args, $url ) use ( &$captured_body ) {
+			$captured_body = $parsed_args['body'];
+
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => json_encode( [] ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		$this->mock_controller->create_and_confirm_payment_intent( $payment_information );
+
+		if ( $expected_setup_future_usage ) {
+			$this->assertArrayHasKey( 'setup_future_usage', $captured_body );
+			$this->assertSame( 'off_session', $captured_body['setup_future_usage'] );
+		} else {
+			$this->assertArrayNotHasKey( 'setup_future_usage', $captured_body );
+		}
+	}
+
+	/**
+	 * @return array
+	 */
+	public function provide_setup_future_usage_respects_per_method_toggle(): array {
+		return [
+			'iDEAL save toggle disabled — intent must not opt into setup_future_usage' => [ 'no', false ],
+			'iDEAL save toggle enabled — intent opts into setup_future_usage'          => [ 'yes', true ],
+		];
+	}
+
+	/**
 	 * Test presence of idempotency key when sending the payment intent request.
 	 */
 	public function test_idempotency_key_for_create_and_confirm_payment_intent() {

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -1521,6 +1521,75 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * Regression test for STRIPE-1139.
+	 *
+	 * `handle_saving_payment_method()` is the single choke point through which all save paths
+	 * (deferred intent, confirmation token, redirect-return, and Adaptive Pricing webhook) reach
+	 * `create_payment_token_for_user()`. When OC is enabled, upstream save signals are computed
+	 * against the OC pseudo-method, which is always reusable — so this function must enforce the
+	 * actual underlying method's `is_reusable()` toggle (e.g. `sepa_tokens_for_ideal`) before
+	 * persisting a token. Without the gate, iDEAL/Wero is tokenized as a SEPA debit despite the
+	 * merchant disabling the per-method save toggle.
+	 *
+	 * @dataProvider provider_handle_saving_payment_method_respects_per_method_toggle
+	 */
+	public function test_handle_saving_payment_method_respects_per_method_toggle( string $sepa_tokens_for_ideal, bool $expected_save ) {
+		// Reproduce the OC scenario: the upstream save signal was computed against the OC pseudo-method
+		// (always reusable), but the actual payment is iDEAL, whose reusability is gated by
+		// `sepa_tokens_for_ideal`. handle_saving_payment_method() must enforce the per-method toggle.
+		$stripe_settings                          = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['sepa_tokens_for_ideal'] = $sepa_tokens_for_ideal;
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+		$this->mock_gateway->oc_enabled = true;
+
+		$user_id = $this->factory()->user->create();
+		$order   = WC_Helper_Order::create_order( $user_id );
+		$order->set_payment_method( WC_Stripe_UPE_Payment_Gateway::ID );
+		$order->save();
+
+		// iDEAL payment methods are tokenized as SEPA debits, so the saved-method path expects the
+		// Stripe payment method object to expose the generated SEPA debit fields.
+		$payment_method_object = (object) [
+			'id'         => 'pm_ideal_mock',
+			'object'     => 'payment_method',
+			'type'       => WC_Stripe_Payment_Methods::IDEAL,
+			'customer'   => 'cus_mock',
+			'sepa_debit' => (object) [
+				'last4'       => '1234',
+				'fingerprint' => 'fp_mock',
+			],
+		];
+
+		$this->mock_gateway->expects( $this->any() )
+			->method( 'get_stripe_customer_id' )
+			->willReturn( 'cus_mock' );
+
+		$action_calls = 0;
+		$listener     = function () use ( &$action_calls ) {
+			++$action_calls;
+		};
+		add_action( 'woocommerce_stripe_add_payment_method', $listener );
+
+		try {
+			$this->mock_gateway->handle_saving_payment_method( $order, $payment_method_object, WC_Stripe_Payment_Methods::IDEAL );
+		} finally {
+			remove_action( 'woocommerce_stripe_add_payment_method', $listener );
+		}
+
+		$this->assertSame( $expected_save ? 1 : 0, $action_calls );
+	}
+
+	/**
+	 * @return array<string, array{0: string, 1: bool}>
+	 */
+	public function provider_handle_saving_payment_method_respects_per_method_toggle(): array {
+		return [
+			'iDEAL save toggle disabled — no token persisted' => [ 'no', false ],
+			'iDEAL save toggle enabled — token persisted'     => [ 'yes', true ],
+		];
+	}
+
+	/**
 	 * Test checkout flow while saving payment method with SEPA generated payment method AND setup intents.
 	 */
 	public function test_setup_intent_checkout_saves_sepa_generated_payment_method_to_order() {


### PR DESCRIPTION
## Summary

Fixes STRIPE-1139: when Optimized Checkout Suite is enabled, the per-method "Save iDEAL | Wero for repeat use" toggle (`sepa_tokens_for_ideal`, and the equivalent for Bancontact) was bypassed. Customers ended up with their iDEAL/Wero method saved/reusable on Stripe (and surfaced on subsequent checkouts) despite the merchant having disabled the toggle.

### Root cause
- `WC_Stripe_Payment_Methods::OC = 'card'` and `WC_Stripe_UPE_Payment_Method_OC` is hard-coded `is_reusable = true`. So under OCS, `should_save_payment_method_from_request()` evaluates against the OC pseudo-method (always reusable), and the resulting `save_payment_method_to_store` flag flows downstream regardless of the actual underlying method's per-method save toggle.
- `WC_Stripe_Intent_Controller::build_base_payment_intent_request_params()` then set `setup_future_usage = 'off_session'` on the PaymentIntent without re-checking the resolved method's reusability — so Stripe stored the SEPA debit even when the merchant had disabled the iDEAL toggle.
- The Adaptive Pricing / Checkout Sessions path additionally persisted a WC payment token via the `checkout.session.completed` webhook handler → `handle_saving_payment_method()`, again with no per-method gate.

### Fix
Two narrow gates added at the actual save decision points; both rely on the already-resolved actual payment method instance.

- **`includes/class-wc-stripe-intent-controller.php`** — `build_base_payment_intent_request_params()` now also gates `setup_future_usage` on the resolved method's `is_reusable()`, so Stripe is never asked to save a non-reusable method (iDEAL/Wero with the toggle off).
- **`includes/payment-methods/class-wc-stripe-upe-payment-gateway.php`** — `handle_saving_payment_method()` early-returns when the resolved method is non-reusable. This is the single choke point all save paths funnel through (deferred-intent, confirmation token, redirect-return, Adaptive Pricing webhook), so this enforces the per-method toggle end-to-end. The webhook handler delegates to this gate rather than duplicating the logic.
- **`phpstan-baseline.neon`** — three pre-existing `method.nonObject` baseline entries became unmatched because the new null-check in `handle_saving_payment_method()` and the extracted `$is_reusable` local in the intent controller resolve them. Removed/decremented those entries (no new baseline rows added).

## Test plan

Automated:
- [x] `WC_Stripe_Intent_Controller_Test::test_setup_future_usage_respects_per_method_toggle` — covers `sepa_tokens_for_ideal=no` (no `setup_future_usage` on the intent) and `sepa_tokens_for_ideal=yes` (intent opts into off-session).
- [x] `WC_Stripe_UPE_Payment_Gateway_Test::test_handle_saving_payment_method_respects_per_method_toggle` — covers OC-enabled save attempt against an iDEAL payment method object; asserts the `woocommerce_stripe_add_payment_method` action only fires when the toggle is on.
- [x] `npm run phpstan` clean.
- [x] `phpcs` clean on changed files.
- [x] Pre-existing checkout/save tests still pass on the gateway test file.

Manual (recommended before merging):
- [ ] OCS + Blocks checkout: with `Enable saved payment methods` ON and `Enable saved iDEAL | Wero payments for repeat payments` OFF, place an iDEAL order and verify that no saved iDEAL/SEPA token surfaces in WC and that the Stripe customer in dashboard does not list a saved SEPA debit.
- [ ] OCS + classic shortcode checkout: same as above.
- [ ] OCS + Adaptive Pricing (Checkout Session redirect path): same as above.
- [ ] Same flows with the iDEAL toggle ON should continue to save and reuse the SEPA debit.
- [ ] Sanity on Bancontact (uses the same SEPA tokenization path / `sepa_tokens_for_bancontact` toggle).

## Notes

- The frontend `wc-stripe-new-payment-method` checkbox state captured at Element init is the upstream source of the leak (it doesn't get unset when the customer switches to a non-reusable method inside the Payment Element). The server-side gates here are the authoritative fix; a follow-up could also clear `setupFutureUsage` client-side when the customer switches methods, to avoid even sending a save request for non-reusable selections.
- Issue tracker reference: `STRIPE-1139`. (No corresponding GitHub issue # was provided, so the PR doesn't auto-close one.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)