### PR TITLE
Guard against multiple WC_Stripe instances before plugin initialization

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ xxxx-xx-xx - version 10.7.0
 * Add - Allow Stripe developer widget to be enabled in test mode via wc_stripe_show_stripe_developer_widget filter
 * Add - Show Stripe's account sync status in the Account details card
 * Update - Improve the behaviour for the Optimized Checkout Suite and Adaptive Pricing settings
+* Fix - Guard against multiple WC_Stripe instances before plugin is fully initialized
 
 2026-04-23 - version 10.6.1
 * Fix - Fix Optimized Checkout Suite bugs that could result in duplicate subscription charges and generic payment methods names

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -80,6 +80,13 @@ class WC_Stripe {
 	protected $stripe_gateway = null;
 
 	/**
+	 * Tracking initialization of various components to prevent repeated work.
+	 *
+	 * @var array<string, bool>
+	 */
+	protected static $initialization_tracking = [];
+
+	/**
 	 * Private clone method to prevent cloning of the instance of the
 	 * *Singleton* instance.
 	 *
@@ -115,7 +122,9 @@ class WC_Stripe {
 	 * @version 5.0.0
 	 */
 	public function init() {
-		if ( is_admin() ) {
+
+		if ( is_admin() && ! isset( self::$initialization_tracking['privacy'] ) ) {
+			self::$initialization_tracking['privacy'] = true;
 			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-privacy.php';
 			new WC_Stripe_Privacy();
 		}
@@ -146,7 +155,11 @@ class WC_Stripe {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-action-scheduler-service.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-webhook-state.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-webhook-handler.php';
-		new WC_Stripe_Webhook_Handler();
+
+		if ( ! isset( self::$initialization_tracking['webhook_handler'] ) ) {
+			self::$initialization_tracking['webhook_handler'] = true;
+			new WC_Stripe_Webhook_Handler();
+		}
 
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/payment-tokens/trait-wc-stripe-fingerprint.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/payment-tokens/interface-wc-stripe-payment-method-comparison.php';
@@ -202,15 +215,25 @@ class WC_Stripe {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/connect/class-wc-stripe-connect.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/connect/class-wc-stripe-connect-api.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-order-handler.php';
-		new WC_Stripe_Order_Handler();
+
+		if ( ! isset( self::$initialization_tracking['order_handler'] ) ) {
+			self::$initialization_tracking['order_handler'] = true;
+			new WC_Stripe_Order_Handler();
+		}
 
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/payment-tokens/class-wc-stripe-payment-tokens.php';
-		new WC_Stripe_Payment_Tokens();
+		if ( ! isset( self::$initialization_tracking['payment_tokens'] ) ) {
+			self::$initialization_tracking['payment_tokens'] = true;
+			new WC_Stripe_Payment_Tokens();
+		}
 
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-customer.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-intent-controller.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-inbox-notes.php';
-		new WC_Stripe_Inbox_Notes();
+		if ( ! isset( self::$initialization_tracking['inbox_notes'] ) ) {
+			self::$initialization_tracking['inbox_notes'] = true;
+			new WC_Stripe_Inbox_Notes();
+		}
 
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-upe-compatibility-controller.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/class-allowed-payment-request-button-types-update.php';
@@ -218,95 +241,145 @@ class WC_Stripe {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/class-migrate-payment-request-data-to-express-checkout-data.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-account.php';
 
-		new Allowed_Payment_Request_Button_Types_Update();
-		new Migrate_Payment_Request_Data_To_Express_Checkout_Data();
-		new Sepa_Tokens_For_Other_Methods_Settings_Update();
+		if ( ! isset( self::$initialization_tracking['updates_and_migrations'] ) ) {
+			self::$initialization_tracking['updates_and_migrations'] = true;
+			new Allowed_Payment_Request_Button_Types_Update();
+			new Migrate_Payment_Request_Data_To_Express_Checkout_Data();
+			new Sepa_Tokens_For_Other_Methods_Settings_Update();
+		}
 
 		$this->api     = new WC_Stripe_Connect_API();
 		$this->connect = new WC_Stripe_Connect( $this->api );
 		$this->account = new WC_Stripe_Account( $this->connect, 'WC_Stripe_API' );
 
-		// Initialize Express Checkout after translations are loaded
-		add_action( 'init', [ $this, 'init_express_checkout' ], 11 );
+		if ( ! isset( self::$initialization_tracking['express_checkout'] ) ) {
+			self::$initialization_tracking['express_checkout'] = true;
+			// Initialize Express Checkout after translations are loaded
+			add_action( 'init', [ $this, 'init_express_checkout' ], 11 );
+		}
 
-		$intent_controller = new WC_Stripe_Intent_Controller();
-		$intent_controller->init_hooks();
+		if ( ! isset( self::$initialization_tracking['intent_controller'] ) ) {
+			self::$initialization_tracking['intent_controller'] = true;
 
-		$checkout_sessions_ajax_handler = new WC_Stripe_Checkout_Sessions_Ajax_Handler();
-		$checkout_sessions_ajax_handler->init_hooks();
+			$intent_controller = new WC_Stripe_Intent_Controller();
+			$intent_controller->init_hooks();
+		}
+
+		if ( ! isset( self::$initialization_tracking['checkout_sessions_ajax_handler'] ) ) {
+			self::$initialization_tracking['checkout_sessions_ajax_handler'] = true;
+
+			$checkout_sessions_ajax_handler = new WC_Stripe_Checkout_Sessions_Ajax_Handler();
+			$checkout_sessions_ajax_handler->init_hooks();
+		}
 
 		if ( is_admin() ) {
 			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-admin-notices.php';
-			new WC_Stripe_Admin_Notices();
+			if ( ! isset( self::$initialization_tracking['admin_notices'] ) ) {
+				self::$initialization_tracking['admin_notices'] = true;
+				new WC_Stripe_Admin_Notices();
+			}
 
 			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-settings-controller.php';
 
 			if ( isset( $_GET['area'] ) && in_array( $_GET['area'], [ 'express_checkout', 'payment_requests' ], true ) ) {
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-express-checkout-controller.php';
-				new WC_Stripe_Express_Checkout_Controller();
+
+				if ( ! isset( self::$initialization_tracking['admin_express_checkout_controller'] ) ) {
+					self::$initialization_tracking['admin_express_checkout_controller'] = true;
+					new WC_Stripe_Express_Checkout_Controller();
+				}
 			} elseif ( isset( $_GET['area'] ) && 'amazon_pay' === $_GET['area'] && WC_Stripe_Feature_Flags::is_amazon_pay_available() ) {
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-amazon-pay-controller.php';
-				new WC_Stripe_Amazon_Pay_Controller();
-			} else {
+				if ( ! isset( self::$initialization_tracking['admin_amazon_pay_controller'] ) ) {
+					self::$initialization_tracking['admin_amazon_pay_controller'] = true;
+					new WC_Stripe_Amazon_Pay_Controller();
+				}
+			} elseif ( ! isset( self::$initialization_tracking['admin_settings_controller'] ) ) {
+				self::$initialization_tracking['admin_settings_controller'] = true;
 				new WC_Stripe_Settings_Controller( $this->account );
 			}
 
 			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-payment-gateways-controller.php';
-			new WC_Stripe_Payment_Gateways_Controller( $this->account );
+			if ( ! isset( self::$initialization_tracking['admin_payment_gateways_controller'] ) ) {
+				self::$initialization_tracking['admin_payment_gateways_controller'] = true;
+				new WC_Stripe_Payment_Gateways_Controller( $this->account );
+			}
 
-			new WC_Stripe_Plugins_Page_Controller( $this->account );
+			if ( ! isset( self::$initialization_tracking['admin_plugins_page_controller'] ) ) {
+				self::$initialization_tracking['admin_plugins_page_controller'] = true;
+				new WC_Stripe_Plugins_Page_Controller( $this->account );
+			}
 
 			if ( WC_Stripe_Subscriptions_Helper::is_subscriptions_enabled() ) {
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-subscription-detached-bulk-action.php';
-				new WC_Stripe_Subscription_Detached_Bulk_Action();
+
+				if ( ! isset( self::$initialization_tracking['admin_subscription_detached_bulk_action'] ) ) {
+					self::$initialization_tracking['admin_subscription_detached_bulk_action'] = true;
+					new WC_Stripe_Subscription_Detached_Bulk_Action();
+				}
 			}
 		}
 
-		add_filter( 'woocommerce_payment_gateways', [ $this, 'add_gateways' ] );
-		add_filter( 'pre_update_option_woocommerce_stripe_settings', [ $this, 'gateway_settings_update' ], 10, 2 );
-		add_filter( 'plugin_action_links_' . plugin_basename( WC_STRIPE_MAIN_FILE ), [ $this, 'plugin_action_links' ] );
-		add_filter( 'plugin_row_meta', [ $this, 'plugin_row_meta' ], 10, 2 );
-		add_action( 'update_option_woocommerce_gateway_order', [ $this, 'set_stripe_gateways_in_list' ] );
+		if ( ! isset( self::$initialization_tracking['plugin_hooks_1'] ) ) {
+			self::$initialization_tracking['plugin_hooks_1'] = true;
+			add_filter( 'woocommerce_payment_gateways', [ $this, 'add_gateways' ] );
+			add_filter( 'pre_update_option_woocommerce_stripe_settings', [ $this, 'gateway_settings_update' ], 10, 2 );
+			add_filter( 'plugin_action_links_' . plugin_basename( WC_STRIPE_MAIN_FILE ), [ $this, 'plugin_action_links' ] );
+			add_filter( 'plugin_row_meta', [ $this, 'plugin_row_meta' ], 10, 2 );
+			add_action( 'update_option_woocommerce_gateway_order', [ $this, 'set_stripe_gateways_in_list' ] );
+		}
 
 		// Update the email field position.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() && ! isset( self::$initialization_tracking['checkout_update_email_field_priority'] ) ) {
+			self::$initialization_tracking['checkout_update_email_field_priority'] = true;
 			add_filter( 'woocommerce_billing_fields', [ $this, 'checkout_update_email_field_priority' ], 50 );
 		}
 
 		// Modify emails emails.
-		add_filter( 'woocommerce_email_classes', [ $this, 'add_emails' ], 20 );
+		if ( ! isset( self::$initialization_tracking['add_emails'] ) ) {
+			self::$initialization_tracking['add_emails'] = true;
+			add_filter( 'woocommerce_email_classes', [ $this, 'add_emails' ], 20 );
+		}
 
-		if ( version_compare( WC_VERSION, '3.4', '<' ) ) {
+		if ( version_compare( WC_VERSION, '3.4', '<' ) && ! isset( self::$initialization_tracking['filter_gateway_order_admin'] ) ) {
+			self::$initialization_tracking['filter_gateway_order_admin'] = true;
 			add_filter( 'woocommerce_get_sections_checkout', [ $this, 'filter_gateway_order_admin' ] );
 		}
 
-		new WC_Stripe_UPE_Compatibility_Controller();
+		if ( ! isset( self::$initialization_tracking['upe_compatibility_controller'] ) ) {
+			self::$initialization_tracking['upe_compatibility_controller'] = true;
+			new WC_Stripe_UPE_Compatibility_Controller();
+		}
 
-		// Initialize the class for updating subscriptions' Legacy SEPA payment methods.
-		add_action( 'init', [ $this, 'initialize_subscriptions_updater' ] );
-		add_action( 'init', [ $this, 'load_plugin_textdomain' ] );
+		if ( ! isset( self::$initialization_tracking['plugin_hooks_2'] ) ) {
+			self::$initialization_tracking['plugin_hooks_2'] = true;
 
-		// Initialize the class for handling the status page.
-		add_action( 'init', [ $this, 'initialize_status_page' ], 15 );
+			// Initialize the class for updating subscriptions' Legacy SEPA payment methods.
+			add_action( 'init', [ $this, 'initialize_subscriptions_updater' ] );
+			add_action( 'init', [ $this, 'load_plugin_textdomain' ] );
 
-		add_action( 'init', [ $this, 'initialize_apple_pay_registration' ] );
+			// Initialize the class for handling the status page.
+			add_action( 'init', [ $this, 'initialize_status_page' ], 15 );
 
-		// Initialize Agentic Commerce integration.
-		add_action( 'woocommerce_init', [ $this, 'initialize_agentic_commerce' ] );
+			add_action( 'init', [ $this, 'initialize_apple_pay_registration' ] );
 
-		// Check for payment methods that should be toggled, e.g. unreleased,
-		// BNPLs when official plugins are active,
-		// cards when the Optimized Checkout is enabled, etc.
-		add_action( 'wc_payment_gateways_initialized', [ $this, 'maybe_toggle_payment_methods' ] );
+			// Initialize Agentic Commerce integration.
+			add_action( 'woocommerce_init', [ $this, 'initialize_agentic_commerce' ] );
 
-		// Reconfigure webhooks when Adaptive Pricing is enabled in the settings.
-		add_action( 'update_option_woocommerce_stripe_settings', [ $this, 'maybe_reconfigure_webhooks_after_adaptive_pricing_enabled' ], 10, 2 );
+			// Check for payment methods that should be toggled, e.g. unreleased,
+			// BNPLs when official plugins are active,
+			// cards when the Optimized Checkout is enabled, etc.
+			add_action( 'wc_payment_gateways_initialized', [ $this, 'maybe_toggle_payment_methods' ] );
 
-		add_action( WC_Stripe_Database_Cache::ASYNC_CLEANUP_ACTION, [ WC_Stripe_Database_Cache::class, 'delete_all_stale_entries_async' ], 10, 2 );
-		add_action( 'action_scheduler_run_recurring_actions_schedule_hook', [ WC_Stripe_Database_Cache::class, 'maybe_schedule_daily_async_cleanup' ], 10, 0 );
+			// Reconfigure webhooks when Adaptive Pricing is enabled in the settings.
+			add_action( 'update_option_woocommerce_stripe_settings', [ $this, 'maybe_reconfigure_webhooks_after_adaptive_pricing_enabled' ], 10, 2 );
 
-		// Handle the async cache prefetch action.
-		add_action( WC_Stripe_Database_Cache_Prefetch::ASYNC_PREFETCH_ACTION, [ WC_Stripe_Database_Cache_Prefetch::get_instance(), 'handle_prefetch_action' ], 10, 1 );
+			add_action( WC_Stripe_Database_Cache::ASYNC_CLEANUP_ACTION, [ WC_Stripe_Database_Cache::class, 'delete_all_stale_entries_async' ], 10, 2 );
+			add_action( 'action_scheduler_run_recurring_actions_schedule_hook', [ WC_Stripe_Database_Cache::class, 'maybe_schedule_daily_async_cleanup' ], 10, 0 );
+
+			// Handle the async cache prefetch action.
+			add_action( WC_Stripe_Database_Cache_Prefetch::ASYNC_PREFETCH_ACTION, [ WC_Stripe_Database_Cache_Prefetch::get_instance(), 'handle_prefetch_action' ], 10, 1 );
+		}
 	}
 
 	/**

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -80,13 +80,6 @@ class WC_Stripe {
 	protected $stripe_gateway = null;
 
 	/**
-	 * Tracking initialization of various components to prevent repeated work.
-	 *
-	 * @var array<string, bool>
-	 */
-	protected static $initialization_tracking = [];
-
-	/**
 	 * Private clone method to prevent cloning of the instance of the
 	 * *Singleton* instance.
 	 *
@@ -107,12 +100,18 @@ class WC_Stripe {
 	 * *Singleton* via the `new` operator from outside of this class.
 	 */
 	public function __construct() {
-		add_action( 'admin_init', [ $this, 'install' ] );
-		add_action( 'admin_init', [ $this, 'maybe_redirect_to_stripe_settings' ], 15 );
+		if ( ! self::$instance ) {
+			self::$instance = $this;
+
+			add_action( 'admin_init', [ $this, 'install' ] );
+			add_action( 'admin_init', [ $this, 'maybe_redirect_to_stripe_settings' ], 15 );
+		}
 
 		$this->init();
 
-		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+		if ( self::$instance === $this ) {
+			add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+		}
 	}
 
 	/**
@@ -123,8 +122,7 @@ class WC_Stripe {
 	 */
 	public function init() {
 
-		if ( is_admin() && ! isset( self::$initialization_tracking['privacy'] ) ) {
-			self::$initialization_tracking['privacy'] = true;
+		if ( is_admin() && self::$instance === $this ) {
 			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-privacy.php';
 			new WC_Stripe_Privacy();
 		}
@@ -156,8 +154,7 @@ class WC_Stripe {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-webhook-state.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-webhook-handler.php';
 
-		if ( ! isset( self::$initialization_tracking['webhook_handler'] ) ) {
-			self::$initialization_tracking['webhook_handler'] = true;
+		if ( self::$instance === $this ) {
 			new WC_Stripe_Webhook_Handler();
 		}
 
@@ -216,22 +213,19 @@ class WC_Stripe {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/connect/class-wc-stripe-connect-api.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-order-handler.php';
 
-		if ( ! isset( self::$initialization_tracking['order_handler'] ) ) {
-			self::$initialization_tracking['order_handler'] = true;
+		if ( self::$instance === $this ) {
 			new WC_Stripe_Order_Handler();
 		}
 
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/payment-tokens/class-wc-stripe-payment-tokens.php';
-		if ( ! isset( self::$initialization_tracking['payment_tokens'] ) ) {
-			self::$initialization_tracking['payment_tokens'] = true;
+		if ( self::$instance === $this ) {
 			new WC_Stripe_Payment_Tokens();
 		}
 
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-customer.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-intent-controller.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-inbox-notes.php';
-		if ( ! isset( self::$initialization_tracking['inbox_notes'] ) ) {
-			self::$initialization_tracking['inbox_notes'] = true;
+		if ( self::$instance === $this ) {
 			new WC_Stripe_Inbox_Notes();
 		}
 
@@ -241,8 +235,7 @@ class WC_Stripe {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/class-migrate-payment-request-data-to-express-checkout-data.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-account.php';
 
-		if ( ! isset( self::$initialization_tracking['updates_and_migrations'] ) ) {
-			self::$initialization_tracking['updates_and_migrations'] = true;
+		if ( self::$instance === $this ) {
 			new Allowed_Payment_Request_Button_Types_Update();
 			new Migrate_Payment_Request_Data_To_Express_Checkout_Data();
 			new Sepa_Tokens_For_Other_Methods_Settings_Update();
@@ -252,21 +245,14 @@ class WC_Stripe {
 		$this->connect = new WC_Stripe_Connect( $this->api );
 		$this->account = new WC_Stripe_Account( $this->connect, 'WC_Stripe_API' );
 
-		if ( ! isset( self::$initialization_tracking['express_checkout'] ) ) {
-			self::$initialization_tracking['express_checkout'] = true;
+		if ( self::$instance === $this ) {
 			// Initialize Express Checkout after translations are loaded
 			add_action( 'init', [ $this, 'init_express_checkout' ], 11 );
 		}
 
-		if ( ! isset( self::$initialization_tracking['intent_controller'] ) ) {
-			self::$initialization_tracking['intent_controller'] = true;
-
+		if ( self::$instance === $this ) {
 			$intent_controller = new WC_Stripe_Intent_Controller();
 			$intent_controller->init_hooks();
-		}
-
-		if ( ! isset( self::$initialization_tracking['checkout_sessions_ajax_handler'] ) ) {
-			self::$initialization_tracking['checkout_sessions_ajax_handler'] = true;
 
 			$checkout_sessions_ajax_handler = new WC_Stripe_Checkout_Sessions_Ajax_Handler();
 			$checkout_sessions_ajax_handler->init_hooks();
@@ -274,8 +260,7 @@ class WC_Stripe {
 
 		if ( is_admin() ) {
 			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-admin-notices.php';
-			if ( ! isset( self::$initialization_tracking['admin_notices'] ) ) {
-				self::$initialization_tracking['admin_notices'] = true;
+			if ( self::$instance === $this ) {
 				new WC_Stripe_Admin_Notices();
 			}
 
@@ -284,44 +269,37 @@ class WC_Stripe {
 			if ( isset( $_GET['area'] ) && in_array( $_GET['area'], [ 'express_checkout', 'payment_requests' ], true ) ) {
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-express-checkout-controller.php';
 
-				if ( ! isset( self::$initialization_tracking['admin_express_checkout_controller'] ) ) {
-					self::$initialization_tracking['admin_express_checkout_controller'] = true;
+				if ( self::$instance === $this ) {
 					new WC_Stripe_Express_Checkout_Controller();
 				}
 			} elseif ( isset( $_GET['area'] ) && 'amazon_pay' === $_GET['area'] && WC_Stripe_Feature_Flags::is_amazon_pay_available() ) {
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-amazon-pay-controller.php';
-				if ( ! isset( self::$initialization_tracking['admin_amazon_pay_controller'] ) ) {
-					self::$initialization_tracking['admin_amazon_pay_controller'] = true;
+				if ( self::$instance === $this ) {
 					new WC_Stripe_Amazon_Pay_Controller();
 				}
-			} elseif ( ! isset( self::$initialization_tracking['admin_settings_controller'] ) ) {
-				self::$initialization_tracking['admin_settings_controller'] = true;
+			} elseif ( self::$instance === $this ) {
 				new WC_Stripe_Settings_Controller( $this->account );
 			}
 
 			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-payment-gateways-controller.php';
-			if ( ! isset( self::$initialization_tracking['admin_payment_gateways_controller'] ) ) {
-				self::$initialization_tracking['admin_payment_gateways_controller'] = true;
+			if ( self::$instance === $this ) {
 				new WC_Stripe_Payment_Gateways_Controller( $this->account );
 			}
 
-			if ( ! isset( self::$initialization_tracking['admin_plugins_page_controller'] ) ) {
-				self::$initialization_tracking['admin_plugins_page_controller'] = true;
+			if ( self::$instance === $this ) {
 				new WC_Stripe_Plugins_Page_Controller( $this->account );
 			}
 
 			if ( WC_Stripe_Subscriptions_Helper::is_subscriptions_enabled() ) {
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-subscription-detached-bulk-action.php';
 
-				if ( ! isset( self::$initialization_tracking['admin_subscription_detached_bulk_action'] ) ) {
-					self::$initialization_tracking['admin_subscription_detached_bulk_action'] = true;
+				if ( self::$instance === $this ) {
 					new WC_Stripe_Subscription_Detached_Bulk_Action();
 				}
 			}
 		}
 
-		if ( ! isset( self::$initialization_tracking['plugin_hooks_1'] ) ) {
-			self::$initialization_tracking['plugin_hooks_1'] = true;
+		if ( self::$instance === $this ) {
 			add_filter( 'woocommerce_payment_gateways', [ $this, 'add_gateways' ] );
 			add_filter( 'pre_update_option_woocommerce_stripe_settings', [ $this, 'gateway_settings_update' ], 10, 2 );
 			add_filter( 'plugin_action_links_' . plugin_basename( WC_STRIPE_MAIN_FILE ), [ $this, 'plugin_action_links' ] );
@@ -330,30 +308,24 @@ class WC_Stripe {
 		}
 
 		// Update the email field position.
-		if ( ! is_admin() && ! isset( self::$initialization_tracking['checkout_update_email_field_priority'] ) ) {
-			self::$initialization_tracking['checkout_update_email_field_priority'] = true;
+		if ( ! is_admin() && self::$instance === $this ) {
 			add_filter( 'woocommerce_billing_fields', [ $this, 'checkout_update_email_field_priority' ], 50 );
 		}
 
 		// Modify emails emails.
-		if ( ! isset( self::$initialization_tracking['add_emails'] ) ) {
-			self::$initialization_tracking['add_emails'] = true;
+		if ( self::$instance === $this ) {
 			add_filter( 'woocommerce_email_classes', [ $this, 'add_emails' ], 20 );
 		}
 
-		if ( version_compare( WC_VERSION, '3.4', '<' ) && ! isset( self::$initialization_tracking['filter_gateway_order_admin'] ) ) {
-			self::$initialization_tracking['filter_gateway_order_admin'] = true;
+		if ( version_compare( WC_VERSION, '3.4', '<' ) && self::$instance === $this ) {
 			add_filter( 'woocommerce_get_sections_checkout', [ $this, 'filter_gateway_order_admin' ] );
 		}
 
-		if ( ! isset( self::$initialization_tracking['upe_compatibility_controller'] ) ) {
-			self::$initialization_tracking['upe_compatibility_controller'] = true;
+		if ( self::$instance === $this ) {
 			new WC_Stripe_UPE_Compatibility_Controller();
 		}
 
-		if ( ! isset( self::$initialization_tracking['plugin_hooks_2'] ) ) {
-			self::$initialization_tracking['plugin_hooks_2'] = true;
-
+		if ( self::$instance === $this ) {
 			// Initialize the class for updating subscriptions' Legacy SEPA payment methods.
 			add_action( 'init', [ $this, 'initialize_subscriptions_updater' ] );
 			add_action( 'init', [ $this, 'load_plugin_textdomain' ] );

--- a/readme.txt
+++ b/readme.txt
@@ -176,5 +176,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Allow Stripe developer widget to be enabled in test mode via wc_stripe_show_stripe_developer_widget filter
 * Add - Show Stripe's account sync status in the Account details card
 * Update - Improve the behaviour for the Optimized Checkout Suite and Adaptive Pricing settings
+* Fix - Guard against multiple WC_Stripe instances before plugin is fully initialized
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-test.php
+++ b/tests/phpunit/class-wc-stripe-test.php
@@ -691,4 +691,214 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			],
 		];
 	}
+
+	/* -----------------------------------------------------------------
+	 * Plugin initialization guards
+	 *
+	 * Cover the `if ( self::$instance === $this )` guard pattern added to
+	 * WC_Stripe::__construct() and WC_Stripe::init() to prevent duplicate
+	 * hook registration and collaborator re-instantiation when WC_Stripe is
+	 * constructed more than once.
+	 * ----------------------------------------------------------------- */
+
+	/**
+	 * The singleton accessor must keep returning the same instance.
+	 */
+	public function test_get_instance_returns_same_singleton_on_repeated_calls(): void {
+		$this->assertSame( WC_Stripe::get_instance(), WC_Stripe::get_instance() );
+	}
+
+	/**
+	 * Constructing a second WC_Stripe via `new` must not replace the singleton.
+	 */
+	public function test_direct_construction_does_not_replace_existing_singleton(): void {
+		$first  = WC_Stripe::get_instance();
+		$second = new WC_Stripe();
+
+		$this->assertSame( $first, WC_Stripe::get_instance() );
+		$this->assertNotSame( $first, $second );
+	}
+
+	/**
+	 * The two admin_init hooks added in __construct()'s guarded block must
+	 * only land on the first instance.
+	 */
+	public function test_admin_init_hooks_registered_only_for_first_instance(): void {
+		$first = WC_Stripe::get_instance();
+
+		$this->assertSame( 10, has_action( 'admin_init', [ $first, 'install' ] ) );
+		$this->assertSame( 15, has_action( 'admin_init', [ $first, 'maybe_redirect_to_stripe_settings' ] ) );
+
+		$second = new WC_Stripe();
+
+		$this->assertFalse( has_action( 'admin_init', [ $second, 'install' ] ) );
+		$this->assertFalse( has_action( 'admin_init', [ $second, 'maybe_redirect_to_stripe_settings' ] ) );
+
+		// First instance's hooks remain at their original priorities.
+		$this->assertSame( 10, has_action( 'admin_init', [ $first, 'install' ] ) );
+		$this->assertSame( 15, has_action( 'admin_init', [ $first, 'maybe_redirect_to_stripe_settings' ] ) );
+	}
+
+	/**
+	 * The rest_api_init guard at the end of __construct() must only register
+	 * register_routes on the first instance.
+	 */
+	public function test_register_routes_hook_registered_only_for_first_instance(): void {
+		$first = WC_Stripe::get_instance();
+
+		$this->assertSame( 10, has_action( 'rest_api_init', [ $first, 'register_routes' ] ) );
+
+		$second = new WC_Stripe();
+
+		$this->assertFalse( has_action( 'rest_api_init', [ $second, 'register_routes' ] ) );
+		$this->assertSame( 10, has_action( 'rest_api_init', [ $first, 'register_routes' ] ) );
+	}
+
+	/**
+	 * Every hook added by the guarded blocks in init() must be registered on
+	 * the first instance and must NOT be registered on a second instance.
+	 *
+	 * Single sweep test — failure messages identify the offending row.
+	 */
+	public function test_init_hooks_registered_only_for_first_instance(): void {
+		$hooks = [
+			[ 'woocommerce_payment_gateways', 'add_gateways', 10 ],
+			[ 'pre_update_option_woocommerce_stripe_settings', 'gateway_settings_update', 10 ],
+			[ 'plugin_action_links_' . plugin_basename( WC_STRIPE_MAIN_FILE ), 'plugin_action_links', 10 ],
+			[ 'plugin_row_meta', 'plugin_row_meta', 10 ],
+			[ 'update_option_woocommerce_gateway_order', 'set_stripe_gateways_in_list', 10 ],
+			[ 'woocommerce_email_classes', 'add_emails', 20 ],
+			[ 'init', 'init_express_checkout', 11 ],
+			[ 'init', 'initialize_subscriptions_updater', 10 ],
+			[ 'init', 'load_plugin_textdomain', 10 ],
+			[ 'init', 'initialize_status_page', 15 ],
+			[ 'init', 'initialize_apple_pay_registration', 10 ],
+			[ 'woocommerce_init', 'initialize_agentic_commerce', 10 ],
+			[ 'wc_payment_gateways_initialized', 'maybe_toggle_payment_methods', 10 ],
+			[ 'update_option_woocommerce_stripe_settings', 'maybe_reconfigure_webhooks_after_adaptive_pricing_enabled', 10 ],
+		];
+
+		$first = WC_Stripe::get_instance();
+
+		foreach ( $hooks as [ $hook, $callback, $priority ] ) {
+			$this->assertSame(
+				$priority,
+				has_filter( $hook, [ $first, $callback ] ),
+				"hook {$hook} -> {$callback} should be registered on the first instance at priority {$priority}"
+			);
+		}
+
+		$second = new WC_Stripe();
+
+		foreach ( $hooks as [ $hook, $callback, $priority ] ) {
+			$this->assertFalse(
+				has_filter( $hook, [ $second, $callback ] ),
+				"hook {$hook} -> {$callback} should NOT be registered on the second instance"
+			);
+			$this->assertSame(
+				$priority,
+				has_filter( $hook, [ $first, $callback ] ),
+				"hook {$hook} -> {$callback} on the first instance should remain at priority {$priority} after second construction"
+			);
+		}
+	}
+
+	/**
+	 * The frontend-only billing-fields filter must follow the same guard.
+	 */
+	public function test_checkout_update_email_field_priority_filter_registered_only_for_first_instance_in_frontend(): void {
+		$initial_screen = $GLOBALS['current_screen'] ?? null;
+		$current_screen = \WP_Screen::get( 'post.php' );
+
+		try {
+			$first = WC_Stripe::get_instance();
+
+			$this->assertSame(
+				50,
+				has_filter( 'woocommerce_billing_fields', [ $first, 'checkout_update_email_field_priority' ] )
+			);
+
+			$second = new WC_Stripe();
+
+			$this->assertFalse(
+				has_filter( 'woocommerce_billing_fields', [ $second, 'checkout_update_email_field_priority' ] )
+			);
+			$this->assertSame(
+				50,
+				has_filter( 'woocommerce_billing_fields', [ $first, 'checkout_update_email_field_priority' ] )
+			);
+		} finally {
+			if ( null !== $initial_screen ) {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$GLOBALS['current_screen'] = $initial_screen;
+			}
+		}
+	}
+
+	/**
+	 * Collaborator classes that init() instantiates inside guarded blocks must
+	 * not be re-instantiated when a second WC_Stripe is constructed.
+	 *
+	 * Detection: count the callbacks registered on a hook unique to each
+	 * collaborator before and after the second construction. The delta must
+	 * be zero.
+	 */
+	public function test_collaborators_not_reinstantiated_on_second_construction(): void {
+		// Hooks chosen because they are registered ONLY by the collaborator's
+		// constructor / init_hooks() — so a duplicate instance bumps the count
+		// by exactly 1.
+		$collaborators = [
+			'WC_Stripe_Webhook_Handler'                => [ 'woocommerce_api_wc_stripe', 10 ],
+			'WC_Stripe_Order_Handler'                  => [ 'woocommerce_admin_order_totals_after_total', 10 ],
+			'WC_Stripe_Payment_Tokens'                 => [ 'woocommerce_payment_methods_list_item', 10 ],
+			'WC_Stripe_Intent_Controller'              => [ 'wc_ajax_wc_stripe_verify_intent', 10 ],
+			'WC_Stripe_Checkout_Sessions_Ajax_Handler' => [ 'wc_ajax_wc_stripe_create_checkout_session', 10 ],
+		];
+
+		$before = [];
+		foreach ( $collaborators as $class => [ $hook, $priority ] ) {
+			$before[ $class ] = $this->count_hook_callbacks( $hook, $priority );
+		}
+
+		$wc_stripe_reflection = new ReflectionClass( WC_Stripe::class );
+		$instance_reflection  = $wc_stripe_reflection->getProperty( 'instance' );
+		$instance_reflection->setAccessible( true );
+		$instance_reflection->setValue( null, null );
+
+		$first = WC_Stripe::get_instance();
+
+		$after_first = [];
+		foreach ( $collaborators as $class => [ $hook, $priority ] ) {
+			$after_first[ $class ] = $this->count_hook_callbacks( $hook, $priority );
+			$this->assertGreaterThan( $before[ $class ], $after_first[ $class ], "{$class} should have been instantiated on the first instance" );
+		}
+
+		$second = new WC_Stripe();
+
+		foreach ( $collaborators as $class => [ $hook, $priority ] ) {
+			$after = $this->count_hook_callbacks( $hook, $priority );
+			$this->assertSame(
+				$after_first[ $class ] ?? -1,
+				$after,
+				"{$class} appears to have been re-instantiated: callback count on {$hook} (priority {$priority}) changed from {$before[ $class ]} to {$after}"
+			);
+		}
+	}
+
+	/**
+	 * Helper: count callbacks registered on `$hook` at `$priority`.
+	 *
+	 * @param string $hook     Hook name.
+	 * @param int    $priority Priority level.
+	 * @return int Number of registered callbacks at that priority.
+	 */
+	private function count_hook_callbacks( string $hook, int $priority ): int {
+		global $wp_filter;
+
+		if ( ! isset( $wp_filter[ $hook ] ) || ! isset( $wp_filter[ $hook ]->callbacks[ $priority ] ) ) {
+			return 0;
+		}
+
+		return count( $wp_filter[ $hook ]->callbacks[ $priority ] );
+	}
 }

--- a/tests/phpunit/class-wc-stripe-test.php
+++ b/tests/phpunit/class-wc-stripe-test.php
@@ -808,7 +808,8 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 */
 	public function test_checkout_update_email_field_priority_filter_registered_only_for_first_instance_in_frontend(): void {
 		$initial_screen = $GLOBALS['current_screen'] ?? null;
-		$current_screen = \WP_Screen::get( 'post.php' );
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$GLOBALS['current_screen'] = \WP_Screen::get( 'post.php' );
 
 		try {
 			$first = WC_Stripe::get_instance();


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR adds safeguards in `WC_Stripe::init()` to prevent duplicate initialisation logic and hook registrations from occurring when `WC_Stripe` is instantiated more than once due to code being called from within `WC_Stripe::init()` making calls to `WC_Stripe::get_instance()` before `WC_Stripe::$instance` is populated.

The specific change is to populate `self::$instance` within the constructor, and then ensuring that all downstream logic only triggers general initialization logic when `self::$instance === $this`, i.e. we are the first `WC_Stripe` instance to be registered. This ensures various objects are only instantiated once, and that hooks are only registered against the first `WC_Stripe` instance.

It's worth noting that this is a relatively messy or noisy change, but the driver for that was to minimise the risks from the change. In particular, we need to run all the `require_once`s during the first run through to ensure that we have the dependencies for the properties of the `WC_Stripe` object, and we were aiming to keep the various `new <something>()` calls inline so they were not at the end of various files which we eventually want to autoload. There is a _lot_ of cleanup that needs to happen in `init()`, but this PR is not the place to tackle that work.

The specific issue this addresses was an infinite loop that I encountered while testing 10.7.0. The trace for the loop was as follows:
* `do_action('plugins_loaded')`
* `WP_Hook->do_action`
* `WP_Hook->apply_filters`
* `woocommerce_gateway_stripe_init`
* `woocommerce_gateway_stripe`
* `WC_Stripe::get_instance`
* `WC_Stripe->__construct`
* `WC_Stripe->init`
* `WC_Stripe_Payment_Gateways_Controller->__construct`
* `WC_Stripe_Payment_Method_Configurations::get_upe_enabled_payment_method_ids`
* `WC_Stripe_Payment_Method_Configurations::maybe_migrate_payment_methods_from_db_to_pmc`
* `WC_Stripe_UPE_Payment_Method_Amazon_Pay::is_amazon_pay_available_for_account_country`
* `WC_Stripe::get_instance`
* `WC_Stripe->__construct`
* `WC_Stripe->init`
* `WC_Stripe_Payment_Gateways_Controller->__construct`
* `WC_Stripe_Payment_Method_Configurations::get_upe_enabled_payment_method_ids`
* ...

The specific trigger for this situation was the dedicated `wc_stripe_amazon_pay_default_on` option being set to `'yes'` (which is the case for recent installs), and the `pmc_enabled` sub-option was deleted. Any admin page visit would then 

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
* Check the code from inspection
* Verify that all unit and e2e tests pass
* Try to replicate the issue with a build from the `release/10.7.0` by doing the following:
  - Connect to Stripe -- I triggered the situation in test mode, so that should be fine
  - Ensure that `wc_stripe_amazon_pay_default_on` is set to `'yes'` -- `wp option update wc_stripe_amazon_pay_default_on yes`
  - Remove the `pmc_enabled` sub-option -- `wp option patch delete woocommerce_stripe_settings pmc_enabled`
  - Immediately load an admin page
  - In my site, that triggered an Out of Memory fatal due to the infinite loop, but the symptoms could be different
* Apply the changes from this PR to the site (or install the new build and replicate the settings above)
  - It's especially crucial to remove the `pmc_enabled` sub-setting

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
