### PR TITLE
Update playwright setup to download only chromium

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     }
   },
   "scripts": {
-    "postinstall": "composer install --classmap-authoritative && npx playwright install",
+    "postinstall": "composer install --classmap-authoritative && npx playwright install chromium",
     "prebuild": "npm install && composer install --classmap-authoritative",
     "prepare": "is-ci || husky install",
     "build": "npm run uglify && npm run sass && rimraf build/* && npm run build:webpack && npm run build:i18n && npm run build:release",


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Update the `postinstall` script to only download the Chromium browser instead of all Playwright browsers (Chromium, Firefox, WebKit).

Per install, this skips the Firefox and WebKit downloads — roughly **~530 MB** of binaries that were never executed (Firefox ~253 MB + WebKit ~275 MB).

If a future test project needs Firefox or WebKit, the Playwright config can be updated alongside reintroducing the relevant browser to the install command.



## Testing instructions

1. Check out this branch and remove any previously installed Playwright browsers:
    ```
    rm -rf ~/Library/Caches/ms-playwright
    ```
2. Run `npm install` from a clean state.
3. Confirm only Chromium is downloaded during `postinstall` (no Firefox/WebKit download lines in the output).
4. Run the E2E setup and a smoke run against your local environment:
    ```
    npm run test:e2e-setup -- --base_url=http://localhost:8072
    npm run test:e2e -- --base_url=http://localhost:8072
    ```
5. Verify tests execute against Chromium and pass as they do on `develop`.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Dev-tooling change only: No runtime/plugin behavior change for merchants or shoppers.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
