### PR TITLE
Don't auto-cancel Stripe orders that have already been paid

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.8.0
+* Fix - Don't auto-cancel Stripe orders that have already been paid, preventing paid orders left at pending (e.g. by a checkout/webhook race) from being cancelled as unpaid
 * Fix - Preserve saved card branding when the same card is later used via a wallet, and render multi-word brands (e.g. Cartes Bancaires) correctly
 * Add - Show Apple Pay / Google Pay branding on saved card tokens in My Account → Payment Methods and at checkout
 * Add - Add a setting to control whether Express Checkout is shown on the WooCommerce Subscriptions change payment method page

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -474,8 +474,20 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 
 		$order_helper = WC_Stripe_Order_Helper::get_instance();
 
-		// Bail if payment method is not stripe or `stripe_{apm_method}` or doesn't have an intent yet.
-		if ( ! $order_helper->is_stripe_gateway_order( $order ) || ! $this->get_intent_from_order( $order ) ) {
+		// Bail if the payment method is not stripe or `stripe_{apm_method}`.
+		if ( ! $order_helper->is_stripe_gateway_order( $order ) ) {
+			return $cancel_order;
+		}
+
+		// Never cancel an order that has already been paid. A race between the Store API checkout
+		// and the Stripe webhook can leave a paid order stuck at `pending` (payment meta written,
+		// status transition lost), which wc_cancel_unpaid_orders() would otherwise cancel.
+		if ( $order->get_date_paid( 'edit' ) ) {
+			return false;
+		}
+
+		// Bail if the order doesn't have an intent yet.
+		if ( ! $this->get_intent_from_order( $order ) ) {
 			return $cancel_order;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -152,6 +152,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.8.0 - xxxx-xx-xx =
+* Fix - Don't auto-cancel Stripe orders that have already been paid, preventing paid orders left at pending (e.g. by a checkout/webhook race) from being cancelled as unpaid
 * Fix - Preserve saved card branding when the same card is later used via a wallet, and render multi-word brands (e.g. Cartes Bancaires) correctly
 * Add - Show Apple Pay / Google Pay branding on saved card tokens in My Account → Payment Methods and at checkout
 * Add - Allow shoppers to change a subscription payment method using Express Checkout (Apple Pay, Google Pay, Link)

--- a/tests/phpunit/class-wc-stripe-order-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-order-handler-test.php
@@ -51,4 +51,21 @@ class WC_Stripe_Order_Handler_Test extends WP_UnitTestCase {
 
 		$this->assertTrue( $this->order_handler->prevent_cancelling_orders_awaiting_action( true, $order ) );
 	}
+
+	public function test_prevent_cancelling_orders_that_have_been_paid() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_payment_method( WC_Stripe_UPE_Payment_Gateway::ID );
+		// Mimic the race outcome: payment captured (date_paid set) but status stuck at pending.
+		$order->set_date_paid( time() );
+		$order->set_status( 'pending' );
+		$order->save();
+
+		// Read in a fresh order object.
+		$order = wc_get_order( $order->get_id() );
+
+		// A paid order must never be cancelled as unpaid, and we shouldn't need to fetch the intent.
+		$this->order_handler->expects( $this->never() )->method( 'get_intent_from_order' );
+
+		$this->assertFalse( $this->order_handler->prevent_cancelling_orders_awaiting_action( true, $order ) );
+	}
 }


### PR DESCRIPTION
Fixes #5485
Fixes STRIPE-1076
Reported in #5268

### Changes proposed in this Pull Request

Prevents paid Stripe orders from being auto-cancelled as "unpaid".

A race between the Store API (block) checkout handler and the Stripe webhook can call `payment_complete()` concurrently on the same order. The payment meta (`_date_paid`, `_stripe_charge_captured`) is written, but the `pending → processing` status transition is lost — on legacy/CPT storage a stale order-object save reverts `post_status` to `pending`. `wc_cancel_unpaid_orders()` then cancels the paid order after `hold_stock_minutes`.

The plugin already hooks `woocommerce_cancel_unpaid_order` via `prevent_cancelling_orders_awaiting_action()`, but it only bailed for orders *awaiting action*. This PR also bails when the order has a `date_paid` set (for Stripe orders), so a paid order is never cancelled as unpaid regardless of the race.

This addresses the customer-visible damage. The deeper fix for the concurrent-save race itself (atomic locking around `payment_complete` and the post-checkout save) is broader and tracked under #2536 / the #5362 lineage.

### Testing instructions

1. Create a Stripe order and put it in the paid-but-pending state (set `_date_paid`, keep status `pending`) — or reproduce via the checkout/webhook race.
2. Run `wc_cancel_unpaid_orders()` (or wait for the scheduled `woocommerce_cancel_unpaid_orders` action).
3. The order is **not** cancelled (previously it would be).
4. Confirm a genuinely unpaid Stripe order (no `date_paid`) past the hold time is still cancelled as before.

Automated coverage:

- `tests/phpunit/class-wc-stripe-order-handler-test.php` — `test_prevent_cancelling_orders_that_have_been_paid` (paid Stripe order → not cancelled, without fetching the intent); existing `test_prevent_cancelling_orders_awaiting_action` still passes.

- [x] Covered with tests
- [ ] Changelog and readme entries — added under 10.8.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
