### PR TITLE
Fix dev setup compatibility error with WP 7.0

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -33,10 +33,10 @@ wp() {
 	if [ ! -f $TMPDIR/wp-cli.phar ]; then
 		download https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar  "$TMPDIR/wp-cli.phar"
 	fi
-	# Invoke the phar directly (instead of wp-cli's `wp` launcher), so it inherits
-	# the container's php CLI memory_limit (128M). That is too low for wp-cli's
-	# Extractor to unpack a current WordPress core archive and it fatals with
-	# "Allowed memory size exhausted". Lift the cap for these setup commands.
+	# wp-cli runs under the container's php CLI memory_limit (128M), which is too
+ 	# low for its Extractor to unpack a current WordPress core archive — it fatals
+	# with "Allowed memory size exhausted".
+	# So, we remove the cap for the setup commands in this script.
 	php -d memory_limit=-1 "$TMPDIR/wp-cli.phar" $@
 
 	cd "$WORKING_DIR"

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -33,7 +33,11 @@ wp() {
 	if [ ! -f $TMPDIR/wp-cli.phar ]; then
 		download https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar  "$TMPDIR/wp-cli.phar"
 	fi
-	php "$TMPDIR/wp-cli.phar" $@
+	# Invoke the phar directly (instead of wp-cli's `wp` launcher), so it inherits
+	# the container's php CLI memory_limit (128M). That is too low for wp-cli's
+	# Extractor to unpack a current WordPress core archive and it fatals with
+	# "Allowed memory size exhausted". Lift the cap for these setup commands.
+	php -d memory_limit=-1 "$TMPDIR/wp-cli.phar" $@
 
 	cd "$WORKING_DIR"
 }
@@ -105,12 +109,15 @@ fi
 set -e
 
 install_wp() {
-	if [ -d $WP_CORE_DIR ]; then
+	# Only treat the install as present when WP core files actually exist.
+	if [ -f "$WP_CORE_DIR/wp-load.php" ]; then
 		patch_ixr_casts
 		return;
 	fi
 
-	mkdir -p $WP_CORE_DIR
+	# Start from a clean directory so a partial/aborted download don't trigger a files are already present error.
+	rm -rf "$WP_CORE_DIR"
+	mkdir -p "$WP_CORE_DIR"
 
 	wp core download --version=$WP_VERSION
 

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -33,9 +33,9 @@ wp() {
 	if [ ! -f $TMPDIR/wp-cli.phar ]; then
 		download https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar  "$TMPDIR/wp-cli.phar"
 	fi
+
 	# wp-cli runs under the container's php CLI memory_limit (128M), which is too
- 	# low for its Extractor to unpack a current WordPress core archive — it fatals
-	# with "Allowed memory size exhausted".
+	# low for its Extractor to unpack a current WordPress core archive.
 	# So, we remove the cap for the setup commands in this script.
 	php -d memory_limit=-1 "$TMPDIR/wp-cli.phar" $@
 


### PR DESCRIPTION
## Changes proposed in this Pull Request:

`wp-cli` was hitting a PHP fatal (`Allowed memory size exhausted`) while unpacking the WordPress archive: it runs at the container's 128M php-CLI `memory_limit`, which is too small for current WP.

The failed download also left an empty `/tmp/wordpress/` behind, wedging later runs into the misleading `This does not seem to be a WordPress installation`.

## Testing instructions

1. With the Docker env running (`npm run up`), run `npm run test:php`.
2. `npm run test:php` → env installs and the suite passes
3. `npm run test:php:parallel` shares the same setup script and should install/run the same way

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Dev tooling only — fixes the local/CI PHPUnit setup script. No user-facing or plugin behavior change.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
