### PR TITLE
Adds an auto-off feature for diagnostics mode

### DIFF
--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -167,6 +167,11 @@ export const useIsShortAccountStatementEnabled = makeSettingsHook(
 );
 export const useDebugLog = makeSettingsHook( 'is_debug_log_enabled' );
 export const useDiagnosticsMode = makeSettingsHook( 'is_diagnostics_enabled' );
+// 10 mirrors PHP DEFAULT_CAPTURE_LIMIT for pre-fetch render.
+export const useDiagnosticsCaptureLimit = makeSettingsHook(
+	'diagnostics_capture_limit',
+	10
+);
 export const useIsOCEnabled = makeSettingsHook( 'is_oc_enabled' );
 export const useIsAdaptivePricingEnabled = makeSettingsHook( 'is_ap_enabled' );
 export const useOCLayout = makeSettingsHook( 'oc_layout' );

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -172,6 +172,11 @@ export const useDiagnosticsCaptureLimit = makeSettingsHook(
 	'diagnostics_capture_limit',
 	10
 );
+// Fallback only - real values come from the settings REST payload.
+export const useDiagnosticsCaptureLimitPresets = makeReadOnlySettingsHook(
+	'diagnostics_capture_limit_presets',
+	[ 5, 10, 25, 50 ]
+);
 export const useIsOCEnabled = makeSettingsHook( 'is_oc_enabled' );
 export const useIsAdaptivePricingEnabled = makeSettingsHook( 'is_ap_enabled' );
 export const useOCLayout = makeSettingsHook( 'oc_layout' );

--- a/client/settings/advanced-settings-section/__tests__/diagnostics-mode.test.js
+++ b/client/settings/advanced-settings-section/__tests__/diagnostics-mode.test.js
@@ -2,11 +2,12 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DiagnosticsMode from '../diagnostics-mode';
-import { useDiagnosticsMode } from 'wcstripe/data';
+import { useDiagnosticsMode, useDiagnosticsCaptureLimit } from 'wcstripe/data';
 import apiFetch from '@wordpress/api-fetch';
 
 jest.mock( 'wcstripe/data', () => ( {
 	useDiagnosticsMode: jest.fn(),
+	useDiagnosticsCaptureLimit: jest.fn(),
 } ) );
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
@@ -26,6 +27,7 @@ jest.mock( '../diagnostics-traces', () => ( {
 describe( 'DiagnosticsMode', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		useDiagnosticsCaptureLimit.mockReturnValue( [ 10, jest.fn() ] );
 		apiFetch.mockResolvedValue( { traces: [], count: 0 } );
 	} );
 

--- a/client/settings/advanced-settings-section/__tests__/diagnostics-mode.test.js
+++ b/client/settings/advanced-settings-section/__tests__/diagnostics-mode.test.js
@@ -2,12 +2,17 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DiagnosticsMode from '../diagnostics-mode';
-import { useDiagnosticsMode, useDiagnosticsCaptureLimit } from 'wcstripe/data';
+import {
+	useDiagnosticsMode,
+	useDiagnosticsCaptureLimit,
+	useDiagnosticsCaptureLimitPresets,
+} from 'wcstripe/data';
 import apiFetch from '@wordpress/api-fetch';
 
 jest.mock( 'wcstripe/data', () => ( {
 	useDiagnosticsMode: jest.fn(),
 	useDiagnosticsCaptureLimit: jest.fn(),
+	useDiagnosticsCaptureLimitPresets: jest.fn(),
 } ) );
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
@@ -28,6 +33,7 @@ describe( 'DiagnosticsMode', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		useDiagnosticsCaptureLimit.mockReturnValue( [ 10, jest.fn() ] );
+		useDiagnosticsCaptureLimitPresets.mockReturnValue( [ 5, 10, 25, 50 ] );
 		apiFetch.mockResolvedValue( { traces: [], count: 0 } );
 	} );
 

--- a/client/settings/advanced-settings-section/__tests__/diagnostics-traces.test.js
+++ b/client/settings/advanced-settings-section/__tests__/diagnostics-traces.test.js
@@ -132,7 +132,7 @@ describe( 'DiagnosticsTraces', () => {
 		render( <DiagnosticsTraces isRecording={ true } /> );
 
 		expect( await screen.findByText( 'Recording' ) ).toBeInTheDocument();
-		expect( screen.getByText( /2 stored traces/ ) ).toBeInTheDocument();
+		expect( screen.getByText( /2 of 10 captured/ ) ).toBeInTheDocument();
 		expect( screen.getByText( '1 failed' ) ).toBeInTheDocument();
 		expect( screen.getByTestId( 'trace-row-tr_a' ) ).toBeInTheDocument();
 		expect( screen.getByTestId( 'trace-row-tr_b' ) ).toBeInTheDocument();
@@ -314,5 +314,94 @@ describe( 'DiagnosticsTraces', () => {
 				{ id: NOTICE_ID }
 			)
 		);
+	} );
+
+	describe( 'auto-off capture limit', () => {
+		it( 'renders the "X of N captured" counter against the active limit', async () => {
+			apiFetch.mockResolvedValueOnce(
+				tracesResponse( [
+					traceFixture( { id: 'tr_a', status: 'failed' } ),
+					traceFixture( { id: 'tr_b', status: 'completed' } ),
+				] )
+			);
+			render(
+				<DiagnosticsTraces
+					isRecording={ true }
+					captureLimit={ 10 }
+					onChangeCaptureLimit={ jest.fn() }
+				/>
+			);
+			expect(
+				await screen.findByText( /2 of 10 captured/ )
+			).toBeInTheDocument();
+		} );
+
+		it( 'shows the inline limit selector while recording and writes preset changes back', async () => {
+			const onChangeCaptureLimit = jest.fn();
+			apiFetch.mockResolvedValueOnce(
+				tracesResponse( [ traceFixture( { id: 'tr_a' } ) ] )
+			);
+			render(
+				<DiagnosticsTraces
+					isRecording={ true }
+					captureLimit={ 10 }
+					onChangeCaptureLimit={ onChangeCaptureLimit }
+				/>
+			);
+			const select = await screen.findByLabelText(
+				'Auto-off capture limit'
+			);
+			expect( select ).toHaveValue( '10' );
+			// Auto-off is mandatory — no opt-out option.
+			expect(
+				screen.queryByRole( 'option', { name: /unlimited/i } )
+			).not.toBeInTheDocument();
+			await userEvent.selectOptions( select, '25' );
+			expect( onChangeCaptureLimit ).toHaveBeenCalledWith( 25 );
+		} );
+
+		it( 'hides the limit selector and progress bar when recording is off', async () => {
+			apiFetch.mockResolvedValueOnce(
+				tracesResponse( [ traceFixture( { id: 'tr_a' } ) ] )
+			);
+			render(
+				<DiagnosticsTraces
+					isRecording={ false }
+					captureLimit={ 10 }
+					onChangeCaptureLimit={ jest.fn() }
+				/>
+			);
+			await screen.findByTestId( 'trace-row-tr_a' );
+			expect(
+				screen.queryByLabelText( 'Auto-off capture limit' )
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'progressbar', {
+					name: /Capture progress/i,
+				} )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'renders a progress bar that reflects captured/limit when recording with a limit set', async () => {
+			apiFetch.mockResolvedValueOnce(
+				tracesResponse( [
+					traceFixture( { id: 'tr_a' } ),
+					traceFixture( { id: 'tr_b' } ),
+					traceFixture( { id: 'tr_c' } ),
+				] )
+			);
+			render(
+				<DiagnosticsTraces
+					isRecording={ true }
+					captureLimit={ 10 }
+					onChangeCaptureLimit={ jest.fn() }
+				/>
+			);
+			const bar = await screen.findByRole( 'progressbar', {
+				name: /Capture progress/i,
+			} );
+			expect( bar ).toHaveAttribute( 'aria-valuemax', '10' );
+			expect( bar ).toHaveAttribute( 'aria-valuenow', '3' );
+		} );
 	} );
 } );

--- a/client/settings/advanced-settings-section/__tests__/diagnostics-traces.test.js
+++ b/client/settings/advanced-settings-section/__tests__/diagnostics-traces.test.js
@@ -345,6 +345,7 @@ describe( 'DiagnosticsTraces', () => {
 				<DiagnosticsTraces
 					isRecording={ true }
 					captureLimit={ 10 }
+					captureLimitPresets={ [ 5, 10, 25, 50 ] }
 					onChangeCaptureLimit={ onChangeCaptureLimit }
 				/>
 			);

--- a/client/settings/advanced-settings-section/__tests__/index.test.js
+++ b/client/settings/advanced-settings-section/__tests__/index.test.js
@@ -6,6 +6,7 @@ import apiFetch from '@wordpress/api-fetch';
 import {
 	useDebugLog,
 	useDiagnosticsMode,
+	useDiagnosticsCaptureLimit,
 	useGetSavingError,
 	useSettings,
 	useIsOCEnabled,
@@ -16,6 +17,7 @@ import {
 jest.mock( 'wcstripe/data', () => ( {
 	useDebugLog: jest.fn(),
 	useDiagnosticsMode: jest.fn(),
+	useDiagnosticsCaptureLimit: jest.fn(),
 	useIsOCEnabled: jest.fn(),
 	useIsAdaptivePricingEnabled: jest.fn(),
 	useOCLayout: jest.fn(),
@@ -46,6 +48,7 @@ describe( 'AdvancedSettings', () => {
 
 		useDebugLog.mockReturnValue( [ true, jest.fn() ] );
 		useDiagnosticsMode.mockReturnValue( [ false, jest.fn() ] );
+		useDiagnosticsCaptureLimit.mockReturnValue( [ 10, jest.fn() ] );
 		useIsOCEnabled.mockReturnValue( [ false, jest.fn() ] );
 		useIsAdaptivePricingEnabled.mockReturnValue( [ false, jest.fn() ] );
 		useOCLayout.mockReturnValue( [ 'accordion', jest.fn() ] );

--- a/client/settings/advanced-settings-section/__tests__/index.test.js
+++ b/client/settings/advanced-settings-section/__tests__/index.test.js
@@ -7,6 +7,7 @@ import {
 	useDebugLog,
 	useDiagnosticsMode,
 	useDiagnosticsCaptureLimit,
+	useDiagnosticsCaptureLimitPresets,
 	useGetSavingError,
 	useSettings,
 	useIsOCEnabled,
@@ -18,6 +19,7 @@ jest.mock( 'wcstripe/data', () => ( {
 	useDebugLog: jest.fn(),
 	useDiagnosticsMode: jest.fn(),
 	useDiagnosticsCaptureLimit: jest.fn(),
+	useDiagnosticsCaptureLimitPresets: jest.fn(),
 	useIsOCEnabled: jest.fn(),
 	useIsAdaptivePricingEnabled: jest.fn(),
 	useOCLayout: jest.fn(),
@@ -49,6 +51,7 @@ describe( 'AdvancedSettings', () => {
 		useDebugLog.mockReturnValue( [ true, jest.fn() ] );
 		useDiagnosticsMode.mockReturnValue( [ false, jest.fn() ] );
 		useDiagnosticsCaptureLimit.mockReturnValue( [ 10, jest.fn() ] );
+		useDiagnosticsCaptureLimitPresets.mockReturnValue( [ 5, 10, 25, 50 ] );
 		useIsOCEnabled.mockReturnValue( [ false, jest.fn() ] );
 		useIsAdaptivePricingEnabled.mockReturnValue( [ false, jest.fn() ] );
 		useOCLayout.mockReturnValue( [ 'accordion', jest.fn() ] );

--- a/client/settings/advanced-settings-section/diagnostics-mode.js
+++ b/client/settings/advanced-settings-section/diagnostics-mode.js
@@ -2,11 +2,12 @@ import React from 'react';
 import DiagnosticsTraces from './diagnostics-traces';
 import { __ } from '@wordpress/i18n';
 import { ToggleControl } from '@wordpress/components';
-import { useDiagnosticsMode } from 'wcstripe/data';
+import { useDiagnosticsMode, useDiagnosticsCaptureLimit } from 'wcstripe/data';
 
 const DiagnosticsMode = () => {
 	const [ isDiagnosticsChecked, setIsDiagnosticsChecked ] =
 		useDiagnosticsMode();
+	const [ captureLimit, setCaptureLimit ] = useDiagnosticsCaptureLimit();
 
 	return (
 		<>
@@ -20,7 +21,7 @@ const DiagnosticsMode = () => {
 					</h4>
 					<p>
 						{ __(
-							'Records structured traces of checkout sessions so support can diagnose issues. Keep this off unless actively troubleshooting.',
+							'Records structured traces of checkout sessions so support can diagnose issues. Turns off automatically once the capture limit is reached.',
 							'woocommerce-gateway-stripe'
 						) }
 					</p>
@@ -34,7 +35,11 @@ const DiagnosticsMode = () => {
 					onChange={ setIsDiagnosticsChecked }
 				/>
 			</div>
-			<DiagnosticsTraces isRecording={ isDiagnosticsChecked } />
+			<DiagnosticsTraces
+				isRecording={ isDiagnosticsChecked }
+				captureLimit={ Number( captureLimit ) }
+				onChangeCaptureLimit={ setCaptureLimit }
+			/>
 		</>
 	);
 };

--- a/client/settings/advanced-settings-section/diagnostics-mode.js
+++ b/client/settings/advanced-settings-section/diagnostics-mode.js
@@ -2,12 +2,17 @@ import React from 'react';
 import DiagnosticsTraces from './diagnostics-traces';
 import { __ } from '@wordpress/i18n';
 import { ToggleControl } from '@wordpress/components';
-import { useDiagnosticsMode, useDiagnosticsCaptureLimit } from 'wcstripe/data';
+import {
+	useDiagnosticsMode,
+	useDiagnosticsCaptureLimit,
+	useDiagnosticsCaptureLimitPresets,
+} from 'wcstripe/data';
 
 const DiagnosticsMode = () => {
 	const [ isDiagnosticsChecked, setIsDiagnosticsChecked ] =
 		useDiagnosticsMode();
 	const [ captureLimit, setCaptureLimit ] = useDiagnosticsCaptureLimit();
+	const captureLimitPresets = useDiagnosticsCaptureLimitPresets();
 
 	return (
 		<>
@@ -38,6 +43,7 @@ const DiagnosticsMode = () => {
 			<DiagnosticsTraces
 				isRecording={ isDiagnosticsChecked }
 				captureLimit={ Number( captureLimit ) }
+				captureLimitPresets={ captureLimitPresets }
 				onChangeCaptureLimit={ setCaptureLimit }
 			/>
 		</>

--- a/client/settings/advanced-settings-section/diagnostics-trace-toolbar.js
+++ b/client/settings/advanced-settings-section/diagnostics-trace-toolbar.js
@@ -7,12 +7,18 @@ import ConfirmationModal from 'wcstripe/components/confirmation-modal';
 const FILTER_ALL = 'all';
 const FILTER_FAILED = 'failed';
 
+// Mirrors PHP CAPTURE_LIMIT_PRESETS / DEFAULT_CAPTURE_LIMIT — keep in sync.
+const LIMIT_PRESETS = [ 5, 10, 25, 50 ];
+const DEFAULT_LIMIT = 10;
+
 const DiagnosticsTraceToolbar = ( {
 	totalCount,
 	failedCount,
 	filter,
 	onFilterChange,
 	isRecording,
+	captureLimit = DEFAULT_LIMIT,
+	onChangeCaptureLimit,
 	onCopy,
 	onClear,
 	isCopying,
@@ -30,61 +36,103 @@ const DiagnosticsTraceToolbar = ( {
 			? __( 'Copy failed', 'woocommerce-gateway-stripe' )
 			: __( 'Copy all', 'woocommerce-gateway-stripe' );
 
+	// Pinned at 100% so a reduced limit doesn't overflow the bar.
+	const progressPct = Math.min( 100, ( totalCount / captureLimit ) * 100 );
+
 	return (
 		<div className="wc-stripe-diagnostics-toolbar">
-			<div className="wc-stripe-diagnostics-toolbar__status">
-				<span
-					className={ classNames(
-						'wc-stripe-diagnostics-recording-indicator',
-						{
-							'is-recording': isRecording,
-						}
-					) }
-					aria-hidden="true"
-				/>
-				<span className="wc-stripe-diagnostics-toolbar__status-label">
-					{ isRecording
-						? __( 'Recording', 'woocommerce-gateway-stripe' )
-						: __( 'Not recording', 'woocommerce-gateway-stripe' ) }
-				</span>
-				<span
-					className="wc-stripe-diagnostics-toolbar__separator"
-					aria-hidden="true"
-				>
-					·
-				</span>
-				<span className="wc-stripe-diagnostics-toolbar__count">
-					{ sprintf(
-						/* translators: %d: total stored trace count */
-						_n(
-							'%d stored trace',
-							'%d stored traces',
+			<div className="wc-stripe-diagnostics-toolbar__row wc-stripe-diagnostics-toolbar__row--status">
+				<div className="wc-stripe-diagnostics-toolbar__status">
+					<span
+						className={ classNames(
+							'wc-stripe-diagnostics-recording-indicator',
+							{
+								'is-recording': isRecording,
+							}
+						) }
+						aria-hidden="true"
+					/>
+					<span className="wc-stripe-diagnostics-toolbar__status-label">
+						{ isRecording
+							? __( 'Recording', 'woocommerce-gateway-stripe' )
+							: __(
+									'Not recording',
+									'woocommerce-gateway-stripe'
+							  ) }
+					</span>
+					<span
+						className="wc-stripe-diagnostics-toolbar__separator"
+						aria-hidden="true"
+					>
+						·
+					</span>
+					<span className="wc-stripe-diagnostics-toolbar__count">
+						{ sprintf(
+							/* translators: 1: captured trace count, 2: capture limit. */
+							__(
+								'%1$d of %2$d captured',
+								'woocommerce-gateway-stripe'
+							),
 							totalCount,
-							'woocommerce-gateway-stripe'
-						),
-						totalCount
-					) }
-					{ failedCount > 0 && (
-						<>
-							{ ' · ' }
-							<span className="wc-stripe-diagnostics-toolbar__failed-count">
-								{ sprintf(
-									/* translators: %d: number of failed traces */
-									_n(
-										'%d failed',
-										'%d failed',
-										failedCount,
-										'woocommerce-gateway-stripe'
-									),
-									failedCount
-								) }
-							</span>
-						</>
-					) }
-				</span>
+							captureLimit
+						) }
+						{ failedCount > 0 && (
+							<>
+								{ ' · ' }
+								<span className="wc-stripe-diagnostics-toolbar__failed-count">
+									{ sprintf(
+										/* translators: %d: number of failed traces */
+										_n(
+											'%d failed',
+											'%d failed',
+											failedCount,
+											'woocommerce-gateway-stripe'
+										),
+										failedCount
+									) }
+								</span>
+							</>
+						) }
+					</span>
+				</div>
+				{ isRecording && onChangeCaptureLimit && (
+					<span className="wc-stripe-diagnostics-toolbar__limit">
+						<span>
+							{ __(
+								'Auto-off after',
+								'woocommerce-gateway-stripe'
+							) }
+						</span>
+						<select
+							className="wc-stripe-diagnostics-toolbar__limit-select"
+							value={ String( captureLimit ) }
+							onChange={ ( event ) =>
+								onChangeCaptureLimit(
+									Number( event.target.value )
+								)
+							}
+							aria-label={ __(
+								'Auto-off capture limit',
+								'woocommerce-gateway-stripe'
+							) }
+						>
+							{ LIMIT_PRESETS.map( ( preset ) => (
+								<option
+									key={ preset }
+									value={ String( preset ) }
+								>
+									{ preset }
+								</option>
+							) ) }
+						</select>
+						<span>
+							{ __( 'orders', 'woocommerce-gateway-stripe' ) }
+						</span>
+					</span>
+				) }
 			</div>
 			<div
-				className="wc-stripe-diagnostics-toolbar__actions"
+				className="wc-stripe-diagnostics-toolbar__row wc-stripe-diagnostics-toolbar__row--actions"
 				role="group"
 				aria-label={ __(
 					'Trace list actions',
@@ -126,24 +174,44 @@ const DiagnosticsTraceToolbar = ( {
 						{ __( 'Failed only', 'woocommerce-gateway-stripe' ) }
 					</button>
 				</div>
-				<Button
-					variant="secondary"
-					onClick={ onCopy }
-					isBusy={ isCopying }
-					disabled={ isCopying || isClearing || totalCount === 0 }
-				>
-					{ copyLabel }
-				</Button>
-				<Button
-					variant="tertiary"
-					isDestructive
-					onClick={ () => setIsConfirmingClear( true ) }
-					isBusy={ isClearing }
-					disabled={ isCopying || isClearing || totalCount === 0 }
-				>
-					{ __( 'Clear', 'woocommerce-gateway-stripe' ) }
-				</Button>
+				<div className="wc-stripe-diagnostics-toolbar__actions">
+					<Button
+						variant="secondary"
+						onClick={ onCopy }
+						isBusy={ isCopying }
+						disabled={ isCopying || isClearing || totalCount === 0 }
+					>
+						{ copyLabel }
+					</Button>
+					<Button
+						variant="tertiary"
+						isDestructive
+						onClick={ () => setIsConfirmingClear( true ) }
+						isBusy={ isClearing }
+						disabled={ isCopying || isClearing || totalCount === 0 }
+					>
+						{ __( 'Clear', 'woocommerce-gateway-stripe' ) }
+					</Button>
+				</div>
 			</div>
+			{ isRecording && (
+				<div
+					className="wc-stripe-diagnostics-toolbar__progress"
+					role="progressbar"
+					aria-valuemin={ 0 }
+					aria-valuemax={ captureLimit }
+					aria-valuenow={ Math.min( totalCount, captureLimit ) }
+					aria-label={ __(
+						'Capture progress',
+						'woocommerce-gateway-stripe'
+					) }
+				>
+					<div
+						className="wc-stripe-diagnostics-toolbar__progress-bar"
+						style={ { width: `${ progressPct }%` } }
+					/>
+				</div>
+			) }
 			{ isConfirmingClear && (
 				<ConfirmationModal
 					onRequestClose={ () => setIsConfirmingClear( false ) }
@@ -191,4 +259,4 @@ const DiagnosticsTraceToolbar = ( {
 };
 
 export default DiagnosticsTraceToolbar;
-export { FILTER_ALL, FILTER_FAILED };
+export { FILTER_ALL, FILTER_FAILED, LIMIT_PRESETS };

--- a/client/settings/advanced-settings-section/diagnostics-trace-toolbar.js
+++ b/client/settings/advanced-settings-section/diagnostics-trace-toolbar.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import classNames from 'classnames';
 import { Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import ConfirmationModal from 'wcstripe/components/confirmation-modal';
 
@@ -97,37 +98,39 @@ const DiagnosticsTraceToolbar = ( {
 				</div>
 				{ isRecording && onChangeCaptureLimit && (
 					<span className="wc-stripe-diagnostics-toolbar__limit">
-						<span>
-							{ __(
-								'Auto-off after',
+						{ createInterpolateElement(
+							/* translators: <select /> is a dropdown for the number of orders before auto-off triggers. */
+							__(
+								'Auto-off after <select /> orders',
 								'woocommerce-gateway-stripe'
-							) }
-						</span>
-						<select
-							className="wc-stripe-diagnostics-toolbar__limit-select"
-							value={ String( captureLimit ) }
-							onChange={ ( event ) =>
-								onChangeCaptureLimit(
-									Number( event.target.value )
-								)
+							),
+							{
+								select: (
+									<select
+										className="wc-stripe-diagnostics-toolbar__limit-select"
+										value={ String( captureLimit ) }
+										onChange={ ( event ) =>
+											onChangeCaptureLimit(
+												Number( event.target.value )
+											)
+										}
+										aria-label={ __(
+											'Auto-off capture limit',
+											'woocommerce-gateway-stripe'
+										) }
+									>
+										{ LIMIT_PRESETS.map( ( preset ) => (
+											<option
+												key={ preset }
+												value={ String( preset ) }
+											>
+												{ preset }
+											</option>
+										) ) }
+									</select>
+								),
 							}
-							aria-label={ __(
-								'Auto-off capture limit',
-								'woocommerce-gateway-stripe'
-							) }
-						>
-							{ LIMIT_PRESETS.map( ( preset ) => (
-								<option
-									key={ preset }
-									value={ String( preset ) }
-								>
-									{ preset }
-								</option>
-							) ) }
-						</select>
-						<span>
-							{ __( 'orders', 'woocommerce-gateway-stripe' ) }
-						</span>
+						) }
 					</span>
 				) }
 			</div>

--- a/client/settings/advanced-settings-section/diagnostics-trace-toolbar.js
+++ b/client/settings/advanced-settings-section/diagnostics-trace-toolbar.js
@@ -8,8 +8,6 @@ import ConfirmationModal from 'wcstripe/components/confirmation-modal';
 const FILTER_ALL = 'all';
 const FILTER_FAILED = 'failed';
 
-// Mirrors PHP CAPTURE_LIMIT_PRESETS / DEFAULT_CAPTURE_LIMIT — keep in sync.
-const LIMIT_PRESETS = [ 5, 10, 25, 50 ];
 const DEFAULT_LIMIT = 10;
 
 const DiagnosticsTraceToolbar = ( {
@@ -19,6 +17,7 @@ const DiagnosticsTraceToolbar = ( {
 	onFilterChange,
 	isRecording,
 	captureLimit = DEFAULT_LIMIT,
+	captureLimitPresets = [],
 	onChangeCaptureLimit,
 	onCopy,
 	onClear,
@@ -119,14 +118,16 @@ const DiagnosticsTraceToolbar = ( {
 											'woocommerce-gateway-stripe'
 										) }
 									>
-										{ LIMIT_PRESETS.map( ( preset ) => (
-											<option
-												key={ preset }
-												value={ String( preset ) }
-											>
-												{ preset }
-											</option>
-										) ) }
+										{ captureLimitPresets.map(
+											( preset ) => (
+												<option
+													key={ preset }
+													value={ String( preset ) }
+												>
+													{ preset }
+												</option>
+											)
+										) }
 									</select>
 								),
 							}
@@ -262,4 +263,4 @@ const DiagnosticsTraceToolbar = ( {
 };
 
 export default DiagnosticsTraceToolbar;
-export { FILTER_ALL, FILTER_FAILED, LIMIT_PRESETS };
+export { FILTER_ALL, FILTER_FAILED };

--- a/client/settings/advanced-settings-section/diagnostics-traces.js
+++ b/client/settings/advanced-settings-section/diagnostics-traces.js
@@ -47,7 +47,11 @@ const copyOrDownload = async ( payload ) => {
 	return 'clipboard';
 };
 
-const DiagnosticsTraces = ( { isRecording = false } ) => {
+const DiagnosticsTraces = ( {
+	isRecording = false,
+	captureLimit = 10,
+	onChangeCaptureLimit,
+} ) => {
 	const [ traces, setTraces ] = useState( null );
 	const [ filter, setFilter ] = useState( FILTER_ALL );
 	const [ viewing, setViewing ] = useState( null );
@@ -231,6 +235,8 @@ const DiagnosticsTraces = ( { isRecording = false } ) => {
 				filter={ filter }
 				onFilterChange={ setFilter }
 				isRecording={ isRecording }
+				captureLimit={ captureLimit }
+				onChangeCaptureLimit={ onChangeCaptureLimit }
 				onCopy={ handleBulkCopy }
 				onClear={ handleClear }
 				isCopying={ isCopying }

--- a/client/settings/advanced-settings-section/diagnostics-traces.js
+++ b/client/settings/advanced-settings-section/diagnostics-traces.js
@@ -50,6 +50,7 @@ const copyOrDownload = async ( payload ) => {
 const DiagnosticsTraces = ( {
 	isRecording = false,
 	captureLimit = 10,
+	captureLimitPresets,
 	onChangeCaptureLimit,
 } ) => {
 	const [ traces, setTraces ] = useState( null );
@@ -236,6 +237,7 @@ const DiagnosticsTraces = ( {
 				onFilterChange={ setFilter }
 				isRecording={ isRecording }
 				captureLimit={ captureLimit }
+				captureLimitPresets={ captureLimitPresets }
 				onChangeCaptureLimit={ onChangeCaptureLimit }
 				onCopy={ handleBulkCopy }
 				onClear={ handleClear }

--- a/client/settings/advanced-settings-section/style.scss
+++ b/client/settings/advanced-settings-section/style.scss
@@ -172,7 +172,7 @@ $diagnostics-bg-toolbar: styles.$wp-gray-0;
 
 	&__progress-bar {
 		height: 100%;
-		background: #2271b1;
+		background: styles.$wp-blue-50;
 		transition: width 0.2s ease-out;
 	}
 }

--- a/client/settings/advanced-settings-section/style.scss
+++ b/client/settings/advanced-settings-section/style.scss
@@ -95,20 +95,28 @@ $diagnostics-bg-toolbar: styles.$wp-gray-0;
 }
 
 .wc-stripe-diagnostics-toolbar {
-	display: flex;
-	align-items: center;
-	gap: 12px;
-	padding: 8px 12px;
 	background: $diagnostics-bg-toolbar;
 	border-bottom: 1px solid $diagnostics-border;
 	font-size: 13px;
-	flex-wrap: wrap;
+
+	&__row {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		flex-wrap: wrap;
+		padding: 8px 12px;
+
+		&--actions {
+			border-top: 1px solid $diagnostics-border;
+		}
+	}
 
 	&__status {
 		display: inline-flex;
 		align-items: center;
 		gap: 6px;
 		color: $diagnostics-strong-fg;
+		flex-wrap: wrap;
 	}
 
 	&__status-label {
@@ -134,6 +142,38 @@ $diagnostics-bg-toolbar: styles.$wp-gray-0;
 		align-items: center;
 		gap: 8px;
 		margin-left: auto;
+	}
+
+	&__limit {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		margin-left: auto;
+		color: $diagnostics-muted-fg;
+		white-space: nowrap;
+	}
+
+	&__limit-select {
+		padding: 3px 6px;
+		font-size: 12px;
+		border: 1px solid $diagnostics-border-strong;
+		border-radius: 2px;
+		background: #fff;
+		color: $diagnostics-strong-fg;
+		font-family: inherit; // some browsers ignore inherited font on <select>.
+		cursor: pointer;
+	}
+
+	&__progress {
+		height: 3px;
+		background: $diagnostics-border;
+		overflow: hidden;
+	}
+
+	&__progress-bar {
+		height: 100%;
+		background: #2271b1;
+		transition: width 0.2s ease-out;
 	}
 }
 

--- a/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
+++ b/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
@@ -330,12 +330,7 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 			return false;
 		}
 
-		$settings = get_option( self::SETTINGS_OPTION, [] );
-		if ( ! is_array( $settings ) ) {
-			$settings = [];
-		}
-		$settings[ self::SETTINGS_KEY ] = 'no';
-		update_option( self::SETTINGS_OPTION, $settings );
+		WC_Stripe::get_instance()->get_main_stripe_gateway()->update_option( self::SETTINGS_KEY, 'no' );
 
 		if ( function_exists( 'wc_admin_record_tracks_event' ) ) {
 			wc_admin_record_tracks_event(

--- a/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
+++ b/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
@@ -324,6 +324,8 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 		}
 		$limit = self::capture_limit();
 		$store = $store ?? new WC_Stripe_Diagnostics_Trace_Store();
+		// Note: parallel ingests can each pass this check and land a trace
+		// before any of them flips the toggle, this is meant to be a soft limit
 		if ( $store->count() < $limit ) {
 			return false;
 		}

--- a/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
+++ b/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
@@ -16,6 +16,12 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 	const SETTINGS_OPTION = 'woocommerce_stripe_settings';
 	const SETTINGS_KEY    = 'diagnostics';
 
+	const CAPTURE_LIMIT_KEY     = 'diagnostics_capture_limit';
+	const DEFAULT_CAPTURE_LIMIT = 10;
+	// Auto-off is mandatory; the REST enum and `capture_limit()` both rely on
+	// this list being a finite set of positive integers.
+	const CAPTURE_LIMIT_PRESETS = [ 5, 10, 25, 50 ];
+
 	protected $namespace = 'wc/v3';
 	protected $rest_base = 'wc_stripe/diagnostics';
 
@@ -271,6 +277,8 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 			}
 		}
 
+		self::enforce_capture_limit( $this->store );
+
 		return new WP_REST_Response( [ 'written' => $written ], 200 );
 	}
 
@@ -284,5 +292,59 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 	public static function is_enabled(): bool {
 		$settings = get_option( self::SETTINGS_OPTION, [] );
 		return is_array( $settings ) && isset( $settings[ self::SETTINGS_KEY ] ) && 'yes' === $settings[ self::SETTINGS_KEY ];
+	}
+
+	/**
+	 * Resolves to a preset; any drifted/legacy value (including 0) falls back
+	 * to DEFAULT_CAPTURE_LIMIT so the auto-off can't be silently disabled.
+	 */
+	public static function capture_limit(): int {
+		$settings = get_option( self::SETTINGS_OPTION, [] );
+		if ( ! is_array( $settings ) || ! array_key_exists( self::CAPTURE_LIMIT_KEY, $settings ) ) {
+			return self::DEFAULT_CAPTURE_LIMIT;
+		}
+		$raw = $settings[ self::CAPTURE_LIMIT_KEY ];
+		if ( ! is_numeric( $raw ) ) {
+			return self::DEFAULT_CAPTURE_LIMIT;
+		}
+		$value = (int) $raw;
+		if ( ! in_array( $value, self::CAPTURE_LIMIT_PRESETS, true ) ) {
+			return self::DEFAULT_CAPTURE_LIMIT;
+		}
+		return $value;
+	}
+
+	/**
+	 * Silently flips the diagnostics toggle to 'no' when the stored trace
+	 * count reaches the capture limit. Returns true when this call flipped.
+	 */
+	public static function enforce_capture_limit( ?WC_Stripe_Diagnostics_Trace_Store $store = null ): bool {
+		if ( ! self::is_enabled() ) {
+			return false;
+		}
+		$limit = self::capture_limit();
+		$store = $store ?? new WC_Stripe_Diagnostics_Trace_Store();
+		if ( $store->count() < $limit ) {
+			return false;
+		}
+
+		$settings = get_option( self::SETTINGS_OPTION, [] );
+		if ( ! is_array( $settings ) ) {
+			$settings = [];
+		}
+		$settings[ self::SETTINGS_KEY ] = 'no';
+		update_option( self::SETTINGS_OPTION, $settings );
+
+		if ( function_exists( 'wc_admin_record_tracks_event' ) ) {
+			wc_admin_record_tracks_event(
+				'wcstripe_diagnostics_auto_off',
+				[
+					'limit'     => $limit,
+					'test_mode' => class_exists( 'WC_Stripe_Mode' ) && WC_Stripe_Mode::is_test() ? 1 : 0,
+				]
+			);
+		}
+
+		return true;
 	}
 }

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -280,6 +280,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				'is_debug_log_enabled'                  => 'yes' === $this->gateway->get_option( 'logging' ),
 				'is_diagnostics_enabled'                => 'yes' === $this->gateway->get_option( 'diagnostics' ),
 				'diagnostics_capture_limit'             => WC_REST_Stripe_Diagnostics_Controller::capture_limit(),
+				'diagnostics_capture_limit_presets'     => WC_REST_Stripe_Diagnostics_Controller::CAPTURE_LIMIT_PRESETS,
 				'is_upe_enabled'                        => true,
 				'is_oc_enabled'                         => 'yes' === $this->gateway->get_option( 'optimized_checkout_element' ),
 				'is_ap_enabled'                         => 'yes' === $this->gateway->get_option( 'adaptive_pricing' ),

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -181,6 +181,12 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
+					'diagnostics_capture_limit'             => [
+						'description'       => __( 'Number of captured checkouts after which diagnostics turns off automatically.', 'woocommerce-gateway-stripe' ),
+						'type'              => 'integer',
+						'enum'              => WC_REST_Stripe_Diagnostics_Controller::CAPTURE_LIMIT_PRESETS,
+						'validate_callback' => 'rest_validate_request_arg',
+					],
 				],
 			]
 		);
@@ -273,6 +279,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				/* Settings > Advanced settings */
 				'is_debug_log_enabled'                  => 'yes' === $this->gateway->get_option( 'logging' ),
 				'is_diagnostics_enabled'                => 'yes' === $this->gateway->get_option( 'diagnostics' ),
+				'diagnostics_capture_limit'             => WC_REST_Stripe_Diagnostics_Controller::capture_limit(),
 				'is_upe_enabled'                        => true,
 				'is_oc_enabled'                         => 'yes' === $this->gateway->get_option( 'optimized_checkout_element' ),
 				'is_ap_enabled'                         => 'yes' === $this->gateway->get_option( 'adaptive_pricing' ),
@@ -316,6 +323,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		/* Settings > Advanced settings */
 		$this->update_is_debug_log_enabled( $request );
 		$this->update_is_diagnostics_enabled( $request );
+		$this->update_diagnostics_capture_limit( $request );
 		$this->update_oc_settings( $request );
 
 		return new WP_REST_Response( [], 200 );
@@ -580,6 +588,26 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				]
 			);
 		}
+	}
+
+	/**
+	 * Updates the diagnostics capture limit. The REST enum already restricts
+	 * input to CAPTURE_LIMIT_PRESETS.
+	 *
+	 * @param WP_REST_Request<array<string, mixed>> $request Request object.
+	 * @return void
+	 */
+	private function update_diagnostics_capture_limit( WP_REST_Request $request ) {
+		$capture_limit = $request->get_param( 'diagnostics_capture_limit' );
+
+		if ( null === $capture_limit ) {
+			return;
+		}
+
+		$this->gateway->update_option(
+			WC_REST_Stripe_Diagnostics_Controller::CAPTURE_LIMIT_KEY,
+			(string) (int) $capture_limit
+		);
 	}
 
 	/**

--- a/includes/diagnostics/class-wc-stripe-diagnostics-recorder.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-recorder.php
@@ -310,6 +310,11 @@ class WC_Stripe_Diagnostics_Recorder {
 		);
 		$this->store->append_event( $session_id, $redacted );
 		$this->promoter->maybe_promote( $session_id, $redacted );
+
+		// Webhook-only traces also spend a slot from the capture budget.
+		if ( class_exists( 'WC_REST_Stripe_Diagnostics_Controller' ) ) {
+			WC_REST_Stripe_Diagnostics_Controller::enforce_capture_limit( $this->store );
+		}
 	}
 
 	/**

--- a/tests/phpunit/admin/class-wc-rest-stripe-settings-controller-test.php
+++ b/tests/phpunit/admin/class-wc-rest-stripe-settings-controller-test.php
@@ -147,6 +147,10 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 			WC_REST_Stripe_Diagnostics_Controller::DEFAULT_CAPTURE_LIMIT,
 			$response->get_data()['diagnostics_capture_limit']
 		);
+		$this->assertSame(
+			WC_REST_Stripe_Diagnostics_Controller::CAPTURE_LIMIT_PRESETS,
+			$response->get_data()['diagnostics_capture_limit_presets']
+		);
 
 		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
 		$request->set_param( 'diagnostics_capture_limit', 25 );

--- a/tests/phpunit/admin/class-wc-rest-stripe-settings-controller-test.php
+++ b/tests/phpunit/admin/class-wc-rest-stripe-settings-controller-test.php
@@ -137,6 +137,38 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 	}
 
 	/**
+	 * Round-trips the diagnostics capture-limit REST field — presets in, 0
+	 * and off-menu values rejected.
+	 */
+	public function test_diagnostics_capture_limit_round_trip() {
+		$response = $this->rest_get_settings();
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame(
+			WC_REST_Stripe_Diagnostics_Controller::DEFAULT_CAPTURE_LIMIT,
+			$response->get_data()['diagnostics_capture_limit']
+		);
+
+		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
+		$request->set_param( 'diagnostics_capture_limit', 25 );
+		$response = rest_do_request( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 25, $this->rest_get_settings()->get_data()['diagnostics_capture_limit'] );
+
+		// 0 is rejected — auto-off can't be disabled.
+		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
+		$request->set_param( 'diagnostics_capture_limit', 0 );
+		$response = rest_do_request( $request );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertSame( 25, $this->rest_get_settings()->get_data()['diagnostics_capture_limit'] );
+
+		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
+		$request->set_param( 'diagnostics_capture_limit', 7 );
+		$response = rest_do_request( $request );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertSame( 25, $this->rest_get_settings()->get_data()['diagnostics_capture_limit'] );
+	}
+
+	/**
 	 * Tests for boolean fields.
 	 *
 	 * @param string $rest_key    REST API key.

--- a/tests/phpunit/diagnostics/class-wc-rest-stripe-diagnostics-controller-test.php
+++ b/tests/phpunit/diagnostics/class-wc-rest-stripe-diagnostics-controller-test.php
@@ -30,11 +30,30 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 	public function tear_down() {
 		$this->clear_state();
 		$this->set_diagnostics_enabled( false );
+		$this->set_capture_limit( null );
 		parent::tear_down();
 	}
 
 	private function clear_state() {
 		$this->store->delete_all();
+	}
+
+	/**
+	 * Writes the capture limit into the shared settings option; null removes it.
+	 *
+	 * @param int|null $limit Preset value, any int for negative-path tests, or null to unset.
+	 */
+	private function set_capture_limit( ?int $limit ): void {
+		$settings = get_option( WC_REST_Stripe_Diagnostics_Controller::SETTINGS_OPTION, [] );
+		if ( ! is_array( $settings ) ) {
+			$settings = [];
+		}
+		if ( null === $limit ) {
+			unset( $settings[ WC_REST_Stripe_Diagnostics_Controller::CAPTURE_LIMIT_KEY ] );
+		} else {
+			$settings[ WC_REST_Stripe_Diagnostics_Controller::CAPTURE_LIMIT_KEY ] = $limit;
+		}
+		update_option( WC_REST_Stripe_Diagnostics_Controller::SETTINGS_OPTION, $settings );
 	}
 
 	/**
@@ -271,6 +290,71 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 		$response = $this->controller->delete_traces();
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( 0, $this->store->count() );
+	}
+
+	/**
+	 * @dataProvider capture_limit_value_matrix
+	 */
+	public function test_capture_limit_falls_back_to_default_when_value_is_invalid( $stored, int $expected ) {
+		$this->set_capture_limit( $stored );
+		$this->assertSame( $expected, WC_REST_Stripe_Diagnostics_Controller::capture_limit() );
+	}
+
+	public function capture_limit_value_matrix(): array {
+		return [
+			'unset → DEFAULT'       => [ null, WC_REST_Stripe_Diagnostics_Controller::DEFAULT_CAPTURE_LIMIT ],
+			'preset 5 → 5'          => [ 5, 5 ],
+			'preset 25 → 25'        => [ 25, 25 ],
+			'legacy 0 → DEFAULT'    => [ 0, WC_REST_Stripe_Diagnostics_Controller::DEFAULT_CAPTURE_LIMIT ],
+			'off-menu 7 → DEFAULT'  => [ 7, WC_REST_Stripe_Diagnostics_Controller::DEFAULT_CAPTURE_LIMIT ],
+			'negative -1 → DEFAULT' => [ -1, WC_REST_Stripe_Diagnostics_Controller::DEFAULT_CAPTURE_LIMIT ],
+		];
+	}
+
+	public function test_enforce_capture_limit_flips_toggle_when_store_reaches_limit() {
+		$this->set_capture_limit( 5 );
+		for ( $i = 0; $i < 5; $i++ ) {
+			$this->store->create( 'trace_' . $i );
+		}
+
+		$this->assertTrue( WC_REST_Stripe_Diagnostics_Controller::is_enabled() );
+		$flipped = WC_REST_Stripe_Diagnostics_Controller::enforce_capture_limit( $this->store );
+		$this->assertTrue( $flipped );
+		$this->assertFalse( WC_REST_Stripe_Diagnostics_Controller::is_enabled() );
+	}
+
+	public function test_enforce_capture_limit_is_a_noop_below_the_limit() {
+		$this->set_capture_limit( 5 );
+		$this->store->create( 'trace_0' );
+
+		$flipped = WC_REST_Stripe_Diagnostics_Controller::enforce_capture_limit( $this->store );
+		$this->assertFalse( $flipped );
+		$this->assertTrue( WC_REST_Stripe_Diagnostics_Controller::is_enabled() );
+	}
+
+	public function test_ingest_events_flips_toggle_when_new_trace_hits_limit() {
+		$this->set_capture_limit( 5 );
+		for ( $i = 0; $i < 4; $i++ ) {
+			$this->store->create( 'seed_' . $i );
+		}
+
+		$request  = $this->make_request(
+			[
+				'diag_session_id' => 'fifth',
+				'events'          => [
+					[
+						'kind'              => 'consoleMessage',
+						'level'             => 'warn',
+						'message_truncated' => 'hello',
+					],
+				],
+			]
+		);
+		$response = $this->controller->ingest_events( $request );
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 5, $this->store->count() );
+		$this->assertFalse( WC_REST_Stripe_Diagnostics_Controller::is_enabled() );
 	}
 
 	public function test_ingest_evicts_oldest_trace_when_store_is_full() {


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes RSM-2302

## Changes proposed in this Pull Request:
Adds an auto-off capture limit to the Checkout Diagnostics card so recording turns off automatically after a configurable number of captured checkouts.

**Trade-offs / decisions**
- Auto-off is mandatory; there is no "unlimited" option. 
- The flip happens *after* the new trace is stored, so the trace that pushes us to the limit is still captured. The next
  request gets 403'd by the existing diagnostics-disabled permission callback.
- Reducing the limit below the current stored count does not retroactively flip the toggle.

<img width="1366" height="908" alt="CleanShot 2026-05-13 at 08 56 33@2x" src="https://github.com/user-attachments/assets/7e7d55ad-bcbd-4ff9-bfca-ab7ae8b0e38e" />

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. Enable Diagnostics mode via **Stripe → Settings → Advanced settings**.
2. Set the inline **Auto-off after** picker to `5`.
3. Run 5 test checkouts so 5 traces accumulate. Refresh the settings page between attempts to watch the counter and progress bar pdate (`1 of 5 captured`, `2 of 5 captured`, …).
4. After the 5th trace lands, refresh the page. Verify:
   - The diagnostics toggle is now **off**.
   - The trace list is still visible and the **Copy all** / **Clear** actions still work.
   - The inline limit picker is hidden .
5. Click **Clear**, confirm - the count resets to 0/5.
6. Toggle diagnostics back on, change the picker to `10`, click **Save changes**, run one more checkout. The counter should now read `1 of 10 captured`.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Unreleased feature merging to a feature branch
</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
