### PR TITLE
ai-review: forward AI_REVIEW_TELEMETRY_TOKEN to reusable

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -14,3 +14,4 @@ jobs:
     uses: woocommerce/.github/.github/workflows/ai-code-review.yml@trunk
     secrets:
       AI_CODE_REVIEW_ANTHROPIC_API_KEY: ${{ secrets.AI_CODE_REVIEW_ANTHROPIC_API_KEY }}
+      AI_REVIEW_TELEMETRY_TOKEN: ${{ secrets.AI_REVIEW_TELEMETRY_TOKEN }}


### PR DESCRIPTION
## Proposed Changes

* Forward the org-level `AI_REVIEW_TELEMETRY_TOKEN` secret to the shared `woocommerce/.github` AI Code Review reusable workflow.

## Why

The reusable workflow now POSTs per-run telemetry (cost, duration, token usage, outcome) to a wpcom endpoint so AI review spend and quality can be tracked across all caller repos in one place. Without this forwarding line, reviews still run normally but the telemetry step posts an empty token and the endpoint rejects (logged as a `::warning::`, does not fail the job).

## Testing

* Merge this PR.
* Open a small follow-up PR against this repo and watch the AI Code Review run.
* Confirm the `Send telemetry to wpcom` step logs `telemetry: HTTP 200` and a row lands on the dashboard with `source = "woocommerce"`, the right `repo`, non-zero `cost_usd` / token counts.