### PR TITLE
Fix misleading notice in settings when express checkout is disabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ xxxx-xx-xx - version 10.8.0
 * Remove - Remove giropay from new checkouts (deprecated by Stripe on 2024-06-30); legacy refund and past-order rendering preserved
 * Dev - Exclude AGENTS.md and CLAUDE.md contributor-instruction files from the built plugin zip
 * Add - Append a "what's new" changelog link to the Updated! message after manually updating the plugin from the Plugins page
+* Fix - Show better message when express checkout preview is not available
 
 2026-05-12 - version 10.7.0
 * Fix - Hide the "move Stripe to the top" Optimized Checkout notice when all payment methods above Stripe are disabled

--- a/client/entrypoints/express-checkout-settings/__tests__/express-checkout-preview-component.test.js
+++ b/client/entrypoints/express-checkout-settings/__tests__/express-checkout-preview-component.test.js
@@ -1,0 +1,293 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { Elements, ExpressCheckoutElement } from '@stripe/react-stripe-js';
+import { loadStripe } from '@stripe/stripe-js';
+import ExpressCheckoutPreviewComponent from '../express-checkout-preview-component';
+import { useExpressCheckoutEnabledSettings } from 'wcstripe/data';
+import { getDefaultBorderRadius } from 'wcstripe/express-checkout/utils';
+
+// `<Notice />` from `@wordpress/components` calls into `@wordpress/a11y` via its
+// bundled dependency path; silence the speak() side effect in tests.
+const realPathToA11yModule =
+	'@wordpress/components/node_modules/@wordpress/a11y';
+
+jest.mock( realPathToA11yModule, () => ( {
+	...jest.requireActual( realPathToA11yModule ),
+	speak: jest.fn(),
+} ) );
+
+jest.mock( '@stripe/react-stripe-js', () => ( {
+	Elements: jest.fn( ( { children } ) => (
+		<div data-testid="stripe-elements">{ children }</div>
+	) ),
+	ExpressCheckoutElement: jest.fn( () => (
+		<div data-testid="express-checkout-element" />
+	) ),
+} ) );
+
+jest.mock( '@stripe/stripe-js', () => ( {
+	loadStripe: jest.fn(),
+} ) );
+
+jest.mock( 'wcstripe/data', () => ( {
+	useExpressCheckoutEnabledSettings: jest.fn(),
+} ) );
+
+jest.mock( 'wcstripe/express-checkout/utils', () => ( {
+	getDefaultBorderRadius: jest.fn(),
+} ) );
+
+describe( 'ExpressCheckoutPreviewComponent', () => {
+	const globalValues = global.wc_stripe_express_checkout_settings_params;
+
+	const defaultProps = {
+		buttonType: 'buy',
+		theme: 'dark',
+		size: 'default',
+	};
+
+	beforeEach( () => {
+		useExpressCheckoutEnabledSettings.mockReturnValue( [
+			true,
+			jest.fn(),
+		] );
+		getDefaultBorderRadius.mockReturnValue( 4 );
+		loadStripe.mockReturnValue( {} );
+
+		global.wc_stripe_express_checkout_settings_params = {
+			...globalValues,
+			key: 'pk_test_123',
+			locale: 'en',
+		};
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+		global.wc_stripe_express_checkout_settings_params = globalValues;
+	} );
+
+	const getExpressCheckoutElementProps = () => {
+		const lastCall =
+			ExpressCheckoutElement.mock.calls[
+				ExpressCheckoutElement.mock.calls.length - 1
+			];
+		return lastCall[ 0 ];
+	};
+
+	it( 'renders the warning notice when express checkout is disabled', () => {
+		useExpressCheckoutEnabledSettings.mockReturnValue( [
+			false,
+			jest.fn(),
+		] );
+
+		render( <ExpressCheckoutPreviewComponent { ...defaultProps } /> );
+
+		expect(
+			screen.getByText( /The preview is only available when/ )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByTestId( 'express-checkout-element' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the Stripe ExpressCheckoutElement when enabled', () => {
+		render( <ExpressCheckoutPreviewComponent { ...defaultProps } /> );
+
+		expect(
+			screen.getByTestId( 'express-checkout-element' )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText( /The preview is only available when/ )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByText(
+				/Failed to preview the Apple Pay or Google Pay/
+			)
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'initializes Stripe with the publishable key and locale from global params', () => {
+		render( <ExpressCheckoutPreviewComponent { ...defaultProps } /> );
+
+		expect( loadStripe ).toHaveBeenCalledWith( 'pk_test_123', {
+			locale: 'en',
+		} );
+	} );
+
+	it( 'passes a payment-mode Elements configuration using the default border radius', () => {
+		getDefaultBorderRadius.mockReturnValue( 8 );
+
+		render( <ExpressCheckoutPreviewComponent { ...defaultProps } /> );
+
+		const elementsProps = Elements.mock.calls.at( -1 )[ 0 ];
+		expect( elementsProps.options ).toEqual(
+			expect.objectContaining( {
+				mode: 'payment',
+				amount: 1000,
+				currency: 'usd',
+				paymentMethodTypes: [ 'card' ],
+			} )
+		);
+		expect( elementsProps.options.appearance.variables.borderRadius ).toBe(
+			'8px'
+		);
+	} );
+
+	it( 'maps the "default" buttonType to "plain" for both Apple Pay and Google Pay', () => {
+		render(
+			<ExpressCheckoutPreviewComponent
+				{ ...defaultProps }
+				buttonType="default"
+			/>
+		);
+
+		const { options } = getExpressCheckoutElementProps();
+		expect( options.buttonType ).toEqual( {
+			googlePay: 'plain',
+			applePay: 'plain',
+		} );
+	} );
+
+	it.each( [
+		[ 'buy', 'buy' ],
+		[ 'book', 'book' ],
+		[ 'donate', 'donate' ],
+		[ 'check-out', 'check-out' ],
+	] )(
+		'passes through the "%s" buttonType unchanged',
+		( buttonType, expected ) => {
+			render(
+				<ExpressCheckoutPreviewComponent
+					{ ...defaultProps }
+					buttonType={ buttonType }
+				/>
+			);
+
+			const { options } = getExpressCheckoutElementProps();
+			expect( options.buttonType ).toEqual( {
+				googlePay: expected,
+				applePay: expected,
+			} );
+		}
+	);
+
+	it.each( [
+		[ 'dark', { googlePay: 'black', applePay: 'black' } ],
+		[ 'light', { googlePay: 'white', applePay: 'white' } ],
+		[ 'light-outline', { googlePay: 'white', applePay: 'white-outline' } ],
+		[ 'unknown-theme', { googlePay: 'black', applePay: 'black' } ],
+	] )(
+		'maps the "%s" theme to the right Stripe theme',
+		( theme, expected ) => {
+			render(
+				<ExpressCheckoutPreviewComponent
+					{ ...defaultProps }
+					theme={ theme }
+				/>
+			);
+
+			const { options } = getExpressCheckoutElementProps();
+			expect( options.buttonTheme ).toEqual( expected );
+		}
+	);
+
+	it.each( [
+		[ 'small', 40 ],
+		[ 'default', 48 ],
+	] )(
+		'maps the "%s" size to a %dpx button height',
+		( size, expectedHeight ) => {
+			render(
+				<ExpressCheckoutPreviewComponent
+					{ ...defaultProps }
+					size={ size }
+				/>
+			);
+
+			const { options } = getExpressCheckoutElementProps();
+			expect( options.buttonHeight ).toBe( expectedHeight );
+		}
+	);
+
+	it( 'clamps the "large" size button height to the 55px Stripe maximum', () => {
+		render(
+			<ExpressCheckoutPreviewComponent { ...defaultProps } size="large" />
+		);
+
+		const { options } = getExpressCheckoutElementProps();
+		// large maps to 56, which gets clamped to the 55 upper bound.
+		expect( options.buttonHeight ).toBe( 55 );
+	} );
+
+	it( 'falls back to the 48px default height when given an unknown size', () => {
+		render(
+			<ExpressCheckoutPreviewComponent
+				{ ...defaultProps }
+				size="unknown-size"
+			/>
+		);
+
+		const { options } = getExpressCheckoutElementProps();
+		expect( options.buttonHeight ).toBe( 48 );
+	} );
+
+	it( 'only enables Google Pay and Apple Pay; Link, Amazon Pay and Klarna are disabled', () => {
+		render( <ExpressCheckoutPreviewComponent { ...defaultProps } /> );
+
+		const { options } = getExpressCheckoutElementProps();
+		expect( options.paymentMethods ).toEqual( {
+			link: 'never',
+			googlePay: 'always',
+			applePay: 'always',
+			amazonPay: 'never',
+			klarna: 'never',
+		} );
+	} );
+
+	it( 'switches to the error notice when onReady reports no available payment methods', () => {
+		render( <ExpressCheckoutPreviewComponent { ...defaultProps } /> );
+
+		const { onReady } = getExpressCheckoutElementProps();
+
+		act( () => {
+			onReady( { availablePaymentMethods: null } );
+		} );
+
+		expect(
+			screen.getByText(
+				/Failed to preview the Apple Pay or Google Pay button/
+			)
+		).toBeInTheDocument();
+		expect(
+			screen.queryByTestId( 'express-checkout-element' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps rendering the button when onReady reports available payment methods', () => {
+		render( <ExpressCheckoutPreviewComponent { ...defaultProps } /> );
+
+		const { onReady } = getExpressCheckoutElementProps();
+
+		act( () => {
+			onReady( { availablePaymentMethods: { applePay: true } } );
+		} );
+
+		expect(
+			screen.getByTestId( 'express-checkout-element' )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(
+				/Failed to preview the Apple Pay or Google Pay button/
+			)
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'sets the wrapper minHeight to match the requested button size', () => {
+		render(
+			<ExpressCheckoutPreviewComponent { ...defaultProps } size="small" />
+		);
+
+		const wrapper = screen.getByTestId( 'stripe-elements' ).parentElement;
+		expect( wrapper ).toHaveStyle( { minHeight: '40px', width: '100%' } );
+	} );
+} );

--- a/client/entrypoints/express-checkout-settings/express-checkout-preview-component.js
+++ b/client/entrypoints/express-checkout-settings/express-checkout-preview-component.js
@@ -4,6 +4,7 @@ import { useState, useMemo } from 'react';
 import { Elements, ExpressCheckoutElement } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 import { __ } from '@wordpress/i18n';
+import { useExpressCheckoutEnabledSettings } from 'wcstripe/data';
 import { getDefaultBorderRadius } from 'wcstripe/express-checkout/utils';
 import InlineNotice from 'components/inline-notice';
 import {
@@ -20,6 +21,7 @@ const buttonSizeToPxMap = {
 
 const ExpressCheckoutPreviewComponent = ( { buttonType, theme, size } ) => {
 	const [ canRenderButtons, setCanRenderButtons ] = useState( true );
+	const [ isExpressCheckoutEnabled ] = useExpressCheckoutEnabledSettings();
 
 	/* eslint-disable camelcase */
 	const stripePromise = useMemo( () => {
@@ -112,6 +114,18 @@ const ExpressCheckoutPreviewComponent = ( { buttonType, theme, size } ) => {
 					/>
 				</Elements>
 			</div>
+		);
+	}
+
+	if ( ! isExpressCheckoutEnabled ) {
+		return (
+			<InlineNotice icon status="warning" isDismissible={ false }>
+				{ __(
+					'Express checkout preview is only available when express checkout is enabled. ' +
+						'Please enable express checkout to view the preview.',
+					'woocommerce-gateway-stripe'
+				) }
+			</InlineNotice>
 		);
 	}
 

--- a/client/entrypoints/express-checkout-settings/express-checkout-preview-component.js
+++ b/client/entrypoints/express-checkout-settings/express-checkout-preview-component.js
@@ -44,7 +44,7 @@ const ExpressCheckoutPreviewComponent = ( { buttonType, theme, size } ) => {
 		paymentMethodTypes: [ PAYMENT_METHOD_CARD ],
 	};
 
-	const height = buttonSizeToPxMap[ size ] || buttonSizeToPxMap.medium;
+	const height = buttonSizeToPxMap[ size ] || buttonSizeToPxMap.default;
 
 	const mapThemeConfigToButtonTheme = ( paymentMethod, buttonTheme ) => {
 		switch ( buttonTheme ) {

--- a/client/entrypoints/express-checkout-settings/express-checkout-preview-component.js
+++ b/client/entrypoints/express-checkout-settings/express-checkout-preview-component.js
@@ -100,6 +100,18 @@ const ExpressCheckoutPreviewComponent = ( { buttonType, theme, size } ) => {
 		}
 	};
 
+	if ( ! isExpressCheckoutEnabled ) {
+		return (
+			<InlineNotice icon status="warning" isDismissible={ false }>
+				{ __(
+					'The preview is only available when Apple Pay and Google Pay are enabled. ' +
+						'Please enable Apple Pay and Google Pay to see the preview.',
+					'woocommerce-gateway-stripe'
+				) }
+			</InlineNotice>
+		);
+	}
+
 	if ( canRenderButtons ) {
 		return (
 			<div
@@ -114,18 +126,6 @@ const ExpressCheckoutPreviewComponent = ( { buttonType, theme, size } ) => {
 					/>
 				</Elements>
 			</div>
-		);
-	}
-
-	if ( ! isExpressCheckoutEnabled ) {
-		return (
-			<InlineNotice icon status="warning" isDismissible={ false }>
-				{ __(
-					'The preview is only available when Apple Pay and Google Pay are enabled. ' +
-						'Please enable Apple Pay and Google Pay to see the preview.',
-					'woocommerce-gateway-stripe'
-				) }
-			</InlineNotice>
 		);
 	}
 

--- a/client/entrypoints/express-checkout-settings/express-checkout-preview-component.js
+++ b/client/entrypoints/express-checkout-settings/express-checkout-preview-component.js
@@ -121,8 +121,8 @@ const ExpressCheckoutPreviewComponent = ( { buttonType, theme, size } ) => {
 		return (
 			<InlineNotice icon status="warning" isDismissible={ false }>
 				{ __(
-					'Express checkout preview is only available when express checkout is enabled. ' +
-						'Please enable express checkout to view the preview.',
+					'The preview is only available when Apple Pay and Google Pay are enabled. ' +
+						'Please enable Apple Pay and Google Pay to see the preview.',
 					'woocommerce-gateway-stripe'
 				) }
 			</InlineNotice>

--- a/readme.txt
+++ b/readme.txt
@@ -158,5 +158,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Remove - Remove giropay from new checkouts (deprecated by Stripe on 2024-06-30); legacy refund and past-order rendering preserved
 * Dev - Exclude AGENTS.md and CLAUDE.md contributor-instruction files from the built plugin zip
 * Add - Append a "what's new" changelog link to the Updated! message after manually updating the plugin from the Plugins page
+* Fix - Show better message when express checkout preview is not available
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-1147

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR ensures that we show a more accurate message in the Apple Pay and Google Pay preview area when those payment methods are disabled. Previously, the message showed an error that directed the merchant to fix things:

<img width="755" height="155" alt="Screenshot 2026-05-14 at 14 18 57" src="https://github.com/user-attachments/assets/3a5e58b1-1269-4526-bf01-07e1162ab157" />

Now we clearly indicate that the preview is only available when Apple Pay and Google Pay are enabled, and we use a warning rather than an error:

<img width="755" height="134" alt="Screenshot 2026-05-14 at 14 24 11" src="https://github.com/user-attachments/assets/7b78c451-3690-41c8-aded-9b0ff0db58a4" />

Note that Amazon Pay doesn't have the same behaviour, so no changes needed there.

In addition, this PR fixes a small bug that may or may not have occurred in the wild: our logic for computing the fallback size was incorrect and was not actually using our default value. That has also been fixed, but it would have been pretty hard to trigger.
<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

* Run a build on a local server so you can see both failure modes
* Connect to Stripe
* Navigate to the Stripe settings page and click on the "Customize" link next to Apple Pay/Google Pay
* Ensure that Apple Pay / Google Pay are enabled
* Confirm that you see the pre-existing error notice
* Now uncheck the Apple Pay / Google Pay checkbox at the top of the screen
* Verify that the new warning is shown instead
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
