### PR TITLE
chore: pin third-party GitHub Actions to SHAs + enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,4 +20,3 @@ updates:
           - "major"
     cooldown:
       default-days: 7
-      semver-major-days: 14

--- a/.github/workflows/format-release-notes.yml
+++ b/.github/workflows/format-release-notes.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: Format release notes with Claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |


### PR DESCRIPTION
Pins third-party GitHub Actions to commit SHAs and adds Dependabot coverage for the `github-actions` ecosystem.

Tracking: DEVPROD-1073

Verification commands:

```bash
# anthropics/claude-code-action # v1.0.133
gh api repos/anthropics/claude-code-action/commits/v1.0.133 --jq '{ref:"v1.0.133",resolved_sha:.sha,expected_sha:"787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251",matches:(.sha=="787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251")}'
```

Dependabot: created .github/dependabot.yml.
