### PR TITLE
Add PP settings migration at OAuth completion

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ xxxx-xx-xx - version 10.8.0
 * Dev - Add Claude Code skills and review rules under .claude/ to capture repo-specific contributor guidance
 * Dev - Move some independent classes into autoloader
 * Dev - Add foundation classes for the Payment Plugins for Stripe settings migration (version detector, pre-migration snapshot, structured ledger, and 3.X mapping table)
+* Add - Pre-fill Woo Stripe settings from Payment Plugins for Stripe at OAuth completion (idempotent, non-destructive, snapshot-backed for rollback)
 
 2026-05-12 - version 10.7.0
 * Fix - Hide the "move Stripe to the top" Optimized Checkout notice when all payment methods above Stripe are disabled

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -324,6 +324,12 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				$this->unschedule_connection_refresh();
 			}
 
+			// Pre-fill settings from Payment Plugins for Stripe when present. Idempotent and
+			// self-gated; safe to call on every OAuth completion. Runs BEFORE the PMC migration
+			// below so the existing PMC migration picks up our PP-derived enabled-methods list.
+			require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/class-wc-stripe-pp-settings-migration.php';
+			WC_Stripe_PP_Settings_Migration::maybe_run();
+
 			// For new installs the legacy gateway gets instantiated because there is no settings in the DB yet,
 			// so we need to instantiate the UPE gateway just for the PMC migration.
 			WC_Stripe::get_instance()->get_main_stripe_gateway();

--- a/includes/migrations/class-wc-stripe-pp-settings-migration.php
+++ b/includes/migrations/class-wc-stripe-pp-settings-migration.php
@@ -218,6 +218,9 @@ class WC_Stripe_PP_Settings_Migration {
 			);
 		}
 
+		// Persist all buffered ledger rows in a single DB write.
+		$ledger->flush();
+
 		update_option( self::COMPLETED_OPTION, 'yes' );
 
 		self::log_info(
@@ -283,6 +286,10 @@ class WC_Stripe_PP_Settings_Migration {
 				continue;
 			}
 
+			// Note: `! empty()` treats '0' as empty, so a future AUTO row targeting a numeric
+			// field where 0 is a meaningful merchant choice (e.g., button radius) would incorrectly
+			// allow an overwrite. Add a sentinel comment in the map row when such a case first
+			// appears so reviewers know to switch this guard to `null !== $dest_before`.
 			if ( ! empty( $dest_before ) ) {
 				$ledger->record_skip(
 					WC_Stripe_Settings_Migration_Ledger::CATEGORY_AUTO,
@@ -361,6 +368,7 @@ class WC_Stripe_PP_Settings_Migration {
 				continue;
 			}
 
+			// Note: see the same guard in apply_auto_rows() — same numeric-zero caveat applies here.
 			if ( ! empty( $dest_before ) ) {
 				$ledger->record_skip(
 					WC_Stripe_Settings_Migration_Ledger::CATEGORY_TRANSFORM,
@@ -460,9 +468,20 @@ class WC_Stripe_PP_Settings_Migration {
 		$dest_before  = $dest[ self::DEST_KEY_ENABLED_METHODS ] ?? [];
 		$enabled_list = is_array( $dest_before ) ? $dest_before : [];
 
+		// Pre-load all PP per-gateway settings in one pass to avoid 21+ individual get_option()
+		// calls inside the loop below.
+		$all_gateway_ids      = array_merge( array_keys( self::PP_GATEWAY_ID_TO_UPE_METHOD ), self::PP_ONLY_GATEWAY_IDS );
+		$gateway_settings_map = [];
+		foreach ( $all_gateway_ids as $gw_id ) {
+			$settings = get_option( 'woocommerce_' . $gw_id . '_settings', null );
+			if ( is_array( $settings ) ) {
+				$gateway_settings_map[ $gw_id ] = $settings;
+			}
+		}
+
 		foreach ( self::PP_GATEWAY_ID_TO_UPE_METHOD as $pp_gateway_id => $upe_method_id ) {
-			$gateway_settings = get_option( 'woocommerce_' . $pp_gateway_id . '_settings', null );
-			if ( ! is_array( $gateway_settings ) ) {
+			$gateway_settings = $gateway_settings_map[ $pp_gateway_id ] ?? null;
+			if ( null === $gateway_settings ) {
 				continue;
 			}
 
@@ -491,8 +510,8 @@ class WC_Stripe_PP_Settings_Migration {
 
 		// Record PP-only methods that were enabled but have no Woo Stripe destination.
 		foreach ( self::PP_ONLY_GATEWAY_IDS as $pp_gateway_id ) {
-			$gateway_settings = get_option( 'woocommerce_' . $pp_gateway_id . '_settings', null );
-			if ( ! is_array( $gateway_settings ) ) {
+			$gateway_settings = $gateway_settings_map[ $pp_gateway_id ] ?? null;
+			if ( null === $gateway_settings ) {
 				continue;
 			}
 			if ( ( $gateway_settings['enabled'] ?? 'no' ) !== 'yes' ) {

--- a/includes/migrations/class-wc-stripe-pp-settings-migration.php
+++ b/includes/migrations/class-wc-stripe-pp-settings-migration.php
@@ -161,7 +161,7 @@ class WC_Stripe_PP_Settings_Migration {
 			return;
 		}
 
-		$map = self::map_for_version( $version );
+		$map = static::map_for_version( $version );
 
 		if ( null === $map ) {
 			// Future version we don't have a map for — fall back to 3.X best-effort.
@@ -236,10 +236,12 @@ class WC_Stripe_PP_Settings_Migration {
 	/**
 	 * Returns a concrete map for the given major version, or null when no map is available.
 	 *
+	 * Protected (not private) so tests can subclass and override with an injected map.
+	 *
 	 * @param string $version Major version string ('3', '4', etc.).
 	 * @return WC_Stripe_PP_Settings_Map|null
 	 */
-	private static function map_for_version( string $version ): ?WC_Stripe_PP_Settings_Map {
+	protected static function map_for_version( string $version ): ?WC_Stripe_PP_Settings_Map {
 		switch ( $version ) {
 			case '3':
 				return new WC_Stripe_PP_Settings_Map_3X();

--- a/includes/migrations/class-wc-stripe-pp-settings-migration.php
+++ b/includes/migrations/class-wc-stripe-pp-settings-migration.php
@@ -27,13 +27,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/class-wc-stripe-pp-version-detector.php';
-require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/class-wc-stripe-pre-migration-snapshot.php';
-require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/class-wc-stripe-settings-migration-ledger.php';
-require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/pp-settings-maps/class-wc-stripe-pp-settings-map.php';
-require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/pp-settings-maps/class-wc-stripe-pp-settings-map-3x.php';
-require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/pp-settings-maps/class-wc-stripe-pp-settings-map-4x.php';
-
 /**
  * PP→Woo Stripe settings migration orchestrator.
  *

--- a/includes/migrations/class-wc-stripe-pp-settings-migration.php
+++ b/includes/migrations/class-wc-stripe-pp-settings-migration.php
@@ -1,0 +1,658 @@
+<?php
+/**
+ * Orchestrator for the Payment Plugins for Stripe (PP) → Woo Stripe settings
+ * migration.
+ *
+ * Triggered once at OAuth completion in
+ * {@see WC_Stripe_Connect::save_stripe_keys()}, between the call to
+ * {@see WC_Stripe_Helper::update_main_stripe_settings()} (which writes OAuth
+ * credentials and Woo Stripe defaults) and
+ * {@see WC_Stripe_Payment_Method_Configurations::maybe_migrate_payment_methods_from_db_to_pmc()}
+ * (which pushes Woo Stripe's enabled payment methods into Stripe PMC). Ordering
+ * is load-bearing: the per-method enable migration writes the PP-derived
+ * enabled list so the existing PMC migration picks it up.
+ *
+ * Idempotent: gated by a `woocommerce_stripe_pp_settings_migrated` option flag.
+ * Safe to call on every OAuth completion; runs at most once per site.
+ *
+ * Non-destructive: PP options are never modified. Woo Stripe destinations are
+ * pre-fill only (`! empty( $dest[ $key ] )` guard preserves merchant overrides
+ * and OAuth-set values). The pre-migration snapshot captures both sides before
+ * any write so the migration is fully reversible.
+ *
+ * @package WooCommerce_Stripe/Migrations
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/class-wc-stripe-pp-version-detector.php';
+require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/class-wc-stripe-pre-migration-snapshot.php';
+require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/class-wc-stripe-settings-migration-ledger.php';
+require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/pp-settings-maps/class-wc-stripe-pp-settings-map.php';
+require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/pp-settings-maps/class-wc-stripe-pp-settings-map-3x.php';
+require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/pp-settings-maps/class-wc-stripe-pp-settings-map-4x.php';
+
+/**
+ * PP→Woo Stripe settings migration orchestrator.
+ *
+ * @since 9.7.0
+ */
+class WC_Stripe_PP_Settings_Migration {
+
+	/**
+	 * Idempotency flag. When 'yes', `maybe_run()` is a no-op.
+	 *
+	 * Must match {@see WC_Stripe_Pre_Migration_Snapshot::COMPLETED_OPTION_NAME} so the
+	 * snapshot's catch-all sweep excludes this key from itself.
+	 *
+	 * @var string
+	 */
+	const COMPLETED_OPTION = 'woocommerce_stripe_pp_settings_migrated';
+
+	/**
+	 * PP gateway ID → Woo Stripe UPE method ID mapping. Used by the per-method
+	 * enable and per-method order migrations.
+	 *
+	 * Verified against {@see WC_Stripe_Payment_Methods} constants. PP gateway IDs not
+	 * representable in Woo Stripe (e.g., `stripe_fpx`, `stripe_billie`) are absent here;
+	 * those methods are recorded as BUILD ledger rows during the migration.
+	 *
+	 * Express checkout methods (`stripe_applepay`, `stripe_googlepay`,
+	 * `stripe_payment_request`) are NOT in this table — they're toggled through the
+	 * existing express-checkout enable settings handled by AUTO/TRANSFORM rows.
+	 *
+	 * @var array<string, string>
+	 */
+	const PP_GATEWAY_ID_TO_UPE_METHOD = [
+		'stripe_cc'            => 'card',
+		'stripe_klarna'        => 'klarna',
+		'stripe_sepa'          => 'sepa_debit',
+		'stripe_ideal'         => 'ideal',
+		'stripe_bancontact'    => 'bancontact',
+		'stripe_eps'           => 'eps',
+		'stripe_p24'           => 'p24',
+		'stripe_giropay'       => 'giropay',
+		'stripe_sofort'        => 'sofort',
+		'stripe_alipay'        => 'alipay',
+		'stripe_wechat'        => 'wechat_pay',
+		'stripe_afterpay'      => 'afterpay_clearpay',
+		'stripe_affirm'        => 'affirm',
+		'stripe_ach'           => 'us_bank_account',
+		'stripe_becs'          => 'au_becs_debit',
+		'stripe_blik'          => 'blik',
+		'stripe_boleto'        => 'boleto',
+		'stripe_oxxo'          => 'oxxo',
+		'stripe_multibanco'    => 'multibanco',
+		'stripe_cashapp'       => 'cashapp',
+		'stripe_amazonpay'     => 'amazon_pay',
+		'stripe_link_checkout' => 'link',
+	];
+
+	/**
+	 * PP gateway IDs known to PP but absent from Woo Stripe. Recorded as BUILD rows when
+	 * encountered in the merchant's PP-enabled list. Source: settings-map.md §7 PP-only methods.
+	 *
+	 * @var array<int, string>
+	 */
+	const PP_ONLY_GATEWAY_IDS = [
+		'stripe_billie',
+		'stripe_konbini',
+		'stripe_mobilepay',
+		'stripe_paynow',
+		'stripe_promptpay',
+		'stripe_revolut',
+		'stripe_swish',
+		'stripe_twint',
+		'stripe_zip',
+		'stripe_paybybank',
+		'stripe_fpx',
+		'stripe_grabpay',
+	];
+
+	/**
+	 * Destination key for the Woo Stripe enabled-methods list (consumed by the PMC migration
+	 * at {@see WC_Stripe_Payment_Method_Configurations::maybe_migrate_payment_methods_from_db_to_pmc()}).
+	 *
+	 * @var string
+	 */
+	const DEST_KEY_ENABLED_METHODS = 'upe_checkout_experience_accepted_payments';
+
+	/**
+	 * Destination key for the Woo Stripe payment method order. Read by
+	 * {@see WC_Stripe_Helper::get_upe_ordered_payment_method_ids()}.
+	 *
+	 * Note: do NOT also write `stripe_legacy_method_order` — that sibling key was deprecated in
+	 * 10.3.0 and only exists to bridge an internal pre-UPE → UPE transition.
+	 *
+	 * @var string
+	 */
+	const DEST_KEY_METHOD_ORDER = 'stripe_upe_payment_method_order';
+
+	/**
+	 * Runs the migration once per site. Idempotent and self-gated; safe to call on every
+	 * OAuth completion.
+	 *
+	 * Order of operations:
+	 *   1. Completed-flag short-circuit.
+	 *   2. Detect PP major version (fall back to 3.X best-effort with warning when unknown).
+	 *   3. Capture pre-migration snapshot (both sides).
+	 *   4. Open a ledger for this run.
+	 *   5. Apply AUTO and TRANSFORM rows.
+	 *   6. Apply per-method enable migration (architecture-gated on UPM/PMC state).
+	 *   7. Apply per-method order migration (runs unconditionally).
+	 *   8. Record DROP/INVESTIGATE/BUILD decisions in the ledger.
+	 *   9. Set the completed flag.
+	 *
+	 * @return void
+	 */
+	public static function maybe_run(): void {
+		if ( 'yes' === get_option( self::COMPLETED_OPTION ) ) {
+			return;
+		}
+
+		$version = WC_Stripe_PP_Version_Detector::detect_major_version();
+
+		if ( WC_Stripe_PP_Version_Detector::VERSION_UNKNOWN === $version ) {
+			// No PP data present. Mark complete and exit; no snapshot, no ledger needed.
+			self::log_info( 'PP settings migration: no PP data detected. Skipping.' );
+			update_option( self::COMPLETED_OPTION, 'yes' );
+			return;
+		}
+
+		$map = self::map_for_version( $version );
+
+		if ( null === $map ) {
+			// Future version we don't have a map for — fall back to 3.X best-effort.
+			self::log_info(
+				sprintf(
+					'PP settings migration: detected PP major version %s but no concrete map available. Falling back to 3.X best-effort mapping.',
+					$version
+				)
+			);
+			$map     = new WC_Stripe_PP_Settings_Map_3X();
+			$version = '3';
+		}
+
+		// Capture the full state of both sides BEFORE any writes. Load-bearing for rollback.
+		$snapshot_at = WC_Stripe_Pre_Migration_Snapshot::capture();
+
+		$run_id = wp_generate_uuid4();
+		$ledger = new WC_Stripe_Settings_Migration_Ledger( $run_id, $snapshot_at, $version );
+
+		self::apply_auto_rows( $map->get_auto_rows(), $ledger );
+		self::apply_transform_rows( $map->get_transform_rows(), $ledger );
+
+		// Per-method enable migration — architecture-gated on UPM (UPM merchants manage methods
+		// centrally via PMC, so per-method `enabled` flags in PP options are likely stale).
+		self::apply_per_method_enable( $ledger );
+
+		// Per-method order migration — runs unconditionally. If OCS is on the stored order sits
+		// dormant; if the merchant ever disables OCS, their historical PP order applies.
+		self::apply_per_method_order( $ledger );
+
+		// Record DROP/INVESTIGATE/BUILD decisions for audit. No writes performed.
+		foreach ( $map->get_dropped_rows() as $key ) {
+			$ledger->record_drop(
+				WC_Stripe_Settings_Migration_Ledger::CATEGORY_DROP,
+				$key,
+				self::source_value_for_key( $key ),
+				'Documented no-op — no Woo Stripe equivalent or auto-handled'
+			);
+		}
+		foreach ( $map->get_investigate_rows() as $key ) {
+			$ledger->record_drop(
+				WC_Stripe_Settings_Migration_Ledger::CATEGORY_INVESTIGATE,
+				$key,
+				self::source_value_for_key( $key ),
+				'Pending product decision — see settings map'
+			);
+		}
+		foreach ( $map->get_build_rows() as $key ) {
+			$ledger->record_drop(
+				WC_Stripe_Settings_Migration_Ledger::CATEGORY_BUILD,
+				$key,
+				self::source_value_for_key( $key ),
+				'No destination feature in Woo Stripe — out of scope'
+			);
+		}
+
+		update_option( self::COMPLETED_OPTION, 'yes' );
+
+		self::log_info(
+			sprintf(
+				'PP settings migration: completed. Run %s. PP version: %s. Snapshot: %s.',
+				$run_id,
+				$version,
+				$snapshot_at
+			)
+		);
+	}
+
+	/**
+	 * Returns a concrete map for the given major version, or null when no map is available.
+	 *
+	 * @param string $version Major version string ('3', '4', etc.).
+	 * @return WC_Stripe_PP_Settings_Map|null
+	 */
+	private static function map_for_version( string $version ): ?WC_Stripe_PP_Settings_Map {
+		switch ( $version ) {
+			case '3':
+				return new WC_Stripe_PP_Settings_Map_3X();
+			case '4':
+				return new WC_Stripe_PP_Settings_Map_4X();
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * Applies AUTO rows: direct copy from source→destination when source is present and
+	 * destination is empty.
+	 *
+	 * @param array<int, array<string, string>> $rows   AUTO row definitions.
+	 * @param WC_Stripe_Settings_Migration_Ledger $ledger Run-scoped ledger.
+	 * @return void
+	 */
+	private static function apply_auto_rows( array $rows, WC_Stripe_Settings_Migration_Ledger $ledger ): void {
+		foreach ( $rows as $row ) {
+			$source_option = $row['source_option'];
+			$source_key    = $row['source_key'];
+			$dest_option   = $row['dest_option'];
+			$dest_key      = $row['dest_key'];
+
+			$source = (array) get_option( $source_option, [] );
+			$dest   = (array) get_option( $dest_option, [] );
+
+			$source_value = $source[ $source_key ] ?? null;
+			$dest_before  = $dest[ $dest_key ] ?? '';
+
+			if ( ! array_key_exists( $source_key, $source ) ) {
+				$ledger->record_skip(
+					WC_Stripe_Settings_Migration_Ledger::CATEGORY_AUTO,
+					$source_option,
+					$source_key,
+					null,
+					$dest_option,
+					$dest_key,
+					$dest_before,
+					WC_Stripe_Settings_Migration_Ledger::OUTCOME_SKIPPED_SOURCE_MISSING,
+					'PP source option/key not present'
+				);
+				continue;
+			}
+
+			if ( ! empty( $dest_before ) ) {
+				$ledger->record_skip(
+					WC_Stripe_Settings_Migration_Ledger::CATEGORY_AUTO,
+					$source_option,
+					$source_key,
+					$source_value,
+					$dest_option,
+					$dest_key,
+					$dest_before,
+					WC_Stripe_Settings_Migration_Ledger::OUTCOME_SKIPPED_DEST_SET,
+					'Destination already had merchant value — preserved'
+				);
+				continue;
+			}
+
+			try {
+				$dest[ $dest_key ] = $source_value;
+				update_option( $dest_option, $dest );
+				$ledger->record_apply(
+					WC_Stripe_Settings_Migration_Ledger::CATEGORY_AUTO,
+					$source_option,
+					$source_key,
+					$source_value,
+					$dest_option,
+					$dest_key,
+					$dest_before,
+					$source_value
+				);
+			} catch ( Throwable $e ) {
+				$ledger->record_error(
+					WC_Stripe_Settings_Migration_Ledger::CATEGORY_AUTO,
+					$source_option,
+					$source_key,
+					$source_value,
+					$dest_option,
+					$dest_key,
+					$e->getMessage()
+				);
+			}
+		}
+	}
+
+	/**
+	 * Applies TRANSFORM rows: source→destination with a transformer callable.
+	 *
+	 * @param array<int, array<string, mixed>>    $rows   TRANSFORM row definitions.
+	 * @param WC_Stripe_Settings_Migration_Ledger $ledger Run-scoped ledger.
+	 * @return void
+	 */
+	private static function apply_transform_rows( array $rows, WC_Stripe_Settings_Migration_Ledger $ledger ): void {
+		foreach ( $rows as $row ) {
+			$source_option = $row['source_option'];
+			$source_key    = $row['source_key'];
+			$dest_option   = $row['dest_option'];
+			$dest_key      = $row['dest_key'];
+			$transformer   = $row['transformer'];
+
+			$source = (array) get_option( $source_option, [] );
+			$dest   = (array) get_option( $dest_option, [] );
+
+			$source_value = $source[ $source_key ] ?? null;
+			$dest_before  = $dest[ $dest_key ] ?? '';
+
+			if ( ! array_key_exists( $source_key, $source ) ) {
+				$ledger->record_skip(
+					WC_Stripe_Settings_Migration_Ledger::CATEGORY_TRANSFORM,
+					$source_option,
+					$source_key,
+					null,
+					$dest_option,
+					$dest_key,
+					$dest_before,
+					WC_Stripe_Settings_Migration_Ledger::OUTCOME_SKIPPED_SOURCE_MISSING,
+					'PP source option/key not present'
+				);
+				continue;
+			}
+
+			if ( ! empty( $dest_before ) ) {
+				$ledger->record_skip(
+					WC_Stripe_Settings_Migration_Ledger::CATEGORY_TRANSFORM,
+					$source_option,
+					$source_key,
+					$source_value,
+					$dest_option,
+					$dest_key,
+					$dest_before,
+					WC_Stripe_Settings_Migration_Ledger::OUTCOME_SKIPPED_DEST_SET,
+					'Destination already had merchant value — preserved'
+				);
+				continue;
+			}
+
+			try {
+				$transformed = call_user_func( $transformer, $source_value );
+			} catch ( Throwable $e ) {
+				$ledger->record_skip(
+					WC_Stripe_Settings_Migration_Ledger::CATEGORY_TRANSFORM,
+					$source_option,
+					$source_key,
+					$source_value,
+					$dest_option,
+					$dest_key,
+					$dest_before,
+					WC_Stripe_Settings_Migration_Ledger::OUTCOME_SKIPPED_TRANSFORM_FAILED,
+					'Transformer threw: ' . $e->getMessage()
+				);
+				continue;
+			}
+
+			try {
+				$dest[ $dest_key ] = $transformed;
+				update_option( $dest_option, $dest );
+				$ledger->record_apply(
+					WC_Stripe_Settings_Migration_Ledger::CATEGORY_TRANSFORM,
+					$source_option,
+					$source_key,
+					$source_value,
+					$dest_option,
+					$dest_key,
+					$dest_before,
+					$transformed
+				);
+			} catch ( Throwable $e ) {
+				$ledger->record_error(
+					WC_Stripe_Settings_Migration_Ledger::CATEGORY_TRANSFORM,
+					$source_option,
+					$source_key,
+					$source_value,
+					$dest_option,
+					$dest_key,
+					$e->getMessage()
+				);
+			}
+		}
+	}
+
+	/**
+	 * Per-method enable migration. Architecture-gated.
+	 *
+	 * - When PP's UPM gateway was enabled, the merchant managed methods centrally via PMC and
+	 *   PP's per-gateway `enabled` flags are likely stale. SKIP.
+	 * - Otherwise: read PP's per-gateway `enabled` flags, map to Woo Stripe UPE method IDs,
+	 *   and write the consolidated list into `upe_checkout_experience_accepted_payments`.
+	 *   The existing PMC migration at
+	 *   {@see WC_Stripe_Payment_Method_Configurations::maybe_migrate_payment_methods_from_db_to_pmc()}
+	 *   then pushes this list to Stripe PMC.
+	 *
+	 * PP-only methods (Billie, Konbini, MobilePay, etc.) are recorded as BUILD ledger rows so
+	 * the audit trail captures the shopper-facing regression.
+	 *
+	 * @param WC_Stripe_Settings_Migration_Ledger $ledger Run-scoped ledger.
+	 * @return void
+	 */
+	private static function apply_per_method_enable( WC_Stripe_Settings_Migration_Ledger $ledger ): void {
+		$upm_settings = get_option( 'woocommerce_stripe_upm_settings', [] );
+		$upm_enabled  = is_array( $upm_settings ) && ( $upm_settings['enabled'] ?? 'no' ) === 'yes';
+
+		if ( $upm_enabled ) {
+			$ledger->record_skip(
+				WC_Stripe_Settings_Migration_Ledger::CATEGORY_AUTO,
+				'woocommerce_stripe_<gateway>_settings',
+				'enabled',
+				null,
+				'woocommerce_stripe_settings',
+				self::DEST_KEY_ENABLED_METHODS,
+				null,
+				WC_Stripe_Settings_Migration_Ledger::OUTCOME_SKIPPED_DEST_SET,
+				'UPM enabled in PP — methods are managed centrally via PMC; per-gateway `enabled` flags are unreliable'
+			);
+			return;
+		}
+
+		$dest         = (array) get_option( 'woocommerce_stripe_settings', [] );
+		$dest_before  = $dest[ self::DEST_KEY_ENABLED_METHODS ] ?? [];
+		$enabled_list = is_array( $dest_before ) ? $dest_before : [];
+
+		foreach ( self::PP_GATEWAY_ID_TO_UPE_METHOD as $pp_gateway_id => $upe_method_id ) {
+			$gateway_settings = get_option( 'woocommerce_' . $pp_gateway_id . '_settings', null );
+			if ( ! is_array( $gateway_settings ) ) {
+				continue;
+			}
+
+			$gateway_enabled = ( $gateway_settings['enabled'] ?? 'no' ) === 'yes';
+			if ( ! $gateway_enabled ) {
+				continue;
+			}
+
+			if ( in_array( $upe_method_id, $enabled_list, true ) ) {
+				continue;
+			}
+
+			$enabled_list[] = $upe_method_id;
+
+			$ledger->record_apply(
+				WC_Stripe_Settings_Migration_Ledger::CATEGORY_AUTO,
+				'woocommerce_' . $pp_gateway_id . '_settings',
+				'enabled',
+				'yes',
+				'woocommerce_stripe_settings',
+				self::DEST_KEY_ENABLED_METHODS,
+				$dest_before,
+				$enabled_list
+			);
+		}
+
+		// Record PP-only methods that were enabled but have no Woo Stripe destination.
+		foreach ( self::PP_ONLY_GATEWAY_IDS as $pp_gateway_id ) {
+			$gateway_settings = get_option( 'woocommerce_' . $pp_gateway_id . '_settings', null );
+			if ( ! is_array( $gateway_settings ) ) {
+				continue;
+			}
+			if ( ( $gateway_settings['enabled'] ?? 'no' ) !== 'yes' ) {
+				continue;
+			}
+
+			$ledger->record_drop(
+				WC_Stripe_Settings_Migration_Ledger::CATEGORY_BUILD,
+				$pp_gateway_id,
+				'yes',
+				'PP-only payment method — no Woo Stripe destination. Shopper-facing regression for this method.'
+			);
+		}
+
+		// Only persist if we added at least one new entry.
+		$current_dest_before = is_array( $dest_before ) ? $dest_before : [];
+		if ( $current_dest_before !== $enabled_list ) {
+			$dest[ self::DEST_KEY_ENABLED_METHODS ] = array_values( array_unique( $enabled_list ) );
+			update_option( 'woocommerce_stripe_settings', $dest );
+		}
+	}
+
+	/**
+	 * Per-method order migration. Runs unconditionally.
+	 *
+	 * Reads WooCommerce core's `woocommerce_gateway_order` option, filters to PP Stripe gateway
+	 * IDs while preserving position, maps each to its Woo Stripe UPE method ID, and writes the
+	 * result to `stripe_upe_payment_method_order` in Woo Stripe's main settings.
+	 *
+	 * If OCS is enabled the stored value sits dormant (PMC handles ordering). If the merchant
+	 * ever disables OCS, their historical PP order applies instead of Woo Stripe defaults.
+	 *
+	 * @param WC_Stripe_Settings_Migration_Ledger $ledger Run-scoped ledger.
+	 * @return void
+	 */
+	private static function apply_per_method_order( WC_Stripe_Settings_Migration_Ledger $ledger ): void {
+		$pp_order = get_option( 'woocommerce_gateway_order', [] );
+		if ( ! is_array( $pp_order ) || empty( $pp_order ) ) {
+			$ledger->record_skip(
+				WC_Stripe_Settings_Migration_Ledger::CATEGORY_AUTO,
+				'woocommerce_gateway_order',
+				'<order>',
+				null,
+				'woocommerce_stripe_settings',
+				self::DEST_KEY_METHOD_ORDER,
+				null,
+				WC_Stripe_Settings_Migration_Ledger::OUTCOME_SKIPPED_SOURCE_MISSING,
+				'WooCommerce gateway order option not set'
+			);
+			return;
+		}
+
+		// `woocommerce_gateway_order` is a map gateway_id => position. Sort by position
+		// (ascending) and extract the gateway IDs.
+		asort( $pp_order );
+		$ordered_gateway_ids = array_keys( $pp_order );
+
+		$mapped_order = [];
+		foreach ( $ordered_gateway_ids as $gateway_id ) {
+			$gateway_id_str = (string) $gateway_id;
+			if ( isset( self::PP_GATEWAY_ID_TO_UPE_METHOD[ $gateway_id_str ] ) ) {
+				$mapped_order[] = self::PP_GATEWAY_ID_TO_UPE_METHOD[ $gateway_id_str ];
+				continue;
+			}
+
+			if ( in_array( $gateway_id_str, self::PP_ONLY_GATEWAY_IDS, true ) ) {
+				$ledger->record_drop(
+					WC_Stripe_Settings_Migration_Ledger::CATEGORY_BUILD,
+					$gateway_id_str,
+					'<in gateway order>',
+					'PP-only payment method appeared in WC gateway order; dropped from Woo Stripe order list'
+				);
+			}
+		}
+
+		// Nothing mappable.
+		if ( empty( $mapped_order ) ) {
+			$ledger->record_skip(
+				WC_Stripe_Settings_Migration_Ledger::CATEGORY_AUTO,
+				'woocommerce_gateway_order',
+				'<order>',
+				$pp_order,
+				'woocommerce_stripe_settings',
+				self::DEST_KEY_METHOD_ORDER,
+				null,
+				WC_Stripe_Settings_Migration_Ledger::OUTCOME_SKIPPED_SOURCE_MISSING,
+				'No PP Stripe gateway IDs found in WC gateway order'
+			);
+			return;
+		}
+
+		$dest        = (array) get_option( 'woocommerce_stripe_settings', [] );
+		$dest_before = $dest[ self::DEST_KEY_METHOD_ORDER ] ?? [];
+
+		if ( ! empty( $dest_before ) ) {
+			$ledger->record_skip(
+				WC_Stripe_Settings_Migration_Ledger::CATEGORY_AUTO,
+				'woocommerce_gateway_order',
+				'<order>',
+				$pp_order,
+				'woocommerce_stripe_settings',
+				self::DEST_KEY_METHOD_ORDER,
+				$dest_before,
+				WC_Stripe_Settings_Migration_Ledger::OUTCOME_SKIPPED_DEST_SET,
+				'Destination already had merchant order — preserved'
+			);
+			return;
+		}
+
+		$mapped_order                        = array_values( array_unique( $mapped_order ) );
+		$dest[ self::DEST_KEY_METHOD_ORDER ] = $mapped_order;
+		update_option( 'woocommerce_stripe_settings', $dest );
+
+		$ledger->record_apply(
+			WC_Stripe_Settings_Migration_Ledger::CATEGORY_AUTO,
+			'woocommerce_gateway_order',
+			'<order>',
+			$pp_order,
+			'woocommerce_stripe_settings',
+			self::DEST_KEY_METHOD_ORDER,
+			$dest_before,
+			$mapped_order
+		);
+	}
+
+	/**
+	 * Looks up a setting's current PP value by source key name. Best-effort: scans the known PP
+	 * option blobs for the key. Used by the ledger to capture context for DROP/INVESTIGATE/BUILD
+	 * rows. Returns null when the key isn't found in any scanned blob.
+	 *
+	 * @param string $key PP source key.
+	 * @return mixed
+	 */
+	private static function source_value_for_key( string $key ) {
+		$scan_options = [
+			'woocommerce_stripe_api_settings',
+			'woocommerce_stripe_advanced_settings',
+			'woocommerce_stripe_cc_settings',
+			'woocommerce_stripe_express_checkout_settings',
+		];
+
+		foreach ( $scan_options as $option_name ) {
+			$blob = get_option( $option_name, null );
+			if ( is_array( $blob ) && array_key_exists( $key, $blob ) ) {
+				return $blob[ $key ];
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Writes an info-level entry to the dedicated migration log file.
+	 *
+	 * @param string $message Log message.
+	 * @return void
+	 */
+	private static function log_info( string $message ): void {
+		if ( class_exists( 'WC_Stripe_Logger' ) ) {
+			WC_Stripe_Logger::info( $message, [ 'source' => WC_Stripe_Settings_Migration_Ledger::LOG_HANDLE ] );
+		}
+	}
+}

--- a/includes/migrations/class-wc-stripe-settings-migration-ledger.php
+++ b/includes/migrations/class-wc-stripe-settings-migration-ledger.php
@@ -124,6 +124,14 @@ class WC_Stripe_Settings_Migration_Ledger {
 	private string $pp_version_detected;
 
 	/**
+	 * In-memory row buffer. Rows accumulate here until `flush()` is called, which
+	 * writes the entire batch to the DB in a single `update_option()` call.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	private array $buffer = [];
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string      $run_id              UUID v4 for this run.
@@ -362,7 +370,39 @@ class WC_Stripe_Settings_Migration_Ledger {
 	}
 
 	/**
-	 * Appends a row to the ledger blob and mirrors it to the WC log.
+	 * Writes all buffered rows to the DB in a single `update_option()` call and mirrors each to
+	 * the WC log. Called once at the end of `WC_Stripe_PP_Settings_Migration::maybe_run()`.
+	 *
+	 * @return void
+	 */
+	public function flush(): void {
+		if ( empty( $this->buffer ) ) {
+			return;
+		}
+
+		$ledger = get_option( self::OPTION_NAME, [] );
+		if ( ! is_array( $ledger ) ) {
+			$ledger = [];
+		}
+
+		foreach ( $this->buffer as $row ) {
+			$ledger[] = $row;
+
+			if ( class_exists( 'WC_Stripe_Logger' ) ) {
+				// Rows go to a dedicated WC log file separate from the main gateway log.
+				$encoded = wp_json_encode( $row );
+				if ( false !== $encoded ) {
+					WC_Stripe_Logger::info( $encoded, [ 'source' => self::LOG_HANDLE ] );
+				}
+			}
+		}
+
+		update_option( self::OPTION_NAME, $ledger, false );
+		$this->buffer = [];
+	}
+
+	/**
+	 * Buffers a row in memory. Rows are persisted to the DB only when `flush()` is called.
 	 *
 	 * Each row receives an id, run_id, snapshot_id, timestamp, and pp_version_detected
 	 * from the instance's context.
@@ -371,7 +411,7 @@ class WC_Stripe_Settings_Migration_Ledger {
 	 * @return void
 	 */
 	private function append( array $row ): void {
-		$row = array_merge(
+		$this->buffer[] = array_merge(
 			[
 				'id'                  => wp_generate_uuid4(),
 				'run_id'              => $this->run_id,
@@ -381,22 +421,6 @@ class WC_Stripe_Settings_Migration_Ledger {
 			],
 			$row
 		);
-
-		$ledger = get_option( self::OPTION_NAME, [] );
-		if ( ! is_array( $ledger ) ) {
-			$ledger = [];
-		}
-		$ledger[] = $row;
-		update_option( self::OPTION_NAME, $ledger, false );
-
-		if ( class_exists( 'WC_Stripe_Logger' ) ) {
-			// Override the default log source so ledger rows go to a dedicated WC log file
-			// (`wp-content/uploads/wc-logs/woocommerce-gateway-stripe-pp-settings-migration-{date}.log`).
-			$encoded = wp_json_encode( $row );
-			if ( false !== $encoded ) {
-				WC_Stripe_Logger::info( $encoded, [ 'source' => self::LOG_HANDLE ] );
-			}
-		}
 	}
 
 	/**

--- a/includes/migrations/class-wc-stripe-settings-migration-ledger.php
+++ b/includes/migrations/class-wc-stripe-settings-migration-ledger.php
@@ -82,12 +82,20 @@ class WC_Stripe_Settings_Migration_Ledger {
 	/**
 	 * Substrings that trigger redaction when found anywhere in a key name.
 	 *
+	 * Covers all Stripe API credential and webhook secret key names known to PP and Woo Stripe at
+	 * the time of writing. When a new sensitive key is introduced (e.g., a new PP auth token or a
+	 * new Stripe API credential field), add its identifying substring here AND update the
+	 * corresponding test in `WC_Stripe_Settings_Migration_Ledger_Test::secret_key_provider()`.
+	 *
 	 * @var array<int, string>
 	 */
 	public const SECRET_PATTERNS = [ 'secret_key', 'webhook_secret', 'refresh_token', 'access_token' ];
 
 	/**
 	 * Suffixes that trigger redaction when the key name ends with them.
+	 *
+	 * Catches generic secret/token field names not enumerated in SECRET_PATTERNS. Extend this list
+	 * if a new category of sensitive suffix is introduced.
 	 *
 	 * @var array<int, string>
 	 */

--- a/readme.txt
+++ b/readme.txt
@@ -170,5 +170,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Add Claude Code skills and review rules under .claude/ to capture repo-specific contributor guidance
 * Dev - Move some independent classes into autoloader
 * Dev - Add foundation classes for the Payment Plugins for Stripe settings migration (version detector, pre-migration snapshot, structured ledger, and 3.X mapping table)
+* Add - Pre-fill Woo Stripe settings from Payment Plugins for Stripe at OAuth completion (idempotent, non-destructive, snapshot-backed for rollback)
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/admin/migrations/class-wc-stripe-pp-settings-map-3x-throwing-first.php
+++ b/tests/phpunit/admin/migrations/class-wc-stripe-pp-settings-map-3x-throwing-first.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Test double for WC_Stripe_PP_Settings_Migration_Test.
+ *
+ * @package WooCommerce_Stripe/Tests
+ */
+
+require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/pp-settings-maps/class-wc-stripe-pp-settings-map-3x.php';
+
+/**
+ * Extends the 3.X map with a first TRANSFORM row whose callable always throws.
+ * Used to verify transformer-exception isolation in the orchestrator.
+ */
+class WC_Stripe_PP_Settings_Map_3X_Throwing_First extends WC_Stripe_PP_Settings_Map_3X {
+	public function get_transform_rows(): array {
+		$rows                   = parent::get_transform_rows();
+		$rows[0]['transformer'] = static function () {
+			throw new \RuntimeException( 'Injected transformer exception for isolation test' );
+		};
+		return $rows;
+	}
+}

--- a/tests/phpunit/admin/migrations/class-wc-stripe-pp-settings-migration-test.php
+++ b/tests/phpunit/admin/migrations/class-wc-stripe-pp-settings-migration-test.php
@@ -1,0 +1,429 @@
+<?php
+/**
+ * Class WC_Stripe_PP_Settings_Migration_Test
+ *
+ * @package WooCommerce_Stripe/Tests
+ */
+
+require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/class-wc-stripe-pp-settings-migration.php';
+
+/**
+ * Unit tests for {@see WC_Stripe_PP_Settings_Migration}.
+ *
+ * Verifies orchestrator behavior end-to-end against seeded PP option state:
+ *   - Idempotency (completed flag short-circuits).
+ *   - Unknown-version fall-through.
+ *   - AUTO and TRANSFORM application with destination-set preservation.
+ *   - Per-method enable migration (UPM-gated).
+ *   - Per-method order migration.
+ *   - Ledger and snapshot side effects.
+ */
+class WC_Stripe_PP_Settings_Migration_Test extends WP_UnitTestCase {
+
+	/**
+	 * PP option keys touched by the orchestrator, for tear_down cleanup.
+	 *
+	 * @var array<int, string>
+	 */
+	private const PP_OPTION_KEYS = [
+		'stripe_wc_version',
+		'woocommerce_stripe_api_settings',
+		'woocommerce_stripe_advanced_settings',
+		'woocommerce_stripe_cc_settings',
+		'woocommerce_stripe_upm_settings',
+		'woocommerce_stripe_express_checkout_settings',
+		'woocommerce_stripe_amazonpay_settings',
+		'woocommerce_stripe_klarna_settings',
+		'woocommerce_stripe_sepa_settings',
+		'woocommerce_stripe_billie_settings',
+		'woocommerce_gateway_order',
+	];
+
+	public function tear_down() {
+		delete_option( WC_Stripe_PP_Settings_Migration::COMPLETED_OPTION );
+		delete_option( WC_Stripe_Pre_Migration_Snapshot::CURRENT_OPTION );
+		delete_option( WC_Stripe_Settings_Migration_Ledger::OPTION_NAME );
+
+		foreach ( self::PP_OPTION_KEYS as $key ) {
+			delete_option( $key );
+		}
+
+		// Reset Woo Stripe main settings to a clean baseline. Test environment may have seeded
+		// gateway defaults; we restore the same baseline before each subsequent test.
+		WC_Stripe_Helper::delete_main_stripe_settings();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Seeds the PP version option so the version detector resolves to 3.X without needing the
+	 * plugin file on disk.
+	 *
+	 * @return void
+	 */
+	private function seed_pp_3x(): void {
+		update_option( 'stripe_wc_version', '3.3.106' );
+	}
+
+	public function test_short_circuits_when_completed_flag_set() {
+		update_option( WC_Stripe_PP_Settings_Migration::COMPLETED_OPTION, 'yes' );
+		$this->seed_pp_3x();
+		update_option(
+			'woocommerce_stripe_advanced_settings',
+			[ 'debug_log' => 'yes' ]
+		);
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		// Migration should not have run, so logging should not have been pre-filled into Woo
+		// Stripe settings, and no ledger or snapshot should have been written.
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertArrayNotHasKey( 'logging', $stripe_settings, 'Completed flag did not short-circuit AUTO row application' );
+		$this->assertNull( WC_Stripe_Pre_Migration_Snapshot::get_current() );
+		$this->assertSame( [], WC_Stripe_Settings_Migration_Ledger::load() );
+	}
+
+	public function test_marks_complete_when_no_pp_data_present() {
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		$this->assertSame( 'yes', get_option( WC_Stripe_PP_Settings_Migration::COMPLETED_OPTION ) );
+		// No snapshot should be captured when no PP data exists.
+		$this->assertNull( WC_Stripe_Pre_Migration_Snapshot::get_current() );
+		// No ledger should be written.
+		$this->assertSame( [], WC_Stripe_Settings_Migration_Ledger::load() );
+	}
+
+	public function test_applies_auto_row_when_source_present_and_dest_empty() {
+		$this->seed_pp_3x();
+		update_option( 'woocommerce_stripe_advanced_settings', [ 'debug_log' => 'yes' ] );
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertSame( 'yes', $stripe_settings['logging'] ?? null );
+
+		// Ledger row recorded.
+		$ledger_rows = WC_Stripe_Settings_Migration_Ledger::find_by_source_key( 'debug_log' );
+		$this->assertCount( 1, $ledger_rows );
+		$this->assertSame( WC_Stripe_Settings_Migration_Ledger::OUTCOME_APPLIED, $ledger_rows[0]['outcome'] );
+	}
+
+	public function test_skips_auto_row_when_destination_already_set() {
+		$this->seed_pp_3x();
+		update_option( 'woocommerce_stripe_advanced_settings', [ 'debug_log' => 'yes' ] );
+		// Merchant already had logging disabled in Woo Stripe — must be preserved.
+		WC_Stripe_Helper::update_main_stripe_settings( [ 'logging' => 'no' ] );
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertSame( 'no', $stripe_settings['logging'], 'Merchant value was overwritten' );
+
+		$ledger_rows = WC_Stripe_Settings_Migration_Ledger::find_by_source_key( 'debug_log' );
+		$this->assertCount( 1, $ledger_rows );
+		$this->assertSame(
+			WC_Stripe_Settings_Migration_Ledger::OUTCOME_SKIPPED_DEST_SET,
+			$ledger_rows[0]['outcome']
+		);
+	}
+
+	public function test_skips_auto_row_when_source_missing() {
+		$this->seed_pp_3x();
+		// `woocommerce_stripe_advanced_settings` exists but does NOT have `debug_log`.
+		update_option( 'woocommerce_stripe_advanced_settings', [ 'other_key' => 'value' ] );
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		$ledger_rows = WC_Stripe_Settings_Migration_Ledger::find_by_source_key( 'debug_log' );
+		$this->assertCount( 1, $ledger_rows );
+		$this->assertSame(
+			WC_Stripe_Settings_Migration_Ledger::OUTCOME_SKIPPED_SOURCE_MISSING,
+			$ledger_rows[0]['outcome']
+		);
+	}
+
+	public function test_applies_transform_row_for_test_mode() {
+		$this->seed_pp_3x();
+		update_option( 'woocommerce_stripe_api_settings', [ 'mode' => 'test' ] );
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertSame( 'yes', $stripe_settings['testmode'] ?? null );
+
+		$ledger_rows = WC_Stripe_Settings_Migration_Ledger::find_by_source_key( 'mode' );
+		$this->assertCount( 1, $ledger_rows );
+		$this->assertSame( WC_Stripe_Settings_Migration_Ledger::OUTCOME_APPLIED, $ledger_rows[0]['outcome'] );
+		$this->assertSame( WC_Stripe_Settings_Migration_Ledger::CATEGORY_TRANSFORM, $ledger_rows[0]['category'] );
+	}
+
+	public function test_applies_transform_row_for_capture() {
+		$this->seed_pp_3x();
+		update_option( 'woocommerce_stripe_cc_settings', [ 'charge_type' => 'authorize' ] );
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertSame( 'no', $stripe_settings['capture'] ?? null );
+	}
+
+	public function test_applies_statement_descriptor_with_placeholder_stripped() {
+		$this->seed_pp_3x();
+		update_option(
+			'woocommerce_stripe_advanced_settings',
+			[
+				'statement_descriptor'        => 'ACME {order_id} STORE',
+				'statement_descriptor_suffix' => '#{order_number}',
+			]
+		);
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertSame( 'ACME STORE', $stripe_settings['statement_descriptor'] ?? null );
+		$this->assertSame( '#', $stripe_settings['short_statement_descriptor'] ?? null );
+	}
+
+	public function test_records_drop_investigate_build_rows_in_ledger() {
+		$this->seed_pp_3x();
+		update_option( 'woocommerce_stripe_advanced_settings', [ 'installments' => 'yes' ] );
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		$ledger = WC_Stripe_Settings_Migration_Ledger::load();
+
+		$drop_rows        = array_filter( $ledger, fn( $r ) => WC_Stripe_Settings_Migration_Ledger::CATEGORY_DROP === $r['category'] );
+		$investigate_rows = array_filter( $ledger, fn( $r ) => WC_Stripe_Settings_Migration_Ledger::CATEGORY_INVESTIGATE === $r['category'] );
+		$build_rows       = array_filter( $ledger, fn( $r ) => WC_Stripe_Settings_Migration_Ledger::CATEGORY_BUILD === $r['category'] );
+
+		$this->assertNotEmpty( $drop_rows, 'No DROP rows recorded' );
+		$this->assertNotEmpty( $investigate_rows, 'No INVESTIGATE rows recorded' );
+		$this->assertNotEmpty( $build_rows, 'No BUILD rows recorded' );
+
+		// `installments` is an INVESTIGATE row and we seeded a value — verify the ledger captured it.
+		$installments_rows = array_values(
+			array_filter(
+				$investigate_rows,
+				fn( $r ) => 'installments' === $r['source_key']
+			)
+		);
+		$this->assertCount( 1, $installments_rows );
+		$this->assertSame( 'yes', $installments_rows[0]['source_value'] );
+	}
+
+	public function test_captures_pre_migration_snapshot_before_writes() {
+		$this->seed_pp_3x();
+		update_option( 'woocommerce_stripe_advanced_settings', [ 'debug_log' => 'yes' ] );
+
+		// Set a sentinel value in Woo Stripe settings that the migration would normally NOT
+		// overwrite (because the destination is non-empty). The snapshot must record this exact
+		// sentinel so we can prove the snapshot was captured BEFORE any AUTO/TRANSFORM writes.
+		$existing                         = WC_Stripe_Helper::get_stripe_settings();
+		$existing['statement_descriptor'] = 'PRE_MIGRATION_SENTINEL';
+		WC_Stripe_Helper::update_main_stripe_settings( $existing );
+
+		$pre_capture_value = WC_Stripe_Helper::get_stripe_settings();
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		$snapshot = WC_Stripe_Pre_Migration_Snapshot::get_current();
+		$this->assertNotNull( $snapshot );
+
+		// Snapshot's recorded Woo Stripe main settings must exactly equal the pre-migration state.
+		// Since `statement_descriptor` is already set, the migration's TRANSFORM row for it is a
+		// no-op; the post-state should equal the pre-state for this key.
+		$captured_stripe = $snapshot['options']['woocommerce_stripe_settings'] ?? [];
+		$this->assertSame(
+			'PRE_MIGRATION_SENTINEL',
+			$captured_stripe['statement_descriptor'] ?? null,
+			'Snapshot did not capture the pre-migration sentinel value'
+		);
+
+		// And the full snapshot equals what get_stripe_settings returned right before the call.
+		$this->assertSame( $pre_capture_value, $captured_stripe );
+	}
+
+	public function test_is_idempotent_across_two_invocations() {
+		$this->seed_pp_3x();
+		update_option( 'woocommerce_stripe_advanced_settings', [ 'debug_log' => 'yes' ] );
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+		$first_ledger_count = count( WC_Stripe_Settings_Migration_Ledger::load() );
+		$this->assertGreaterThan( 0, $first_ledger_count );
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+		$second_ledger_count = count( WC_Stripe_Settings_Migration_Ledger::load() );
+		$this->assertSame( $first_ledger_count, $second_ledger_count, 'Second invocation appended ledger rows' );
+	}
+
+	public function test_per_method_enable_migration_writes_upe_method_ids() {
+		$this->seed_pp_3x();
+		// UPM is OFF — per-method enable migration should run.
+		update_option( 'woocommerce_stripe_upm_settings', [ 'enabled' => 'no' ] );
+		update_option( 'woocommerce_stripe_cc_settings', [ 'enabled' => 'yes' ] );
+		update_option( 'woocommerce_stripe_klarna_settings', [ 'enabled' => 'yes' ] );
+		update_option( 'woocommerce_stripe_sepa_settings', [ 'enabled' => 'yes' ] );
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$enabled_methods = $stripe_settings[ WC_Stripe_PP_Settings_Migration::DEST_KEY_ENABLED_METHODS ] ?? [];
+
+		$this->assertContains( 'card', $enabled_methods );
+		$this->assertContains( 'klarna', $enabled_methods );
+		$this->assertContains( 'sepa_debit', $enabled_methods );
+	}
+
+	public function test_per_method_enable_migration_skipped_when_upm_enabled() {
+		$this->seed_pp_3x();
+		// UPM is ON — per-method enable migration should SKIP because UPM merchants manage
+		// methods centrally via PMC and per-gateway flags are unreliable.
+		update_option( 'woocommerce_stripe_upm_settings', [ 'enabled' => 'yes' ] );
+		update_option( 'woocommerce_stripe_klarna_settings', [ 'enabled' => 'yes' ] );
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$enabled_methods = $stripe_settings[ WC_Stripe_PP_Settings_Migration::DEST_KEY_ENABLED_METHODS ] ?? null;
+
+		// Klarna should NOT have been added to the Woo Stripe enabled list because UPM-gated.
+		$this->assertTrue(
+			null === $enabled_methods || ! in_array( 'klarna', $enabled_methods, true ),
+			'Per-method enable migration ran despite UPM being enabled'
+		);
+	}
+
+	public function test_per_method_enable_records_pp_only_methods_as_build_rows() {
+		$this->seed_pp_3x();
+		update_option( 'woocommerce_stripe_upm_settings', [ 'enabled' => 'no' ] );
+		update_option( 'woocommerce_stripe_billie_settings', [ 'enabled' => 'yes' ] );
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		$build_rows = array_values(
+			array_filter(
+				WC_Stripe_Settings_Migration_Ledger::load(),
+				fn( $r ) => WC_Stripe_Settings_Migration_Ledger::CATEGORY_BUILD === $r['category']
+					&& 'stripe_billie' === $r['source_key']
+			)
+		);
+
+		$this->assertCount( 1, $build_rows, 'PP-only method not recorded as BUILD row' );
+	}
+
+	public function test_per_method_order_migration_writes_mapped_order() {
+		$this->seed_pp_3x();
+		// Merchant put Klarna first, then CC, then SEPA in WC core's gateway order.
+		update_option(
+			'woocommerce_gateway_order',
+			[
+				'stripe_klarna' => 0,
+				'stripe_cc'     => 1,
+				'stripe_sepa'   => 2,
+				'cheque'        => 3, // non-Stripe gateway — should be dropped.
+			]
+		);
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$order           = $stripe_settings[ WC_Stripe_PP_Settings_Migration::DEST_KEY_METHOD_ORDER ] ?? null;
+
+		$this->assertSame(
+			[ 'klarna', 'card', 'sepa_debit' ],
+			$order
+		);
+	}
+
+	public function test_per_method_order_skipped_when_no_pp_stripe_gateways_in_order() {
+		$this->seed_pp_3x();
+		update_option(
+			'woocommerce_gateway_order',
+			[
+				'cheque' => 0,
+				'bacs'   => 1,
+			]
+		);
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertArrayNotHasKey( WC_Stripe_PP_Settings_Migration::DEST_KEY_METHOD_ORDER, $stripe_settings );
+	}
+
+	public function test_per_method_order_does_not_overwrite_existing_woo_stripe_order() {
+		$this->seed_pp_3x();
+		update_option(
+			'woocommerce_gateway_order',
+			[
+				'stripe_klarna' => 0,
+				'stripe_cc'     => 1,
+			]
+		);
+
+		// Merchant already configured order on Woo Stripe — must not be overwritten.
+		WC_Stripe_Helper::update_main_stripe_settings(
+			[
+				WC_Stripe_PP_Settings_Migration::DEST_KEY_METHOD_ORDER => [ 'card', 'klarna' ],
+			]
+		);
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertSame(
+			[ 'card', 'klarna' ],
+			$stripe_settings[ WC_Stripe_PP_Settings_Migration::DEST_KEY_METHOD_ORDER ]
+		);
+	}
+
+	public function test_orchestrator_sets_completed_flag_after_run() {
+		$this->seed_pp_3x();
+		update_option( 'woocommerce_stripe_advanced_settings', [ 'debug_log' => 'yes' ] );
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		$this->assertSame( 'yes', get_option( WC_Stripe_PP_Settings_Migration::COMPLETED_OPTION ) );
+	}
+
+	public function test_falls_back_to_3x_mapping_for_unknown_future_version() {
+		// PP 5.X (hypothetical) — no concrete map. Detector returns '5'; orchestrator should
+		// fall back to 3.X best-effort.
+		update_option( 'stripe_wc_version', '5.0.0' );
+		update_option( 'woocommerce_stripe_advanced_settings', [ 'debug_log' => 'yes' ] );
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		// 3.X mapping was applied as fallback.
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertSame( 'yes', $stripe_settings['logging'] ?? null );
+	}
+
+	public function test_pp_4x_map_returns_empty_so_no_writes_happen() {
+		// PP 4.X has an empty placeholder map — orchestrator uses it directly (no fallback
+		// because the map class exists). No AUTO/TRANSFORM rows means no writes.
+		update_option( 'stripe_wc_version', '4.0.0' );
+		update_option( 'woocommerce_stripe_advanced_settings', [ 'debug_log' => 'yes' ] );
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertArrayNotHasKey( 'logging', $stripe_settings, '4.X placeholder map performed writes' );
+
+		// But completed flag is still set so we don't re-run.
+		$this->assertSame( 'yes', get_option( WC_Stripe_PP_Settings_Migration::COMPLETED_OPTION ) );
+	}
+
+	public function test_ledger_run_id_groups_all_decisions_from_one_invocation() {
+		$this->seed_pp_3x();
+		update_option( 'woocommerce_stripe_advanced_settings', [ 'debug_log' => 'yes' ] );
+		update_option( 'woocommerce_stripe_api_settings', [ 'mode' => 'live' ] );
+
+		WC_Stripe_PP_Settings_Migration::maybe_run();
+
+		$rows    = WC_Stripe_Settings_Migration_Ledger::load();
+		$run_ids = array_unique( array_column( $rows, 'run_id' ) );
+
+		$this->assertCount( 1, $run_ids, 'Multiple run_ids found in a single orchestrator invocation' );
+	}
+}

--- a/tests/phpunit/admin/migrations/class-wc-stripe-pp-settings-migration-test.php
+++ b/tests/phpunit/admin/migrations/class-wc-stripe-pp-settings-migration-test.php
@@ -6,6 +6,7 @@
  */
 
 require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/class-wc-stripe-pp-settings-migration.php';
+require_once __DIR__ . '/class-wc-stripe-pp-settings-migration-throwing-first-transform.php';
 
 /**
  * Unit tests for {@see WC_Stripe_PP_Settings_Migration}.
@@ -425,5 +426,33 @@ class WC_Stripe_PP_Settings_Migration_Test extends WP_UnitTestCase {
 		$run_ids = array_unique( array_column( $rows, 'run_id' ) );
 
 		$this->assertCount( 1, $run_ids, 'Multiple run_ids found in a single orchestrator invocation' );
+	}
+
+	/**
+	 * When one TRANSFORM row's callable throws, the remaining rows must still be applied.
+	 * Verifies that apply_transform_rows() isolates per-row exceptions.
+	 */
+	public function test_transform_exception_in_one_row_does_not_abort_remaining_rows() {
+		$this->seed_pp_3x();
+		// Seed both `mode` (first TRANSFORM row) and `charge_type` (second TRANSFORM row).
+		update_option( 'woocommerce_stripe_api_settings', [ 'mode' => 'test' ] );
+		update_option( 'woocommerce_stripe_cc_settings', [ 'charge_type' => 'capture' ] );
+
+		// Subclass injects a map where the first transformer always throws; second is the real one.
+		WC_Stripe_PP_Settings_Migration_Throwing_First_Transform::maybe_run();
+
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+
+		// Second transformer (charge_type→capture) must have applied despite the first throwing.
+		$this->assertSame( 'yes', $stripe_settings['capture'] ?? null, 'Second TRANSFORM row did not apply after first threw' );
+
+		// First row must be recorded as SKIPPED_TRANSFORM_FAILED.
+		$mode_rows = WC_Stripe_Settings_Migration_Ledger::find_by_source_key( 'mode' );
+		$this->assertCount( 1, $mode_rows );
+		$this->assertSame(
+			WC_Stripe_Settings_Migration_Ledger::OUTCOME_SKIPPED_TRANSFORM_FAILED,
+			$mode_rows[0]['outcome'],
+			'Throwing transformer row was not recorded as SKIPPED_TRANSFORM_FAILED'
+		);
 	}
 }

--- a/tests/phpunit/admin/migrations/class-wc-stripe-pp-settings-migration-throwing-first-transform.php
+++ b/tests/phpunit/admin/migrations/class-wc-stripe-pp-settings-migration-throwing-first-transform.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Test double for WC_Stripe_PP_Settings_Migration_Test.
+ *
+ * @package WooCommerce_Stripe/Tests
+ */
+
+require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/class-wc-stripe-pp-settings-migration.php';
+require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/pp-settings-maps/class-wc-stripe-pp-settings-map-3x.php';
+require_once __DIR__ . '/class-wc-stripe-pp-settings-map-3x-throwing-first.php';
+
+/**
+ * Overrides map_for_version() to inject a map whose first TRANSFORM callable always throws.
+ * Used to verify that apply_transform_rows() isolates per-row exceptions.
+ */
+class WC_Stripe_PP_Settings_Migration_Throwing_First_Transform extends WC_Stripe_PP_Settings_Migration {
+	protected static function map_for_version( string $version ): ?WC_Stripe_PP_Settings_Map {
+		return new WC_Stripe_PP_Settings_Map_3X_Throwing_First();
+	}
+}

--- a/tests/phpunit/admin/migrations/class-wc-stripe-settings-migration-ledger-test.php
+++ b/tests/phpunit/admin/migrations/class-wc-stripe-settings-migration-ledger-test.php
@@ -44,6 +44,7 @@ class WC_Stripe_Settings_Migration_Ledger_Test extends WP_UnitTestCase {
 			'',
 			'yes'
 		);
+		$this->ledger->flush();
 
 		$rows = WC_Stripe_Settings_Migration_Ledger::load();
 		$this->assertCount( 1, $rows );
@@ -82,6 +83,7 @@ class WC_Stripe_Settings_Migration_Ledger_Test extends WP_UnitTestCase {
 			WC_Stripe_Settings_Migration_Ledger::OUTCOME_SKIPPED_DEST_SET,
 			'Destination already had merchant value — preserved'
 		);
+		$this->ledger->flush();
 
 		$row = WC_Stripe_Settings_Migration_Ledger::load()[0];
 		$this->assertSame( WC_Stripe_Settings_Migration_Ledger::TYPE_SKIP, $row['type'] );
@@ -103,6 +105,7 @@ class WC_Stripe_Settings_Migration_Ledger_Test extends WP_UnitTestCase {
 			WC_Stripe_Settings_Migration_Ledger::OUTCOME_SKIPPED_SOURCE_MISSING,
 			'PP source option/key not present'
 		);
+		$this->ledger->flush();
 
 		$row = WC_Stripe_Settings_Migration_Ledger::load()[0];
 		$this->assertNull( $row['source_value'] );
@@ -132,6 +135,8 @@ class WC_Stripe_Settings_Migration_Ledger_Test extends WP_UnitTestCase {
 			'No destination feature in Woo Stripe'
 		);
 
+		$this->ledger->flush();
+
 		$rows = WC_Stripe_Settings_Migration_Ledger::load();
 		$this->assertCount( 3, $rows );
 
@@ -157,6 +162,7 @@ class WC_Stripe_Settings_Migration_Ledger_Test extends WP_UnitTestCase {
 			[ 'enabled' => 'yes' ],  // current (post-migration) value
 			$snapshot_to_restore_from
 		);
+		$this->ledger->flush();
 
 		$row = WC_Stripe_Settings_Migration_Ledger::load()[0];
 		$this->assertSame( WC_Stripe_Settings_Migration_Ledger::TYPE_REVERT, $row['type'] );
@@ -180,6 +186,8 @@ class WC_Stripe_Settings_Migration_Ledger_Test extends WP_UnitTestCase {
 			'',
 			'sk_live_super_secret_value'
 		);
+
+		$this->ledger->flush();
 
 		$row = WC_Stripe_Settings_Migration_Ledger::load()[0];
 		$this->assertSame( WC_Stripe_Settings_Migration_Ledger::REDACTED, $row['source_value'] );
@@ -211,6 +219,7 @@ class WC_Stripe_Settings_Migration_Ledger_Test extends WP_UnitTestCase {
 			'',
 			'yes'
 		);
+		$this->ledger->flush();
 
 		$row = WC_Stripe_Settings_Migration_Ledger::load()[0];
 		$this->assertSame( 'yes', $row['source_value'] );
@@ -239,6 +248,8 @@ class WC_Stripe_Settings_Migration_Ledger_Test extends WP_UnitTestCase {
 			'dest preserved'
 		);
 
+		$this->ledger->flush();
+
 		foreach ( WC_Stripe_Settings_Migration_Ledger::load() as $row ) {
 			$this->assertSame( $this->run_id, $row['run_id'] );
 		}
@@ -265,6 +276,8 @@ class WC_Stripe_Settings_Migration_Ledger_Test extends WP_UnitTestCase {
 			'',
 			'yes'
 		);
+
+		$this->ledger->flush();
 
 		$matches = WC_Stripe_Settings_Migration_Ledger::find_by_source_key( 'debug_log' );
 		$this->assertCount( 1, $matches );
@@ -296,6 +309,9 @@ class WC_Stripe_Settings_Migration_Ledger_Test extends WP_UnitTestCase {
 			'c'
 		);
 
+		$this->ledger->flush();
+		$other_ledger->flush();
+
 		$mine  = WC_Stripe_Settings_Migration_Ledger::find_by_run_id( $this->run_id );
 		$other = WC_Stripe_Settings_Migration_Ledger::find_by_run_id( $other_run_id );
 
@@ -316,6 +332,7 @@ class WC_Stripe_Settings_Migration_Ledger_Test extends WP_UnitTestCase {
 			'',
 			'a'
 		);
+		$this->ledger->flush();
 		$this->assertCount( 1, WC_Stripe_Settings_Migration_Ledger::load() );
 
 		// Second run, second ledger instance — must append, not overwrite.
@@ -330,6 +347,7 @@ class WC_Stripe_Settings_Migration_Ledger_Test extends WP_UnitTestCase {
 			'',
 			'c'
 		);
+		$next->flush();
 
 		$this->assertCount( 2, WC_Stripe_Settings_Migration_Ledger::load() );
 	}
@@ -345,6 +363,7 @@ class WC_Stripe_Settings_Migration_Ledger_Test extends WP_UnitTestCase {
 			'',
 			'a'
 		);
+		$this->ledger->flush();
 
 		global $wpdb;
 		$autoload = $wpdb->get_var(
@@ -372,6 +391,7 @@ class WC_Stripe_Settings_Migration_Ledger_Test extends WP_UnitTestCase {
 				'a'
 			);
 		}
+		$this->ledger->flush();
 
 		$ids = array_map(
 			static function ( $row ) {


### PR DESCRIPTION
## Summary

PR 2 of 2 — adds the orchestrator that ties together the foundation classes and wires it into the OAuth completion handler. The migration is functional end-to-end after this PR.

**Depends on [#5444](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5444) (foundation classes).** Targets the foundation branch so the diff shown here is only the new code on top.

## What's in this PR

| Change | Description |
| --- | --- |
| `WC_Stripe_PP_Settings_Migration` (orchestrator) | `maybe_run()` + AUTO/TRANSFORM application + per-method enable/order migrations + DROP/INVESTIGATE/BUILD recording. |
| `WC_Stripe_Connect::save_stripe_keys()` wiring | One-line addition between OAuth credential write (line 297) and PMC migration (line 333). |
| Orchestrator unit tests | 21 tests, 44 assertions covering idempotency, no-PP-data short-circuit, AUTO/TRANSFORM behavior, snapshot ordering, per-method enable UPM-gating, PP-only-as-BUILD, per-method order mapping, unknown-version fallback. |

## Order of operations inside `save_stripe_keys()`

The wiring is between two existing calls — ordering is load-bearing:

1. `update_main_stripe_settings($options)` — OAuth writes credentials + Woo Stripe defaults (line 297)
2. `clear_caches_after_key_update()` (line 304)
3. Connection-refresh scheduling
4. **`WC_Stripe_PP_Settings_Migration::maybe_run()`** ← NEW
5. `get_main_stripe_gateway()` (gateway instantiation)
6. `maybe_migrate_payment_methods_from_db_to_pmc(true)` — picks up our PP-derived enabled list (line ~333)
7. `configure_webhooks()`

Without ordering before step 6, merchants who switch from PP to Woo Stripe would land in PMC with Woo Stripe's empty default enabled list, losing the fidelity of their PP method selection.

## Design notes

- **Idempotent and self-detecting.** Gated by `woocommerce_stripe_pp_settings_migrated` option flag. Safe to call on every OAuth completion. If no PP data is present, marks itself complete with no writes.
- **Snapshot captured BEFORE any writes.** Load-bearing for rollback correctness. Verified by `test_captures_pre_migration_snapshot_before_writes`.
- **Per-method enable migration is architecture-gated.** When `woocommerce_stripe_upm_settings.enabled === 'yes'`, the merchant managed methods centrally via PMC, so per-gateway `enabled` flags in PP options are stale — we SKIP and record the decision.
- **Per-method order runs unconditionally.** If OCS is on, the stored order sits dormant (PMC handles ordering). If the merchant ever disables OCS, their historical PP order applies instead of Woo Stripe defaults.
- **PP-only methods recorded as BUILD ledger rows.** Billie, Konbini, MobilePay, PayNow, PromptPay, Revolut Pay, Swish, TWINT, Zip, Pay by Bank, FPX, GrabPay — none have Woo Stripe destinations. Audit trail captures the shopper-facing regression.
- **Don't write `stripe_legacy_method_order`.** The orchestrator only writes the modern `stripe_upe_payment_method_order` key. Writing the deprecated sibling would collide with Woo Stripe's internal pre-UPE → UPE bridge logic.

## Test plan

- [x] PHPStan level 8 clean — `npm run phpstan`
- [x] PHPCS clean — `npm run lint:php`
- [x] PHPUnit clean — `npm run test:php -- --filter='WC_Stripe_PP_Settings_Migration_Test'` → 21/21 tests, 44 assertions
- [x] Full migration suite + connect tests — 107/107 tests, 332 assertions
- [x] Pre-commit hook passed on every commit
- [ ] **Reviewers:** verify the `save_stripe_keys()` insertion point and ordering against `WC_Stripe_Payment_Method_Configurations::maybe_migrate_payment_methods_from_db_to_pmc()`
- [ ] **Reviewers:** verify PP gateway ID → UPE method ID mapping table against `WC_Stripe_Payment_Methods` constants
- [ ] **Manual QA (future):** install PP 3.X test site with seeded values, complete OAuth in Woo Stripe, verify pre-fill produces expected merchant-visible state in Settings → Payments → Stripe

### Coverage highlights

- Idempotency: completed flag short-circuits; running twice produces no additional ledger rows
- No-PP-data short-circuit: marks complete without snapshot or ledger writes
- Pre-fill behavior: applies when source present + dest empty; preserves merchant overrides; preserves OAuth-set values; records each decision with proper outcome
- Snapshot ordering: assertion proves snapshot reflects pre-call state, not post-call state
- Per-method enable: writes mapped UPE method IDs; skips when UPM enabled; records PP-only methods as BUILD
- Per-method order: maps PP gateway IDs to UPE methods, drops unmappable / non-Stripe entries, preserves existing Woo Stripe order
- Version fallback: unknown 5.X → 3.X best-effort with logged warning; 4.X placeholder → no writes but completed flag still set

## Follow-up tasks

- [ ] **Remove `require_once` statements from migration files** — `class-wc-stripe-pp-settings-migration.php` and its peers still have `require_once` guards that predate the composer classmap addition in #5444. Once this PR merges and the orchestrator relies on autoload, those guards can be deleted in a dedicated cleanup commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)