### PR TITLE
[RSM - Diagnostics Mode] [DO NOT MERGE] Rate-limit the diagnostics /events endpoint

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ xxxx-xx-xx - version 10.8.0
 * Dev - Exclude AGENTS.md and CLAUDE.md contributor-instruction files from the built plugin zip
 * Add - Append a "what's new" changelog link to the Updated! message after manually updating the plugin from the Plugins page
 * Add - Implement diagnostic mode to help debug checkout issues
+* Dev - Rate-limit the diagnostics /events endpoint per-IP (2s default, filterable) and emit a Tracks event when the limit trips
 * Fix - Add guards against invalid values for webhook state timestamps
 
 2026-05-12 - version 10.7.0

--- a/client/diagnostics/__tests__/recorder.test.js
+++ b/client/diagnostics/__tests__/recorder.test.js
@@ -286,6 +286,205 @@ describe( 'Recorder', () => {
 			);
 		} );
 
+		describe( 'client-side rate-limit throttle', () => {
+			// Wire a manual scheduler so the throttle's deferred flush is
+			// observable without a real timer: capture the (fn, ms) pair on
+			// setTimer and fire it manually after asserting on it.
+			function makeManualScheduler() {
+				const scheduled = [];
+				return {
+					setTimer: ( fn, ms ) => {
+						scheduled.push( { fn, ms } );
+						return scheduled.length;
+					},
+					clearTimer: () => {},
+					scheduled,
+				};
+			}
+
+			it( 'flushes immediately on the first record() when rateLimitMs is set', () => {
+				window.wcStripeDiag.rateLimitMs = 2000;
+				const mockTime = 0;
+
+				const recorder = makeRecorder( { now: () => mockTime } );
+				recorder.boot();
+				recorder.record( 'element.ready', { element_type: 'card' } );
+				recorder.flush();
+
+				expect( sendBeaconSpy ).toHaveBeenCalledTimes( 1 );
+			} );
+
+			it( 'defers a second flush within the rate window to a deferred-flush timer instead of firing sendBeacon', () => {
+				window.wcStripeDiag.rateLimitMs = 2000;
+				let mockTime = 0;
+				const scheduler = makeManualScheduler();
+
+				const recorder = makeRecorder( {
+					now: () => mockTime,
+					setTimer: scheduler.setTimer,
+					clearTimer: scheduler.clearTimer,
+				} );
+				recorder.boot();
+
+				// First flush goes through.
+				recorder.record( 'element.ready', { element_type: 'card' } );
+				recorder.flush();
+				expect( sendBeaconSpy ).toHaveBeenCalledTimes( 1 );
+
+				// 500ms later (well inside the 2s window), record + flush again.
+				mockTime = 500;
+				recorder.record( 'element.change', { element_type: 'card' } );
+				recorder.flush();
+
+				// sendBeacon must NOT have been called a second time — the
+				// recorder should have scheduled a deferred flush for the
+				// remainder of the window (1500ms).
+				expect( sendBeaconSpy ).toHaveBeenCalledTimes( 1 );
+
+				const deferred = scheduler.scheduled.find(
+					( s ) => s.ms === 1500
+				);
+				expect( deferred ).toBeDefined();
+			} );
+
+			it( 'coalesces a burst of record() calls during the wait into a single deferred flush', () => {
+				window.wcStripeDiag.rateLimitMs = 2000;
+				let mockTime = 0;
+				const scheduler = makeManualScheduler();
+
+				const recorder = makeRecorder( {
+					now: () => mockTime,
+					setTimer: scheduler.setTimer,
+					clearTimer: scheduler.clearTimer,
+				} );
+				recorder.boot();
+
+				recorder.record( 'element.ready', { element_type: 'card' } );
+				recorder.flush();
+
+				mockTime = 100;
+				recorder.record( 'a', {} );
+				recorder.flush();
+				recorder.record( 'b', {} );
+				recorder.flush();
+				recorder.record( 'c', {} );
+				recorder.flush();
+
+				// Only one throttle timer should be in flight regardless of
+				// how many flushes were attempted during the wait.
+				const throttleTimers = scheduler.scheduled.filter(
+					( s ) => s.ms === 1900
+				);
+				expect( throttleTimers ).toHaveLength( 1 );
+			} );
+
+			it( 'fires the deferred flush when its timer elapses, sending all buffered events in one batch', async () => {
+				window.wcStripeDiag.rateLimitMs = 2000;
+				let mockTime = 0;
+				const scheduler = makeManualScheduler();
+
+				const recorder = makeRecorder( {
+					now: () => mockTime,
+					setTimer: scheduler.setTimer,
+					clearTimer: scheduler.clearTimer,
+				} );
+				recorder.boot();
+
+				recorder.record( 'element.ready', { element_type: 'card' } );
+				recorder.flush();
+
+				// During the wait, buffer two more events.
+				mockTime = 500;
+				recorder.record( 'a', {} );
+				recorder.record( 'b', {} );
+				recorder.flush();
+
+				expect( sendBeaconSpy ).toHaveBeenCalledTimes( 1 );
+
+				// Advance past the window and fire the deferred callback.
+				mockTime = 2000;
+				const deferred = scheduler.scheduled.find(
+					( s ) => s.ms === 1500
+				);
+				deferred.fn();
+
+				expect( sendBeaconSpy ).toHaveBeenCalledTimes( 2 );
+				const secondBody = await readBeaconBody(
+					sendBeaconSpy.mock.calls[ 1 ]
+				);
+				expect( secondBody.events.map( ( e ) => e.kind ) ).toEqual( [
+					'a',
+					'b',
+				] );
+			} );
+
+			it( 'does not throttle when rateLimitMs is unset (default config)', () => {
+				delete window.wcStripeDiag.rateLimitMs;
+				let mockTime = 0;
+
+				const recorder = makeRecorder( { now: () => mockTime } );
+				recorder.boot();
+				recorder.record( 'a', {} );
+				recorder.flush();
+				mockTime = 1;
+				recorder.record( 'b', {} );
+				recorder.flush();
+
+				expect( sendBeaconSpy ).toHaveBeenCalledTimes( 2 );
+			} );
+
+			it( 'pagehide flush forces past the throttle so the buffer drains before the tab is torn down', () => {
+				window.wcStripeDiag.rateLimitMs = 2000;
+				let mockTime = 0;
+				const scheduler = makeManualScheduler();
+
+				const recorder = makeRecorder( {
+					now: () => mockTime,
+					setTimer: scheduler.setTimer,
+					clearTimer: scheduler.clearTimer,
+				} );
+				recorder.boot();
+				recorder.record( 'element.ready', { element_type: 'card' } );
+				recorder.flush();
+
+				// Pagehide fires inside the throttle window.
+				mockTime = 500;
+				recorder.record( 'last-gasp', {} );
+				window.dispatchEvent( new Event( 'pagehide' ) );
+
+				// Pagehide must drain immediately, not schedule a deferred
+				// flush that the closing tab will never service.
+				expect( sendBeaconSpy ).toHaveBeenCalledTimes( 2 );
+			} );
+
+			it( 'destroy() clears any pending throttle timer so the recorder leaves no scheduled work behind', () => {
+				window.wcStripeDiag.rateLimitMs = 2000;
+				const cleared = [];
+				let mockTime = 0;
+				const scheduler = makeManualScheduler();
+
+				const recorder = makeRecorder( {
+					now: () => mockTime,
+					setTimer: scheduler.setTimer,
+					clearTimer: ( id ) => cleared.push( id ),
+				} );
+				recorder.boot();
+				recorder.record( 'a', {} );
+				recorder.flush();
+
+				mockTime = 100;
+				recorder.record( 'b', {} );
+				recorder.flush();
+				// Confirms a throttle timer was actually scheduled.
+				expect( scheduler.scheduled.length ).toBeGreaterThan( 1 );
+
+				recorder.destroy();
+
+				// The throttle timer's id is one of the cleared ids.
+				expect( cleared.length ).toBeGreaterThan( 0 );
+			} );
+		} );
+
 		describe( 'attach() integration with Stripe Element instances', () => {
 			function makeFakeElement() {
 				const handlers = {};

--- a/client/diagnostics/recorder.js
+++ b/client/diagnostics/recorder.js
@@ -24,6 +24,15 @@ export class Recorder {
 		this.idleTimer = null;
 		this.pagehideHandler = null;
 		this.originalConsole = null;
+		// Tracks the timestamp of the most recent flush so we can coalesce a
+		// burst of record() calls into a single flush per server-side rate
+		// window. `sendBeacon` is fire-and-forget — we can't observe a 429 —
+		// so the recorder leans on this preemptive throttle instead of a
+		// post-hoc retry, and accepts that multi-tab / shared-NAT clients can
+		// still 429 (and silently drop) on the server side. `null` means no
+		// flush has happened yet — the first one always goes through.
+		this._lastFlushAtMs = null;
+		this._throttleTimer = null;
 	}
 
 	boot() {
@@ -109,7 +118,10 @@ export class Recorder {
 				bufferedEvents: [ ...this.buffer ],
 			} );
 		}
-		this.flush();
+		// Force the flush past the rate-limit throttle — pagehide is our last
+		// chance to drain before the tab is gone, and dropping the events here
+		// for the sake of a 429 we couldn't observe anyway is the wrong trade.
+		this.flush( { force: true } );
 		// Only clear the persisted copy if flush() actually drained the
 		// buffer. If sendBeacon refused (returned false), flush() preserves
 		// `this.buffer`, but on pagehide that in-memory buffer is useless —
@@ -268,10 +280,28 @@ export class Recorder {
 		this._resetIdleTimer();
 	}
 
-	flush() {
+	flush( { force = false } = {} ) {
 		if ( ! this.config?.active || this.buffer.length === 0 ) {
 			return;
 		}
+
+		if ( ! force ) {
+			const wait = this._throttleRemainingMs();
+			if ( wait > 0 ) {
+				// Match the server-side rate-limit window. Coalesces a burst
+				// of record() calls into a single flush per window so a noisy
+				// page doesn't burn 429s. One in-flight deferred timer covers
+				// any number of queued events.
+				if ( this._throttleTimer === null ) {
+					this._throttleTimer = this.setTimer( () => {
+						this._throttleTimer = null;
+						this.flush();
+					}, wait );
+				}
+				return;
+			}
+		}
+
 		const payload = buildIngestBlob( {
 			diag_session_id: this.config.sessionId,
 			events: this.buffer,
@@ -285,12 +315,14 @@ export class Recorder {
 		// of silently dropping events.
 		if ( queued ) {
 			this.buffer = [];
+			this._lastFlushAtMs = this.now();
 		}
 		this._clearIdleTimer();
 	}
 
 	destroy() {
 		this._clearIdleTimer();
+		this._clearThrottleTimer();
 		if ( this.pagehideHandler ) {
 			window.removeEventListener( 'pagehide', this.pagehideHandler );
 			this.pagehideHandler = null;
@@ -309,6 +341,29 @@ export class Recorder {
 			this.clearTimer( this.idleTimer );
 			this.idleTimer = null;
 		}
+	}
+
+	_clearThrottleTimer() {
+		if ( this._throttleTimer !== null ) {
+			this.clearTimer( this._throttleTimer );
+			this._throttleTimer = null;
+		}
+	}
+
+	/**
+	 * Milliseconds the next flush must wait so we don't outrun the server
+	 * rate window. Returns 0 when there's nothing to wait for (no prior
+	 * flush, or no configured window).
+	 *
+	 * @return {number} Remaining throttle time in ms.
+	 */
+	_throttleRemainingMs() {
+		const limit = Number( this.config?.rateLimitMs ) || 0;
+		if ( limit <= 0 || this._lastFlushAtMs === null ) {
+			return 0;
+		}
+		const elapsed = this.now() - this._lastFlushAtMs;
+		return elapsed >= limit ? 0 : limit - elapsed;
 	}
 }
 

--- a/client/settings/advanced-settings-section/__tests__/diagnostics-mode.test.js
+++ b/client/settings/advanced-settings-section/__tests__/diagnostics-mode.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DiagnosticsMode from '../diagnostics-mode';
 import {
@@ -73,5 +73,51 @@ describe( 'DiagnosticsMode', () => {
 		expect( screen.getByTestId( 'diagnostics-traces' ) ).toHaveTextContent(
 			'recording=true'
 		);
+	} );
+
+	describe( 'rate-limit notice', () => {
+		it( 'hides the notice when the summary reports zero rate-limited events', async () => {
+			useDiagnosticsMode.mockReturnValue( [ true, jest.fn() ] );
+			apiFetch.mockResolvedValue( { rate_limited_count: 0 } );
+
+			render( <DiagnosticsMode /> );
+
+			await waitFor( () =>
+				expect( apiFetch ).toHaveBeenCalledWith( {
+					path: expect.stringContaining( '/diagnostics/summary' ),
+				} )
+			);
+			expect(
+				screen.queryByText( /rate-limited in the last 24 hours/i )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'renders the notice with the count when the summary reports a non-zero value', async () => {
+			useDiagnosticsMode.mockReturnValue( [ true, jest.fn() ] );
+			apiFetch.mockResolvedValue( { rate_limited_count: 7 } );
+
+			render( <DiagnosticsMode /> );
+
+			await screen.findByText(
+				/7 diagnostics event requests were rate-limited in the last 24 hours/i
+			);
+			// Surfacing the filter name lets the merchant act on the notice
+			// without leaving the page to look it up.
+			expect(
+				screen.getByText( /wc_stripe_diagnostics_events_rate_limit/i )
+			).toBeInTheDocument();
+		} );
+
+		it( 'falls back to hiding the notice when the summary fetch fails', async () => {
+			useDiagnosticsMode.mockReturnValue( [ true, jest.fn() ] );
+			apiFetch.mockRejectedValue( new Error( 'boom' ) );
+
+			render( <DiagnosticsMode /> );
+
+			await waitFor( () => expect( apiFetch ).toHaveBeenCalled() );
+			expect(
+				screen.queryByText( /rate-limited in the last 24 hours/i )
+			).not.toBeInTheDocument();
+		} );
 	} );
 } );

--- a/client/settings/advanced-settings-section/diagnostics-mode.js
+++ b/client/settings/advanced-settings-section/diagnostics-mode.js
@@ -1,18 +1,40 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import DiagnosticsTraces from './diagnostics-traces';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { ToggleControl } from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+import { NAMESPACE } from 'wcstripe/data/constants';
 import {
 	useDiagnosticsMode,
 	useDiagnosticsCaptureLimit,
 	useDiagnosticsCaptureLimitPresets,
 } from 'wcstripe/data';
 
+const SUMMARY_PATH = `${ NAMESPACE }/diagnostics/summary`;
+
 const DiagnosticsMode = () => {
 	const [ isDiagnosticsChecked, setIsDiagnosticsChecked ] =
 		useDiagnosticsMode();
 	const [ captureLimit, setCaptureLimit ] = useDiagnosticsCaptureLimit();
 	const captureLimitPresets = useDiagnosticsCaptureLimitPresets();
+	// Rolling 24-hour count of /events 429s for this store. Read from the
+	// summary endpoint so a merchant can tell whether the recorder is being
+	// throttled (typically wallet bursts or shared-NAT traffic) without
+	// needing access to fleet Tracks data. Fetched here rather than in
+	// DiagnosticsTraces so the indicator survives even when the trace list
+	// is empty — that "I see no traces" case is exactly when a merchant
+	// needs to know whether the rate limit ate them.
+	const [ rateLimitedCount, setRateLimitedCount ] = useState( 0 );
+
+	useEffect( () => {
+		apiFetch( { path: SUMMARY_PATH } )
+			.then( ( response ) =>
+				setRateLimitedCount(
+					Number( response?.rate_limited_count ) || 0
+				)
+			)
+			.catch( () => setRateLimitedCount( 0 ) );
+	}, [] );
 
 	return (
 		<>
@@ -40,6 +62,23 @@ const DiagnosticsMode = () => {
 					onChange={ setIsDiagnosticsChecked }
 				/>
 			</div>
+			{ rateLimitedCount > 0 && (
+				<div
+					className="wc-stripe-diagnostics-rate-limit-notice"
+					role="status"
+				>
+					{ sprintf(
+						/* translators: %d: number of rate-limited /events requests in the last 24h */
+						_n(
+							'%d diagnostics event request was rate-limited in the last 24 hours. Some traces may be incomplete; widen the window via the wc_stripe_diagnostics_events_rate_limit filter if this persists.',
+							'%d diagnostics event requests were rate-limited in the last 24 hours. Some traces may be incomplete; widen the window via the wc_stripe_diagnostics_events_rate_limit filter if this persists.',
+							rateLimitedCount,
+							'woocommerce-gateway-stripe'
+						),
+						rateLimitedCount
+					) }
+				</div>
+			) }
 			<DiagnosticsTraces
 				isRecording={ isDiagnosticsChecked }
 				captureLimit={ Number( captureLimit ) }

--- a/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
+++ b/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
@@ -25,9 +25,11 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 	// EXPLORATION (RSM-1638): per-IP rate-limit window for the unauthenticated
 	// /events endpoint. A single token over N seconds — enough to bound disk
 	// I/O and FIFO-eviction cost against a basic flooder. Filterable so we
-	// can tune without a release if 1s proves too tight in production.
+	// can tune without a release. Default is 2s rather than 1s so wallet flows
+	// (Apple Pay / Google Pay can emit a quick burst) and shoppers behind a
+	// shared NAT egress don't 429 each other on legitimate double-taps.
 	const EVENTS_RATE_LIMIT_KEY_PREFIX  = 'stripe_diag_events_';
-	const DEFAULT_EVENTS_RATE_LIMIT_SEC = 1;
+	const DEFAULT_EVENTS_RATE_LIMIT_SEC = 2;
 
 	protected $namespace = 'wc/v3';
 	protected $rest_base = 'wc_stripe/diagnostics';
@@ -235,9 +237,32 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 			return new WP_Error( 'wc_stripe_diagnostics_disabled', 'Diagnostics mode is not enabled.', [ 'status' => 403 ] );
 		}
 		if ( self::is_rate_limited() ) {
+			self::record_rate_limited_event();
 			return new WP_Error( 'wc_stripe_diagnostics_rate_limited', 'Too many requests.', [ 'status' => 429 ] );
 		}
 		return true;
+	}
+
+	/**
+	 * EXPLORATION (RSM-1638): emit a Tracks event when the /events rate limit
+	 * trips. Parallels the `wcstripe_diagnostics_auto_off` event so operators
+	 * have visibility into whether the limit is biting in the wild — useful
+	 * for tuning the default window via the
+	 * `wc_stripe_diagnostics_events_rate_limit` filter.
+	 *
+	 * Deliberately omits any IP-derived field; the gate is meant to bound
+	 * abuse, not to identify the actor.
+	 */
+	private static function record_rate_limited_event(): void {
+		if ( ! function_exists( 'wc_admin_record_tracks_event' ) ) {
+			return;
+		}
+		wc_admin_record_tracks_event(
+			'wcstripe_diagnostics_rate_limited',
+			[
+				'test_mode' => class_exists( 'WC_Stripe_Mode' ) && WC_Stripe_Mode::is_test() ? 1 : 0,
+			]
+		);
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
+++ b/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
@@ -22,6 +22,13 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 	// this list being a finite set of positive integers.
 	const CAPTURE_LIMIT_PRESETS = [ 5, 10, 25, 50 ];
 
+	// EXPLORATION (RSM-1638): per-IP rate-limit window for the unauthenticated
+	// /events endpoint. A single token over N seconds — enough to bound disk
+	// I/O and FIFO-eviction cost against a basic flooder. Filterable so we
+	// can tune without a release if 1s proves too tight in production.
+	const EVENTS_RATE_LIMIT_KEY_PREFIX  = 'stripe_diag_events_';
+	const DEFAULT_EVENTS_RATE_LIMIT_SEC = 1;
+
 	protected $namespace = 'wc/v3';
 	protected $rest_base = 'wc_stripe/diagnostics';
 
@@ -227,7 +234,76 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 		if ( ! self::is_enabled() ) {
 			return new WP_Error( 'wc_stripe_diagnostics_disabled', 'Diagnostics mode is not enabled.', [ 'status' => 403 ] );
 		}
+		if ( self::is_rate_limited() ) {
+			return new WP_Error( 'wc_stripe_diagnostics_rate_limited', 'Too many requests.', [ 'status' => 429 ] );
+		}
 		return true;
+	}
+
+	/**
+	 * EXPLORATION (RSM-1638): per-IP rate-limit gate for the unauthenticated
+	 * /events endpoint.
+	 *
+	 * The endpoint stays unauthenticated by design (guest shoppers need to
+	 * post traces), and `is_enabled()` is the only existing gate. An
+	 * attacker can spam the endpoint while diagnostics is on — burning disk
+	 * I/O, padding traces to the 200-event cap, and (if `capture_limit` is
+	 * high) evicting legitimate sessions from the FIFO trace store. A
+	 * per-IP delay window bounds the attack rate without locking out
+	 * legitimate shoppers.
+	 *
+	 * Caveats worth weighing in review:
+	 *   - Per-IP keys collide for shoppers behind the same NAT/proxy; the
+	 *     current 1s window is loose enough that this should be tolerable
+	 *     for the bounded debug session this feature targets, but it is
+	 *     an inherent trade-off.
+	 *   - `WC_Rate_Limiter::set_rate_limit()` writes to the
+	 *     `wc_rate_limits` table on every request; expensive at scale but
+	 *     scoped to the diagnostics-on window.
+	 *   - The IP is hashed (`wp_hash`) so the rate-limit table never holds
+	 *     a raw client address.
+	 */
+	private static function is_rate_limited(): bool {
+		if ( ! class_exists( 'WC_Geolocation' ) || ! class_exists( 'WC_Rate_Limiter' ) ) {
+			return false;
+		}
+		$ip = WC_Geolocation::get_ip_address();
+		if ( '' === $ip ) {
+			// No IP signal (CLI/cron path or a hosting setup we can't read);
+			// don't block — the diagnostics-enabled gate upstream still applies.
+			return false;
+		}
+		$key = self::EVENTS_RATE_LIMIT_KEY_PREFIX . substr( wp_hash( $ip ), 0, 16 );
+		return WC_Rate_Limiter::retried_too_soon( $key );
+	}
+
+	/**
+	 * Counterpart to {@see self::is_rate_limited()} — extends the per-IP
+	 * window after a request lands. Kept private and called from
+	 * `ingest_events()` so the gate trips on the next request rather than
+	 * the current one.
+	 */
+	private static function arm_rate_limit(): void {
+		if ( ! class_exists( 'WC_Geolocation' ) || ! class_exists( 'WC_Rate_Limiter' ) ) {
+			return;
+		}
+		$ip = WC_Geolocation::get_ip_address();
+		if ( '' === $ip ) {
+			return;
+		}
+		/**
+		 * EXPLORATION (RSM-1638): filter the per-IP rate-limit window in
+		 * seconds for the diagnostics /events endpoint. Default is 1s — a
+		 * single batch (up to 200 events) per second per IP.
+		 *
+		 * @param int $delay Window in seconds.
+		 */
+		$delay = (int) apply_filters( 'wc_stripe_diagnostics_events_rate_limit', self::DEFAULT_EVENTS_RATE_LIMIT_SEC );
+		if ( $delay <= 0 ) {
+			return;
+		}
+		$key = self::EVENTS_RATE_LIMIT_KEY_PREFIX . substr( wp_hash( $ip ), 0, 16 );
+		WC_Rate_Limiter::set_rate_limit( $key, $delay );
 	}
 
 	/**
@@ -237,6 +313,12 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function ingest_events( $request ) {
+		// EXPLORATION (RSM-1638): arm the next-request rate-limit window for
+		// this IP as soon as we accept a request, regardless of whether the
+		// payload is valid. A malformed-events flooder still costs disk and
+		// CPU, so the window has to start before we bail on validation.
+		self::arm_rate_limit();
+
 		$session_id = WC_Stripe_Diagnostics_Trace_Store::sanitize_id( (string) $request->get_param( 'diag_session_id' ) );
 		if ( '' === $session_id ) {
 			return new WP_Error( 'wc_stripe_diagnostics_bad_session', 'Invalid diag_session_id.', [ 'status' => 400 ] );

--- a/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
+++ b/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
@@ -31,6 +31,13 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 	const EVENTS_RATE_LIMIT_KEY_PREFIX  = 'stripe_diag_events_';
 	const DEFAULT_EVENTS_RATE_LIMIT_SEC = 2;
 
+	// Per-store 429 counter surfaced in the admin summary so operators can see
+	// whether the limit is biting on this store without needing fleet Tracks
+	// data. Transient (24h TTL) — decays naturally so a single old spike doesn't
+	// linger forever.
+	const RATE_LIMITED_COUNT_TRANSIENT = 'wc_stripe_diag_rate_limited_count_24h';
+	const RATE_LIMITED_COUNT_TTL       = DAY_IN_SECONDS;
+
 	protected $namespace = 'wc/v3';
 	protected $rest_base = 'wc_stripe/diagnostics';
 
@@ -164,11 +171,23 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 		$counts = $this->store->count_by_status();
 		return new WP_REST_Response(
 			[
-				'counts' => $counts,
-				'total'  => array_sum( $counts ),
+				'counts'             => $counts,
+				'total'              => array_sum( $counts ),
+				'rate_limited_count' => self::get_rate_limited_count(),
 			],
 			200
 		);
+	}
+
+	/**
+	 * Read the rolling 24-hour 429 count. Returns 0 when no requests have been
+	 * rate-limited recently, which is the common case. Surfaced via
+	 * {@see self::get_summary()} and used by the admin UI to indicate whether
+	 * the /events rate limit has been tripping for this store.
+	 */
+	public static function get_rate_limited_count(): int {
+		$value = get_transient( self::RATE_LIMITED_COUNT_TRANSIENT );
+		return is_numeric( $value ) ? (int) $value : 0;
 	}
 
 	/**
@@ -254,6 +273,8 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 	 * abuse, not to identify the actor.
 	 */
 	private static function record_rate_limited_event(): void {
+		self::increment_rate_limited_count();
+
 		if ( ! function_exists( 'wc_admin_record_tracks_event' ) ) {
 			return;
 		}
@@ -263,6 +284,23 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 				'test_mode' => class_exists( 'WC_Stripe_Mode' ) && WC_Stripe_Mode::is_test() ? 1 : 0,
 			]
 		);
+	}
+
+	/**
+	 * Bump the 24h 429 counter that {@see self::get_summary()} surfaces.
+	 *
+	 * Transient rather than option so the count fades out 24h after the
+	 * last hit — operators see "recent abuse" rather than a lifetime
+	 * total that gives no signal about the current state of the store.
+	 *
+	 * The read-modify-write race window is acceptable: a missed increment
+	 * under contention only undercounts the surface; the gate itself is
+	 * still firing and the Tracks event still emits.
+	 */
+	private static function increment_rate_limited_count(): void {
+		$current = get_transient( self::RATE_LIMITED_COUNT_TRANSIENT );
+		$next    = ( is_numeric( $current ) ? (int) $current : 0 ) + 1;
+		set_transient( self::RATE_LIMITED_COUNT_TRANSIENT, $next, self::RATE_LIMITED_COUNT_TTL );
 	}
 
 	/**
@@ -317,10 +355,23 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 			return;
 		}
 		/**
-		 * EXPLORATION (RSM-1638): filter the per-IP rate-limit window in
-		 * seconds for the diagnostics /events endpoint. Default is 1s — a
-		 * single batch (up to 200 events) per second per IP.
+		 * Filter the per-IP rate-limit window, in seconds, for the
+		 * shopper-facing diagnostics `/events` endpoint.
 		 *
+		 * Defaults to 2s. A single accepted POST opens a window of this
+		 * length for the requester's IP; subsequent posts inside the
+		 * window return HTTP 429 and increment the admin-visible
+		 * `rate_limited_count` returned by `/diagnostics/summary`. The
+		 * frontend recorder reads the same value (in ms) via
+		 * `wcStripeDiag.rateLimitMs` and coalesces its own flushes so a
+		 * single shopper does not burn 429s on the server.
+		 *
+		 * Set to 0 (or any non-positive value) to disable the gate
+		 * entirely. Raise it for high-NAT environments where legitimate
+		 * shoppers share an egress IP and trip the limit on wallet
+		 * bursts.
+		 *
+		 * @since 10.8.0
 		 * @param int $delay Window in seconds.
 		 */
 		$delay = (int) apply_filters( 'wc_stripe_diagnostics_events_rate_limit', self::DEFAULT_EVENTS_RATE_LIMIT_SEC );

--- a/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
+++ b/includes/admin/class-wc-rest-stripe-diagnostics-controller.php
@@ -22,12 +22,13 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 	// this list being a finite set of positive integers.
 	const CAPTURE_LIMIT_PRESETS = [ 5, 10, 25, 50 ];
 
-	// EXPLORATION (RSM-1638): per-IP rate-limit window for the unauthenticated
-	// /events endpoint. A single token over N seconds — enough to bound disk
-	// I/O and FIFO-eviction cost against a basic flooder. Filterable so we
-	// can tune without a release. Default is 2s rather than 1s so wallet flows
-	// (Apple Pay / Google Pay can emit a quick burst) and shoppers behind a
-	// shared NAT egress don't 429 each other on legitimate double-taps.
+	// Per-IP rate-limit window for the unauthenticated /events endpoint.
+	// A single token over N seconds — enough to bound disk I/O and
+	// FIFO-eviction cost against a basic flooder. Filterable via
+	// `wc_stripe_diagnostics_events_rate_limit` (see {@see self::arm_rate_limit()}).
+	// The 2-second default gives wallet flows (Apple Pay / Google Pay can emit a
+	// quick burst) and shoppers behind a shared NAT egress room to land legitimate
+	// double-taps without tripping the gate.
 	const EVENTS_RATE_LIMIT_KEY_PREFIX  = 'stripe_diag_events_';
 	const DEFAULT_EVENTS_RATE_LIMIT_SEC = 2;
 
@@ -263,11 +264,11 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * EXPLORATION (RSM-1638): emit a Tracks event when the /events rate limit
-	 * trips. Parallels the `wcstripe_diagnostics_auto_off` event so operators
-	 * have visibility into whether the limit is biting in the wild — useful
-	 * for tuning the default window via the
-	 * `wc_stripe_diagnostics_events_rate_limit` filter.
+	 * Emit a Tracks event when the /events rate limit trips. Parallels the
+	 * `wcstripe_diagnostics_auto_off` event so operators have visibility
+	 * into whether the limit is biting in the wild — useful for tuning the
+	 * default window via the `wc_stripe_diagnostics_events_rate_limit`
+	 * filter.
 	 *
 	 * Deliberately omits any IP-derived field; the gate is meant to bound
 	 * abuse, not to identify the actor.
@@ -304,8 +305,7 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * EXPLORATION (RSM-1638): per-IP rate-limit gate for the unauthenticated
-	 * /events endpoint.
+	 * Per-IP rate-limit gate for the unauthenticated /events endpoint.
 	 *
 	 * The endpoint stays unauthenticated by design (guest shoppers need to
 	 * post traces), and `is_enabled()` is the only existing gate. An
@@ -389,10 +389,10 @@ class WC_REST_Stripe_Diagnostics_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function ingest_events( $request ) {
-		// EXPLORATION (RSM-1638): arm the next-request rate-limit window for
-		// this IP as soon as we accept a request, regardless of whether the
-		// payload is valid. A malformed-events flooder still costs disk and
-		// CPU, so the window has to start before we bail on validation.
+		// Arm the next-request rate-limit window for this IP as soon as we
+		// accept a request, regardless of whether the payload is valid. A
+		// malformed-events flooder still costs disk and CPU, so the window
+		// has to start before we bail on validation.
 		self::arm_rate_limit();
 
 		$session_id = WC_Stripe_Diagnostics_Trace_Store::sanitize_id( (string) $request->get_param( 'diag_session_id' ) );

--- a/includes/diagnostics/class-wc-stripe-diagnostics-frontend-loader.php
+++ b/includes/diagnostics/class-wc-stripe-diagnostics-frontend-loader.php
@@ -85,11 +85,24 @@ class WC_Stripe_Diagnostics_Frontend_Loader {
 			return $this->cached;
 		}
 
+		// Mirror the server-side `/events` rate limit so the recorder can throttle
+		// itself client-side and avoid burning 429s for traffic it could have
+		// coalesced. The recorder reads this as milliseconds; the filter is in
+		// seconds to match the server-side configuration. A non-positive value
+		// disables client-side throttling, matching the server-side filter
+		// semantics (zero seconds = no gate).
+		$rate_limit_seconds = (int) apply_filters(
+			'wc_stripe_diagnostics_events_rate_limit',
+			WC_REST_Stripe_Diagnostics_Controller::DEFAULT_EVENTS_RATE_LIMIT_SEC
+		);
+		$rate_limit_ms      = max( 0, $rate_limit_seconds ) * 1000;
+
 		$config = [
-			'active'    => true,
-			'sessionId' => $this->get_or_create_session_id(),
-			'endpoint'  => rest_url( 'wc/v3/wc_stripe/diagnostics/events' ),
-			'nonce'     => wp_create_nonce( 'wp_rest' ),
+			'active'      => true,
+			'sessionId'   => $this->get_or_create_session_id(),
+			'endpoint'    => rest_url( 'wc/v3/wc_stripe/diagnostics/events' ),
+			'nonce'       => wp_create_nonce( 'wp_rest' ),
+			'rateLimitMs' => $rate_limit_ms,
 		];
 
 		$encoded = wp_json_encode( $config );

--- a/readme.txt
+++ b/readme.txt
@@ -159,6 +159,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Exclude AGENTS.md and CLAUDE.md contributor-instruction files from the built plugin zip
 * Add - Append a "what's new" changelog link to the Updated! message after manually updating the plugin from the Plugins page
 * Add - Implement diagnostic mode to help debug checkout issues
+* Dev - Rate-limit the diagnostics /events endpoint per-IP (2s default, filterable) and emit a Tracks event when the limit trips
 * Fix - Add guards against invalid values for webhook state timestamps
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/diagnostics/class-wc-rest-stripe-diagnostics-controller-test.php
+++ b/tests/phpunit/diagnostics/class-wc-rest-stripe-diagnostics-controller-test.php
@@ -116,8 +116,6 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 	 * After a request lands, a second request from the same IP within the
 	 * window must trip the new rate-limit gate with HTTP 429. Guards against
 	 * volume abuse of the unauthenticated events endpoint.
-	 *
-	 * EXPLORATION (RSM-1638).
 	 */
 	public function test_permission_rate_limited_on_second_request_within_window() {
 		$first = $this->make_request(
@@ -150,8 +148,6 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 	 * If we can't read an IP (no $_SERVER headers at all — CLI/cron-like
 	 * paths), the gate must default to allowing the request. The
 	 * diagnostics-enabled toggle is the only upstream gate in that case.
-	 *
-	 * EXPLORATION (RSM-1638).
 	 */
 	public function test_permission_not_rate_limited_when_no_client_ip() {
 		unset( $_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_X_REAL_IP'], $_SERVER['HTTP_X_FORWARDED_FOR'] );
@@ -182,8 +178,6 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 	 * Requests from a different IP must not be blocked by the previous
 	 * request's window — confirms the rate-limit key is partitioned per
 	 * client, not global.
-	 *
-	 * EXPLORATION (RSM-1638).
 	 */
 	public function test_permission_rate_limit_is_per_ip() {
 		$first = $this->make_request(
@@ -213,8 +207,6 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * A filter that returns 0 must disable the rate limit. Lets operators
 	 * opt out without a code change if the 2s/IP default proves too tight.
-	 *
-	 * EXPLORATION (RSM-1638).
 	 */
 	public function test_rate_limit_window_is_filterable_to_zero() {
 		add_filter( 'wc_stripe_diagnostics_events_rate_limit', '__return_zero' );

--- a/tests/phpunit/diagnostics/class-wc-rest-stripe-diagnostics-controller-test.php
+++ b/tests/phpunit/diagnostics/class-wc-rest-stripe-diagnostics-controller-test.php
@@ -45,6 +45,7 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 		if ( class_exists( 'WC_Cache_Helper' ) ) {
 			WC_Cache_Helper::invalidate_cache_group( 'wc_rate_limit' );
 		}
+		delete_transient( WC_REST_Stripe_Diagnostics_Controller::RATE_LIMITED_COUNT_TRANSIENT );
 	}
 
 	/**
@@ -242,6 +243,48 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 		} finally {
 			remove_filter( 'wc_stripe_diagnostics_events_rate_limit', '__return_zero' );
 		}
+	}
+
+	/**
+	 * The admin summary surface needs to tell operators whether the /events
+	 * gate is biting on this store. Every 429 must bump the rolling
+	 * 24-hour counter; the surface returns 0 when nothing has been
+	 * rate-limited recently.
+	 */
+	public function test_summary_includes_rate_limited_count_and_increments_on_429() {
+		$this->assertSame( 0, $this->controller->get_summary()->get_data()['rate_limited_count'] );
+
+		$first = $this->make_request(
+			[
+				'diag_session_id' => 'rl-count-1',
+				'events'          => [
+					[
+						'kind'              => 'consoleMessage',
+						'level'             => 'warn',
+						'message_truncated' => 'hi',
+					],
+				],
+			]
+		);
+		$this->controller->ingest_events( $first );
+
+		// Trip the gate twice in a row from the same IP.
+		$second = $this->make_request(
+			[
+				'diag_session_id' => 'rl-count-2',
+				'events'          => [],
+			]
+		);
+		$this->controller->permissions_check( $second );
+		$third = $this->make_request(
+			[
+				'diag_session_id' => 'rl-count-3',
+				'events'          => [],
+			]
+		);
+		$this->controller->permissions_check( $third );
+
+		$this->assertSame( 2, $this->controller->get_summary()->get_data()['rate_limited_count'] );
 	}
 
 	public function test_ingest_rejects_invalid_session_id() {

--- a/tests/phpunit/diagnostics/class-wc-rest-stripe-diagnostics-controller-test.php
+++ b/tests/phpunit/diagnostics/class-wc-rest-stripe-diagnostics-controller-test.php
@@ -211,7 +211,7 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 
 	/**
 	 * A filter that returns 0 must disable the rate limit. Lets operators
-	 * opt out without a code change if 1s/IP proves too tight.
+	 * opt out without a code change if the 2s/IP default proves too tight.
 	 *
 	 * EXPLORATION (RSM-1638).
 	 */

--- a/tests/phpunit/diagnostics/class-wc-rest-stripe-diagnostics-controller-test.php
+++ b/tests/phpunit/diagnostics/class-wc-rest-stripe-diagnostics-controller-test.php
@@ -25,17 +25,26 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 		$this->controller = new WC_REST_Stripe_Diagnostics_Controller( $this->store );
 		$this->set_diagnostics_enabled( true );
 		$this->clear_state();
+		$_SERVER['REMOTE_ADDR'] = '203.0.113.7';
 	}
 
 	public function tear_down() {
 		$this->clear_state();
 		$this->set_diagnostics_enabled( false );
 		$this->set_capture_limit( null );
+		unset( $_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_X_REAL_IP'], $_SERVER['HTTP_X_FORWARDED_FOR'] );
 		parent::tear_down();
 	}
 
 	private function clear_state() {
 		$this->store->delete_all();
+		global $wpdb;
+		// WC_Rate_Limiter is transient/DB-backed; reset between tests so
+		// rate-limit assertions don't carry state across cases.
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_rate_limits" );
+		if ( class_exists( 'WC_Cache_Helper' ) ) {
+			WC_Cache_Helper::invalidate_cache_group( 'wc_rate_limit' );
+		}
 	}
 
 	/**
@@ -100,6 +109,139 @@ class WC_REST_Stripe_Diagnostics_Controller_Test extends WP_UnitTestCase {
 			]
 		);
 		$this->assertTrue( $this->controller->permissions_check( $request ) );
+	}
+
+	/**
+	 * After a request lands, a second request from the same IP within the
+	 * window must trip the new rate-limit gate with HTTP 429. Guards against
+	 * volume abuse of the unauthenticated events endpoint.
+	 *
+	 * EXPLORATION (RSM-1638).
+	 */
+	public function test_permission_rate_limited_on_second_request_within_window() {
+		$first = $this->make_request(
+			[
+				'diag_session_id' => 'rate-limit-burst',
+				'events'          => [
+					[
+						'kind'              => 'consoleMessage',
+						'level'             => 'warn',
+						'message_truncated' => 'hi',
+					],
+				],
+			]
+		);
+		$this->controller->ingest_events( $first );
+
+		$second = $this->make_request(
+			[
+				'diag_session_id' => 'rate-limit-burst-2',
+				'events'          => [],
+			]
+		);
+		$result = $this->controller->permissions_check( $second );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'wc_stripe_diagnostics_rate_limited', $result->get_error_code() );
+		$this->assertSame( 429, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * If we can't read an IP (no $_SERVER headers at all — CLI/cron-like
+	 * paths), the gate must default to allowing the request. The
+	 * diagnostics-enabled toggle is the only upstream gate in that case.
+	 *
+	 * EXPLORATION (RSM-1638).
+	 */
+	public function test_permission_not_rate_limited_when_no_client_ip() {
+		unset( $_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_X_REAL_IP'], $_SERVER['HTTP_X_FORWARDED_FOR'] );
+		$first = $this->make_request(
+			[
+				'diag_session_id' => 'no-ip-1',
+				'events'          => [
+					[
+						'kind'              => 'consoleMessage',
+						'level'             => 'warn',
+						'message_truncated' => 'hi',
+					],
+				],
+			]
+		);
+		$this->controller->ingest_events( $first );
+
+		$second = $this->make_request(
+			[
+				'diag_session_id' => 'no-ip-2',
+				'events'          => [],
+			]
+		);
+		$this->assertTrue( $this->controller->permissions_check( $second ) );
+	}
+
+	/**
+	 * Requests from a different IP must not be blocked by the previous
+	 * request's window — confirms the rate-limit key is partitioned per
+	 * client, not global.
+	 *
+	 * EXPLORATION (RSM-1638).
+	 */
+	public function test_permission_rate_limit_is_per_ip() {
+		$first = $this->make_request(
+			[
+				'diag_session_id' => 'ip-a',
+				'events'          => [
+					[
+						'kind'              => 'consoleMessage',
+						'level'             => 'warn',
+						'message_truncated' => 'hi',
+					],
+				],
+			]
+		);
+		$this->controller->ingest_events( $first );
+
+		$_SERVER['REMOTE_ADDR'] = '198.51.100.42';
+		$second                 = $this->make_request(
+			[
+				'diag_session_id' => 'ip-b',
+				'events'          => [],
+			]
+		);
+		$this->assertTrue( $this->controller->permissions_check( $second ) );
+	}
+
+	/**
+	 * A filter that returns 0 must disable the rate limit. Lets operators
+	 * opt out without a code change if 1s/IP proves too tight.
+	 *
+	 * EXPLORATION (RSM-1638).
+	 */
+	public function test_rate_limit_window_is_filterable_to_zero() {
+		add_filter( 'wc_stripe_diagnostics_events_rate_limit', '__return_zero' );
+		try {
+			$first = $this->make_request(
+				[
+					'diag_session_id' => 'filter-zero-1',
+					'events'          => [
+						[
+							'kind'              => 'consoleMessage',
+							'level'             => 'warn',
+							'message_truncated' => 'hi',
+						],
+					],
+				]
+			);
+			$this->controller->ingest_events( $first );
+
+			$second = $this->make_request(
+				[
+					'diag_session_id' => 'filter-zero-2',
+					'events'          => [],
+				]
+			);
+			$this->assertTrue( $this->controller->permissions_check( $second ) );
+		} finally {
+			remove_filter( 'wc_stripe_diagnostics_events_rate_limit', '__return_zero' );
+		}
 	}
 
 	public function test_ingest_rejects_invalid_session_id() {

--- a/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-frontend-loader-test.php
+++ b/tests/phpunit/diagnostics/class-wc-stripe-diagnostics-frontend-loader-test.php
@@ -95,6 +95,74 @@ class WC_Stripe_Diagnostics_Frontend_Loader_Test extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Helper to invoke the private build_inline_config() method and return
+	 * the decoded config payload so individual assertions stay terse.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function build_decoded_config(): array {
+		$method = new ReflectionMethod(
+			WC_Stripe_Diagnostics_Frontend_Loader::class,
+			'build_inline_config'
+		);
+		$method->setAccessible( true );
+		$inline = $method->invoke( $this->loader );
+		$this->assertNotNull( $inline, 'build_inline_config returned null.' );
+		$json = preg_replace( '/^window\.wcStripeDiag = (.+);$/', '$1', $inline );
+		return json_decode( $json, true );
+	}
+
+	/**
+	 * The frontend recorder coalesces flushes inside the server-side rate
+	 * window via `wcStripeDiag.rateLimitMs`. Confirm the loader passes the
+	 * default (2s, the controller's `DEFAULT_EVENTS_RATE_LIMIT_SEC` × 1000)
+	 * straight through so the JS-side throttle matches the PHP-side gate.
+	 */
+	public function test_inline_config_includes_default_rate_limit_in_ms() {
+		$this->simulate_active_wc_session();
+
+		$config = $this->build_decoded_config();
+
+		$this->assertArrayHasKey( 'rateLimitMs', $config );
+		$this->assertSame(
+			WC_REST_Stripe_Diagnostics_Controller::DEFAULT_EVENTS_RATE_LIMIT_SEC * 1000,
+			$config['rateLimitMs']
+		);
+	}
+
+	/**
+	 * Operator overrides via the same filter the controller honours should
+	 * flow through to the recorder so client- and server-side windows stay
+	 * synchronized.
+	 */
+	public function test_inline_config_rate_limit_honours_server_filter() {
+		$this->simulate_active_wc_session();
+		add_filter( 'wc_stripe_diagnostics_events_rate_limit', fn() => 5 );
+		try {
+			$config = $this->build_decoded_config();
+			$this->assertSame( 5000, $config['rateLimitMs'] );
+		} finally {
+			remove_all_filters( 'wc_stripe_diagnostics_events_rate_limit' );
+		}
+	}
+
+	/**
+	 * A filter that disables the server-side gate (returns 0) should also
+	 * disable the client-side throttle; the recorder treats `0` as "no
+	 * window" and flushes on every call.
+	 */
+	public function test_inline_config_rate_limit_is_zero_when_filter_disables_gate() {
+		$this->simulate_active_wc_session();
+		add_filter( 'wc_stripe_diagnostics_events_rate_limit', '__return_zero' );
+		try {
+			$config = $this->build_decoded_config();
+			$this->assertSame( 0, $config['rateLimitMs'] );
+		} finally {
+			remove_all_filters( 'wc_stripe_diagnostics_events_rate_limit' );
+		}
+	}
+
 	public function test_session_id_regenerates_when_stored_value_is_invalid() {
 		$this->simulate_active_wc_session();
 		WC()->session->set(


### PR DESCRIPTION
Fixes RSM-1638

## Changes proposed in this Pull Request:

Adds a per-IP rate-limit gate to the unauthenticated `POST /wc/v3/wc_stripe/diagnostics/events` endpoint so a flooder can't fill the FIFO trace store, pad existing traces to their 200-event cap, or burn disk/CPU while diagnostics mode is on. The endpoint must stay unauthenticated (guest shoppers post traces), so a rate limit was the natural mitigation.

**Server**

- New `is_rate_limited()` / `arm_rate_limit()` helpers on `WC_REST_Stripe_Diagnostics_Controller` consult `WC_Rate_Limiter` (already used by `WC_Stripe_Intent_Controller`) keyed on `wp_hash` of the client IP. The rate-limit table never holds a raw IP.
- `permissions_check()` returns `WP_Error 429 wc_stripe_diagnostics_rate_limited` when the window is active, emits a `wcstripe_diagnostics_rate_limited` Tracks event (parallels the existing `wcstripe_diagnostics_auto_off`), and bumps a 24-hour transient counter.
- `ingest_events()` arms the next-request window up-front so malformed-event flooders are also bounded.
- Window is filterable via `wc_stripe_diagnostics_events_rate_limit` (default 2 seconds). Set to 0 to disable.
- `/diagnostics/summary` now returns `rate_limited_count` (rolling 24h).

**Client**

- Frontend loader passes the same window value (in ms) into `wcStripeDiag.rateLimitMs` so the recorder mirrors the server-side gate.
- `Recorder.flush()` coalesces flushes inside the window: a burst of `record()` calls schedules a single deferred flush instead of firing N `sendBeacon` calls the server will 429. `sendBeacon` is fire-and-forget so we can't observe 429s post-hoc; preempting them is the only honest path. Pagehide flushes force past the throttle.
- `DiagnosticsMode` renders an inline notice with the 24h 429 count and the filter name when the count is non-zero — operator-facing signal that the gate is biting on this store.

**Design decisions**

| Question | Decision | Rationale |
| --- | --- | --- |
| Per-IP vs per-session | Per-IP only | Attacker controls `diag_session_id` and will rotate it, so a per-session gate buys nothing against the actual abuse case (slot eviction). The 200-event-per-trace cap already bounds within-trace cost. |
| Default window | 2s | Loose enough that wallet bursts (Apple Pay / Google Pay) and shoppers behind a shared NAT egress don't 429 each other on a legitimate double-tap. Filter still scales per-store. |
| Storage | `WC_Rate_Limiter` (`wc_rate_limits` table) | Consistent with neighbour code. Bounded by the diagnostics-on window. |
| Observability | Tracks event + admin counter | Fleet visibility + per-store signal so operators can act without leaving the page. |
| IP resolver | `WC_Geolocation::get_ip_address()` | Same primitive WC core uses elsewhere. Spoofable behind a misconfigured proxy; trade-off documented in the docblock. |

### How can this code break?

- A merchant on a high-NAT egress (corporate proxy, mobile carrier) could see legitimate shoppers 429 each other on the same window. Mitigations: the 2s default is loose, the filter lets operators widen it, and the admin notice tells them when this is happening.
- `sendBeacon` is fire-and-forget so we can't actually retry a 429 — affected events drop silently when multi-tab / shared-NAT clients trip the gate. The client-side throttle eliminates the single-tab case; multi-tab is acceptable loss given diagnostics is a short debug window.
- The Stripe API still serves traffic — only the diagnostics ingest path is gated.

### What are we doing to make sure this code doesn't break?

- 39 PHPUnit + 10 Jest tests covering: rate-limit trip, per-IP partitioning, no-IP fallback, filter-to-zero disable, Tracks counter increment, client-side throttle coalescing, deferred-flush behaviour, pagehide force, destroy cleanup, and the admin notice render.
- `npm run phpstan` and `npm run lint:php` clean.

## Testing instructions

1. Turn diagnostics mode on (**WooCommerce → Settings → Payments → Stripe → Advanced** → Checkout diagnostics).
2. From a single tab, open the cart/checkout and interact with the Stripe Elements normally — payments should still work end-to-end, with no client-visible delay.
3. From two browser windows on the same machine (same IP, different sessions), drive checkout in both within a one-second span. The second window's diagnostics requests should `429`; trace capture for that window may be incomplete.
4. Reload the **Stripe → Advanced** page. The diagnostics section should now show a notice like _"N diagnostics event requests were rate-limited in the last 24 hours…"_ referencing the `wc_stripe_diagnostics_events_rate_limit` filter.
5. Apply `add_filter( 'wc_stripe_diagnostics_events_rate_limit', '__return_zero' );` in a quick must-use plugin and confirm the gate stops firing for new requests. Remove the filter.
6. Confirm the existing `wcstripe_diagnostics_auto_off` flow is unaffected — turn diagnostics on, drive `capture_limit` traces to completion, and the toggle should still auto-off as before.

---

-   [x] Covered with tests
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

`Dev - Rate-limit the diagnostics /events endpoint per-IP (2s default, filterable) and emit a Tracks event when the limit trips` — added to `changelog.txt` and `readme.txt` under the 10.8.0 section.

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

cc @malithsen
