### PR TITLE
Add 'Optimized Checkout Suite is active' acknowledgment banner

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.8.0
+* Add - New promotional banner highlighting Adaptive Pricing for OCS-enabled merchants who have not enabled it yet
 * Fix - Preserve saved card branding when the same card is later used via a wallet, and render multi-word brands (e.g. Cartes Bancaires) correctly
 * Add - Show Apple Pay / Google Pay branding on saved card tokens in My Account → Payment Methods and at checkout
 * Add - Add a setting to control whether Express Checkout is shown on the WooCommerce Subscriptions change payment method page

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.8.0
-* Add - New promotional banner highlighting Adaptive Pricing for OCS-enabled merchants who have not enabled it yet
+* Add - New promotional banner acknowledging the Optimized Checkout Suite is active and highlighting its local-currency presentment feature
 * Fix - Preserve saved card branding when the same card is later used via a wallet, and render multi-word brands (e.g. Cartes Bancaires) correctly
 * Add - Show Apple Pay / Google Pay branding on saved card tokens in My Account → Payment Methods and at checkout
 * Add - Add a setting to control whether Express Checkout is shown on the WooCommerce Subscriptions change payment method page

--- a/client/settings/payment-settings/constants.js
+++ b/client/settings/payment-settings/constants.js
@@ -2,3 +2,4 @@ export const RECONNECT_BANNER = 'stripe-reconnect';
 export const BNPL_PROMOTION_BANNER = 'bnpl_promotion_banner';
 export const OC_PROMOTION_BANNER = 'oc_promotion_banner';
 export const STRIPE_TAX_BANNER = 'stripe-tax-banner';
+export const ADAPTIVE_PRICING_BANNER = 'adaptive_pricing_banner';

--- a/client/settings/payment-settings/promotional-banner/__tests__/get-promotional-banner-type.test.js
+++ b/client/settings/payment-settings/promotional-banner/__tests__/get-promotional-banner-type.test.js
@@ -1,5 +1,6 @@
 import { getPromotionalBannerType } from 'wcstripe/settings/payment-settings/promotional-banner/get-promotional-banner-type';
 import {
+	ADAPTIVE_PRICING_BANNER,
 	BNPL_PROMOTION_BANNER,
 	OC_PROMOTION_BANNER,
 	RECONNECT_BANNER,
@@ -29,7 +30,7 @@ describe( 'getPromotionalBannerType', () => {
 			)
 		).toBe( RECONNECT_BANNER );
 	} );
-	it( 'Stripe Tax banner', () => {
+	it( 'Adaptive Pricing banner — OC enabled, AP disabled', () => {
 		global.wc_stripe_settings_params = {
 			is_oc_available: true,
 		};
@@ -42,12 +43,38 @@ describe( 'getPromotionalBannerType', () => {
 		};
 		const isOCEnabled = true;
 		const enabledPaymentMethodIds = [ PAYMENT_METHOD_CARD ];
+		const isAdaptivePricingEnabled = false;
 
 		expect(
 			getPromotionalBannerType(
 				accountData,
 				isOCEnabled,
-				enabledPaymentMethodIds
+				enabledPaymentMethodIds,
+				isAdaptivePricingEnabled
+			)
+		).toBe( ADAPTIVE_PRICING_BANNER );
+	} );
+	it( 'Stripe Tax banner — OC enabled and AP also enabled', () => {
+		global.wc_stripe_settings_params = {
+			is_oc_available: true,
+		};
+
+		const accountData = {
+			testmode: false,
+			oauth_connections: {
+				live: { connected: true },
+			},
+		};
+		const isOCEnabled = true;
+		const enabledPaymentMethodIds = [ PAYMENT_METHOD_CARD ];
+		const isAdaptivePricingEnabled = true;
+
+		expect(
+			getPromotionalBannerType(
+				accountData,
+				isOCEnabled,
+				enabledPaymentMethodIds,
+				isAdaptivePricingEnabled
 			)
 		).toBe( STRIPE_TAX_BANNER );
 	} );

--- a/client/settings/payment-settings/promotional-banner/__tests__/get-promotional-banner-type.test.js
+++ b/client/settings/payment-settings/promotional-banner/__tests__/get-promotional-banner-type.test.js
@@ -30,31 +30,7 @@ describe( 'getPromotionalBannerType', () => {
 			)
 		).toBe( RECONNECT_BANNER );
 	} );
-	it( 'Adaptive Pricing banner — OC enabled, AP disabled', () => {
-		global.wc_stripe_settings_params = {
-			is_oc_available: true,
-		};
-
-		const accountData = {
-			testmode: false,
-			oauth_connections: {
-				live: { connected: true },
-			},
-		};
-		const isOCEnabled = true;
-		const enabledPaymentMethodIds = [ PAYMENT_METHOD_CARD ];
-		const isAdaptivePricingEnabled = false;
-
-		expect(
-			getPromotionalBannerType(
-				accountData,
-				isOCEnabled,
-				enabledPaymentMethodIds,
-				isAdaptivePricingEnabled
-			)
-		).toBe( ADAPTIVE_PRICING_BANNER );
-	} );
-	it( 'Stripe Tax banner — OC enabled and AP also enabled', () => {
+	it( 'OCS-active banner — OC enabled and AP also enabled', () => {
 		global.wc_stripe_settings_params = {
 			is_oc_available: true,
 		};
@@ -68,6 +44,30 @@ describe( 'getPromotionalBannerType', () => {
 		const isOCEnabled = true;
 		const enabledPaymentMethodIds = [ PAYMENT_METHOD_CARD ];
 		const isAdaptivePricingEnabled = true;
+
+		expect(
+			getPromotionalBannerType(
+				accountData,
+				isOCEnabled,
+				enabledPaymentMethodIds,
+				isAdaptivePricingEnabled
+			)
+		).toBe( ADAPTIVE_PRICING_BANNER );
+	} );
+	it( 'Stripe Tax banner — OC enabled, AP disabled', () => {
+		global.wc_stripe_settings_params = {
+			is_oc_available: true,
+		};
+
+		const accountData = {
+			testmode: false,
+			oauth_connections: {
+				live: { connected: true },
+			},
+		};
+		const isOCEnabled = true;
+		const enabledPaymentMethodIds = [ PAYMENT_METHOD_CARD ];
+		const isAdaptivePricingEnabled = false;
 
 		expect(
 			getPromotionalBannerType(

--- a/client/settings/payment-settings/promotional-banner/adaptive-pricing-banner.js
+++ b/client/settings/payment-settings/promotional-banner/adaptive-pricing-banner.js
@@ -41,13 +41,13 @@ export const AdaptivePricingBanner = ( { setShowPromotionalBanner } ) => {
 				<CardColumn>
 					<TitleAP>
 						{ __(
-							'A new (included) feature to sell more globally',
+							'Stripe Optimized Checkout Suite is now active',
 							'woocommerce-gateway-stripe'
 						) }
 					</TitleAP>
 					<IntroAP>
 						{ __(
-							'Did you know that around 90% of buyers prefer to pay in their local currency? By using local currency presentment, you can grow your global revenue by an average of 17.8%.',
+							"Your checkout dynamically displays the most relevant payment methods you've enabled for each customer. International shoppers also see prices in their local currency, growing cross-border revenue by an average of 17.8%.",
 							'woocommerce-gateway-stripe'
 						) }
 					</IntroAP>
@@ -62,18 +62,15 @@ export const AdaptivePricingBanner = ( { setShowPromotionalBanner } ) => {
 					<BannerIllustrationWithOffset
 						src={ illustration }
 						alt={ __(
-							'Try Adaptive Pricing',
+							'Optimized Checkout Suite is active',
 							'woocommerce-gateway-stripe'
 						) }
 					/>
 				</CenteredColumnIllustration>
 			</CardInner>
 			<ButtonsRowWithMargin>
-				<ExternalLink href="https://docs.stripe.com/payments/currencies/localize-prices/adaptive-pricing">
-					{ __(
-						'Learn more about Adaptive Pricing',
-						'woocommerce-gateway-stripe'
-					) }
+				<ExternalLink href="https://woocommerce.com/product-update/stripe-for-woocommerce-10-8-0">
+					{ __( 'Learn more', 'woocommerce-gateway-stripe' ) }
 				</ExternalLink>
 				<DismissButton
 					variant="secondary"

--- a/client/settings/payment-settings/promotional-banner/adaptive-pricing-banner.js
+++ b/client/settings/payment-settings/promotional-banner/adaptive-pricing-banner.js
@@ -1,0 +1,88 @@
+import { React } from 'react';
+import styled from '@emotion/styled';
+import { __ } from '@wordpress/i18n';
+import { ExternalLink } from '@wordpress/components';
+import CardBody from 'wcstripe/settings/card-body';
+import illustration from 'wcstripe/settings/payment-settings/promotional-banner/illustrations/default.svg';
+import {
+	CardColumn,
+	CardInner,
+	DismissButton,
+	BannerIllustrationWithOffset,
+	ButtonsRowWithMargin,
+	CenteredColumnIllustration,
+} from 'wcstripe/settings/payment-settings/promotional-banner/banner-layout';
+import { dismissNotice } from 'wcstripe/utils';
+
+const IntroAP = styled.p`
+	line-height: 20px;
+`;
+
+const TitleAP = styled.h4`
+	margin-top: 0.6em !important;
+	font-weight: 500;
+`;
+
+const FootnoteAP = styled.p`
+	font-size: 12px;
+	color: #757575;
+`;
+
+export const AdaptivePricingBanner = ( { setShowPromotionalBanner } ) => {
+	const handleBannerDismiss = () => {
+		dismissNotice( 'wc_stripe_show_adaptive_pricing_banner', () => {
+			setShowPromotionalBanner( false );
+		} );
+	};
+
+	return (
+		<CardBody>
+			<CardInner>
+				<CardColumn>
+					<TitleAP>
+						{ __(
+							'A new (included) feature to sell more globally',
+							'woocommerce-gateway-stripe'
+						) }
+					</TitleAP>
+					<IntroAP>
+						{ __(
+							'Did you know that around 90% of buyers prefer to pay in their local currency? By using local currency presentment, you can grow your global revenue by an average of 17.8%.',
+							'woocommerce-gateway-stripe'
+						) }
+					</IntroAP>
+					<FootnoteAP>
+						{ __(
+							'*Data is from a Stripe global holdback study conducted in 2024.',
+							'woocommerce-gateway-stripe'
+						) }
+					</FootnoteAP>
+				</CardColumn>
+				<CenteredColumnIllustration>
+					<BannerIllustrationWithOffset
+						src={ illustration }
+						alt={ __(
+							'Try Adaptive Pricing',
+							'woocommerce-gateway-stripe'
+						) }
+					/>
+				</CenteredColumnIllustration>
+			</CardInner>
+			<ButtonsRowWithMargin>
+				<ExternalLink href="https://docs.stripe.com/payments/currencies/localize-prices/adaptive-pricing">
+					{ __(
+						'Learn more about Adaptive Pricing',
+						'woocommerce-gateway-stripe'
+					) }
+				</ExternalLink>
+				<DismissButton
+					variant="secondary"
+					onClick={ handleBannerDismiss }
+					data-testid="dismiss"
+				>
+					{ __( 'Dismiss', 'woocommerce-gateway-stripe' ) }
+				</DismissButton>
+			</ButtonsRowWithMargin>
+		</CardBody>
+	);
+};

--- a/client/settings/payment-settings/promotional-banner/get-promotional-banner-type.js
+++ b/client/settings/payment-settings/promotional-banner/get-promotional-banner-type.js
@@ -37,7 +37,7 @@ export const getPromotionalBannerType = (
 		// eslint-disable-next-line camelcase
 		wc_stripe_settings_params?.is_oc_available &&
 		isOCEnabled &&
-		! isAdaptivePricingEnabled
+		isAdaptivePricingEnabled
 	) {
 		return ADAPTIVE_PRICING_BANNER;
 	} else if (

--- a/client/settings/payment-settings/promotional-banner/get-promotional-banner-type.js
+++ b/client/settings/payment-settings/promotional-banner/get-promotional-banner-type.js
@@ -1,5 +1,6 @@
 /* global wc_stripe_settings_params */
 import {
+	ADAPTIVE_PRICING_BANNER,
 	BNPL_PROMOTION_BANNER,
 	OC_PROMOTION_BANNER,
 	RECONNECT_BANNER,
@@ -10,15 +11,17 @@ import { BNPL_METHODS } from 'wcstripe/stripe-utils/constants';
 /**
  * Returns the type of promotional banner to display based on the current extension state.
  *
- * @param {Object}  accountData             The account data object containing information about the Stripe account.
- * @param {boolean} isOCEnabled             Whether the Optimized Checkout Suite (OC) is enabled.
- * @param {Array}   enabledPaymentMethodIds List of enabled payment method IDs.
+ * @param {Object}  accountData              The account data object containing information about the Stripe account.
+ * @param {boolean} isOCEnabled              Whether the Optimized Checkout Suite (OC) is enabled.
+ * @param {Array}   enabledPaymentMethodIds  List of enabled payment method IDs.
+ * @param {boolean} isAdaptivePricingEnabled Whether Adaptive Pricing is enabled.
  * @return {null|string} The type of promotional banner to display, or null if no banner is applicable.
  */
 export const getPromotionalBannerType = (
 	accountData,
 	isOCEnabled,
-	enabledPaymentMethodIds
+	enabledPaymentMethodIds,
+	isAdaptivePricingEnabled
 ) => {
 	const isTestModeEnabled = Boolean( accountData.testmode );
 	const oauthConnected = isTestModeEnabled
@@ -30,6 +33,13 @@ export const getPromotionalBannerType = (
 
 	if ( oauthConnected === false ) {
 		return RECONNECT_BANNER;
+	} else if (
+		// eslint-disable-next-line camelcase
+		wc_stripe_settings_params?.is_oc_available &&
+		isOCEnabled &&
+		! isAdaptivePricingEnabled
+	) {
+		return ADAPTIVE_PRICING_BANNER;
 	} else if (
 		// eslint-disable-next-line camelcase
 		wc_stripe_settings_params?.is_oc_available &&

--- a/client/settings/payment-settings/promotional-banner/index.js
+++ b/client/settings/payment-settings/promotional-banner/index.js
@@ -1,5 +1,6 @@
 import { React } from 'react';
 import {
+	ADAPTIVE_PRICING_BANNER,
 	RECONNECT_BANNER,
 	BNPL_PROMOTION_BANNER,
 	OC_PROMOTION_BANNER,
@@ -10,6 +11,7 @@ import { BNPLPromotionBanner } from 'wcstripe/settings/payment-settings/promotio
 import { BannerCard } from 'wcstripe/settings/payment-settings/promotional-banner/banner-layout';
 import { OCPromotionBanner } from 'wcstripe/settings/payment-settings/promotional-banner/oc-promotion-banner';
 import { StripeTaxBanner } from 'wcstripe/settings/payment-settings/promotional-banner/stripe-tax-banner';
+import { AdaptivePricingBanner } from 'wcstripe/settings/payment-settings/promotional-banner/adaptive-pricing-banner';
 
 const PromotionalBanner = ( {
 	setShowPromotionalBanner,
@@ -24,6 +26,13 @@ const PromotionalBanner = ( {
 		case STRIPE_TAX_BANNER:
 			BannerContent = (
 				<StripeTaxBanner
+					setShowPromotionalBanner={ setShowPromotionalBanner }
+				/>
+			);
+			break;
+		case ADAPTIVE_PRICING_BANNER:
+			BannerContent = (
+				<AdaptivePricingBanner
 					setShowPromotionalBanner={ setShowPromotionalBanner }
 				/>
 			);

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -7,7 +7,11 @@ import SettingsLayout from '../settings-layout';
 import PaymentSettingsPanel from '../payment-settings';
 import PaymentMethodsPanel from '../payment-methods';
 import SaveSettingsSection from '../save-settings-section';
-import { useEnabledPaymentMethodIds, useSettings } from '../../data';
+import {
+	useEnabledPaymentMethodIds,
+	useIsAdaptivePricingEnabled,
+	useSettings,
+} from '../../data';
 import { TabPanel } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
@@ -15,6 +19,7 @@ import { useAccount } from 'wcstripe/data/account';
 import OCToggleContext from 'wcstripe/settings/oc-toggle/context';
 import { getPromotionalBannerType } from 'wcstripe/settings/payment-settings/promotional-banner/get-promotional-banner-type';
 import {
+	ADAPTIVE_PRICING_BANNER,
 	BNPL_PROMOTION_BANNER,
 	OC_PROMOTION_BANNER,
 	STRIPE_TAX_BANNER,
@@ -52,10 +57,12 @@ const SettingsManager = () => {
 	const { data } = useAccount();
 	const { isOCEnabled, setIsOCEnabled } = useContext( OCToggleContext );
 	const [ enabledPaymentMethodIds ] = useEnabledPaymentMethodIds();
+	const [ isAdaptivePricingEnabled ] = useIsAdaptivePricingEnabled();
 	const promotionalBannerType = getPromotionalBannerType(
 		data,
 		isOCEnabled,
-		enabledPaymentMethodIds
+		enabledPaymentMethodIds,
+		isAdaptivePricingEnabled
 	);
 	let initialBannerState;
 	if (
@@ -76,6 +83,13 @@ const SettingsManager = () => {
 		promotionalBannerType === OC_PROMOTION_BANNER &&
 		// eslint-disable-next-line camelcase
 		wc_stripe_settings_params?.show_oc_promotional_banner === '1'
+	) {
+		initialBannerState = true;
+	}
+	if (
+		promotionalBannerType === ADAPTIVE_PRICING_BANNER &&
+		// eslint-disable-next-line camelcase
+		wc_stripe_settings_params?.show_adaptive_pricing_banner === '1'
 	) {
 		initialBannerState = true;
 	}

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -679,6 +679,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			&& null === $request->get_param( 'wc_stripe_show_optimized_checkout_notice' )
 			&& null === $request->get_param( 'wc_stripe_show_bnpl_promotion_banner' )
 			&& null === $request->get_param( 'wc_stripe_show_oc_promotion_banner' )
+			&& null === $request->get_param( 'wc_stripe_show_adaptive_pricing_banner' )
 			&& null === $request->get_param( 'wc_stripe_show_stripe_first_method_notice' ) ) {
 			return new WP_REST_Response( [], 200 );
 		}
@@ -697,6 +698,10 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 
 		if ( null !== $request->get_param( 'wc_stripe_show_oc_promotion_banner' ) ) {
 			update_option( 'wc_stripe_show_oc_promotion_banner', 'no' );
+		}
+
+		if ( null !== $request->get_param( 'wc_stripe_show_adaptive_pricing_banner' ) ) {
+			update_option( 'wc_stripe_show_adaptive_pricing_banner', 'no' );
 		}
 
 		if ( null !== $request->get_param( 'wc_stripe_show_stripe_first_method_notice' ) ) {

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -215,6 +215,12 @@ class WC_Stripe_Settings_Controller {
 			// Show the Stripe Tax banner only if OC is enabled
 			&& $is_oc_enabled;
 
+		$is_adaptive_pricing_enabled  = 'yes' === $this->get_gateway()->get_option( 'adaptive_pricing' );
+		$show_adaptive_pricing_banner = get_option( 'wc_stripe_show_adaptive_pricing_banner', 'yes' ) === 'yes'
+			// Show the Adaptive Pricing banner only when OC is enabled but AP is not.
+			&& $is_oc_enabled
+			&& ! $is_adaptive_pricing_enabled;
+
 		$is_checkout_sessions_available      = false;
 		$adaptive_pricing_unavailable_reason = 'disabled';
 		if ( WC_Stripe_Feature_Flags::is_checkout_sessions_available() ) {
@@ -233,6 +239,7 @@ class WC_Stripe_Settings_Controller {
 			'show_bnpl_promotional_banner'          => $show_bnpl_promotion_banner,
 			'show_oc_promotional_banner'            => $show_oc_promotion_banner,
 			'show_stripe_tax_banner'                => $show_stripe_tax_banner,
+			'show_adaptive_pricing_banner'          => $show_adaptive_pricing_banner,
 			'is_test_mode'                          => $this->get_gateway()->is_in_test_mode(),
 			'plugin_version'                        => WC_STRIPE_VERSION,
 			'account_country'                       => $this->account->get_account_country(),

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -217,9 +217,9 @@ class WC_Stripe_Settings_Controller {
 
 		$is_adaptive_pricing_enabled  = 'yes' === $this->get_gateway()->get_option( 'adaptive_pricing' );
 		$show_adaptive_pricing_banner = get_option( 'wc_stripe_show_adaptive_pricing_banner', 'yes' ) === 'yes'
-			// Show the Adaptive Pricing banner only when OC is enabled but AP is not.
+			// Show the "OCS is now active" acknowledgment banner only when both OC and AP are enabled.
 			&& $is_oc_enabled
-			&& ! $is_adaptive_pricing_enabled;
+			&& $is_adaptive_pricing_enabled;
 
 		$is_checkout_sessions_available      = false;
 		$adaptive_pricing_unavailable_reason = 'disabled';

--- a/readme.txt
+++ b/readme.txt
@@ -152,7 +152,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.8.0 - xxxx-xx-xx =
-* Add - New promotional banner highlighting Adaptive Pricing for OCS-enabled merchants who have not enabled it yet
+* Add - New promotional banner acknowledging the Optimized Checkout Suite is active and highlighting its local-currency presentment feature
 * Fix - Preserve saved card branding when the same card is later used via a wallet, and render multi-word brands (e.g. Cartes Bancaires) correctly
 * Add - Show Apple Pay / Google Pay branding on saved card tokens in My Account → Payment Methods and at checkout
 * Add - Allow shoppers to change a subscription payment method using Express Checkout (Apple Pay, Google Pay, Link)

--- a/readme.txt
+++ b/readme.txt
@@ -152,6 +152,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.8.0 - xxxx-xx-xx =
+* Add - New promotional banner highlighting Adaptive Pricing for OCS-enabled merchants who have not enabled it yet
 * Fix - Preserve saved card branding when the same card is later used via a wallet, and render multi-word brands (e.g. Cartes Bancaires) correctly
 * Add - Show Apple Pay / Google Pay branding on saved card tokens in My Account → Payment Methods and at checkout
 * Add - Allow shoppers to change a subscription payment method using Express Checkout (Apple Pay, Google Pay, Link)


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Adds a new promotional banner on the Stripe settings page that surfaces for merchants who have **both OCS and Adaptive Pricing enabled**. It acknowledges that OCS is active, explains AP's local-currency presentment as a built-in feature (citing the Stripe 2024 global holdback study: ~17.8% lift in cross-border revenue), and links to the 10.8.0 product update post on woocommerce.com.

Slots into the existing promotional-banner machinery:
- New `ADAPTIVE_PRICING_BANNER` constant + `adaptive-pricing-banner.js` component.
- `getPromotionalBannerType` now takes `isAdaptivePricingEnabled` and prefers this banner over the Stripe Tax banner when both OC and AP are on; Stripe Tax falls back to the OC-on/AP-off slot.
- Server-side `show_adaptive_pricing_banner` flag in `wc_stripe_settings_params`, computed from a new `wc_stripe_show_adaptive_pricing_banner` option AND the OC-on/AP-on gate.
- Dismissal goes through the same `/wc/v3/wc_stripe/settings/notice` REST handler as the other banners (`dismissNotice` utility).

Uses `illustrations/default.svg` as a placeholder until design provides a banner-specific illustration.

Preview:
<img width="806" height="241" alt="Screenshot 2026-05-26 at 08 56 22" src="https://github.com/user-attachments/assets/26cd1186-9003-4b33-b053-1d168db1f25a" />

## Testing instructions

1. Set up a Stripe-connected store with OCS available.
2. **OC off, AP irrelevant**: settings page shows the OC promotion banner (existing behavior).
3. **OC on, AP off**: settings page shows the Stripe Tax banner (existing behavior — fall-through).
4. **OC on, AP on**: settings page shows the new "Stripe Optimized Checkout Suite is now active" banner with the local-currency copy and a "Learn more" external link to https://woocommerce.com/product-update/stripe-for-woocommerce-10-8-0.
5. Click **Dismiss** — banner disappears and stays dismissed across reloads (the `wc_stripe_show_adaptive_pricing_banner` option flips to `no`).
6. Verify the banner does not appear once it's been dismissed, even when OC and AP remain enabled.

---

- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

### Changelog entry

- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

- [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
- [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
- [ ] Included this PR in the Release Thread scope (or does not apply)