### PR TITLE
Send Klarna preferred_locale in the confirmation token (Optimized Checkout) flow

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.8.0
+* Fix - Send Klarna's preferred locale in the confirmation token (Optimized Checkout) flow so cross-border customers can complete identity verification
 * Fix - Preserve saved card branding when the same card is later used via a wallet, and render multi-word brands (e.g. Cartes Bancaires) correctly
 * Add - Show Apple Pay / Google Pay branding on saved card tokens in My Account → Payment Methods and at checkout
 * Add - Add a setting to control whether Express Checkout is shown on the WooCommerce Subscriptions change payment method page

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3348,6 +3348,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 				$payment_information,
 				$selected_payment_type,
 				$capture_method,
+				$order,
 			);
 		} else {
 			// Add fields that are only set when using the payment method flow.
@@ -3363,15 +3364,26 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 * @param array $payment_information The base payment information.
 	 * @param string $selected_payment_type The selected payment type.
 	 * @param string $capture_method The capture method to be used.
+	 * @param WC_Order $order The WC Order being processed.
 	 * @return array The customized payment information for the confirmation token flow.
 	 */
-	private function prepare_payment_information_for_confirmation_token( $payment_information, $selected_payment_type, $capture_method ) {
+	private function prepare_payment_information_for_confirmation_token( $payment_information, $selected_payment_type, $capture_method, $order ) {
 		// These fields should not be set when using confirmation tokens to create a payment intent.
 		unset( $payment_information['payment_method'] );
 		unset( $payment_information['payment_method_details'] );
 
 		$confirmation_token_id                     = sanitize_text_field( wp_unslash( $_POST['wc-stripe-confirmation-token'] ?? '' ) );
 		$payment_information['confirmation_token'] = $confirmation_token_id;
+
+		// Klarna routes identity verification by the locale we send; without it Stripe falls back
+		// to the account country, which fails for cross-border customers. The payment method flow
+		// sets this via get_payment_method_options(); the confirmation token flow must too.
+		if ( WC_Stripe_Payment_Methods::KLARNA === $selected_payment_type ) {
+			$preferred_locale = WC_Stripe_Helper::get_klarna_preferred_locale( get_locale(), $order->get_billing_country() );
+			if ( ! empty( $preferred_locale ) ) {
+				$payment_information['payment_method_options'][ WC_Stripe_Payment_Methods::KLARNA ]['preferred_locale'] = $preferred_locale;
+			}
+		}
 
 		// Some payment methods such as Amazon Pay will only accept a capture_method of 'manual'
 		// under payment_method_options instead of at the top level.

--- a/readme.txt
+++ b/readme.txt
@@ -152,6 +152,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.8.0 - xxxx-xx-xx =
+* Fix - Send Klarna's preferred locale in the confirmation token (Optimized Checkout) flow so cross-border customers can complete identity verification
 * Fix - Preserve saved card branding when the same card is later used via a wallet, and render multi-word brands (e.g. Cartes Bancaires) correctly
 * Add - Show Apple Pay / Google Pay branding on saved card tokens in My Account → Payment Methods and at checkout
 * Add - Allow shoppers to change a subscription payment method using Express Checkout (Apple Pay, Google Pay, Link)

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -3945,6 +3945,44 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * The confirmation token flow must still send Klarna's preferred_locale, so cross-border
+	 * customers aren't routed through the Stripe account country's identity verification.
+	 */
+	public function test_prepare_payment_information_sets_klarna_preferred_locale_for_confirmation_token() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_billing_country( 'FI' );
+		$order->save();
+
+		$this->mock_gateway->oc_enabled = true;
+
+		$_POST = [
+			'payment_method'               => 'stripe_klarna',
+			'wc-stripe-confirmation-token' => 'ctoken_mock',
+		];
+
+		$locale_filter = static function () {
+			return 'fi_FI';
+		};
+		add_filter( 'locale', $locale_filter );
+
+		$this->mock_gateway->method( 'get_stripe_customer_id' )->willReturn( 'cus_mock' );
+
+		$reflection = new \ReflectionClass( WC_Stripe_UPE_Payment_Gateway::class );
+		$method     = $reflection->getMethod( 'prepare_payment_information_from_request' );
+		$method->setAccessible( true );
+
+		try {
+			$payment_information = $method->invoke( $this->mock_gateway, $order );
+		} finally {
+			remove_filter( 'locale', $locale_filter );
+			$_POST = [];
+		}
+
+		$this->assertSame( 'ctoken_mock', $payment_information['confirmation_token'] );
+		$this->assertSame( 'fi-FI', $payment_information['payment_method_options'][ WC_Stripe_Payment_Methods::KLARNA ]['preferred_locale'] );
+	}
+
+	/**
 	 * Under OCS, save_payment_method_to_store must be re-evaluated against the resolved method type, not the OC pseudo-method.
 	 *
 	 * @dataProvider provide_test_prepare_payment_information_oc_drops_save_flag_when_resolved_method_not_reusable


### PR DESCRIPTION
Fixes #5483
Fixes STRIPE-1163
Reported in #5432

### Changes proposed in this Pull Request

Fixes Klarna identity verification failing ("We were unable to verify your identity.") for customers whose billing country differs from the merchant's Stripe **account** country, when the store uses **Optimized Checkout** (the confirmation token flow). Regression since 10.6.0.

**Root cause:** Klarna's `preferred_locale` is only set in the payment method flow — `prepare_payment_information_for_payment_method()` → `get_payment_method_options()` → `get_klarna_preferred_locale()`. The confirmation token flow (`prepare_payment_information_for_confirmation_token()`) never set it, so `payment_method_options[klarna][preferred_locale]` was omitted and Stripe fell back to the account country (e.g. it-IT), routing e.g. Finnish customers through Italian identity verification they cannot complete.

This PR sets `payment_method_options[klarna][preferred_locale]` in the confirmation token flow too, derived from the store locale + order billing country (matching the payment method flow).

Verified against the merchant's Stripe logs: failed 10.6.x PaymentIntents had `preferred_locale: null`; the successful 10.5.3 one had `fi-FI`. Their debug logs show the regular `process_upe_redirect_payment` flow with order-based PaymentIntents — i.e. this is the confirmation token path, **not** Checkout Sessions / Adaptive Pricing.

### Testing instructions

1. Stripe account registered in country A (e.g. Italy); store/customer in country B (e.g. Finland), store language `fi`.
2. Enable Optimized Checkout and Klarna.
3. As a Finnish customer, pay with Klarna → identity verification now completes (locale `fi-FI` is sent).
4. Inspect the PaymentIntent in Stripe: `payment_method_options.klarna.preferred_locale` is set (not `null`).

Automated coverage:

- `tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php` — `test_prepare_payment_information_sets_klarna_preferred_locale_for_confirmation_token` (FI billing + `fi_FI` locale + confirmation token → asserts `preferred_locale` = `fi-FI`).

- [x] Covered with tests
- [ ] Changelog and readme entries — added under 10.8.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
