### PR TITLE
Add type guards to webhook state getters

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,7 +6,7 @@ xxxx-xx-xx - version 10.8.0
 * Remove - Remove giropay from new checkouts (deprecated by Stripe on 2024-06-30); legacy refund and past-order rendering preserved
 * Dev - Exclude AGENTS.md and CLAUDE.md contributor-instruction files from the built plugin zip
 * Add - Append a "what's new" changelog link to the Updated! message after manually updating the plugin from the Plugins page
-* Fix - Add guards against invalid values for webhook state timestamps"
+* Fix - Add guards against invalid values for webhook state timestamps
 
 2026-05-12 - version 10.7.0
 * Fix - Hide the "move Stripe to the top" Optimized Checkout notice when all payment methods above Stripe are disabled

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ xxxx-xx-xx - version 10.8.0
 * Remove - Remove giropay from new checkouts (deprecated by Stripe on 2024-06-30); legacy refund and past-order rendering preserved
 * Dev - Exclude AGENTS.md and CLAUDE.md contributor-instruction files from the built plugin zip
 * Add - Append a "what's new" changelog link to the Updated! message after manually updating the plugin from the Plugins page
+* Fix - Add guards against invalid values for webhook state timestamps"
 
 2026-05-12 - version 10.7.0
 * Fix - Hide the "move Stripe to the top" Optimized Checkout notice when all payment methods above Stripe are disabled

--- a/includes/class-wc-stripe-webhook-state.php
+++ b/includes/class-wc-stripe-webhook-state.php
@@ -76,7 +76,7 @@ class WC_Stripe_Webhook_State {
 	 * started tracking webhook failure and successes.
 	 *
 	 * @since 5.0.0
-	 * @return integer UTC seconds since 1970.
+	 * @return int UTC seconds since 1970.
 	 */
 	public static function get_monitoring_began_at() {
 		$option              = WC_Stripe_Mode::is_test() ? self::OPTION_TEST_MONITORING_BEGAN_AT : self::OPTION_LIVE_MONITORING_BEGAN_AT;
@@ -99,7 +99,7 @@ class WC_Stripe_Webhook_State {
 	 * Sets the timestamp of the last successfully processed webhook.
 	 *
 	 * @since 5.0.0
-	 * @param integer UTC seconds since 1970.
+	 * @param int $timestamp UTC seconds since 1970.
 	 */
 	public static function set_last_webhook_success_at( $timestamp ) {
 		$option = WC_Stripe_Mode::is_test() ? self::OPTION_TEST_LAST_SUCCESS_AT : self::OPTION_LIVE_LAST_SUCCESS_AT;
@@ -122,7 +122,7 @@ class WC_Stripe_Webhook_State {
 	 * Sets the timestamp of the last failed webhook.
 	 *
 	 * @since 5.0.0
-	 * @param int UTC seconds since 1970.
+	 * @param int $timestamp UTC seconds since 1970.
 	 */
 	public static function set_last_webhook_failure_at( $timestamp ) {
 		$option = WC_Stripe_Mode::is_test() ? self::OPTION_TEST_LAST_FAILURE_AT : self::OPTION_LIVE_LAST_FAILURE_AT;
@@ -134,7 +134,7 @@ class WC_Stripe_Webhook_State {
 	 * or returns 0 if no webhook has ever failed to process.
 	 *
 	 * @since 5.0.0
-	 * @return integer UTC seconds since 1970 | 0.
+	 * @return int UTC seconds since 1970 | 0.
 	 */
 	public static function get_last_webhook_failure_at() {
 		$option = WC_Stripe_Mode::is_test() ? self::OPTION_TEST_LAST_FAILURE_AT : self::OPTION_LIVE_LAST_FAILURE_AT;
@@ -145,7 +145,7 @@ class WC_Stripe_Webhook_State {
 	 * Sets the reason for the last failed webhook.
 	 *
 	 * @since 5.0.0
-	 * @param string Reason code.
+	 * @param string $reason Reason code.
 	 */
 	public static function set_last_error_reason( $reason ) {
 		$option = WC_Stripe_Mode::is_test() ? self::OPTION_TEST_LAST_ERROR : self::OPTION_LIVE_LAST_ERROR;

--- a/includes/class-wc-stripe-webhook-state.php
+++ b/includes/class-wc-stripe-webhook-state.php
@@ -111,18 +111,18 @@ class WC_Stripe_Webhook_State {
 	 * or returns 0 if no webhook has ever been successfully processed.
 	 *
 	 * @since 5.0.0
-	 * @return integer UTC seconds since 1970 | 0.
+	 * @return int UTC seconds since 1970 | 0.
 	 */
 	public static function get_last_webhook_success_at() {
 		$option = WC_Stripe_Mode::is_test() ? self::OPTION_TEST_LAST_SUCCESS_AT : self::OPTION_LIVE_LAST_SUCCESS_AT;
-		return get_option( $option, 0 );
+		return self::get_int_option( $option );
 	}
 
 	/**
 	 * Sets the timestamp of the last failed webhook.
 	 *
 	 * @since 5.0.0
-	 * @param integer UTC seconds since 1970.
+	 * @param int UTC seconds since 1970.
 	 */
 	public static function set_last_webhook_failure_at( $timestamp ) {
 		$option = WC_Stripe_Mode::is_test() ? self::OPTION_TEST_LAST_FAILURE_AT : self::OPTION_LIVE_LAST_FAILURE_AT;
@@ -138,7 +138,7 @@ class WC_Stripe_Webhook_State {
 	 */
 	public static function get_last_webhook_failure_at() {
 		$option = WC_Stripe_Mode::is_test() ? self::OPTION_TEST_LAST_FAILURE_AT : self::OPTION_LIVE_LAST_FAILURE_AT;
-		return get_option( $option, 0 );
+		return self::get_int_option( $option );
 	}
 
 	/**
@@ -252,7 +252,7 @@ class WC_Stripe_Webhook_State {
 	 */
 	public static function get_pending_webhooks_count() {
 		$option = WC_Stripe_Mode::is_test() ? self::OPTION_TEST_PENDING_WEBHOOKS : self::OPTION_LIVE_PENDING_WEBHOOKS;
-		return get_option( $option, 0 );
+		return self::get_int_option( $option );
 	}
 
 	/**
@@ -363,5 +363,22 @@ class WC_Stripe_Webhook_State {
 			'live' => empty( $live_webhook['url'] ) ? null : rawurlencode( $live_webhook['url'] ),
 			'test' => empty( $test_webhook['url'] ) ? null : rawurlencode( $test_webhook['url'] ),
 		];
+	}
+
+	/**
+	 * Gets an option value that must be an integer. Stringified integers will be cast to int,
+	 * but other non-integer values will be returned as 0.
+	 *
+	 * @since 10.8.0
+	 * @param string $option_name The name of the option to get.
+	 * @return int The integer value of the option, or 0 if the option is not an integer.
+	 */
+	protected static function get_int_option( string $option_name ): int {
+		$option_value = get_option( $option_name, 0 );
+		if ( ! ctype_digit( (string) $option_value ) ) {
+			return 0;
+		}
+
+		return (int) $option_value;
 	}
 }

--- a/includes/class-wc-stripe-webhook-state.php
+++ b/includes/class-wc-stripe-webhook-state.php
@@ -80,7 +80,7 @@ class WC_Stripe_Webhook_State {
 	 */
 	public static function get_monitoring_began_at() {
 		$option              = WC_Stripe_Mode::is_test() ? self::OPTION_TEST_MONITORING_BEGAN_AT : self::OPTION_LIVE_MONITORING_BEGAN_AT;
-		$monitoring_began_at = get_option( $option, 0 );
+		$monitoring_began_at = self::get_int_option( $option );
 		if ( 0 == $monitoring_began_at ) {
 			$monitoring_began_at = time();
 			update_option( $option, $monitoring_began_at );

--- a/includes/class-wc-stripe-webhook-state.php
+++ b/includes/class-wc-stripe-webhook-state.php
@@ -53,7 +53,7 @@ class WC_Stripe_Webhook_State {
 	 *
 	 * @param string $mode Optional. The mode to clear the webhook state for. Can be 'all', 'live', or 'test'. Default is 'all'.
 	 */
-	public static function clear_state( $mode = 'all' ) {
+	public static function clear_state( $mode = 'all' ): void {
 		if ( 'all' === $mode || 'live' === $mode ) {
 			delete_option( self::OPTION_LIVE_MONITORING_BEGAN_AT );
 			delete_option( self::OPTION_LIVE_LAST_SUCCESS_AT );
@@ -101,7 +101,7 @@ class WC_Stripe_Webhook_State {
 	 * @since 5.0.0
 	 * @param int $timestamp UTC seconds since 1970.
 	 */
-	public static function set_last_webhook_success_at( $timestamp ) {
+	public static function set_last_webhook_success_at( $timestamp ): void {
 		$option = WC_Stripe_Mode::is_test() ? self::OPTION_TEST_LAST_SUCCESS_AT : self::OPTION_LIVE_LAST_SUCCESS_AT;
 		update_option( $option, $timestamp );
 	}
@@ -124,7 +124,7 @@ class WC_Stripe_Webhook_State {
 	 * @since 5.0.0
 	 * @param int $timestamp UTC seconds since 1970.
 	 */
-	public static function set_last_webhook_failure_at( $timestamp ) {
+	public static function set_last_webhook_failure_at( $timestamp ): void {
 		$option = WC_Stripe_Mode::is_test() ? self::OPTION_TEST_LAST_FAILURE_AT : self::OPTION_LIVE_LAST_FAILURE_AT;
 		update_option( $option, $timestamp );
 	}
@@ -147,7 +147,7 @@ class WC_Stripe_Webhook_State {
 	 * @since 5.0.0
 	 * @param string $reason Reason code.
 	 */
-	public static function set_last_error_reason( $reason ) {
+	public static function set_last_error_reason( $reason ): void {
 		$option = WC_Stripe_Mode::is_test() ? self::OPTION_TEST_LAST_ERROR : self::OPTION_LIVE_LAST_ERROR;
 		update_option( $option, $reason );
 	}
@@ -238,7 +238,7 @@ class WC_Stripe_Webhook_State {
 	 *
 	 * @param int $pending_webhooks The number of pending webhooks.
 	 */
-	public static function set_pending_webhooks_count( $pending_webhooks ) {
+	public static function set_pending_webhooks_count( $pending_webhooks ): void {
 		$option = WC_Stripe_Mode::is_test() ? self::OPTION_TEST_PENDING_WEBHOOKS : self::OPTION_LIVE_PENDING_WEBHOOKS;
 		update_option( $option, $pending_webhooks );
 	}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1189,12 +1189,6 @@ parameters:
 			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
 
 		-
-			message: '#^Method WC_REST_Stripe_Agentic_Commerce_Controller\:\:update_agentic_settings\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
-
-		-
 			message: '#^Method WC_REST_Stripe_Account_Keys_Controller\:\:test_account_keys\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1
@@ -1229,6 +1223,12 @@ parameters:
 			identifier: missingType.generics
 			count: 1
 			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
+
+		-
+			message: '#^Method WC_REST_Stripe_Agentic_Commerce_Controller\:\:update_agentic_settings\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
+			identifier: missingType.generics
+			count: 1
+			path: includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
 
 		-
 			message: '#^Method WC_REST_Stripe_Connection_Tokens_Controller\:\:create_token\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
@@ -3395,72 +3395,6 @@ parameters:
 			identifier: deadCode.unreachable
 			count: 1
 			path: includes/class-wc-stripe-webhook-handler.php
-
-		-
-			message: '#^Method WC_Stripe_Webhook_State\:\:clear_state\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-webhook-state.php
-
-		-
-			message: '#^Method WC_Stripe_Webhook_State\:\:set_last_error_reason\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-webhook-state.php
-
-		-
-			message: '#^Method WC_Stripe_Webhook_State\:\:set_last_error_reason\(\) has parameter \$reason with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: includes/class-wc-stripe-webhook-state.php
-
-		-
-			message: '#^Method WC_Stripe_Webhook_State\:\:set_last_webhook_failure_at\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-webhook-state.php
-
-		-
-			message: '#^Method WC_Stripe_Webhook_State\:\:set_last_webhook_failure_at\(\) has parameter \$timestamp with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: includes/class-wc-stripe-webhook-state.php
-
-		-
-			message: '#^Method WC_Stripe_Webhook_State\:\:set_last_webhook_success_at\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-webhook-state.php
-
-		-
-			message: '#^Method WC_Stripe_Webhook_State\:\:set_last_webhook_success_at\(\) has parameter \$timestamp with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: includes/class-wc-stripe-webhook-state.php
-
-		-
-			message: '#^Method WC_Stripe_Webhook_State\:\:set_pending_webhooks_count\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-webhook-state.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(integer UTC seconds since 1970\.\)\: Unexpected token "UTC", expected variable at offset 111 on line 5$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: includes/class-wc-stripe-webhook-state.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(integer UTC seconds since 1970\.\)\: Unexpected token "UTC", expected variable at offset 95 on line 5$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: includes/class-wc-stripe-webhook-state.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(string Reason code\.\)\: Unexpected token "Reason", expected variable at offset 92 on line 5$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: includes/class-wc-stripe-webhook-state.php
 
 		-
 			message: '#^Call to an undefined method WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens\:\:init\(\)\.$#'

--- a/readme.txt
+++ b/readme.txt
@@ -157,6 +157,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Remove - Remove giropay from new checkouts (deprecated by Stripe on 2024-06-30); legacy refund and past-order rendering preserved
 * Dev - Exclude AGENTS.md and CLAUDE.md contributor-instruction files from the built plugin zip
 * Add - Append a "what's new" changelog link to the Updated! message after manually updating the plugin from the Plugins page
-* Fix - Add guards against invalid values for webhook state timestamps"
+* Fix - Add guards against invalid values for webhook state timestamps
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -157,5 +157,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Remove - Remove giropay from new checkouts (deprecated by Stripe on 2024-06-30); legacy refund and past-order rendering preserved
 * Dev - Exclude AGENTS.md and CLAUDE.md contributor-instruction files from the built plugin zip
 * Add - Append a "what's new" changelog link to the Updated! message after manually updating the plugin from the Plugins page
+* Fix - Add guards against invalid values for webhook state timestamps"
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-webhook-state-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-state-test.php
@@ -295,4 +295,98 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 			'signature mismatch' => [ 'signature_mismatch', '/was not signed with the expected signing secret/', false ],
 		];
 	}
+
+	/**
+	 * Tests the timestamp getter methods correctly return integer values
+	 * for stored integer and stringified integer values.
+	 *
+	 * @param string     $option_constant Constant name on WC_Stripe_Webhook_State that references the option name.
+	 * @param string     $getter_method   Static getter under test.
+	 * @param int|string $stored_value    Value to store via update_option.
+	 * @param int        $expected        Expected return value.
+	 * @dataProvider provide_timestamp_getter_integer_values
+	 */
+	public function test_timestamp_getters_coerce_integer_values( string $option_constant, string $getter_method, $stored_value, int $expected ) {
+		$this->set_testmode( 'no' );
+		$option_name = constant( 'WC_Stripe_Webhook_State::' . $option_constant );
+		update_option( $option_name, $stored_value );
+
+		$actual = call_user_func( [ 'WC_Stripe_Webhook_State', $getter_method ] );
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Data provider for {@see test_timestamp_getters_coerce_integer_values()}.
+	 *
+	 * @return array
+	 */
+	public function provide_timestamp_getter_integer_values(): array {
+		$getters = [
+			[ 'OPTION_LIVE_LAST_SUCCESS_AT', 'get_last_webhook_success_at' ],
+			[ 'OPTION_LIVE_LAST_FAILURE_AT', 'get_last_webhook_failure_at' ],
+			[ 'OPTION_LIVE_PENDING_WEBHOOKS', 'get_pending_webhooks_count' ],
+		];
+
+		$cases = [];
+		foreach ( $getters as [ $option_constant, $method ] ) {
+			$cases[ $method . ' / integer' ]             = [ $option_constant, $method, 1234567890, 1234567890 ];
+			$cases[ $method . ' / stringified integer' ] = [ $option_constant, $method, '1234567890', 1234567890 ];
+			$cases[ $method . ' / zero integer' ]        = [ $option_constant, $method, 0, 0 ];
+			$cases[ $method . ' / stringified zero' ]    = [ $option_constant, $method, '0', 0 ];
+		}
+
+		return $cases;
+	}
+
+	/**
+	 * Tests that the integer-coercing getters return 0 for any non-integer stored value.
+	 *
+	 * @param string $option_constant Constant suffix on WC_Stripe_Webhook_State for the option name.
+	 * @param string $getter_method   Static getter under test.
+	 * @param mixed  $stored_value    Value to store via update_option.
+	 * @dataProvider provide_timestamp_getter_non_integer_values
+	 */
+	public function test_timestamp_getters_return_zero_for_non_integer_values( string $option_constant, string $getter_method, $stored_value ) {
+		$this->set_testmode( 'no' );
+		$option_name = constant( 'WC_Stripe_Webhook_State::' . $option_constant );
+		update_option( $option_name, $stored_value );
+
+		$actual = call_user_func( [ 'WC_Stripe_Webhook_State', $getter_method ] );
+		$this->assertSame( 0, $actual );
+	}
+
+	/**
+	 * Data provider for {@see test_timestamp_getters_return_zero_for_non_integer_values()}.
+	 *
+	 * @return array
+	 */
+	public function provide_timestamp_getter_non_integer_values(): array {
+		$getters = [
+			[ 'OPTION_LIVE_LAST_SUCCESS_AT', 'get_last_webhook_success_at' ],
+			[ 'OPTION_LIVE_LAST_FAILURE_AT', 'get_last_webhook_failure_at' ],
+			[ 'OPTION_LIVE_PENDING_WEBHOOKS', 'get_pending_webhooks_count' ],
+		];
+
+		$invalid_values = [
+			'negative integer string' => '-1',
+			'float'                   => 1.5,
+			'float string'            => '1.5',
+			'leading whitespace'      => ' 123',
+			'trailing whitespace'     => '123 ',
+			'alphabetic string'       => 'abc',
+			'alphanumeric string'     => '123abc',
+			'empty string'            => '',
+			// Note: true is stored as '1' in the database, so it's handled as an integer.
+			'boolean false'           => false,
+		];
+
+		$cases = [];
+		foreach ( $getters as [ $option_constant, $method ] ) {
+			foreach ( $invalid_values as $description => $value ) {
+				$cases[ $method . ' / ' . $description ] = [ $option_constant, $method, $value ];
+			}
+		}
+
+		return $cases;
+	}
 }

--- a/tests/phpunit/class-wc-stripe-webhook-state-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-state-test.php
@@ -297,16 +297,16 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests the timestamp getter methods correctly return integer values
+	 * Tests the integer getter methods correctly return integer values
 	 * for stored integer and stringified integer values.
 	 *
 	 * @param string     $option_constant Constant name on WC_Stripe_Webhook_State that references the option name.
 	 * @param string     $getter_method   Static getter under test.
 	 * @param int|string $stored_value    Value to store via update_option.
 	 * @param int        $expected        Expected return value.
-	 * @dataProvider provide_timestamp_getter_integer_values
+	 * @dataProvider provide_integer_getter_integer_values
 	 */
-	public function test_timestamp_getters_coerce_integer_values( string $option_constant, string $getter_method, $stored_value, int $expected ) {
+	public function test_integer_getters_coerce_integer_values( string $option_constant, string $getter_method, $stored_value, int $expected ) {
 		$this->set_testmode( 'no' );
 		$option_name = constant( 'WC_Stripe_Webhook_State::' . $option_constant );
 		update_option( $option_name, $stored_value );
@@ -316,11 +316,11 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for {@see test_timestamp_getters_coerce_integer_values()}.
+	 * Data provider for {@see test_integer_getters_coerce_integer_values()}.
 	 *
 	 * @return array
 	 */
-	public function provide_timestamp_getter_integer_values(): array {
+	public function provide_integer_getter_integer_values(): array {
 		$getters = [
 			[ 'OPTION_LIVE_LAST_SUCCESS_AT', 'get_last_webhook_success_at' ],
 			[ 'OPTION_LIVE_LAST_FAILURE_AT', 'get_last_webhook_failure_at' ],
@@ -339,14 +339,14 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the integer-coercing getters return 0 for any non-integer stored value.
+	 * Tests that the integer getters return 0 for any non-integer stored value.
 	 *
 	 * @param string $option_constant Constant suffix on WC_Stripe_Webhook_State for the option name.
 	 * @param string $getter_method   Static getter under test.
 	 * @param mixed  $stored_value    Value to store via update_option.
-	 * @dataProvider provide_timestamp_getter_non_integer_values
+	 * @dataProvider provide_integer_getter_non_integer_values
 	 */
-	public function test_timestamp_getters_return_zero_for_non_integer_values( string $option_constant, string $getter_method, $stored_value ) {
+	public function test_integer_getters_return_zero_for_non_integer_values( string $option_constant, string $getter_method, $stored_value ) {
 		$this->set_testmode( 'no' );
 		$option_name = constant( 'WC_Stripe_Webhook_State::' . $option_constant );
 		update_option( $option_name, $stored_value );
@@ -356,11 +356,11 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for {@see test_timestamp_getters_return_zero_for_non_integer_values()}.
+	 * Data provider for {@see test_integer_getters_return_zero_for_non_integer_values()}.
 	 *
 	 * @return array
 	 */
-	public function provide_timestamp_getter_non_integer_values(): array {
+	public function provide_integer_getter_non_integer_values(): array {
 		$getters = [
 			[ 'OPTION_LIVE_LAST_SUCCESS_AT', 'get_last_webhook_success_at' ],
 			[ 'OPTION_LIVE_LAST_FAILURE_AT', 'get_last_webhook_failure_at' ],


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
The main aim of this PR is to ensure that the getter methods in `WC_Stripe_Webhook_State` that are supposed to return integer values handle unexpected option values safely. This was triggered by some fatal errors I noticed as a result of the timestamp option values being `''`.

In addition, this PR updates some PHPDoc and specifies some `void` return types in the `WC_Stripe_Webhook_State` class.
<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
I believe that the unit tests and code inspection should be sufficient for this PR.
<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)