### PR TITLE
Small improvements to Jurassic Ninja preview comments

### DIFF
--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -139,7 +139,7 @@ jobs:
           :turtle: Navigate to [jurassic.ninja](https://jurassic.ninja/) :turtle:
           * Click on \"See more options\"
           * Check \"Jetpack Beta\"
-          * Enter `${PR_HEAD_REF}` for the WooCommerce Stripe Gateway line
+          * Enter \`${PR_HEAD_REF}\` for the WooCommerce Stripe Gateway line
           * Check \"WooCommerce\"
           * Check \"Import sample product data\"
           * Enter your email address

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -132,7 +132,7 @@ jobs:
 
           **If you are a logged-in Automattic staff member:**
 
-          :rocket: [Launch a Jurassic Ninja site with this branch](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-import-sample-data&woocommerce-gateway-stripe-dev-tools&branches.woocommerce-gateway-stripe=${PR_HEAD_REF}) :rocket:
+          :rocket: [Launch a Jurassic Ninja site with this branch and sample products](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-import-sample-data&woocommerce-gateway-stripe-dev-tools&branches.woocommerce-gateway-stripe=${PR_HEAD_REF}) :rocket:
           
           **Otherwise, use the following manual flow:**
 
@@ -141,7 +141,7 @@ jobs:
           * Check \"Jetpack Beta\"
           * Enter \`${PR_HEAD_REF}\` for the WooCommerce Stripe Gateway line
           * Check \"WooCommerce\"
-          * Check \"Import sample product data\"
+          * Check \"Import sample product data\" (it should be immediately below the WooCommerce option)
           * Enter your email address
           * Click on \"Launch single site\"
 

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -132,7 +132,7 @@ jobs:
 
           **This auto-creation flow is only available to logged-in Automattic staff members.**
 
-          :rocket: [Launch a Jurassic Ninja site with this branch](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-gateway-stripe-dev-tools&branches.woocommerce-gateway-stripe=${PR_HEAD_REF}) :rocket:
+          :rocket: [Launch a Jurassic Ninja site with this branch](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-import-sample-data&woocommerce-gateway-stripe-dev-tools&branches.woocommerce-gateway-stripe=${PR_HEAD_REF}) :rocket:
           
           For everyone else, use the following manual flow:
 

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -130,17 +130,18 @@ jobs:
         run: |
           BODY="### Test the build
 
-          **This auto-creation flow is only available to logged-in Automattic staff members.**
+          **If you are a logged-in Automattic staff member:**
 
           :rocket: [Launch a Jurassic Ninja site with this branch](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-import-sample-data&woocommerce-gateway-stripe-dev-tools&branches.woocommerce-gateway-stripe=${PR_HEAD_REF}) :rocket:
           
-          For everyone else, use the following manual flow:
+          **Otherwise, use the following manual flow:**
 
           :turtle: Navigate to [jurassic.ninja](https://jurassic.ninja/) :turtle:
           * Click on \"See more options\"
           * Check \"Jetpack Beta\"
           * Enter `${PR_HEAD_REF}` for the WooCommerce Stripe Gateway line
           * Check \"WooCommerce\"
+          * Check \"Import sample product data\"
           * Enter your email address
           * Click on \"Launch single site\"
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Related to #5376

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR makes some small changes to the Jurassic Ninja comment that was added in #5376:
 * The wording for the Automattic-specific and manual flows are now given equal weight, and both descriptions are simpler
 * The generated Jurassic Ninja link includes the `woocommerce-import-sample-data` URL parameter, which imports sample products
 * The manual flow includes a step to check the import sample data option
 * The branch name in the manual steps is now visible -- the <code>`</code> characters were not escaped correctly before

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
* Check the comment that is logged on this PR
* Verify that it's easy to work out which flow is for Automattic staff, and which is not
* Click on the Jurassic Ninja link
* Once the site is ready, navigate to the shop for the site
* Verify that some products have been imported

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [N/A] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This is a minor tweak to a GitHub only workflow. No changelog required.
</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
