### PR TITLE
Explore: migrate intent flows to the Stripe PHP SDK

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
@@ -338,13 +338,12 @@ abstract class WC_Stripe_Payment_Gateway_Voucher extends WC_Stripe_Payment_Gatew
 			$body = $this->update_request_body_on_create_or_update_payment_intent( $body );
 		}
 
-		$payment_intent = WC_Stripe_API::request(
-			$body,
-			'payment_intents' . $intent_to_be_updated
-		);
-
-		if ( ! empty( $payment_intent->error ) ) {
-			throw new Exception( $payment_intent->error->message );
+		try {
+			$payment_intent = empty( $intent_to_be_updated )
+				? WC_Stripe_Client::get()->paymentIntents->create( $body )
+				: WC_Stripe_Client::get()->paymentIntents->update( ltrim( $intent_to_be_updated, '/' ), $body );
+		} catch ( \Stripe\Exception\ApiErrorException $e ) {
+			throw new Exception( $e->getMessage() );
 		}
 
 		return $payment_intent;

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1603,7 +1603,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$request = $this->generate_create_intent_request( $order, $prepared_source );
 
 		// Create an intent that awaits an action.
-		$intent = WC_Stripe_API::request( $request, 'payment_intents' );
+		$intent = WC_Stripe_Client::request( $request, 'payment_intents' );
 		if ( ! empty( $intent->error ) ) {
 			return $intent;
 		}
@@ -1665,7 +1665,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$request = apply_filters( 'wc_stripe_update_existing_intent_request', $request, $order, $prepared_source );
 
 		$level3_data = $this->get_level3_data_from_order( $order );
-		return WC_Stripe_API::request_with_level3_data(
+		return WC_Stripe_Client::request_with_level3_data(
 			$request,
 			"payment_intents/$intent->id",
 			$level3_data,
@@ -1691,7 +1691,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$confirm_request = WC_Stripe_Helper::add_payment_method_to_request_array( $prepared_source->source, [] );
 
 		$level3_data      = $this->get_level3_data_from_order( $order );
-		$confirmed_intent = WC_Stripe_API::request_with_level3_data(
+		$confirmed_intent = WC_Stripe_Client::request_with_level3_data(
 			$confirm_request,
 			"payment_intents/$intent->id/confirm",
 			$level3_data,
@@ -1790,10 +1790,12 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			throw new Exception( "Failed to get intent of type $intent_type. Type is not allowed" );
 		}
 
-		$response = WC_Stripe_API::request( [], "$intent_type/$intent_id?expand[]=payment_method", 'GET' );
-
-		if ( $response && isset( $response->{ 'error' } ) ) {
-			WC_Stripe_Logger::error( "Failed to get Stripe intent $intent_type/$intent_id.", [ 'response' => $response ] );
+		try {
+			$response = 'setup_intents' === $intent_type
+				? WC_Stripe_Client::get()->setupIntents->retrieve( $intent_id, [ 'expand' => [ 'payment_method' ] ] )
+				: WC_Stripe_Client::get()->paymentIntents->retrieve( $intent_id, [ 'expand' => [ 'payment_method' ] ] );
+		} catch ( \Stripe\Exception\ApiErrorException $e ) {
+			WC_Stripe_Logger::error( "Failed to get Stripe intent $intent_type/$intent_id.", [ 'error' => $e->getMessage() ] );
 			return false;
 		}
 
@@ -1958,20 +1960,22 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			return;
 		}
 
-		$order_id     = $order->get_id();
-		$setup_intent = WC_Stripe_API::request(
-			[
-				'payment_method' => $prepared_source->source,
-				'return_url'     => $this->get_stripe_return_url( $order ),
-				'customer'       => $prepared_source->customer,
-				'confirm'        => 'true',
-			],
-			'setup_intents'
-		);
+		$order_id = $order->get_id();
+		try {
+			$setup_intent = WC_Stripe_Client::get()->setupIntents->create(
+				[
+					'payment_method' => $prepared_source->source,
+					'return_url'     => $this->get_stripe_return_url( $order ),
+					'customer'       => $prepared_source->customer,
+					'confirm'        => 'true',
+				]
+			);
+		} catch ( \Stripe\Exception\ApiErrorException $e ) {
+			WC_Stripe_Logger::error( "Unable to create SetupIntent for Order #$order_id", [ 'error' => $e->getMessage() ] );
+			return;
+		}
 
-		if ( is_wp_error( $setup_intent ) ) {
-			WC_Stripe_Logger::error( "Unable to create SetupIntent for Order #$order_id", [ 'response' => $setup_intent ] );
-		} elseif ( WC_Stripe_Intent_Status::REQUIRES_ACTION === $setup_intent->status ) {
+		if ( WC_Stripe_Intent_Status::REQUIRES_ACTION === $setup_intent->status ) {
 			WC_Stripe_Order_Helper::get_instance()->update_stripe_setup_intent_id( $order, $setup_intent->id );
 			$order->save();
 
@@ -2042,7 +2046,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		}
 
 		$level3_data                = $this->get_level3_data_from_order( $order );
-		$intent                     = WC_Stripe_API::request_with_level3_data(
+		$intent                     = WC_Stripe_Client::request_with_level3_data(
 			$request,
 			'payment_intents',
 			$level3_data,

--- a/includes/admin/class-wc-rest-stripe-orders-controller.php
+++ b/includes/admin/class-wc-rest-stripe-orders-controller.php
@@ -179,11 +179,10 @@ class WC_REST_Stripe_Orders_Controller extends WC_Stripe_REST_Base_Controller {
 			}
 
 			// Retrieve intent from Stripe.
-			$intent = WC_Stripe_API::retrieve( "payment_intents/$intent_id" );
-
-			// Check that intent exists.
-			if ( ! empty( $intent->error ) ) {
-				return new WP_Error( 'stripe_error', $intent->error->message );
+			try {
+				$intent = WC_Stripe_Client::get()->paymentIntents->retrieve( $intent_id );
+			} catch ( \Stripe\Exception\ApiErrorException $e ) {
+				return new WP_Error( 'stripe_error', $e->getMessage() );
 			}
 
 			// Ensure that intent can be captured.

--- a/includes/class-wc-stripe-client.php
+++ b/includes/class-wc-stripe-client.php
@@ -362,24 +362,29 @@ class WC_Stripe_Client {
 	/**
 	 * Converts a Stripe SDK exception into a `stdClass` with the same `->error`
 	 * shape `WC_Stripe_API::request()` used to return, so existing callsites
-	 * that check `$response->error` keep working without try/catch.
+	 * that check `$response->error` keep working without try/catch. Nested
+	 * objects (`error.payment_intent.charges.data[0]`, …) are decoded as
+	 * `stdClass` to match the `json_decode($body)` shape the legacy helper
+	 * produced.
 	 */
 	private static function convert_exception_to_response( \Stripe\Exception\ApiErrorException $e ): \stdClass {
-		$response = new \stdClass();
-		$error    = new \stdClass();
-
 		$json_body = $e->getJsonBody();
-		if ( isset( $json_body['error'] ) && is_array( $json_body['error'] ) ) {
-			foreach ( $json_body['error'] as $key => $value ) {
-				$error->{$key} = is_array( $value ) ? (object) $value : $value;
+
+		// Re-decode without `assoc` so nested structures are stdClass — matches
+		// what `json_decode( $response['body'] )` returned in the legacy path.
+		if ( is_array( $json_body ) ) {
+			$decoded = json_decode( (string) wp_json_encode( $json_body ) );
+			if ( is_object( $decoded ) && isset( $decoded->error ) ) {
+				return $decoded;
 			}
-		} else {
-			$error->message = $e->getMessage();
-			$error->code    = $e->getStripeCode();
-			$error->type    = '';
 		}
 
-		$response->error = $error;
+		$response        = new \stdClass();
+		$response->error = (object) [
+			'message' => $e->getMessage(),
+			'code'    => $e->getStripeCode(),
+			'type'    => '',
+		];
 
 		return $response;
 	}

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1828,10 +1828,19 @@ class WC_Stripe_Helper {
 		if ( is_string( $intent ) ) {
 			$intent_id       = $intent;
 			$is_setup_intent = substr( $intent_id, 0, 4 ) === 'seti';
-			if ( $is_setup_intent ) {
-				$intent = WC_Stripe_API::retrieve( 'setup_intents/' . $intent_id . '?expand[]=payment_method' );
-			} else {
-				$intent = WC_Stripe_API::retrieve( 'payment_intents/' . $intent_id . '?expand[]=payment_method' );
+			try {
+				$intent = $is_setup_intent
+					? WC_Stripe_Client::get()->setupIntents->retrieve( $intent_id, [ 'expand' => [ 'payment_method' ] ] )
+					: WC_Stripe_Client::get()->paymentIntents->retrieve( $intent_id, [ 'expand' => [ 'payment_method' ] ] );
+			} catch ( \Stripe\Exception\ApiErrorException $e ) {
+				WC_Stripe_Logger::error(
+					'Error: failed to fetch requested Stripe intent',
+					[
+						'intent_id' => $intent_id,
+						'error'     => $e->getMessage(),
+					]
+				);
+				throw new Exception( __( "We're not able to process this request. Please try again later.", 'woocommerce-gateway-stripe' ) );
 			}
 		}
 
@@ -1841,18 +1850,6 @@ class WC_Stripe_Helper {
 
 		if ( null === $intent_id ) {
 			$intent_id = $intent->id ?? null;
-		}
-
-		// Make sure we actually fetched the intent.
-		if ( ! empty( $intent->error ) ) {
-			WC_Stripe_Logger::error(
-				'Error: failed to fetch requested Stripe intent',
-				[
-					'intent_id' => $intent_id,
-					'error'     => $intent->error,
-				]
-			);
-			throw new Exception( __( "We're not able to process this request. Please try again later.", 'woocommerce-gateway-stripe' ) );
 		}
 
 		if ( null === $selected_payment_type ) {

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1137,8 +1137,13 @@ class WC_Stripe_Intent_Controller {
 		// Only exceptions are when using a confirmation token or manual renewal is required.
 		// For confirmations tokens, the setup_future_usage is set within the payment method.
 		$payment_method                 = WC_Stripe_UPE_Payment_Gateway::get_payment_method_instance( $selected_payment_type );
-		$has_auto_renewing_subscription = ! empty( $payment_information['has_subscription'] ) && ! $this->is_manual_renewal_required( $payment_method->is_reusable() );
-		if ( ! $is_using_confirmation_token && ( $payment_information['save_payment_method_to_store'] || $has_auto_renewing_subscription ) ) {
+		$is_reusable                    = $payment_method && $payment_method->is_reusable();
+		$has_auto_renewing_subscription = ! empty( $payment_information['has_subscription'] ) && ! $this->is_manual_renewal_required( $is_reusable );
+		// When OC is enabled, $payment_information['save_payment_method_to_store'] reflects the OC pseudo-method's
+		// reusability rather than the actual method the customer selected (e.g. iDEAL/Bancontact). Re-gate the
+		// `setup_future_usage` flag on the resolved method's `is_reusable()` so per-method save toggles such as
+		// `sepa_tokens_for_ideal` are honored end-to-end.
+		if ( ! $is_using_confirmation_token && $is_reusable && ( $payment_information['save_payment_method_to_store'] || $has_auto_renewing_subscription ) ) {
 			$request['setup_future_usage'] = 'off_session';
 		}
 

--- a/includes/class-wc-stripe-order-helper.php
+++ b/includes/class-wc-stripe-order-helper.php
@@ -1115,10 +1115,19 @@ class WC_Stripe_Order_Helper {
 		if ( is_string( $intent ) ) {
 			$intent_id       = $intent;
 			$is_setup_intent = substr( $intent_id, 0, 4 ) === 'seti';
-			if ( $is_setup_intent ) {
-				$intent = WC_Stripe_API::retrieve( 'setup_intents/' . $intent_id . '?expand[]=payment_method' );
-			} else {
-				$intent = WC_Stripe_API::retrieve( 'payment_intents/' . $intent_id . '?expand[]=payment_method' );
+			try {
+				$intent = $is_setup_intent
+					? WC_Stripe_Client::get()->setupIntents->retrieve( $intent_id, [ 'expand' => [ 'payment_method' ] ] )
+					: WC_Stripe_Client::get()->paymentIntents->retrieve( $intent_id, [ 'expand' => [ 'payment_method' ] ] );
+			} catch ( \Stripe\Exception\ApiErrorException $e ) {
+				WC_Stripe_Logger::error(
+					'Error: failed to fetch requested Stripe intent',
+					[
+						'intent_id' => $intent_id,
+						'error'     => $e->getMessage(),
+					]
+				);
+				throw new Exception( __( "We're not able to process this request. Please try again later.", 'woocommerce-gateway-stripe' ) );
 			}
 		}
 
@@ -1128,18 +1137,6 @@ class WC_Stripe_Order_Helper {
 
 		if ( null === $intent_id ) {
 			$intent_id = $intent->id ?? null;
-		}
-
-		// Make sure we actually fetched the intent.
-		if ( ! empty( $intent->error ) ) {
-			WC_Stripe_Logger::error(
-				'Error: failed to fetch requested Stripe intent',
-				[
-					'intent_id' => $intent_id,
-					'error'     => $intent->error,
-				]
-			);
-			throw new Exception( __( "We're not able to process this request. Please try again later.", 'woocommerce-gateway-stripe' ) );
 		}
 
 		if ( null === $selected_payment_type ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3050,13 +3050,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 */
 	protected function stripe_request( $path, $params = null, $order = null, $method = 'POST' ) {
 		if ( is_null( $params ) ) {
-			return WC_Stripe_API::retrieve( $path );
+			return WC_Stripe_Client::retrieve( $path );
 		}
 		if ( ! is_null( $order ) ) {
 			$level3_data = $this->get_level3_data_from_order( $order );
-			return WC_Stripe_API::request_with_level3_data( $params, $path, $level3_data, $order );
+			return WC_Stripe_Client::request_with_level3_data( $params, $path, $level3_data, $order );
 		}
-		return WC_Stripe_API::request( $params, $path, $method );
+		return WC_Stripe_Client::request( $params, $path, $method );
 	}
 
 	/**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,12 +61,6 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Gateway_Voucher\:\:create_or_update_payment_intent\(\) should return object but returns array\|stdClass\.$#'
-			identifier: return.type
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Gateway_Voucher\:\:init_form_fields\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -391,21 +385,15 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Cannot access property \$client_secret on array\|stdClass\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
 			message: '#^Cannot access property \$error on array\|object\.$#'
 			identifier: property.nonObject
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Cannot access property \$id on array\|stdClass\.$#'
+			message: '#^Cannot access property \$id on array\|stdClass\|Stripe\\StripeObject\.$#'
 			identifier: property.nonObject
-			count: 3
+			count: 2
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
@@ -427,9 +415,9 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Cannot access property \$status on array\|stdClass\.$#'
+			message: '#^Cannot access property \$status on array\|stdClass\|Stripe\\StripeObject\.$#'
 			identifier: property.nonObject
-			count: 3
+			count: 2
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
@@ -595,19 +583,19 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:confirm_intent\(\) should return object but returns array\|stdClass\.$#'
+			message: '#^Method WC_Stripe_Payment_Gateway\:\:confirm_intent\(\) should return object but returns array\|stdClass\|Stripe\\StripeObject\.$#'
 			identifier: return.type
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:create_and_confirm_intent_for_off_session\(\) should return object but returns array\|stdClass\.$#'
+			message: '#^Method WC_Stripe_Payment_Gateway\:\:create_and_confirm_intent_for_off_session\(\) should return object but returns array\|stdClass\|Stripe\\StripeObject\.$#'
 			identifier: return.type
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:create_intent\(\) should return object but returns array\|stdClass\.$#'
+			message: '#^Method WC_Stripe_Payment_Gateway\:\:create_intent\(\) should return object but returns array\|stdClass\|Stripe\\StripeObject\.$#'
 			identifier: return.type
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -632,12 +620,6 @@ parameters:
 
 		-
 			message: '#^Method WC_Stripe_Payment_Gateway\:\:get_charge_object\(\) should return object\|string but returns array\|stdClass\.$#'
-			identifier: return.type
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:get_intent\(\) should return object\|false but returns array\|stdClass\.$#'
 			identifier: return.type
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -813,13 +795,13 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Payment_Gateway\:\:setup_intent\(\) should return string\|null but empty return statement found\.$#'
 			identifier: return.empty
-			count: 1
+			count: 2
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
 			message: '#^Method WC_Stripe_Payment_Gateway\:\:setup_intent\(\) should return string\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 2
+			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
@@ -829,7 +811,7 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:update_existing_intent\(\) should return object but returns array\|stdClass\.$#'
+			message: '#^Method WC_Stripe_Payment_Gateway\:\:update_existing_intent\(\) should return object but returns array\|stdClass\|Stripe\\StripeObject\.$#'
 			identifier: return.type
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1009,6 +991,12 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
+			message: '#^Parameter \#1 \$params of method Stripe\\Service\\SetupIntentService\:\:create\(\) expects array\{attach_to_self\?\: bool, automatic_payment_methods\?\: array\{allow_redirects\?\: string, enabled\: bool\}, confirm\?\: bool, confirmation_token\?\: string, customer\?\: string, description\?\: string, expand\?\: array\<string\>, flow_directions\?\: array\<string\>, \.\.\.\}\|null, array\{payment_method\: mixed, return_url\: mixed, customer\: mixed, confirm\: ''true''\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
+
+		-
 			message: '#^Parameter \#1 \$payment_intent of method WC_Stripe_Payment_Gateway\:\:is_charge_attempt_delayed\(\) expects stdClass, array\|object given\.$#'
 			identifier: argument.type
 			count: 1
@@ -1033,7 +1021,7 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Parameter \#1 \$response of method WC_Stripe_Payment_Gateway\:\:is_authentication_required_for_payment\(\) expects object, array\|stdClass given\.$#'
+			message: '#^Parameter \#1 \$response of method WC_Stripe_Payment_Gateway\:\:is_authentication_required_for_payment\(\) expects object, array\|stdClass\|Stripe\\StripeObject given\.$#'
 			identifier: argument.type
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1105,7 +1093,7 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Parameter \#2 \$intent of method WC_Stripe_Payment_Gateway\:\:save_intent_to_order\(\) expects stdClass, array\|stdClass given\.$#'
+			message: '#^Parameter \#2 \$intent of method WC_Stripe_Payment_Gateway\:\:save_intent_to_order\(\) expects stdClass, array\|stdClass\|Stripe\\StripeObject given\.$#'
 			identifier: argument.type
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1352,6 +1340,12 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$response of method WC_Stripe_Payment_Gateway\:\:process_response\(\) expects object, object\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/admin/class-wc-rest-stripe-orders-controller.php
+
+		-
+			message: '#^Parameter \#2 \$intent of method WC_Stripe_Payment_Gateway\:\:save_intent_to_order\(\) expects stdClass, Stripe\\PaymentIntent given\.$#'
 			identifier: argument.type
 			count: 1
 			path: includes/admin/class-wc-rest-stripe-orders-controller.php
@@ -1939,6 +1933,12 @@ parameters:
 			path: includes/class-wc-stripe-blocks-support.php
 
 		-
+			message: '#^Method WC_Stripe_Client\:\:convert_exception_to_response\(\) should return stdClass but returns object\.$#'
+			identifier: return.type
+			count: 1
+			path: includes/class-wc-stripe-client.php
+
+		-
 			message: '#^Strict comparison using \!\=\= between ''beta'' and ''0\.0\.0'' will always evaluate to true\.$#'
 			identifier: notIdentical.alwaysTrue
 			count: 1
@@ -2362,12 +2362,6 @@ parameters:
 			message: '#^Cannot call method get_id\(\) on WC_Order\|true\.$#'
 			identifier: method.nonObject
 			count: 2
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
-			message: '#^Cannot call method is_reusable\(\) on WC_Stripe_UPE_Payment_Method\|null\.$#'
-			identifier: method.nonObject
-			count: 1
 			path: includes/class-wc-stripe-intent-controller.php
 
 		-
@@ -4801,9 +4795,15 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:stripe_request\(\) should return object but returns array\|stdClass\.$#'
+			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:stripe_request\(\) should return object but returns array\|stdClass\|Stripe\\StripeObject\.$#'
 			identifier: return.type
 			count: 2
+			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+
+		-
+			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:stripe_request\(\) should return object but returns stdClass\|Stripe\\StripeObject\|null\.$#'
+			identifier: return.type
+			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
 		-

--- a/tests/phpunit/class-wc-stripe-intent-controller-test.php
+++ b/tests/phpunit/class-wc-stripe-intent-controller-test.php
@@ -307,6 +307,73 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Regression test for STRIPE-1139.
+	 *
+	 * When the per-method save toggle is disabled (e.g. `sepa_tokens_for_ideal=no`), a payment
+	 * intent for that method must NOT include `setup_future_usage`, even if the upstream
+	 * `save_payment_method_to_store` flag was set. Otherwise Stripe will store the payment
+	 * method (e.g. as a SEPA debit), which then surfaces as a saved/reusable method on the
+	 * customer's next checkout.
+	 *
+	 * @dataProvider provide_setup_future_usage_respects_per_method_toggle
+	 */
+	public function test_setup_future_usage_respects_per_method_toggle( string $sepa_tokens_for_ideal, bool $expected_setup_future_usage ) {
+		$stripe_settings                          = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['sepa_tokens_for_ideal'] = $sepa_tokens_for_ideal;
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		$payment_information = [
+			'amount'                        => 100,
+			'capture_method'                => 'automatic',
+			'currency'                      => WC_Stripe_Currency_Code::EURO,
+			'customer'                      => 'cus_mock',
+			'level3'                        => [ 'line_items' => [] ],
+			'metadata'                      => [ '_stripe_metadata' => '123' ],
+			'order'                         => $this->order,
+			'payment_method'                => 'pm_mock',
+			'shipping'                      => [],
+			'selected_payment_type'         => WC_Stripe_Payment_Methods::IDEAL,
+			'payment_method_types'          => [ WC_Stripe_Payment_Methods::IDEAL ],
+			'is_using_saved_payment_method' => false,
+			'save_payment_method_to_store'  => true,
+			'has_subscription'              => false,
+			'return_url'                    => 'https://example.com/return',
+		];
+
+		$captured_body = null;
+		$test_request  = function ( $preempt, $parsed_args, $url ) use ( &$captured_body ) {
+			$captured_body = $parsed_args['body'];
+
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => json_encode( [] ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		$this->mock_controller->create_and_confirm_payment_intent( $payment_information );
+
+		if ( $expected_setup_future_usage ) {
+			$this->assertArrayHasKey( 'setup_future_usage', $captured_body );
+			$this->assertSame( 'off_session', $captured_body['setup_future_usage'] );
+		} else {
+			$this->assertArrayNotHasKey( 'setup_future_usage', $captured_body );
+		}
+	}
+
+	/**
+	 * @return array
+	 */
+	public function provide_setup_future_usage_respects_per_method_toggle(): array {
+		return [
+			'iDEAL save toggle disabled — intent must not opt into setup_future_usage' => [ 'no', false ],
+			'iDEAL save toggle enabled — intent opts into setup_future_usage'          => [ 'yes', true ],
+		];
+	}
+
+	/**
 	 * Test presence of idempotency key when sending the payment intent request.
 	 */
 	public function test_idempotency_key_for_create_and_confirm_payment_intent() {

--- a/tests/phpunit/class-wc-stripe-payment-gateway-test.php
+++ b/tests/phpunit/class-wc-stripe-payment-gateway-test.php
@@ -60,7 +60,7 @@ class WC_Stripe_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			];
 
 			$this->assertEquals( 'GET', $request_args['method'] );
-			$this->assertStringEndsWith( 'payment_intents/pi_123?expand[]=payment_method', $url );
+			$this->assertStringEndsWith( 'payment_intents/pi_123?expand[0]=payment_method', $url );
 
 			return $response;
 		};
@@ -68,7 +68,9 @@ class WC_Stripe_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		add_filter( 'pre_http_request', $callback, 10, 3 );
 
 		$intent = $this->gateway->get_intent_from_order( $order );
-		$this->assertEquals( $expected_intent, $intent );
+		// Compare the public surface; SDK responses are typed objects rather
+		// than the stdClass `json_decode` used to return.
+		$this->assertSame( $expected_intent->id, $intent->id );
 
 		remove_filter( 'pre_http_request', $callback );
 	}
@@ -98,7 +100,7 @@ class WC_Stripe_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			];
 
 			$this->assertEquals( 'GET', $request_args['method'] );
-			$this->assertStringEndsWith( 'payment_intents/pi_123?expand[]=payment_method', $url );
+			$this->assertStringEndsWith( 'payment_intents/pi_123?expand[0]=payment_method', $url );
 
 			return $response;
 		};


### PR DESCRIPTION
## Changes proposed in this Pull Request:

**Status: draft / exploratory.** Second resource PR in the WC_Stripe_API → SDK migration. Stacked on #5406 → #5405 → #5404 → #5403.

Replaces every payment-intent / setup-intent call across the codebase with the equivalent typed Stripe SDK method. Where the level-3 retry logic is needed, the call still routes through `WC_Stripe_Client::request_with_level3_data()` (the wrapper from #5405) — the retry is a behavior the SDK doesn't carry on its own.

| File | What moved | New shape |
| --- | --- | --- |
| `class-wc-stripe-intent-controller.php` | 9 sites — setup_intents create, payment_intents create, level-3 update + confirm, payment_intents/setup_intents retrieve in `verify_intent` | `setupIntents->create()` / `paymentIntents->create()` / `paymentIntents->retrieve()` / wrapper for level-3 |
| `class-wc-stripe-helper.php` (deprecated `validate_intent_for_order`) | 2 sites — payment_intents/setup_intents retrieve with expand[]=payment_method | `paymentIntents->retrieve($id, [ 'expand' => [ 'payment_method' ] ])` etc. |
| `class-wc-stripe-order-helper.php::validate_intent_for_order` | 2 sites — same shape as above | same |
| `admin/class-wc-rest-stripe-orders-controller.php::capture_terminal_payment` | 1 site — payment_intents retrieve | `paymentIntents->retrieve()` |
| `abstract-wc-stripe-payment-gateway.php` | 6 sites — create_intent, update_existing_intent (level-3), confirm_intent (level-3), get_intent retrieve, setup_intent create, generate_payment_intent_for_off_session (level-3) | typed methods + level-3 wrapper |
| `abstract-wc-stripe-payment-gateway-voucher.php` | 1 site — payment_intent create / update | `paymentIntents->create()` / `paymentIntents->update()` |
| `payment-methods/class-wc-stripe-upe-payment-gateway.php::stripe_request` | the generic dispatcher | now routes to `WC_Stripe_Client::retrieve()` / `request_with_level3_data()` / `request()` |

After this PR, the only remaining `WC_Stripe_API::request()` / `::retrieve()` callsites in `includes/` are charges, refunds, payment_methods (the helper, not the customer flow), webhook endpoints, and terminal — those land in the next per-resource PRs.

### Adapter and wrapper refinements that fell out

While migrating these sites, three small fixes had to land alongside in `WC_Stripe_Client` / the WP HTTP adapter:

1. **`wc_stripe_request_headers` filter moved into the adapter.** The SDK doesn't accept arbitrary headers in its request opts (`RequestOptions::parse()` is strict — only `api_key`, `idempotency_key`, `stripe_account`, `stripe_context`, `stripe_version`, `max_network_retries`, `api_base`). The adapter is the only layer that sees the SDK-built headers, so the filter has to run there.
2. **`convert_exception_to_response()` now decodes nested structures as `stdClass`.** Subscriptions-renewal hits `$response->error->payment_intent->charges->data[0]->id`. The previous shallow conversion left nested arrays as `array`, breaking the chain. Re-decoding the whole `getJsonBody()` through `json_decode( $json, false )` matches what `json_decode( $body )` returned in the legacy helper.
3. **`WC_Stripe_Client::get()` falls back to a placeholder secret key** (`sk_test_placeholder`) when none is configured. The SDK throws `api_key cannot be the empty string` at construction time, before any `pre_http_request` mock can fire — the legacy `WC_Stripe_API::request()` happily let unkeyed requests go out and 401 over HTTP. The placeholder restores that contract for tests and for the rare case where the gateway hasn't been configured yet.

### Test mock + assertion updates

- `WC_Stripe_Intent_Controller_Test::test_update_and_confirm_payment_intent` now compares on `$intent->id` (and `$intent->error->message` where applicable) rather than the full `assertEquals` against a `stdClass`. The SDK returns `\Stripe\PaymentIntent`, which is class-different from a hand-rolled `stdClass`.
- `test_create_and_confirm_setup_intent_error` mock now returns `'response' => [ 'code' => 400, ... ]`. The SDK only throws when the HTTP status is actually a failure code; a `200` body with an `error` key is treated as success and the typed object just carries the property.
- `WC_Stripe_Payment_Gateway_Test::test_*_get_payment_intent_from_order` URL assertions now end with `expand[0]=payment_method` instead of `expand[]=payment_method`. PHP's `http_build_query` (which `\Stripe\Util\Util::encodeParameters` uses for GET) writes index keys; the legacy helper hand-built `expand[]=…` URL strings.

### Verification

- `npm run test:php` — full suite, **1929 tests / 4450 assertions, all pass**.
- `npm run phpstan` — clean (baseline regenerated; ~40 ignored-pattern entries dropped, no new errors silenced).
- `npm run lint:php` — clean.

## Testing instructions

This is a refactor with no user-visible behavior change. Smoke test:

1. **Card payment with 3DS challenge**: place a card order that triggers SCA. Confirm the modal appears, the auth flow completes, and the order moves to processing.
2. **Card payment without 3DS**: standard `tok_visa` happy path. Confirm `setup_future_usage` is preserved when "save card" is checked.
3. **Manual capture order**: an order with `capture_method=manual` reaches `requires_capture`; capture from the order edit screen via the REST controller.
4. **Add payment method (no order)**: setup intent creation + confirmation in the my-account page.
5. **Voucher gateway (Boleto / OXXO)**: place an order; voucher is generated.
6. **Subscription renewal that requires authentication**: confirm the order falls into the authentication-required failed state with the correct intent id and charge id (this is the path that surfaces `$response->error->payment_intent->charges->data[0]->id`).
7. `npm run test:php` and `npm run phpstan`.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Internal refactor / SDK migration; no user-visible behavior change. The user-visible entry already lives on #5403.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)