### PR TITLE
Add tools to support autoload rollout

### DIFF
--- a/bin/build-class-dependency-map.php
+++ b/bin/build-class-dependency-map.php
@@ -1,0 +1,636 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+/**
+ * AST-based class dependency map for includes/.
+ *
+ * Walks every PHP file under --path (default: includes/) and emits a map of
+ * each internal class/interface/trait's dependencies on other internal
+ * classes. Internal-only by design — external symbols (WP/WC/SPL/
+ * Automattic\WooCommerce\*) are filtered out.
+ *
+ * Two edge buckets:
+ *   - strict: explicit declared relationships (extends, implements, use trait,
+ *     and native param/return/property type declarations).
+ *   - loose: named runtime references (new X, X::y, instanceof X, catch X,
+ *     and docblock types in @var/@param/@return/@throws/@property).
+ */
+
+declare( strict_types=1 );
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\ParserFactory;
+
+// ---------------------------------------------------------------------------
+// CLI parsing
+// ---------------------------------------------------------------------------
+
+$cli_options = getopt( '', [ 'path::', 'format::', 'output::', 'include-external', 'exclude-autoloaded', 'help' ] );
+
+if ( isset( $cli_options['help'] ) ) {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+	fwrite(
+		STDERR,
+		"Usage: php bin/build-class-dependency-map.php [--path=<dir>] [--format=json|mermaid] [--output=<file>] [--exclude-autoloaded]\n"
+		. "  --path=<dir>           Directory to scan (default: includes)\n"
+		. "  --format=json|mermaid  Output format (default: json)\n"
+		. "  --output=<file>        Write to file instead of stdout\n"
+		. "  --exclude-autoloaded   Drop classes covered by composer.json's autoload.classmap,\n"
+		. "                         and strip references to them from remaining classes' edges.\n"
+	);
+	exit( 0 );
+}
+
+$directory          = $cli_options['path'] ?? 'includes';
+$format             = $cli_options['format'] ?? 'json';
+$output             = $cli_options['output'] ?? null;
+$exclude_autoloaded = isset( $cli_options['exclude-autoloaded'] );
+
+if ( ! in_array( $format, [ 'json', 'mermaid' ], true ) ) {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+	fwrite( STDERR, "Unknown --format: {$format} (expected json or mermaid)\n" );
+	exit( 2 );
+}
+
+$root = realpath( $directory );
+if ( false === $root || ! is_dir( $root ) ) {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+	fwrite( STDERR, "Not a directory: {$directory}\n" );
+	exit( 2 );
+}
+
+// ---------------------------------------------------------------------------
+// File discovery
+// ---------------------------------------------------------------------------
+
+$files    = [];
+$iterator = new RecursiveIteratorIterator(
+	new RecursiveDirectoryIterator( $root, RecursiveDirectoryIterator::SKIP_DOTS )
+);
+foreach ( $iterator as $file ) {
+	if ( $file->isFile() && $file->getExtension() === 'php' ) {
+		$files[] = $file->getPathname();
+	}
+}
+sort( $files );
+
+// ---------------------------------------------------------------------------
+// Composer autoload membership.
+//
+// We resolve classes against composer.json's `autoload.classmap` directly
+// rather than vendor/composer/autoload_classmap.php so the result is
+// deterministic (production-only, no autoload-dev) and works without a
+// `composer install`.
+// ---------------------------------------------------------------------------
+
+$project_root   = realpath( __DIR__ . '/..' );
+$composer_path  = $project_root . '/composer.json';
+$autoload_dirs  = [];
+$autoload_files = [];
+
+if ( is_file( $composer_path ) ) {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	$composer_json = json_decode( file_get_contents( $composer_path ), true );
+	$entries       = $composer_json['autoload']['classmap'] ?? [];
+	foreach ( $entries as $entry ) {
+		$abs = realpath( $project_root . '/' . $entry );
+		if ( false === $abs ) {
+			continue;
+		}
+		if ( is_dir( $abs ) ) {
+			$autoload_dirs[] = $abs;
+		} else {
+			$autoload_files[ $abs ] = true;
+		}
+	}
+} else {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+	fwrite( STDERR, "Warning: composer.json not found at {$composer_path}; autoload status will be false for all classes.\n" );
+}
+
+$is_autoloaded_file = static function ( string $file ) use ( $autoload_dirs, $autoload_files ): bool {
+	if ( isset( $autoload_files[ $file ] ) ) {
+		return true;
+	}
+	foreach ( $autoload_dirs as $dir ) {
+		if ( strpos( $file, $dir . DIRECTORY_SEPARATOR ) === 0 ) {
+			return true;
+		}
+	}
+	return false;
+};
+
+// ---------------------------------------------------------------------------
+// Parser + helpers
+// ---------------------------------------------------------------------------
+
+$parser = ( new ParserFactory() )->createForNewestSupportedVersion();
+
+$builtin_types = array_flip(
+	[
+		'int',
+		'integer',
+		'string',
+		'bool',
+		'boolean',
+		'float',
+		'double',
+		'array',
+		'iterable',
+		'callable',
+		'void',
+		'mixed',
+		'never',
+		'object',
+		'resource',
+		'self',
+		'static',
+		'parent',
+		'null',
+		'false',
+		'true',
+		'numeric',
+		'scalar',
+	]
+);
+
+$is_builtin = static function ( string $name ) use ( $builtin_types ): bool {
+	return isset( $builtin_types[ strtolower( ltrim( $name, '\\' ) ) ] );
+};
+
+// ---------------------------------------------------------------------------
+// Pass 1: index every class/interface/trait declared under $root.
+// ---------------------------------------------------------------------------
+
+class ClassIndexVisitor extends NodeVisitorAbstract {
+	public array $names = [];
+
+	public function enterNode( Node $node ) {
+		if ( $node instanceof Node\Stmt\Class_
+			|| $node instanceof Node\Stmt\Interface_
+			|| $node instanceof Node\Stmt\Trait_
+		) {
+			$name = $this->resolve( $node );
+			if ( null !== $name ) {
+				$this->names[ $name ] = true;
+			}
+		}
+	}
+
+	private function resolve( Node $node ): ?string {
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		if ( isset( $node->namespacedName ) && null !== $node->namespacedName ) {
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			return $node->namespacedName->toString();
+		}
+		if ( null !== $node->name ) {
+			return $node->name->toString();
+		}
+		return null;
+	}
+}
+
+$index      = [];
+$autoloaded = [];
+foreach ( $files as $file ) {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	$code = file_get_contents( $file );
+	if ( false === $code ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+		fwrite( STDERR, "Could not read {$file}\n" );
+		continue;
+	}
+	try {
+		$stmts = $parser->parse( $code );
+	} catch ( \Throwable $e ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+		fwrite( STDERR, "Parse error in {$file}: " . $e->getMessage() . "\n" );
+		continue;
+	}
+	if ( null === $stmts ) {
+		continue;
+	}
+	$traverser = new NodeTraverser();
+	$traverser->addVisitor( new NameResolver() );
+	$visitor = new ClassIndexVisitor();
+	$traverser->addVisitor( $visitor );
+	$traverser->traverse( $stmts );
+	$file_is_autoloaded = $is_autoloaded_file( $file );
+	foreach ( $visitor->names as $name => $_ ) {
+		$index[ $name ]      = true;
+		$autoloaded[ $name ] = $file_is_autoloaded;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pass 2: collect edges per class.
+// ---------------------------------------------------------------------------
+
+// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
+class EdgeVisitor extends NodeVisitorAbstract {
+	/**
+	 * Edges between classes.
+	 *
+	 * @var array<string, array>
+	 */
+	public array $edges = [];
+
+	/**
+	 * Stack of class names.
+	 *
+	 * @var list<string>
+	 */
+	private array $stack = [];
+
+	/**
+	 * Callback to determine if a type is a built-in type.
+	 *
+	 * @var callable
+	 */
+	private $is_builtin;
+
+	/**
+	 * EdgeVisitor constructor.
+	 *
+	 * @param callable $is_builtin Callback to determine if a type is a built-in type.
+	 * @return void
+	 */
+	public function __construct( callable $is_builtin ) {
+		$this->is_builtin = $is_builtin;
+	}
+
+	public function enterNode( Node $node ) {
+		if ( $this->is_class_like( $node ) ) {
+			$owner = $this->resolve_name( $node );
+			if ( null === $owner ) {
+				return;
+			}
+			$this->stack[] = $owner;
+			$this->ensure( $owner );
+
+			if ( $node instanceof Node\Stmt\Class_ ) {
+				if ( null !== $node->extends ) {
+					$this->add_strict( 'extends', $this->fq( $node->extends ), true );
+				}
+				foreach ( $node->implements as $impl ) {
+					$this->add_strict( 'implements', $this->fq( $impl ) );
+				}
+			} elseif ( $node instanceof Node\Stmt\Interface_ ) {
+				foreach ( $node->extends as $impl ) {
+					$this->add_strict( 'implements', $this->fq( $impl ) );
+				}
+			}
+
+			$this->collect_docblock( $node->getDocComment() );
+			return;
+		}
+
+		if ( empty( $this->stack ) ) {
+			return;
+		}
+
+		if ( $node instanceof Node\Stmt\TraitUse ) {
+			foreach ( $node->traits as $t ) {
+				$this->add_strict( 'uses_traits', $this->fq( $t ) );
+			}
+			return;
+		}
+
+		if ( $node instanceof Node\Param ) {
+			foreach ( $this->unwrap_type( $node->type ) as $name ) {
+				$this->add_strict( 'param_types', $name );
+			}
+			return;
+		}
+
+		if ( $node instanceof Node\Stmt\ClassMethod || $node instanceof Node\Stmt\Function_ ) {
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			foreach ( $this->unwrap_type( $node->returnType ) as $name ) {
+				$this->add_strict( 'return_types', $name );
+			}
+			$this->collect_docblock( $node->getDocComment() );
+			return;
+		}
+
+		if ( $node instanceof Node\Stmt\Property ) {
+			foreach ( $this->unwrap_type( $node->type ) as $name ) {
+				$this->add_strict( 'property_types', $name );
+			}
+			$this->collect_docblock( $node->getDocComment() );
+			return;
+		}
+
+		if ( $node instanceof Node\Expr\New_
+			|| $node instanceof Node\Expr\StaticCall
+			|| $node instanceof Node\Expr\StaticPropertyFetch
+			|| $node instanceof Node\Expr\ClassConstFetch
+			|| $node instanceof Node\Expr\Instanceof_
+		) {
+			if ( $node->class instanceof Node\Name ) {
+				$this->add_loose( $this->fq( $node->class ) );
+			}
+			return;
+		}
+
+		if ( $node instanceof Node\Stmt\Catch_ ) {
+			foreach ( $node->types as $t ) {
+				$this->add_loose( $this->fq( $t ) );
+			}
+		}
+	}
+
+	public function leaveNode( Node $node ) {
+		if ( $this->is_class_like( $node ) && ! empty( $this->stack ) ) {
+			array_pop( $this->stack );
+		}
+	}
+
+	private function is_class_like( Node $node ): bool {
+		return ( $node instanceof Node\Stmt\Class_
+				|| $node instanceof Node\Stmt\Interface_
+				|| $node instanceof Node\Stmt\Trait_ )
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			&& ( ( isset( $node->namespacedName ) && null !== $node->namespacedName )
+				|| null !== $node->name );
+	}
+
+	private function resolve_name( Node $node ): ?string {
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		if ( isset( $node->namespacedName ) && null !== $node->namespacedName ) {
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			return $node->namespacedName->toString();
+		}
+		if ( null !== $node->name ) {
+			return $node->name->toString();
+		}
+		return null;
+	}
+
+	private function ensure( string $owner ): void {
+		if ( ! isset( $this->edges[ $owner ] ) ) {
+			$this->edges[ $owner ] = [
+				'strict' => [
+					'extends'        => null,
+					'implements'     => [],
+					'uses_traits'    => [],
+					'param_types'    => [],
+					'return_types'   => [],
+					'property_types' => [],
+				],
+				'loose'  => [],
+			];
+		}
+	}
+
+	private function add_strict( string $field, ?string $target, bool $single = false ): void {
+		$owner = $this->guarded_target( $target );
+		if ( null === $owner ) {
+			return;
+		}
+		if ( $single ) {
+			$this->edges[ $owner ]['strict'][ $field ] = $target;
+		} else {
+			$this->edges[ $owner ]['strict'][ $field ][] = $target;
+		}
+	}
+
+	private function add_loose( ?string $target ): void {
+		$owner = $this->guarded_target( $target );
+		if ( null === $owner ) {
+			return;
+		}
+		$this->edges[ $owner ]['loose'][] = $target;
+	}
+
+	/**
+	 * Returns the current owner if the target is acceptable (non-empty,
+	 * non-builtin, non-self), else null. Used to short-circuit both add_*
+	 * paths with one check.
+	 */
+	private function guarded_target( ?string $target ): ?string {
+		if ( null === $target || '' === $target ) {
+			return null;
+		}
+		if ( ( $this->is_builtin )( $target ) ) {
+			return null;
+		}
+		$owner = end( $this->stack );
+		if ( false === $owner || $owner === $target ) {
+			return null;
+		}
+		return $owner;
+	}
+
+	private function fq( Node\Name $name ): string {
+		$resolved = $name->getAttribute( 'resolvedName' );
+		if ( $resolved instanceof Node\Name ) {
+			return $resolved->toString();
+		}
+		return $name->toString();
+	}
+
+	/**
+	 * Unwrap a type annotation (param/return/property) into the underlying
+	 * class-name strings. Strips NullableType / UnionType / IntersectionType.
+	 *
+	 * @return string[]
+	 */
+	private function unwrap_type( $type ): array {
+		if ( null === $type ) {
+			return [];
+		}
+		if ( $type instanceof Node\NullableType ) {
+			return $this->unwrap_type( $type->type );
+		}
+		if ( $type instanceof Node\UnionType || $type instanceof Node\IntersectionType ) {
+			$out = [];
+			foreach ( $type->types as $sub ) {
+				foreach ( $this->unwrap_type( $sub ) as $name ) {
+					$out[] = $name;
+				}
+			}
+			return $out;
+		}
+		if ( $type instanceof Node\Identifier ) {
+			return [ $type->name ];
+		}
+		if ( $type instanceof Node\Name ) {
+			return [ $this->fq( $type ) ];
+		}
+		return [];
+	}
+
+	private function collect_docblock( $doc ): void {
+		if ( null === $doc ) {
+			return;
+		}
+		if ( ! preg_match_all(
+			'/@(?:var|param|return|throws|property|property-read|property-write)\s+([^\s\*\/][^\*\/\r\n]*)/',
+			$doc->getText(),
+			$matches
+		) ) {
+			return;
+		}
+		foreach ( $matches[1] as $type_expr ) {
+			// Stop at the first variable name or description boundary.
+			$type_expr = preg_split( '/\s+\$|\s+--?\s/', $type_expr, 2 )[0] ?? '';
+			$tokens    = preg_split( '/[\s\|\&<>,\(\)\?\[\]]+/', $type_expr );
+			if ( ! is_array( $tokens ) ) {
+				continue;
+			}
+			foreach ( $tokens as $tok ) {
+				$tok = ltrim( $tok, '\\' );
+				if ( '' === $tok ) {
+					continue;
+				}
+				if ( ! preg_match( '/^[A-Za-z_][A-Za-z0-9_\\\\]*$/', $tok ) ) {
+					continue;
+				}
+				$this->add_loose( $tok );
+			}
+		}
+	}
+}
+
+$edge_visitor = new EdgeVisitor( $is_builtin );
+
+foreach ( $files as $file ) {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	$code = file_get_contents( $file );
+	if ( false === $code ) {
+		continue;
+	}
+	try {
+		$stmts = $parser->parse( $code );
+	} catch ( \Throwable $e ) {
+		continue;
+	}
+	if ( null === $stmts ) {
+		continue;
+	}
+	$traverser = new NodeTraverser();
+	$traverser->addVisitor( new NameResolver() );
+	$traverser->addVisitor( $edge_visitor );
+	$traverser->traverse( $stmts );
+}
+
+// ---------------------------------------------------------------------------
+// Filter (internal-only) + dedupe + sort.
+// ---------------------------------------------------------------------------
+
+$keep = static function ( string $target ) use ( $index, $autoloaded, $exclude_autoloaded ): bool {
+	if ( ! isset( $index[ $target ] ) ) {
+		return false;
+	}
+	if ( $exclude_autoloaded && ! empty( $autoloaded[ $target ] ) ) {
+		return false;
+	}
+	return true;
+};
+
+$result = [];
+foreach ( $edge_visitor->edges as $owner => $data ) {
+	if ( ! isset( $index[ $owner ] ) ) {
+		continue;
+	}
+	if ( $exclude_autoloaded && ! empty( $autoloaded[ $owner ] ) ) {
+		continue;
+	}
+	$strict = $data['strict'];
+
+	if ( null !== $strict['extends'] && ! $keep( $strict['extends'] ) ) {
+		$strict['extends'] = null;
+	}
+	foreach ( [ 'implements', 'uses_traits', 'param_types', 'return_types', 'property_types' ] as $field ) {
+		$strict[ $field ] = array_values( array_unique( array_filter( $strict[ $field ], $keep ) ) );
+		sort( $strict[ $field ] );
+	}
+	$loose = array_values( array_unique( array_filter( $data['loose'], $keep ) ) );
+	sort( $loose );
+
+	$result[ $owner ] = [
+		'autoloaded' => ! empty( $autoloaded[ $owner ] ),
+		'strict'     => $strict,
+		'loose'      => $loose,
+	];
+}
+
+ksort( $result );
+
+// ---------------------------------------------------------------------------
+// Emit
+// ---------------------------------------------------------------------------
+
+if ( 'json' === $format ) {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+	$payload = json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n";
+} else {
+	$payload = render_mermaid( $result );
+}
+
+if ( null !== $output ) {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+	$bytes = file_put_contents( $output, $payload );
+	if ( false === $bytes ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+		fwrite( STDERR, "Failed to write {$output}\n" );
+		exit( 1 );
+	}
+} else {
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo $payload;
+}
+
+/**
+ * Render the dependency map as a Mermaid `classDiagram`.
+ *
+ * @param array $result
+ */
+function render_mermaid( array $result ): string { // phpcs:ignore Universal.Files.SeparateFunctionsFromOO.Mixed
+	$sanitize = static function ( string $name ): string {
+		return str_replace( '\\', '__', $name );
+	};
+
+	$lines = [ 'classDiagram' ];
+	foreach ( $result as $owner => $data ) {
+		$own     = $sanitize( $owner );
+		$lines[] = "    class {$own}";
+		if ( ! empty( $data['autoloaded'] ) ) {
+			$lines[] = "    <<autoloaded>> {$own}";
+		}
+		$strict = $data['strict'];
+
+		if ( null !== $strict['extends'] ) {
+			$lines[] = "    {$sanitize( $strict['extends'] )} <|-- {$own}";
+		}
+		foreach ( $strict['implements'] as $t ) {
+			$lines[] = "    {$sanitize( $t )} <|.. {$own}";
+		}
+		foreach ( $strict['uses_traits'] as $t ) {
+			$lines[] = "    {$own} --* {$sanitize( $t )} : uses";
+		}
+
+		$declared = array_values(
+			array_unique(
+				array_merge(
+					$strict['param_types'],
+					$strict['return_types'],
+					$strict['property_types']
+				)
+			)
+		);
+		sort( $declared );
+		foreach ( $declared as $t ) {
+			$lines[] = "    {$own} --> {$sanitize( $t )}";
+		}
+
+		foreach ( $data['loose'] as $t ) {
+			$lines[] = "    {$own} ..> {$sanitize( $t )}";
+		}
+	}
+	return implode( "\n", $lines ) . "\n";
+}

--- a/bin/build-class-dependency-map.php
+++ b/bin/build-class-dependency-map.php
@@ -8,11 +8,11 @@
  * classes. Internal-only by design — external symbols (WP/WC/SPL/
  * Automattic\WooCommerce\*) are filtered out.
  *
- * Two edge buckets:
- *   - strict: explicit declared relationships (extends, implements, use trait,
- *     and native param/return/property type declarations).
- *   - loose: named runtime references (new X, X::y, instanceof X, catch X,
- *     and docblock types in @var/@param/@return/@throws/@property).
+ * Three edge buckets:
+ *   - compile_time: compile-time dependencies (including extends, implements, trait usage,
+ *     and explicit param/return/property type declarations).
+ *   - runtime: runtime references within method implementations (including new X, X::y, instanceof X, catch X).
+ *   - doc_only: docblock types in @var/@param/@return/@throws/@property.
  */
 
 declare( strict_types=1 );
@@ -734,31 +734,9 @@ function render_mermaid( array $result ): string { // phpcs:ignore Universal.Fil
 		if ( ! empty( $data['autoloaded'] ) ) {
 			$lines[] = "    <<autoloaded>> {$own}";
 		}
-		$compile_time = $data['compile_time'];
 
-		if ( null !== $compile_time['extends'] ) {
-			$lines[] = "    {$sanitize( $compile_time['extends'] )} <|-- {$own}";
-		}
-		foreach ( $compile_time['implements'] as $t ) {
-			$lines[] = "    {$sanitize( $t )} <|.. {$own}";
-		}
-		foreach ( $compile_time['uses_traits'] as $t ) {
-			$lines[] = "    {$own} --* {$sanitize( $t )} : uses";
-		}
-
-		$declared = array_values(
-			array_unique(
-				array_merge(
-					$compile_time['param_types'],
-					$compile_time['return_types'],
-					$compile_time['property_types'],
-					$compile_time['const_refs']
-				)
-			)
-		);
-		sort( $declared );
-		foreach ( $declared as $t ) {
-			$lines[] = "    {$own} --> {$sanitize( $t )}";
+		foreach ( $data['compile_time'] as $t ) {
+			$lines[] = "    {$sanitize( $t )} --> {$own}";
 		}
 
 		foreach ( $data['runtime'] as $t ) {

--- a/bin/build-class-dependency-map.php
+++ b/bin/build-class-dependency-map.php
@@ -29,7 +29,7 @@ use PhpParser\ParserFactory;
 // CLI parsing
 // ---------------------------------------------------------------------------
 
-$cli_options = getopt( '', [ 'path::', 'format::', 'output::', 'include-external', 'exclude-autoloaded', 'no-tier-dedupe', 'help' ] );
+$cli_options = getopt( '', [ 'path::', 'format::', 'output::', 'exclude-autoloaded', 'no-tier-dedupe', 'help' ] );
 
 if ( isset( $cli_options['help'] ) ) {
 	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite

--- a/bin/build-class-dependency-map.php
+++ b/bin/build-class-dependency-map.php
@@ -29,18 +29,21 @@ use PhpParser\ParserFactory;
 // CLI parsing
 // ---------------------------------------------------------------------------
 
-$cli_options = getopt( '', [ 'path::', 'format::', 'output::', 'include-external', 'exclude-autoloaded', 'help' ] );
+$cli_options = getopt( '', [ 'path::', 'format::', 'output::', 'include-external', 'exclude-autoloaded', 'no-tier-dedupe', 'help' ] );
 
 if ( isset( $cli_options['help'] ) ) {
 	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
 	fwrite(
 		STDERR,
-		"Usage: php bin/build-class-dependency-map.php [--path=<dir>] [--format=json|mermaid] [--output=<file>] [--exclude-autoloaded]\n"
+		"Usage: php bin/build-class-dependency-map.php [--path=<dir>] [--format=json|mermaid] [--output=<file>] [--exclude-autoloaded] [--no-tier-dedupe]\n"
 		. "  --path=<dir>           Directory to scan (default: includes)\n"
 		. "  --format=json|mermaid  Output format (default: json)\n"
 		. "  --output=<file>        Write to file instead of stdout\n"
 		. "  --exclude-autoloaded   Drop classes covered by composer.json's autoload.classmap,\n"
 		. "                         and strip references to them from remaining classes' edges.\n"
+		. "  --no-tier-dedupe       Emit each target in every tier it's referenced from, instead\n"
+		. "                         of collapsing to the strongest tier (compile_time > runtime >\n"
+		. "                         doc_only). Useful for diagnostics.\n"
 	);
 	exit( 0 );
 }
@@ -49,6 +52,7 @@ $directory          = $cli_options['path'] ?? 'includes';
 $format             = $cli_options['format'] ?? 'json';
 $output             = $cli_options['output'] ?? null;
 $exclude_autoloaded = isset( $cli_options['exclude-autoloaded'] );
+$tier_dedupe        = ! isset( $cli_options['no-tier-dedupe'] );
 
 if ( ! in_array( $format, [ 'json', 'mermaid' ], true ) ) {
 	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
@@ -237,7 +241,7 @@ class EdgeVisitor extends NodeVisitorAbstract {
 	 *
 	 * @var array<string, array>
 	 */
-	public array $edges = [];
+	private array $edges = [];
 
 	/**
 	 * Stack of class names.
@@ -245,6 +249,14 @@ class EdgeVisitor extends NodeVisitorAbstract {
 	 * @var list<string>
 	 */
 	private array $stack = [];
+
+	/**
+	 * Depth of nested class-const declarations currently being visited.
+	 * ClassConstFetch nodes encountered while > 0 are compile-time.
+	 *
+	 * @var int
+	 */
+	private int $const_depth = 0;
 
 	/**
 	 * Callback to determine if a type is a built-in type.
@@ -263,6 +275,64 @@ class EdgeVisitor extends NodeVisitorAbstract {
 		$this->is_builtin = $is_builtin;
 	}
 
+	/**
+	 * Returns all classes that are depended on by the current class.
+	 *
+	 * @return string[]
+	 */
+	public function getAllDependedOnClasses(): array {
+		return array_keys( $this->edges );
+	}
+
+	/**
+	 * Returns the compile-time dependencies of the given class.
+	 *
+	 * @param string  $owner The class to get the compile-time dependencies of.
+	 * @param Closure $keep  Callback to determine if a target is valid.
+	 * @return string[]
+	 */
+	public function getCompileTimeDependencies( string $owner, Closure $keep ): array {
+		if ( ! isset( $this->edges[ $owner ] ) ) {
+			return [];
+		}
+
+		$compile_time = [];
+		if ( null !== $this->edges[ $owner ]['compile_time']['extends'] ) {
+			$compile_time[] = $this->edges[ $owner ]['compile_time']['extends'];
+		}
+		$compile_time = array_merge(
+			$compile_time,
+			$this->edges[ $owner ]['compile_time']['implements'],
+			$this->edges[ $owner ]['compile_time']['uses_traits'],
+			$this->edges[ $owner ]['compile_time']['param_types'],
+			$this->edges[ $owner ]['compile_time']['return_types'],
+			$this->edges[ $owner ]['compile_time']['property_types'],
+			$this->edges[ $owner ]['compile_time']['const_refs'],
+		);
+		$compile_time = array_values( array_unique( array_filter( $compile_time, $keep ) ) );
+		sort( $compile_time );
+
+		return $compile_time;
+	}
+
+	public function getRuntimeDependencies( string $owner, Closure $keep ): array {
+		return $this->getDependencies( $owner, 'runtime', $keep );
+	}
+
+	public function getDocOnlyDependencies( string $owner, Closure $keep ): array {
+		return $this->getDependencies( $owner, 'doc_only', $keep );
+	}
+
+	private function getDependencies( string $owner, string $dependency_type, Closure $keep ): array {
+		if ( ! isset( $this->edges[ $owner ] ) ) {
+			return [];
+		}
+
+		$dependencies = array_values( array_unique( array_filter( $this->edges[ $owner ][ $dependency_type ], $keep ) ) );
+		sort( $dependencies );
+		return $dependencies;
+	}
+
 	public function enterNode( Node $node ) {
 		if ( $this->is_class_like( $node ) ) {
 			$owner = $this->resolve_name( $node );
@@ -274,14 +344,14 @@ class EdgeVisitor extends NodeVisitorAbstract {
 
 			if ( $node instanceof Node\Stmt\Class_ ) {
 				if ( null !== $node->extends ) {
-					$this->add_strict( 'extends', $this->fq( $node->extends ), true );
+					$this->add_parent_class( $this->fq( $node->extends ) );
 				}
 				foreach ( $node->implements as $impl ) {
-					$this->add_strict( 'implements', $this->fq( $impl ) );
+					$this->add_interface( $this->fq( $impl ) );
 				}
 			} elseif ( $node instanceof Node\Stmt\Interface_ ) {
 				foreach ( $node->extends as $impl ) {
-					$this->add_strict( 'implements', $this->fq( $impl ) );
+					$this->add_interface( $this->fq( $impl ) );
 				}
 			}
 
@@ -293,16 +363,21 @@ class EdgeVisitor extends NodeVisitorAbstract {
 			return;
 		}
 
+		if ( $node instanceof Node\Stmt\ClassConst ) {
+			++$this->const_depth;
+			return;
+		}
+
 		if ( $node instanceof Node\Stmt\TraitUse ) {
 			foreach ( $node->traits as $t ) {
-				$this->add_strict( 'uses_traits', $this->fq( $t ) );
+				$this->add_trait( $this->fq( $t ) );
 			}
 			return;
 		}
 
 		if ( $node instanceof Node\Param ) {
 			foreach ( $this->unwrap_type( $node->type ) as $name ) {
-				$this->add_strict( 'param_types', $name );
+				$this->add_parameter( $name );
 			}
 			return;
 		}
@@ -310,7 +385,7 @@ class EdgeVisitor extends NodeVisitorAbstract {
 		if ( $node instanceof Node\Stmt\ClassMethod || $node instanceof Node\Stmt\Function_ ) {
 			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			foreach ( $this->unwrap_type( $node->returnType ) as $name ) {
-				$this->add_strict( 'return_types', $name );
+				$this->add_return_type( $name );
 			}
 			$this->collect_docblock( $node->getDocComment() );
 			return;
@@ -318,27 +393,38 @@ class EdgeVisitor extends NodeVisitorAbstract {
 
 		if ( $node instanceof Node\Stmt\Property ) {
 			foreach ( $this->unwrap_type( $node->type ) as $name ) {
-				$this->add_strict( 'property_types', $name );
+				$this->add_property_type( $name );
 			}
 			$this->collect_docblock( $node->getDocComment() );
+			return;
+		}
+
+		if ( $node instanceof Node\Expr\ClassConstFetch ) {
+			if ( $node->class instanceof Node\Name ) {
+				$target = $this->fq( $node->class );
+				if ( $this->const_depth > 0 ) {
+					$this->add_const_ref( $target );
+				} else {
+					$this->add_runtime( $target );
+				}
+			}
 			return;
 		}
 
 		if ( $node instanceof Node\Expr\New_
 			|| $node instanceof Node\Expr\StaticCall
 			|| $node instanceof Node\Expr\StaticPropertyFetch
-			|| $node instanceof Node\Expr\ClassConstFetch
 			|| $node instanceof Node\Expr\Instanceof_
 		) {
 			if ( $node->class instanceof Node\Name ) {
-				$this->add_loose( $this->fq( $node->class ) );
+				$this->add_runtime( $this->fq( $node->class ) );
 			}
 			return;
 		}
 
 		if ( $node instanceof Node\Stmt\Catch_ ) {
 			foreach ( $node->types as $t ) {
-				$this->add_loose( $this->fq( $t ) );
+				$this->add_runtime( $this->fq( $t ) );
 			}
 		}
 	}
@@ -346,6 +432,10 @@ class EdgeVisitor extends NodeVisitorAbstract {
 	public function leaveNode( Node $node ) {
 		if ( $this->is_class_like( $node ) && ! empty( $this->stack ) ) {
 			array_pop( $this->stack );
+			return;
+		}
+		if ( $node instanceof Node\Stmt\ClassConst && $this->const_depth > 0 ) {
+			--$this->const_depth;
 		}
 	}
 
@@ -373,37 +463,71 @@ class EdgeVisitor extends NodeVisitorAbstract {
 	private function ensure( string $owner ): void {
 		if ( ! isset( $this->edges[ $owner ] ) ) {
 			$this->edges[ $owner ] = [
-				'strict' => [
+				'compile_time' => [
 					'extends'        => null,
 					'implements'     => [],
 					'uses_traits'    => [],
 					'param_types'    => [],
 					'return_types'   => [],
 					'property_types' => [],
+					'const_refs'     => [],
 				],
-				'loose'  => [],
+				'runtime'      => [],
+				'doc_only'     => [],
 			];
 		}
 	}
 
-	private function add_strict( string $field, ?string $target, bool $single = false ): void {
+	private function add_compile_time( string $field, ?string $target ): void {
 		$owner = $this->guarded_target( $target );
-		if ( null === $owner ) {
-			return;
-		}
-		if ( $single ) {
-			$this->edges[ $owner ]['strict'][ $field ] = $target;
-		} else {
-			$this->edges[ $owner ]['strict'][ $field ][] = $target;
+		if ( null !== $owner && ! in_array( $target, $this->edges[ $owner ]['compile_time'][ $field ], true ) ) {
+			$this->edges[ $owner ]['compile_time'][ $field ][] = $target;
 		}
 	}
 
-	private function add_loose( ?string $target ): void {
+	private function add_parameter( string $target ): void {
+		$this->add_compile_time( 'param_types', $target );
+	}
+
+	private function add_trait( string $target ): void {
+		$this->add_compile_time( 'uses_traits', $target );
+	}
+
+	private function add_parent_class( string $target ): void {
 		$owner = $this->guarded_target( $target );
-		if ( null === $owner ) {
-			return;
+		if ( null !== $owner ) {
+			$this->edges[ $owner ]['compile_time']['extends'] = $target;
 		}
-		$this->edges[ $owner ]['loose'][] = $target;
+	}
+
+	private function add_interface( string $target ): void {
+		$this->add_compile_time( 'implements', $target );
+	}
+
+	private function add_return_type( string $target ): void {
+		$this->add_compile_time( 'return_types', $target );
+	}
+
+	private function add_property_type( string $target ): void {
+		$this->add_compile_time( 'property_types', $target );
+	}
+
+	private function add_const_ref( string $target ): void {
+		$this->add_compile_time( 'const_refs', $target );
+	}
+
+	private function add_runtime( ?string $target ): void {
+		$owner = $this->guarded_target( $target );
+		if ( null !== $owner && ! in_array( $target, $this->edges[ $owner ]['runtime'], true ) ) {
+			$this->edges[ $owner ]['runtime'][] = $target;
+		}
+	}
+
+	private function add_doc_only( ?string $target ): void {
+		$owner = $this->guarded_target( $target );
+		if ( null !== $owner && ! in_array( $target, $this->edges[ $owner ]['doc_only'], true ) ) {
+			$this->edges[ $owner ]['doc_only'][] = $target;
+		}
 	}
 
 	/**
@@ -490,7 +614,7 @@ class EdgeVisitor extends NodeVisitorAbstract {
 				if ( ! preg_match( '/^[A-Za-z_][A-Za-z0-9_\\\\]*$/', $tok ) ) {
 					continue;
 				}
-				$this->add_loose( $tok );
+				$this->add_doc_only( $tok );
 			}
 		}
 	}
@@ -533,29 +657,37 @@ $keep = static function ( string $target ) use ( $index, $autoloaded, $exclude_a
 };
 
 $result = [];
-foreach ( $edge_visitor->edges as $owner => $data ) {
+foreach ( $edge_visitor->getAllDependedOnClasses() as $owner ) {
 	if ( ! isset( $index[ $owner ] ) ) {
 		continue;
 	}
 	if ( $exclude_autoloaded && ! empty( $autoloaded[ $owner ] ) ) {
 		continue;
 	}
-	$strict = $data['strict'];
+	$compile_time = $edge_visitor->getCompileTimeDependencies( $owner, $keep );
 
-	if ( null !== $strict['extends'] && ! $keep( $strict['extends'] ) ) {
-		$strict['extends'] = null;
+	$runtime  = $edge_visitor->getRuntimeDependencies( $owner, $keep );
+	$doc_only = $edge_visitor->getDocOnlyDependencies( $owner, $keep );
+
+	if ( $tier_dedupe ) {
+		$runtime  = array_values( array_diff( $runtime, $compile_time ) );
+		$doc_only = array_values(
+			array_diff(
+				$doc_only,
+				$compile_time,
+				$runtime
+			)
+		);
 	}
-	foreach ( [ 'implements', 'uses_traits', 'param_types', 'return_types', 'property_types' ] as $field ) {
-		$strict[ $field ] = array_values( array_unique( array_filter( $strict[ $field ], $keep ) ) );
-		sort( $strict[ $field ] );
-	}
-	$loose = array_values( array_unique( array_filter( $data['loose'], $keep ) ) );
-	sort( $loose );
+
+	sort( $runtime );
+	sort( $doc_only );
 
 	$result[ $owner ] = [
-		'autoloaded' => ! empty( $autoloaded[ $owner ] ),
-		'strict'     => $strict,
-		'loose'      => $loose,
+		'autoloaded'   => ! empty( $autoloaded[ $owner ] ),
+		'compile_time' => $compile_time,
+		'runtime'      => $runtime,
+		'doc_only'     => $doc_only,
 	];
 }
 
@@ -602,24 +734,25 @@ function render_mermaid( array $result ): string { // phpcs:ignore Universal.Fil
 		if ( ! empty( $data['autoloaded'] ) ) {
 			$lines[] = "    <<autoloaded>> {$own}";
 		}
-		$strict = $data['strict'];
+		$compile_time = $data['compile_time'];
 
-		if ( null !== $strict['extends'] ) {
-			$lines[] = "    {$sanitize( $strict['extends'] )} <|-- {$own}";
+		if ( null !== $compile_time['extends'] ) {
+			$lines[] = "    {$sanitize( $compile_time['extends'] )} <|-- {$own}";
 		}
-		foreach ( $strict['implements'] as $t ) {
+		foreach ( $compile_time['implements'] as $t ) {
 			$lines[] = "    {$sanitize( $t )} <|.. {$own}";
 		}
-		foreach ( $strict['uses_traits'] as $t ) {
+		foreach ( $compile_time['uses_traits'] as $t ) {
 			$lines[] = "    {$own} --* {$sanitize( $t )} : uses";
 		}
 
 		$declared = array_values(
 			array_unique(
 				array_merge(
-					$strict['param_types'],
-					$strict['return_types'],
-					$strict['property_types']
+					$compile_time['param_types'],
+					$compile_time['return_types'],
+					$compile_time['property_types'],
+					$compile_time['const_refs']
 				)
 			)
 		);
@@ -628,7 +761,7 @@ function render_mermaid( array $result ): string { // phpcs:ignore Universal.Fil
 			$lines[] = "    {$own} --> {$sanitize( $t )}";
 		}
 
-		foreach ( $data['loose'] as $t ) {
+		foreach ( $data['runtime'] as $t ) {
 			$lines[] = "    {$own} ..> {$sanitize( $t )}";
 		}
 	}

--- a/bin/find-autoload-candidates.php
+++ b/bin/find-autoload-candidates.php
@@ -160,19 +160,9 @@ if ( empty( $graph ) ) {
 // after the --exclude-autoloaded filter).
 // ---------------------------------------------------------------------------
 
-$compile_time_fields = [ 'implements', 'uses_traits', 'param_types', 'return_types', 'property_types', 'const_refs' ];
-
-$is_unblocked = static function ( array $entry ) use ( $blockers, $compile_time_fields ): bool {
-	if ( $blockers['compile_time'] ) {
-		$ct = $entry['compile_time'] ?? [];
-		if ( null !== ( $ct['extends'] ?? null ) ) {
-			return false;
-		}
-		foreach ( $compile_time_fields as $field ) {
-			if ( ! empty( $ct[ $field ] ?? [] ) ) {
-				return false;
-			}
-		}
+$is_unblocked = static function ( array $entry ) use ( $blockers ): bool {
+	if ( $blockers['compile_time'] && ! empty( $entry['compile_time'] ?? [] ) ) {
+		return false;
 	}
 	if ( $blockers['runtime'] && ! empty( $entry['runtime'] ?? [] ) ) {
 		return false;
@@ -233,14 +223,8 @@ $adjacency = [];
 foreach ( $graph as $owner => $entry ) {
 	$deps = [];
 	if ( $blockers['compile_time'] ) {
-		$ct = $entry['compile_time'] ?? [];
-		if ( null !== ( $ct['extends'] ?? null ) ) {
-			$deps[ $ct['extends'] ] = true;
-		}
-		foreach ( $compile_time_fields as $field ) {
-			foreach ( $ct[ $field ] ?? [] as $dep ) {
-				$deps[ $dep ] = true;
-			}
+		foreach ( $entry['compile_time'] ?? [] as $dep ) {
+			$deps[ $dep ] = true;
 		}
 	}
 	if ( $blockers['runtime'] ) {

--- a/bin/find-autoload-candidates.php
+++ b/bin/find-autoload-candidates.php
@@ -1,0 +1,268 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+/**
+ * Surface autoloader-rollout candidates from the dependency map.
+ *
+ * Pipeline:
+ *   1. Shell out to bin/build-class-dependency-map.php with --exclude-autoloaded
+ *      --format=json to get the graph of classes still outside the classmap,
+ *      with edges to already-autoloaded classes stripped.
+ *   2. Step 1 — list "unblocked" classes: every strict field is empty, meaning
+ *      the class has no strict deps on non-autoloaded classes and can be added
+ *      to the classmap in isolation.
+ *   3. If step 1 is empty (and --deep is not set), prompt the user. If they
+ *      decline, exit. If they accept (or --deep is set), run the deep pass.
+ *   4. Deep pass — compute each class's transitive strict closure. A closure is
+ *      a set closed under strict-deps, i.e. a valid rollout group. Emit unique
+ *      closures up to --max-group-size, smallest first.
+ *
+ * Loose references are intentionally ignored — they don't constrain autoload
+ * ordering, only strict declarations (extends/implements/use/param/return/property)
+ * do.
+ */
+
+declare( strict_types=1 );
+
+// ---------------------------------------------------------------------------
+// CLI parsing
+// ---------------------------------------------------------------------------
+
+$cli_options = getopt( '', [ 'path::', 'max-group-size::', 'deep', 'strict-only', 'help' ] );
+
+if ( isset( $cli_options['help'] ) ) {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+	fwrite(
+		STDERR,
+		"Usage: php bin/find-autoload-candidates.php [--path=<dir>] [--max-group-size=<n>] [--deep] [--strict-only]\n"
+		. "  --path=<dir>            Directory to scan (default: includes). Passed through to\n"
+		. "                          build-class-dependency-map.php.\n"
+		. "  --max-group-size=<n>    Cap on closure size for the deep pass (default: 10).\n"
+		. "  --deep                  Always run the deep pass without prompting.\n"
+		. "  --strict-only           Ignore loose deps (docblocks, new X, X::y, instanceof,\n"
+		. "                          catch). Default behavior counts loose deps as blockers.\n"
+	);
+	exit( 0 );
+}
+
+$directory      = $cli_options['path'] ?? 'includes';
+$max_group_size = isset( $cli_options['max-group-size'] ) ? (int) $cli_options['max-group-size'] : 10;
+$deep           = isset( $cli_options['deep'] );
+$strict_only    = isset( $cli_options['strict-only'] );
+$deps_label     = $strict_only ? 'strict' : 'strict or loose';
+$closed_label   = $strict_only ? 'strict' : 'strict and loose';
+
+if ( $max_group_size < 1 ) {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+	fwrite( STDERR, "--max-group-size must be >= 1\n" );
+	exit( 2 );
+}
+
+// ---------------------------------------------------------------------------
+// Step 0: run build-class-dependency-map.php and capture JSON.
+// ---------------------------------------------------------------------------
+
+$child_script = __DIR__ . '/build-class-dependency-map.php';
+if ( ! is_file( $child_script ) ) {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+	fwrite( STDERR, "Missing dependency map script: {$child_script}\n" );
+	exit( 1 );
+}
+
+$cmd = sprintf(
+	'%s %s --exclude-autoloaded --format=json --path=%s',
+	escapeshellarg( PHP_BINARY ),
+	escapeshellarg( $child_script ),
+	escapeshellarg( $directory )
+);
+
+$descriptors = [
+	0 => [ 'pipe', 'r' ],
+	1 => [ 'pipe', 'w' ],
+	2 => STDERR,
+];
+
+// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_proc_open
+$process = proc_open( $cmd, $descriptors, $pipes );
+if ( ! is_resource( $process ) ) {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+	fwrite( STDERR, "Failed to spawn dependency map process\n" );
+	exit( 1 );
+}
+
+// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+fclose( $pipes[0] );
+$json_raw = stream_get_contents( $pipes[1] );
+// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+fclose( $pipes[1] );
+$exit_code = proc_close( $process );
+
+if ( 0 !== $exit_code ) {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+	fwrite( STDERR, "build-class-dependency-map.php exited with code {$exit_code}\n" );
+	exit( 1 );
+}
+
+$graph = json_decode( (string) $json_raw, true );
+if ( ! is_array( $graph ) ) {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+	fwrite( STDERR, "Could not parse JSON output from build-class-dependency-map.php\n" );
+	exit( 1 );
+}
+
+if ( empty( $graph ) ) {
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo "All classes in {$directory} are already autoloaded.\n";
+	exit( 0 );
+}
+
+// ---------------------------------------------------------------------------
+// Step 1: collect unblocked classes (no remaining strict deps after the
+// --exclude-autoloaded filter).
+// ---------------------------------------------------------------------------
+
+$is_unblocked = static function ( array $entry ) use ( $strict_only ): bool {
+	$strict = $entry['strict'] ?? [];
+	if ( null !== ( $strict['extends'] ?? null ) ) {
+		return false;
+	}
+	foreach ( [ 'implements', 'uses_traits', 'param_types', 'return_types', 'property_types' ] as $field ) {
+		if ( ! empty( $strict[ $field ] ) ) {
+			return false;
+		}
+	}
+	if ( ! $strict_only && ! empty( $entry['loose'] ?? [] ) ) {
+		return false;
+	}
+	return true;
+};
+
+$unblocked = [];
+foreach ( $graph as $owner => $entry ) {
+	if ( $is_unblocked( $entry ) ) {
+		$unblocked[] = $owner;
+	}
+}
+sort( $unblocked );
+
+if ( ! $deep ) {
+	if ( ! empty( $unblocked ) ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo "Unblocked classes (no {$deps_label} deps on non-autoloaded classes):\n\n";
+		foreach ( $unblocked as $name ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo "    {$name}\n";
+		}
+		exit( 0 );
+	}
+
+	// ---------------------------------------------------------------------------
+	// Step 2: prompt for deep analysis.
+	// ---------------------------------------------------------------------------
+
+	$is_tty = function_exists( 'stream_isatty' ) ? stream_isatty( STDIN ) : false;
+	if ( ! $is_tty ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo "No unblocked classes found. Re-run with --deep to enumerate small interrelated groups.\n";
+		exit( 0 );
+	}
+
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo 'No unblocked classes found. Run deeper analysis to find small interrelated groups? [y/N]: ';
+	$answer = fgets( STDIN );
+	if ( false === $answer ) {
+		exit( 0 );
+	}
+	$answer = strtolower( trim( $answer ) );
+	if ( 'y' !== $answer && 'yes' !== $answer ) {
+		exit( 0 );
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Step 3: deep pass — transitive strict closures.
+// ---------------------------------------------------------------------------
+
+$adjacency = [];
+foreach ( $graph as $owner => $entry ) {
+	$strict = $entry['strict'] ?? [];
+	$deps   = [];
+	if ( null !== ( $strict['extends'] ?? null ) ) {
+		$deps[ $strict['extends'] ] = true;
+	}
+	foreach ( [ 'implements', 'uses_traits', 'param_types', 'return_types', 'property_types' ] as $field ) {
+		foreach ( $strict[ $field ] ?? [] as $dep ) {
+			$deps[ $dep ] = true;
+		}
+	}
+	if ( ! $strict_only ) {
+		foreach ( $entry['loose'] ?? [] as $dep ) {
+			$deps[ $dep ] = true;
+		}
+	}
+	$adjacency[ $owner ] = array_keys( $deps );
+}
+
+$closure_of = static function ( string $start ) use ( $adjacency ): array {
+	$seen  = [];
+	$stack = [ $start ];
+	while ( ! empty( $stack ) ) {
+		$node = array_pop( $stack );
+		if ( isset( $seen[ $node ] ) ) {
+			continue;
+		}
+		$seen[ $node ] = true;
+		foreach ( $adjacency[ $node ] ?? [] as $dep ) {
+			if ( ! isset( $seen[ $dep ] ) ) {
+				$stack[] = $dep;
+			}
+		}
+	}
+	$members = array_keys( $seen );
+	sort( $members );
+	return $members;
+};
+
+$groups = [];
+foreach ( array_keys( $graph ) as $owner ) {
+	$members = $closure_of( $owner );
+	if ( count( $members ) > $max_group_size ) {
+		continue;
+	}
+	$key = implode( "\0", $members );
+	if ( ! isset( $groups[ $key ] ) ) {
+		$groups[ $key ] = $members;
+	}
+}
+
+$groups = array_values( $groups );
+usort(
+	$groups,
+	static function ( array $a, array $b ): int {
+		$size_diff = count( $a ) - count( $b );
+		if ( 0 !== $size_diff ) {
+			return $size_diff;
+		}
+		return strcmp( $a[0], $b[0] );
+	}
+);
+
+if ( empty( $groups ) ) {
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo "No candidate groups within size <= {$max_group_size}. Try a larger --max-group-size.\n";
+	exit( 0 );
+}
+
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo "Candidate groups (each is closed under {$closed_label} deps; size <= {$max_group_size}):\n\n";
+$index = 1;
+foreach ( $groups as $members ) {
+	$size = count( $members );
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo "[{$index}] (size {$size})\n";
+	foreach ( $members as $name ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo "    {$name}\n";
+	}
+	echo "\n";
+	++$index;
+}

--- a/bin/find-autoload-candidates.php
+++ b/bin/find-autoload-candidates.php
@@ -27,19 +27,21 @@ declare( strict_types=1 );
 // CLI parsing
 // ---------------------------------------------------------------------------
 
-$cli_options = getopt( '', [ 'path::', 'max-group-size::', 'deep', 'strict-only', 'help' ] );
+$cli_options = getopt( '', [ 'path::', 'max-group-size::', 'deep', 'types::', 'help' ] );
 
 if ( isset( $cli_options['help'] ) ) {
 	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
 	fwrite(
 		STDERR,
-		"Usage: php bin/find-autoload-candidates.php [--path=<dir>] [--max-group-size=<n>] [--deep] [--strict-only]\n"
+		"Usage: php bin/find-autoload-candidates.php [--path=<dir>] [--max-group-size=<n>] [--deep] [--types=<csv>]\n"
 		. "  --path=<dir>            Directory to scan (default: includes). Passed through to\n"
 		. "                          build-class-dependency-map.php.\n"
 		. "  --max-group-size=<n>    Cap on closure size for the deep pass (default: 10).\n"
 		. "  --deep                  Always run the deep pass without prompting.\n"
-		. "  --strict-only           Ignore loose deps (docblocks, new X, X::y, instanceof,\n"
-		. "                          catch). Default behavior counts loose deps as blockers.\n"
+		. "  --types=<csv>           Which dependency tiers count as blockers (default: all).\n"
+		. "                          Accepts: all, compile-time, runtime, doc. Combine tiers\n"
+		. "                          via commas, e.g. --types=compile-time,runtime. 'all' is\n"
+		. "                          mutually exclusive with the others.\n"
 	);
 	exit( 0 );
 }
@@ -47,9 +49,47 @@ if ( isset( $cli_options['help'] ) ) {
 $directory      = $cli_options['path'] ?? 'includes';
 $max_group_size = isset( $cli_options['max-group-size'] ) ? (int) $cli_options['max-group-size'] : 10;
 $deep           = isset( $cli_options['deep'] );
-$strict_only    = isset( $cli_options['strict-only'] );
-$deps_label     = $strict_only ? 'strict' : 'strict or loose';
-$closed_label   = $strict_only ? 'strict' : 'strict and loose';
+
+$types_raw = strtolower( (string) ( $cli_options['types'] ?? 'all' ) );
+$tokens    = array_values( array_filter( array_map( 'trim', explode( ',', $types_raw ) ) ) );
+$valid     = [ 'all', 'compile-time', 'runtime', 'doc' ];
+foreach ( $tokens as $tok ) {
+	if ( ! in_array( $tok, $valid, true ) ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+		fwrite( STDERR, "Unknown --types value: {$tok} (expected one or more of: all, compile-time, runtime, doc)\n" );
+		exit( 2 );
+	}
+}
+if ( in_array( 'all', $tokens, true ) && count( $tokens ) > 1 ) {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+	fwrite( STDERR, "--types=all cannot be combined with other values\n" );
+	exit( 2 );
+}
+
+$blockers = ( empty( $tokens ) || in_array( 'all', $tokens, true ) )
+	? [
+		'compile_time' => true,
+		'runtime'      => true,
+		'doc_only'     => true,
+	]
+	: [
+		'compile_time' => in_array( 'compile-time', $tokens, true ),
+		'runtime'      => in_array( 'runtime', $tokens, true ),
+		'doc_only'     => in_array( 'doc', $tokens, true ),
+	];
+
+$tier_label_map = [
+	'compile_time' => 'compile-time',
+	'runtime'      => 'runtime',
+	'doc_only'     => 'doc-only',
+];
+$active_labels  = [];
+foreach ( $blockers as $key => $on ) {
+	if ( $on ) {
+		$active_labels[] = $tier_label_map[ $key ];
+	}
+}
+$active_label = implode( ' + ', $active_labels );
 
 if ( $max_group_size < 1 ) {
 	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
@@ -116,21 +156,28 @@ if ( empty( $graph ) ) {
 }
 
 // ---------------------------------------------------------------------------
-// Step 1: collect unblocked classes (no remaining strict deps after the
-// --exclude-autoloaded filter).
+// Step 1: collect unblocked classes (no remaining deps in the selected tiers
+// after the --exclude-autoloaded filter).
 // ---------------------------------------------------------------------------
 
-$is_unblocked = static function ( array $entry ) use ( $strict_only ): bool {
-	$strict = $entry['strict'] ?? [];
-	if ( null !== ( $strict['extends'] ?? null ) ) {
-		return false;
-	}
-	foreach ( [ 'implements', 'uses_traits', 'param_types', 'return_types', 'property_types' ] as $field ) {
-		if ( ! empty( $strict[ $field ] ) ) {
+$compile_time_fields = [ 'implements', 'uses_traits', 'param_types', 'return_types', 'property_types', 'const_refs' ];
+
+$is_unblocked = static function ( array $entry ) use ( $blockers, $compile_time_fields ): bool {
+	if ( $blockers['compile_time'] ) {
+		$ct = $entry['compile_time'] ?? [];
+		if ( null !== ( $ct['extends'] ?? null ) ) {
 			return false;
 		}
+		foreach ( $compile_time_fields as $field ) {
+			if ( ! empty( $ct[ $field ] ?? [] ) ) {
+				return false;
+			}
+		}
 	}
-	if ( ! $strict_only && ! empty( $entry['loose'] ?? [] ) ) {
+	if ( $blockers['runtime'] && ! empty( $entry['runtime'] ?? [] ) ) {
+		return false;
+	}
+	if ( $blockers['doc_only'] && ! empty( $entry['doc_only'] ?? [] ) ) {
 		return false;
 	}
 	return true;
@@ -147,7 +194,7 @@ sort( $unblocked );
 if ( ! $deep ) {
 	if ( ! empty( $unblocked ) ) {
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo "Unblocked classes (no {$deps_label} deps on non-autoloaded classes):\n\n";
+		echo "Unblocked classes (no {$active_label} deps on non-autoloaded classes):\n\n";
 		foreach ( $unblocked as $name ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			echo "    {$name}\n";
@@ -184,18 +231,25 @@ if ( ! $deep ) {
 
 $adjacency = [];
 foreach ( $graph as $owner => $entry ) {
-	$strict = $entry['strict'] ?? [];
-	$deps   = [];
-	if ( null !== ( $strict['extends'] ?? null ) ) {
-		$deps[ $strict['extends'] ] = true;
+	$deps = [];
+	if ( $blockers['compile_time'] ) {
+		$ct = $entry['compile_time'] ?? [];
+		if ( null !== ( $ct['extends'] ?? null ) ) {
+			$deps[ $ct['extends'] ] = true;
+		}
+		foreach ( $compile_time_fields as $field ) {
+			foreach ( $ct[ $field ] ?? [] as $dep ) {
+				$deps[ $dep ] = true;
+			}
+		}
 	}
-	foreach ( [ 'implements', 'uses_traits', 'param_types', 'return_types', 'property_types' ] as $field ) {
-		foreach ( $strict[ $field ] ?? [] as $dep ) {
+	if ( $blockers['runtime'] ) {
+		foreach ( $entry['runtime'] ?? [] as $dep ) {
 			$deps[ $dep ] = true;
 		}
 	}
-	if ( ! $strict_only ) {
-		foreach ( $entry['loose'] ?? [] as $dep ) {
+	if ( $blockers['doc_only'] ) {
+		foreach ( $entry['doc_only'] ?? [] as $dep ) {
 			$deps[ $dep ] = true;
 		}
 	}
@@ -253,7 +307,7 @@ if ( empty( $groups ) ) {
 }
 
 // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-echo "Candidate groups (each is closed under {$closed_label} deps; size <= {$max_group_size}):\n\n";
+echo "Candidate groups (each is closed under {$active_label} deps; size <= {$max_group_size}):\n\n";
 $index = 1;
 foreach ( $groups as $members ) {
 	$size = count( $members );

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "woocommerce/woocommerce-sniffs": "1.0.0",
         "wp-cli/wp-cli-bundle": "^2.12",
         "yoast/phpunit-polyfills": "^2.0",
-        "brianium/paratest": "^6.0"
+        "brianium/paratest": "^6.0",
+        "nikic/php-parser": "^5.7"
     },
     "autoload": {
       "classmap": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5b902fe9fbd5436e6c65600b25f6b8bd",
+    "content-hash": "93a6c12dcd489fbadaeec550274b5ed0",
     "packages": [],
     "packages-dev": [
         {
@@ -7876,5 +7876,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->
Towards STRIPE-504

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR adds two scripts to make it easier to roll out autoload support across the plugin:
 * `bin/build-class-dependency-map.php` - scan the files in the `includes/` directory to identify how each of the classes interrelate, what types of dependencies exist, and whether each class is already part of the autoloader
    - Usage: `php bin/build-class-dependency-map.php [--path=<dir>] [--format=json|mermaid] [--output=<file>] [--exclude-autoloaded] [--no-tier-dedupe]`
       * `--path=<directory>` - directory to scan; defaults to `includes`
       * `--format=(json|mermaid)` - output format; defaults to `json` -- note that no MermaidJS renderer is included
       * `--output=<file>` - file to write to; defaults to stdout rather than a file
       * `--exclude-autoloaded` - skip classes that are already being autoloaded via the classmap in `composer.json`; this also ignores them as dependencies
       * `--no-tier-dedupe` - skip the deduplication that removes lower tier dependencies when a higher tier dependency exists; the hierarchy is compile-time > runtime > PHPdoc
 * `bin/find-autoload-candidates.php` - call the tool above to build a dependency map and identify the next set of classes that make sense for autoloading.
   - Usage: `php bin/find-autoload-candidates.php [--path=<dir>] [--max-group-size=<n>] [--deep] [--types=<csv>]`
     * `--path=<directory>` - Directory to scan; defaults to `includes`
     * `--max-group-size=<size>` - Largest permissible group size when trying to identify groups of interrelated classes that could be added as a group.
     * `--deep` - Always run the deep checks for groups of interrelated classes. Without this flag, the tool will prompt the user.
     * `[--types=<dependency_types>]` - The dependency types to check. Defaults to `all` or `compile-time,runtime,doc`, but can also be any comma-separated combination of `compile-time`, `runtime`, and `doc`.
        - Allows for control over what types of dependencies we want to use for our checks -- for our early waves of checks, we're going to want to use `compile-time,runtime`

The tools depend on existing dev dependencies, and were 100% put together by Claude. The base-level scans seem to be working, but we'll likely need to get the initial files autoloaded before we can get a better sense for how well the tool works for identifying groups of interrelated classes.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

* Run `composer install`
* Run both tools, especially `find-autoloader-candidates` in multiple ways and spot check the output.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [N/A] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This is an internal-only tooling change that will have no merchant-facing impact. It doesn't warrant a changelog entry.
</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
