### PR TITLE
Migrate webhook refund handler call sites to WC_Stripe_Refund

### DIFF
--- a/includes/class-wc-stripe-refund.php
+++ b/includes/class-wc-stripe-refund.php
@@ -27,17 +27,17 @@ class WC_Stripe_Refund {
 	/**
 	 * The underlying Refund payload.
 	 *
-	 * @var stdClass
+	 * @var object
 	 */
-	private stdClass $refund;
+	private object $refund;
 
 	/**
 	 * Constructor.
 	 *
 	 * @since 10.8.0
-	 * @param stdClass $refund The Stripe refund payload (as returned by `json_decode`).
+	 * @param object $refund The Stripe refund payload (typically stdClass produced by `json_decode`).
 	 */
-	public function __construct( stdClass $refund ) {
+	public function __construct( object $refund ) {
 		$this->refund = $refund;
 	}
 
@@ -48,7 +48,7 @@ class WC_Stripe_Refund {
 	 *
 	 * @since 10.8.0
 	 */
-	public function raw(): stdClass {
+	public function raw(): object {
 		return $this->refund;
 	}
 
@@ -139,8 +139,8 @@ class WC_Stripe_Refund {
 			return null;
 		}
 
-		$currency = null !== $currency_override ? strtolower( $currency_override ) : $this->get_currency();
-		if ( null !== $currency && in_array( $currency, WC_Stripe_Helper::no_decimal_currencies(), true ) ) {
+		$currency = null !== $currency_override ? strtoupper( $currency_override ) : strtoupper( (string) $this->get_currency() );
+		if ( '' !== $currency && in_array( $currency, WC_Stripe_Currency_Code::NO_DECIMAL_CURRENCY_CODES, true ) ) {
 			return (float) $amount;
 		}
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -553,8 +553,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				if ( $this->is_partial_capture( $notification ) ) {
 					$partial_amount = $this->get_partial_amount_to_charge( $notification );
 					$order->set_total( $partial_amount );
-					$refund_object = $this->get_refund_object( $notification );
-					$this->update_fees( $order, $refund_object->balance_transaction );
+					$partial_refund         = new WC_Stripe_Refund( $this->get_refund_object( $notification ) );
+					$balance_transaction_id = $partial_refund->get_balance_transaction_id();
+					if ( null !== $balance_transaction_id ) {
+						$this->update_fees( $order, $balance_transaction_id );
+					}
 					/* translators: partial captured amount */
 					$order->add_order_note( sprintf( __( 'This charge was partially captured via Stripe Dashboard in the amount of: %s', 'woocommerce-gateway-stripe' ), $partial_amount ) );
 				} else {
@@ -738,16 +741,17 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification
 	 */
 	public function process_webhook_refund( $notification ) {
-		$refund_object = $this->get_refund_object( $notification );
-		$order         = WC_Stripe_Helper::get_order_by_refund_id( $refund_object->id );
+		$refund    = new WC_Stripe_Refund( $this->get_refund_object( $notification ) );
+		$refund_id = (string) $refund->get_id();
+		$order     = WC_Stripe_Helper::get_order_by_refund_id( $refund_id );
 
 		if ( ! $order ) {
-			WC_Stripe_Logger::debug( 'Could not find order via refund ID: ' . $refund_object->id );
+			WC_Stripe_Logger::debug( 'Could not find order via refund ID: ' . $refund_id );
 			$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->id );
 		}
 
 		if ( ! $order ) {
-			WC_Stripe_Logger::warning( "Could not find order via refund ID ({$refund_object->id}) or charge ID ({$notification->data->object->id})" );
+			WC_Stripe_Logger::warning( "Could not find order via refund ID ({$refund_id}) or charge ID ({$notification->data->object->id})" );
 			return;
 		}
 
@@ -759,17 +763,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$order_helper = WC_Stripe_Order_Helper::get_instance();
 
 		if ( $order_helper->is_stripe_gateway_order( $order ) ) {
-			$charge     = $order->get_transaction_id();
-			$captured   = $order_helper->is_stripe_charge_captured( $order );
-			$refund_id  = $order_helper->get_stripe_refund_id( $order );
-			$currency   = $order->get_currency();
-			$raw_amount = $refund_object->amount;
-
-			if ( ! in_array( strtoupper( $currency ), WC_Stripe_Currency_Code::NO_DECIMAL_CURRENCY_CODES, true ) ) {
-				$raw_amount /= 100;
-			}
-
-			$amount = wc_price( $raw_amount, [ 'currency' => $currency ] );
+			$charge          = $order->get_transaction_id();
+			$captured        = $order_helper->is_stripe_charge_captured( $order );
+			$saved_refund_id = $order_helper->get_stripe_refund_id( $order );
+			$currency        = $order->get_currency();
+			$amount          = wc_price( (float) $refund->get_amount_decimal( $currency ), [ 'currency' => $currency ] );
 
 			// If charge wasn't captured, skip creating a refund.
 			if ( ! $captured ) {
@@ -789,7 +787,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			}
 
 			// If the refund ID matches, don't continue to prevent double refunding.
-			if ( $refund_object->id === $refund_id ) {
+			if ( $refund_id === $saved_refund_id ) {
 				return;
 			}
 
@@ -799,7 +797,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				$this->set_stripe_order_status_before_refund( $order, $order->get_status() );
 
 				// Create the refund.
-				$refund = wc_create_refund(
+				$wc_refund = wc_create_refund(
 					[
 						'order_id' => $order_id,
 						'amount'   => $this->get_refund_amount( $notification ),
@@ -807,20 +805,21 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					]
 				);
 
-				if ( is_wp_error( $refund ) ) {
-					WC_Stripe_Logger::error( 'Error creating refund for order: ' . $order_id, [ 'error_message' => $refund->get_error_message() ] );
+				if ( is_wp_error( $wc_refund ) ) {
+					WC_Stripe_Logger::error( 'Error creating refund for order: ' . $order_id, [ 'error_message' => $wc_refund->get_error_message() ] );
 				}
 
-				$order_helper->update_stripe_refund_id( $order, $refund_object->id );
+				$order_helper->update_stripe_refund_id( $order, $refund_id );
 
-				if ( isset( $refund_object->balance_transaction ) ) {
-					$this->update_fees( $order, $refund_object->balance_transaction );
+				$balance_transaction_id = $refund->get_balance_transaction_id();
+				if ( null !== $balance_transaction_id ) {
+					$this->update_fees( $order, $balance_transaction_id );
 				}
 
 				$order_helper->unlock_order_refund( $order );
 
 				/* translators: 1) amount (including currency symbol) 2) transaction id 3) refund message */
-				$order->add_order_note( sprintf( __( 'Refunded %1$s - Refund ID: %2$s - %3$s', 'woocommerce-gateway-stripe' ), $amount, $refund_object->id, $reason ) );
+				$order->add_order_note( sprintf( __( 'Refunded %1$s - Refund ID: %2$s - %3$s', 'woocommerce-gateway-stripe' ), $amount, $refund_id, $reason ) );
 			}
 		}
 	}
@@ -831,11 +830,12 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification
 	 */
 	public function process_webhook_refund_updated( $notification ) {
-		$refund_object = $notification->data->object;
-		$order         = WC_Stripe_Helper::get_order_by_charge_id( $refund_object->charge );
+		$refund    = new WC_Stripe_Refund( $notification->data->object );
+		$charge_id = (string) $refund->get_charge_id();
+		$order     = WC_Stripe_Helper::get_order_by_charge_id( $charge_id );
 
 		if ( ! $order ) {
-			WC_Stripe_Logger::warning( 'Could not find order to update refund via charge ID: ' . $refund_object->charge );
+			WC_Stripe_Logger::warning( 'Could not find order to update refund via charge ID: ' . $charge_id );
 			return;
 		}
 
@@ -845,19 +845,14 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$order_id     = $order->get_id();
 		$order_helper = WC_Stripe_Order_Helper::get_instance();
 		if ( $order_helper->is_stripe_gateway_order( $order ) ) {
-			$charge     = $order->get_transaction_id();
-			$refund_id  = $order_helper->get_stripe_refund_id( $order );
-			$currency   = $order->get_currency();
-			$raw_amount = $refund_object->amount;
-
-			if ( ! in_array( strtoupper( $currency ), WC_Stripe_Currency_Code::NO_DECIMAL_CURRENCY_CODES, true ) ) {
-				$raw_amount /= 100;
-			}
-
-			$amount = wc_price( $raw_amount, [ 'currency' => $currency ] );
+			$charge          = $order->get_transaction_id();
+			$saved_refund_id = $order_helper->get_stripe_refund_id( $order );
+			$refund_id       = (string) $refund->get_id();
+			$currency        = $order->get_currency();
+			$amount          = wc_price( (float) $refund->get_amount_decimal( $currency ), [ 'currency' => $currency ] );
 
 			// If the refund IDs do not match stop.
-			if ( $refund_object->id !== $refund_id ) {
+			if ( $refund_id !== $saved_refund_id ) {
 				return;
 			}
 
@@ -874,29 +869,34 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					return;
 				}
 
-				$refund = $refunds[0];
+				$wc_refund = $refunds[0];
 
-				if ( in_array( $refund_object->status, [ 'failed', 'canceled' ], true ) ) {
-					if ( isset( $refund_object->failure_balance_transaction ) ) {
-						$this->update_fees( $order, $refund_object->failure_balance_transaction );
+				if ( $refund->is_failed_or_canceled() ) {
+					$failure_balance_transaction_id = $refund->get_failure_balance_transaction_id();
+					if ( null !== $failure_balance_transaction_id ) {
+						$this->update_fees( $order, $failure_balance_transaction_id );
 					}
-					$refund->delete( true );
+					$wc_refund->delete( true );
 					do_action( 'woocommerce_refund_deleted', $refund_id, $order_id );
 
-					$order_helper->update_stripe_refund_status( $order, $refund_object->status );
+					$order_helper->update_stripe_refund_status( $order, (string) $refund->get_status() );
 
-					$friendly_failure_reason = WC_Stripe_Helper::get_refund_reason_description( $refund_object->failure_reason );
-					if ( 'failed' === $refund_object->status ) {
+					// Match the legacy call site's "Unknown reason" fallback when `failure_reason`
+					// is absent: `get_friendly_failure_reason()` returns null in that case, but
+					// the helper's default branch produces the localised string we want in the note.
+					$friendly_failure_reason = WC_Stripe_Helper::get_refund_reason_description( $refund->get_failure_reason() );
+					if ( $refund->is_failed() ) {
 						/* translators: 1) amount (including currency symbol) 2) transaction id 3) refund failure code */
-						$note = sprintf( __( 'Refund failed for %1$s - Refund ID: %2$s - Reason: %3$s', 'woocommerce-gateway-stripe' ), $amount, $refund_object->id, $friendly_failure_reason );
+						$note = sprintf( __( 'Refund failed for %1$s - Refund ID: %2$s - Reason: %3$s', 'woocommerce-gateway-stripe' ), $amount, $refund_id, $friendly_failure_reason );
 					} else {
 						/* translators: 1) amount (including currency symbol) 2) transaction id 3) refund failure code */
-						$note = sprintf( __( 'Refund canceled for %1$s - Refund ID: %2$s - Reason: %3$s', 'woocommerce-gateway-stripe' ), $amount, $refund_object->id, $friendly_failure_reason );
+						$note = sprintf( __( 'Refund canceled for %1$s - Refund ID: %2$s - Reason: %3$s', 'woocommerce-gateway-stripe' ), $amount, $refund_id, $friendly_failure_reason );
 					}
 
 					// Store the raw failure reason
-					if ( isset( $refund_object->failure_reason ) ) {
-						$order_helper->update_stripe_refund_failure_reason( $order, $refund_object->failure_reason );
+					$failure_reason = $refund->get_failure_reason();
+					if ( null !== $failure_reason ) {
+						$order_helper->update_stripe_refund_failure_reason( $order, $failure_reason );
 					} else {
 						$order_helper->delete_stripe_refund_failure_reason( $order );
 					}
@@ -1054,14 +1054,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public function get_refund_amount( $notification ) {
 		if ( $this->is_partial_capture( $notification ) ) {
-			$refund_object = $this->get_refund_object( $notification );
-			$amount        = $refund_object->amount / 100;
-
-			if ( in_array( strtoupper( $notification->data->object->currency ), WC_Stripe_Currency_Code::NO_DECIMAL_CURRENCY_CODES, true ) ) {
-				$amount = $refund_object->amount;
-			}
-
-			return $amount;
+			$refund = new WC_Stripe_Refund( $this->get_refund_object( $notification ) );
+			return $refund->get_amount_decimal( $notification->data->object->currency );
 		}
 
 		return false;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3019,18 +3019,6 @@ parameters:
 			path: includes/class-wc-stripe-webhook-handler.php
 
 		-
-			message: '#^Access to an undefined property object\:\:\$amount\.$#'
-			identifier: property.notFound
-			count: 3
-			path: includes/class-wc-stripe-webhook-handler.php
-
-		-
-			message: '#^Access to an undefined property object\:\:\$balance_transaction\.$#'
-			identifier: property.notFound
-			count: 1
-			path: includes/class-wc-stripe-webhook-handler.php
-
-		-
 			message: '#^Access to an undefined property object\:\:\$data\.$#'
 			identifier: property.notFound
 			count: 45
@@ -3039,7 +3027,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property object\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 8
+			count: 2
 			path: includes/class-wc-stripe-webhook-handler.php
 
 		-


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Follow-up to #5298. Wires the new `WC_Stripe_Refund` domain wrapper into the four hand-rolled refund-handling sites in `WC_Stripe_Webhook_Handler` so the wrapper actually carries the weight it was written for.

- **`process_webhook_refund()`** — wraps the refund object once, replaces direct property reads with the wrapper's typed getters (`get_id()`, `get_balance_transaction_id()`), and uses `get_amount_decimal( $order->get_currency() )` so the decimal-currency branch lives in one place.
- **`process_webhook_refund_updated()`** — same pattern, plus `is_failed_or_canceled()` / `is_failed()` in place of inlined `in_array( $status, ['failed', 'canceled'], true )` predicates. The legacy `WC_Stripe_Helper::get_refund_reason_description()` call is retained at this site (rather than using the wrapper's `get_friendly_failure_reason()`) because the wrapper returns null when `failure_reason` is absent, while the helper falls through to its default branch — preserving the "Unknown reason" fallback that the existing order note relies on.
- **`get_refund_amount()`** — collapses the hand-rolled decimal-currency check to a single `get_amount_decimal( $notification->data->object->currency )` call.
- **Partial-capture path in `charge.succeeded`** — `$refund_object->balance_transaction` now goes through `get_balance_transaction_id()` with a null guard.

**Drive-by fix:** `WC_Stripe_Refund::get_amount_decimal()` was calling `WC_Stripe_Helper::no_decimal_currencies()`, which `develop` deprecated in 10.7.0 in favour of `WC_Stripe_Currency_Code::NO_DECIMAL_CURRENCY_CODES`. #5298 has no production call sites yet, so the deprecation never fired — this PR adds the call sites, which would surface the deprecation warning under `WP_DEBUG`. Switched the comparison to the non-deprecated constant (uppercase) and uppercased the currency before checking. The wrapper's unit tests still pass without changes because they pass lowercase currencies and the constructor's `strtolower()` / `strtoupper()` normalisation handles both shapes.

**PHPStan baseline.** Three suppressions drop because the property reads are now mediated by the typed wrapper:

- `object::$amount` (count 3 → 0)
- `object::$balance_transaction` (count 1 → 0)
- `object::$id` (count 8 → 2; remaining 2 are non-refund sites)

## Testing instructions

This is a behaviour-preserving refactor. Reviewer verification is the test suite:

- `npm run test:php -- --filter=WC_Stripe_Webhook_Handler_Test::test_process_webhook_refund_updated` — the existing data-provider parameterised case (invalid_status / failed / canceled) continues to exercise the migrated function end-to-end.
- `npm run test:php -- --filter=WC_Stripe_Refund_Test` — the wrapper's 33 PHPUnit cases still pass.
- `npm run phpstan` — no new errors at level 8; baseline shrinks.
- `npm run lint:php` on the modified files — clean.

End-to-end refund regression (Stripe Dashboard refund → `charge.refunded` webhook → order note; `refund.updated` with failed status → email + status revert) was not re-run locally — the test matrix is doing the lift.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Internal refactor of the webhook refund paths with no user-visible behaviour change. Lands in the same unreleased 10.8.0 cycle as its parent #5298, which already covers the new class.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)