### PR TITLE
Add webpack-bundle-analyzer for bundle size investigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ sftp-config.json
 vendor
 release/
 build/
+bundle-report.html
 woocommerce-gateway-stripe.zip
 languages/woocommerce-gateway-stripe.pot
 *.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Use the smallest command set needed for the task:
 | Start local environment | `npm run up` | Docker-based site at `http://localhost:8072`. |
 | Stop local environment | `npm run down` | Preserves local Docker state. |
 | Build frontend assets | `npm run build:webpack` | Use when editing client-side sources that ship built assets. |
+| Analyze bundle sizes | `BUNDLE_ANALYZE=true npm run build:webpack` | Writes `bundle-report.html` (gitignored) to the repo root. Open it to see a per-bundle module treemap. |
 | Dev hot reload | `npm start` | Webpack watch/dev mode. |
 | PHPUnit | `npm run test:php` | Requires Docker environment running. |
 | PHPUnit (parallel) | `npm run test:php:parallel` | Runs tests in parallel via paratest; requires Docker. Set `XDEBUG_MODE_PHPUNIT=coverage` to enable coverage. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,7 @@
         "typescript": "^5.3.3",
         "uglify-js": "^3.1.3",
         "webpack": "^5.101.3",
+        "webpack-bundle-analyzer": "^4.10.2",
         "webpack-cli": "^5.1.4",
         "yarnhook": "^0.5.1"
       },

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "typescript": "^5.3.3",
     "uglify-js": "^3.1.3",
     "webpack": "^5.101.3",
+    "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^5.1.4",
     "yarnhook": "^0.5.1"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require( 'path' );
 const webpack = require( 'webpack' );
 const DependencyExtractionWebpackPlugin = require( '@woocommerce/dependency-extraction-webpack-plugin' );
 const LiveReloadWebpackPlugin = require( '@kooneko/livereload-webpack-plugin' );
+const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 
 const defaultConfigOutput = defaultConfig.output;
@@ -52,6 +53,12 @@ module.exports = {
 				process.env.PAYMENT_METHOD_FEES_ENABLED === 'true'
 			),
 		} ),
+		process.env.BUNDLE_ANALYZE === 'true' &&
+			new BundleAnalyzerPlugin( {
+				analyzerMode: 'static',
+				reportFilename: '../bundle-report.html',
+				openAnalyzer: false,
+			} ),
 		! isProduction &&
 			new LiveReloadWebpackPlugin( {
 				port: process.env.WP_LIVE_RELOAD_PORT || 35729,


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Add [`webpack-bundle-analyzer`](https://github.com/webpack-contrib/webpack-bundle-analyzer) as an opt-in webpack plugin. When `BUNDLE_ANALYZE=true` is set, the build writes a `bundle-report.html` treemap at the repo root for per-bundle module inspection. Dev-only — no runtime impact, no shipped artifact.

Usage:

```bash
BUNDLE_ANALYZE=true npm run build:webpack
```

`bundle-report.html` is gitignored. `AGENTS.md` documents the workflow.

Extracted from #5475 so the analyzer can be reviewed and merged independently of the corejs polyfill work that motivated it.

## Testing instructions

1. `npm install`
2. `BUNDLE_ANALYZE=true npm run build:webpack`
3. Confirm `bundle-report.html` is generated at the repo root and renders the bundle treemap when opened in a browser.
4. `npm run build:webpack` (without the env var) — confirm `bundle-report.html` is not produced and build output is unchanged.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️) — dev-only tooling; no runtime behavior to test.
-   [x] Tested on mobile (or does not apply) — does not apply.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Dev-only tooling; no user-visible behavior change.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)