### PR TITLE
Preserve wallet_type on saved tokens; widen wallet brand label regex

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.8.0
-* Fix - Address wallet branding edge cases on saved cards: stop re-badging a card when it's later used via Apple Pay or Google Pay, and render multi-word card brands (e.g. Cartes Bancaires) correctly
+* Fix - Preserve saved card branding when the same card is later used via a wallet, and render multi-word brands (e.g. Cartes Bancaires) correctly
 * Add - Show Apple Pay / Google Pay branding on saved card tokens in My Account → Payment Methods and at checkout
 * Add - Add a setting to control whether Express Checkout is shown on the WooCommerce Subscriptions change payment method page
 * Add - Allow shoppers to change a subscription payment method using Express Checkout (Apple Pay, Google Pay, Link)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.8.0
+* Fix - Address wallet branding edge cases on saved cards: stop re-badging a card when it's later used via Apple Pay or Google Pay, and render multi-word card brands (e.g. Cartes Bancaires) correctly
 * Add - Show Apple Pay / Google Pay branding on saved card tokens in My Account → Payment Methods and at checkout
 * Add - Add a setting to control whether Express Checkout is shown on the WooCommerce Subscriptions change payment method page
 * Add - Allow shoppers to change a subscription payment method using Express Checkout (Apple Pay, Google Pay, Link)

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3618,15 +3618,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		$found_token = WC_Stripe_Payment_Tokens::get_duplicate_token( $payment_method_object, $customer->get_user_id(), $this->id );
 
 		if ( $found_token ) {
-			// Update the token with the new payment method ID.
+			// Update the token with the new payment method ID. `wallet_type` is
+			// intentionally not touched here — it reflects how the token was
+			// originally created, and overwriting it would re-badge a card saved
+			// directly as "Google Pay" the first time the shopper paid with the
+			// same card through the Google Pay sheet.
 			$payment_method_instance->update_payment_token( $found_token, $payment_method_object->id );
-
-			// `update_payment_token` only refreshes the PM id, so backfill wallet_type
-			// when reusing a pre-existing token (e.g. same card paid via a wallet).
-			if ( $found_token instanceof WC_Stripe_Payment_Token_CC && isset( $payment_method_object->card ) ) {
-				$found_token->set_wallet_type( (string) ( $payment_method_object->card->wallet->type ?? '' ) );
-				$found_token->save();
-			}
 		} else {
 			// Create a payment token for the user in the store.
 			$payment_method_instance->create_payment_token_for_user( $user->ID, $payment_method_object );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3618,11 +3618,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		$found_token = WC_Stripe_Payment_Tokens::get_duplicate_token( $payment_method_object, $customer->get_user_id(), $this->id );
 
 		if ( $found_token ) {
-			// Update the token with the new payment method ID. `wallet_type` is
-			// intentionally not touched here — it reflects how the token was
-			// originally created, and overwriting it would re-badge a card saved
-			// directly as "Google Pay" the first time the shopper paid with the
-			// same card through the Google Pay sheet.
+			// `wallet_type` is intentionally not refreshed — it reflects how the
+			// token was created and must not flip when the same card is reused
+			// through a wallet sheet.
 			$payment_method_instance->update_payment_token( $found_token, $payment_method_object->id );
 		} else {
 			// Create a payment token for the user in the store.

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -88,9 +88,11 @@ class WC_Stripe_Payment_Tokens {
 		}
 
 		// The My Account template re-applies wc_get_credit_card_type_label to our wrapped
-		// brand. Its ucwords pass leaves the inner card name lowercase because `(` isn't
-		// a word boundary — restore it here.
-		if ( preg_match( '/^(Apple Pay|Google Pay) \(([a-z][a-z ]*)\)$/', $label, $matches ) ) {
+		// brand, mangling the inner card name through ucwords. Restore it through the
+		// label helper, which handles its own normalization. Match any inner content so
+		// multi-word brands like "Cartes Bancaires" — which ucwords leaves as
+		// "cartes Bancaires" because `(` isn't a word boundary — still get re-labelled.
+		if ( preg_match( '/^(Apple Pay|Google Pay) \(([^)]+)\)$/', $label, $matches ) ) {
 			return $matches[1] . ' (' . wc_get_credit_card_type_label( $matches[2] ) . ')';
 		}
 
@@ -794,12 +796,14 @@ class WC_Stripe_Payment_Tokens {
 				// Card fingerprint hashes the card number only, so a fingerprint
 				// match can still carry a different expiry or brand. Refresh the
 				// mutable card metadata so the UI reflects the replacement.
+				// `wallet_type` is intentionally not refreshed — it reflects how
+				// the token was originally created and must not be overwritten
+				// when the same card is later used via a different wallet.
 				if ( WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID === $payment_method_type && $found_token instanceof WC_Stripe_Payment_Token_CC ) {
 					$found_token->set_expiry_month( $payment_method->card->exp_month );
 					$found_token->set_expiry_year( $payment_method->card->exp_year );
 					$found_token->set_card_type( strtolower( $payment_method->card->display_brand ?? $payment_method->card->networks->preferred ?? $payment_method->card->brand ) );
 					$found_token->set_last4( $payment_method->card->last4 );
-					$found_token->set_wallet_type( (string) ( $payment_method->card->wallet->type ?? '' ) );
 				}
 
 				$found_token->save();

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -87,11 +87,9 @@ class WC_Stripe_Payment_Tokens {
 				return 'SEPA IBAN';
 		}
 
-		// The My Account template re-applies wc_get_credit_card_type_label to our wrapped
-		// brand, mangling the inner card name through ucwords. Restore it through the
-		// label helper, which handles its own normalization. Match any inner content so
-		// multi-word brands like "Cartes Bancaires" — which ucwords leaves as
-		// "cartes Bancaires" because `(` isn't a word boundary — still get re-labelled.
+		// WC's `ucwords` pass on our wrapped brand mangles the inner card name
+		// (the first letter after `(` stays lowercase). Match any inner content
+		// and re-normalize through the label helper.
 		if ( preg_match( '/^(Apple Pay|Google Pay) \(([^)]+)\)$/', $label, $matches ) ) {
 			return $matches[1] . ' (' . wc_get_credit_card_type_label( $matches[2] ) . ')';
 		}
@@ -796,9 +794,7 @@ class WC_Stripe_Payment_Tokens {
 				// Card fingerprint hashes the card number only, so a fingerprint
 				// match can still carry a different expiry or brand. Refresh the
 				// mutable card metadata so the UI reflects the replacement.
-				// `wallet_type` is intentionally not refreshed — it reflects how
-				// the token was originally created and must not be overwritten
-				// when the same card is later used via a different wallet.
+				// `wallet_type` is left as-is so a later wallet use doesn't re-badge a saved card.
 				if ( WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID === $payment_method_type && $found_token instanceof WC_Stripe_Payment_Token_CC ) {
 					$found_token->set_expiry_month( $payment_method->card->exp_month );
 					$found_token->set_expiry_year( $payment_method->card->exp_year );

--- a/readme.txt
+++ b/readme.txt
@@ -152,7 +152,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.8.0 - xxxx-xx-xx =
-* Fix - Address wallet branding edge cases on saved cards: stop re-badging a card when it's later used via Apple Pay or Google Pay, and render multi-word card brands (e.g. Cartes Bancaires) correctly
+* Fix - Preserve saved card branding when the same card is later used via a wallet, and render multi-word brands (e.g. Cartes Bancaires) correctly
 * Add - Show Apple Pay / Google Pay branding on saved card tokens in My Account → Payment Methods and at checkout
 * Add - Allow shoppers to change a subscription payment method using Express Checkout (Apple Pay, Google Pay, Link)
 * Add - Add a setting to control whether Express Checkout is shown on the WooCommerce Subscriptions change payment method page

--- a/readme.txt
+++ b/readme.txt
@@ -152,6 +152,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.8.0 - xxxx-xx-xx =
+* Fix - Address wallet branding edge cases on saved cards: stop re-badging a card when it's later used via Apple Pay or Google Pay, and render multi-word card brands (e.g. Cartes Bancaires) correctly
 * Add - Show Apple Pay / Google Pay branding on saved card tokens in My Account → Payment Methods and at checkout
 * Add - Allow shoppers to change a subscription payment method using Express Checkout (Apple Pay, Google Pay, Link)
 * Add - Add a setting to control whether Express Checkout is shown on the WooCommerce Subscriptions change payment method page

--- a/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
+++ b/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
@@ -384,12 +384,9 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Guards that `add_token_to_user`'s duplicate-match path does not overwrite
-	 * the original `wallet_type`. `wallet_type` reflects how the token was created,
-	 * so re-using the same card via a wallet (e.g. saving a card directly, then
-	 * later paying via Google Pay with the same card) must not re-badge the
-	 * existing token — the shopper would see their saved Visa flipped to a
-	 * "Google Pay (Visa)" entry in My Account.
+	 * `add_token_to_user`'s duplicate-match path must not overwrite the
+	 * original `wallet_type` when the same card is later used via a wallet —
+	 * otherwise a saved plain card flips to "Google Pay (Visa)" in My Account.
 	 *
 	 * @return void
 	 */
@@ -420,8 +417,7 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 				'exp_year'      => 2028,
 				'last4'         => '4242',
 				'fingerprint'   => 'F_wallet',
-				// Same card paid via Apple Pay this time — the existing token's
-				// wallet_type must NOT be flipped to 'apple_pay'.
+				// Same card paid via Apple Pay this time — must not flip wallet_type.
 				'wallet'        => (object) [ 'type' => 'apple_pay' ],
 			],
 		];
@@ -434,7 +430,7 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 
 		$this->assertSame( $seed_token_id, $result->get_id() );
 		$this->assertSame( '', $result->get_wallet_type(), 'wallet_type must be preserved on duplicate-match.' );
-		// Other mutable card metadata still refreshes (expiry was 01/2027 → 02/2028).
+		// Other mutable card metadata still refreshes.
 		$this->assertEquals( '02', $result->get_expiry_month() );
 		$this->assertEquals( '2028', $result->get_expiry_year() );
 
@@ -660,11 +656,8 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 			'Google Pay + visa'                          => [ 'Google Pay (visa)', 'Google Pay (Visa)' ],
 			'Google Pay + mastercard'                    => [ 'Google Pay (mastercard)', 'Google Pay (MasterCard)' ],
 			'Apple Pay + amex'                           => [ 'Apple Pay (american express)', 'Apple Pay (American Express)' ],
-			// Multi-word brands: WC's `ucwords` pass on our wrapped value
-			// "Apple Pay (Cartes Bancaires)" mangles it to
-			// "Apple Pay (cartes Bancaires)" because `(` isn't a word
-			// boundary, so the first inner letter stays lowercase while the
-			// second word gets re-capitalized. The repair must still kick in.
+			// Multi-word brands: ucwords leaves the first inner letter lowercase
+			// (because `(` isn't a word boundary) but capitalizes the second word.
 			'Apple Pay + cartes_bancaires post-ucwords'  => [ 'Apple Pay (cartes Bancaires)', 'Apple Pay (Cartes Bancaires)' ],
 			'Google Pay + cartes_bancaires post-ucwords' => [ 'Google Pay (cartes Bancaires)', 'Google Pay (Cartes Bancaires)' ],
 			'Bare Visa (pass-through)'                   => [ 'Visa', 'Visa' ],

--- a/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
+++ b/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
@@ -384,13 +384,16 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Guards that a wallet-tokenized card (Apple Pay / Google Pay) persists the
-	 * `wallet_type` so the saved-methods list can show the wallet brand instead of
-	 * just the underlying card.
+	 * Guards that `add_token_to_user`'s duplicate-match path does not overwrite
+	 * the original `wallet_type`. `wallet_type` reflects how the token was created,
+	 * so re-using the same card via a wallet (e.g. saving a card directly, then
+	 * later paying via Google Pay with the same card) must not re-badge the
+	 * existing token — the shopper would see their saved Visa flipped to a
+	 * "Google Pay (Visa)" entry in My Account.
 	 *
 	 * @return void
 	 */
-	public function test_add_token_to_user_persists_wallet_type_on_refresh() {
+	public function test_add_token_to_user_preserves_wallet_type_on_refresh() {
 		$user_id = $this->factory->user->create();
 		update_user_option( $user_id, '_stripe_customer_id', 'cus_test_wallet', false );
 
@@ -403,6 +406,7 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 		$seed_token->set_card_type( 'visa' );
 		$seed_token->set_last4( '4242' );
 		$seed_token->set_fingerprint( 'F_wallet' );
+		// Saved as a plain card — no wallet branding.
 		$seed_token->save();
 		$seed_token_id = $seed_token->get_id();
 
@@ -416,6 +420,8 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 				'exp_year'      => 2028,
 				'last4'         => '4242',
 				'fingerprint'   => 'F_wallet',
+				// Same card paid via Apple Pay this time — the existing token's
+				// wallet_type must NOT be flipped to 'apple_pay'.
 				'wallet'        => (object) [ 'type' => 'apple_pay' ],
 			],
 		];
@@ -427,10 +433,13 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 		$result = $reflection->invoke( $this->stripe_payment_tokens, $incoming_pm, $customer, [] );
 
 		$this->assertSame( $seed_token_id, $result->get_id() );
-		$this->assertSame( 'apple_pay', $result->get_wallet_type(), 'wallet_type must be refreshed on duplicate-match.' );
+		$this->assertSame( '', $result->get_wallet_type(), 'wallet_type must be preserved on duplicate-match.' );
+		// Other mutable card metadata still refreshes (expiry was 01/2027 → 02/2028).
+		$this->assertEquals( '02', $result->get_expiry_month() );
+		$this->assertEquals( '2028', $result->get_expiry_year() );
 
 		$reloaded = WC_Payment_Tokens::get( $seed_token_id );
-		$this->assertSame( 'apple_pay', $reloaded->get_wallet_type(), 'wallet_type must be persisted to storage.' );
+		$this->assertSame( '', $reloaded->get_wallet_type(), 'preserved wallet_type must be persisted.' );
 	}
 
 	/**
@@ -647,12 +656,19 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 	 */
 	public function provide_test_normalize_payment_method_label_wallet_pattern() {
 		return [
-			'Apple Pay + visa'         => [ 'Apple Pay (visa)', 'Apple Pay (Visa)' ],
-			'Google Pay + visa'        => [ 'Google Pay (visa)', 'Google Pay (Visa)' ],
-			'Google Pay + mastercard'  => [ 'Google Pay (mastercard)', 'Google Pay (MasterCard)' ],
-			'Apple Pay + amex'         => [ 'Apple Pay (american express)', 'Apple Pay (American Express)' ],
-			'Bare Visa (pass-through)' => [ 'Visa', 'Visa' ],
-			'BECS still normalized'    => [ 'becs direct debit', 'BECS Direct Debit' ],
+			'Apple Pay + visa'                           => [ 'Apple Pay (visa)', 'Apple Pay (Visa)' ],
+			'Google Pay + visa'                          => [ 'Google Pay (visa)', 'Google Pay (Visa)' ],
+			'Google Pay + mastercard'                    => [ 'Google Pay (mastercard)', 'Google Pay (MasterCard)' ],
+			'Apple Pay + amex'                           => [ 'Apple Pay (american express)', 'Apple Pay (American Express)' ],
+			// Multi-word brands: WC's `ucwords` pass on our wrapped value
+			// "Apple Pay (Cartes Bancaires)" mangles it to
+			// "Apple Pay (cartes Bancaires)" because `(` isn't a word
+			// boundary, so the first inner letter stays lowercase while the
+			// second word gets re-capitalized. The repair must still kick in.
+			'Apple Pay + cartes_bancaires post-ucwords'  => [ 'Apple Pay (cartes Bancaires)', 'Apple Pay (Cartes Bancaires)' ],
+			'Google Pay + cartes_bancaires post-ucwords' => [ 'Google Pay (cartes Bancaires)', 'Google Pay (Cartes Bancaires)' ],
+			'Bare Visa (pass-through)'                   => [ 'Visa', 'Visa' ],
+			'BECS still normalized'                      => [ 'becs direct debit', 'BECS Direct Debit' ],
 		];
 	}
 


### PR DESCRIPTION
Follow-up to #5439 addressing two issues @mayisha caught post-merge.

## Changes proposed in this Pull Request:

**1. Stop refreshing `wallet_type` on the duplicate-match token paths.**

`wallet_type` was being overwritten in two spots:
- `WC_Stripe_UPE_Payment_Gateway::handle_saving_payment_method` (the order-save path)
- `WC_Stripe_Payment_Tokens::add_token_to_user` (the token-sync path)

Repro: save a card directly in My Account (no wallet), then pay a subscription via Google Pay using the same card. Stripe returns a new PM with `wallet.type = google_pay`; the duplicate-match path matched by fingerprint and re-saved the existing token with the new wallet type, re-badging the shopper's saved Visa as "Google Pay (Visa)".

Treating `wallet_type` as create-time state and not refreshing it on subsequent uses. Other mutable card metadata (expiry, last4, card_type) still refreshes — only `wallet_type` is now pinned. Trade-off: legacy tokens that pre-date the `wallet_type` field don't get backfilled by a later wallet payment. The alternative (silently flipping the shopper's saved card to a wallet brand) is the worse failure mode for what's essentially a display field.

**2. Widen `normalize_payment_method_label`'s wallet brand regex to handle multi-word brands.**

The repair regex was `^(Apple Pay|Google Pay) \(([a-z][a-z ]*)\)$`. WC core's `wc_get_credit_card_type_label` runs `ucwords` on our wrapped value, and for multi-word brands the inner string comes out half-capitalized — e.g. `"Apple Pay (Cartes Bancaires)"` becomes `"Apple Pay (cartes Bancaires)"` because `(` isn't a word boundary (first letter stays lowercase) but the space before the second word is (so `Bancaires` gets re-capitalized). The original lowercase-only regex rejected the capital B and the repair never fired, leaving the mangled label on the page.

Widened the inner group to `[^)]+` and let `wc_get_credit_card_type_label` handle the case normalization — it does its own `strtolower` + label lookup. Single-word brands still work; `cartes_bancaires`, `american_express`, `unionpay` now do too.

## Testing instructions

**Fix 1 (`wallet_type` preservation):**
1. In a Stripe test account, save card `4000056655665556` in My Account → Payment Methods.
2. Confirm the saved card shows as a plain Visa (no wallet branding).
3. Purchase a subscription via Google Pay, selecting the same card from the Google Pay sheet.
4. Reload My Account → Payment Methods.
5. **Expected:** the saved card still shows as plain Visa. Without this fix, it flips to "Google Pay (Visa)".

**Fix 2 (regex for multi-word brands):**
This is hard to reproduce manually without a `cartes_bancaires`-branded test card. The new unit-test data provider rows feed `normalize_payment_method_label` the exact post-`ucwords` string the filter sees in production (`"Apple Pay (cartes Bancaires)"`) and assert it's re-labelled to `"Apple Pay (Cartes Bancaires)"`. Run `npm run test:php -- --filter WC_Stripe_Payment_Tokens_Test`.

---

- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

### Changelog entry

- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

- [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
- [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
- [ ] Included this PR in the Release Thread scope (or does not apply)
