### PR TITLE
Bump WP compatibility to 7.0 to fix QIT post-merge errors

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -45,6 +45,7 @@ xxxx-xx-xx - version 10.8.0
 * Dev - Add wc_stripe_agentic_commerce_should_sync_product filter so adapters can exclude products from the Agentic Commerce catalog, inventory, and archive syncs
 * Dev - Move additional classes to autoloader, including email and migration classes
 * Add - Register Stripe gateway capabilities with the WordPress Abilities API for agent access (default off; opt in via the `wc_stripe_abilities_enabled` filter)
+* Update - Declare compatibility with WordPress 7.0
 
 2026-05-12 - version 10.7.0
 * Fix - Hide the "move Stripe to the top" Optimized Checkout notice when all payment methods above Stripe are disabled

--- a/changelog.txt
+++ b/changelog.txt
@@ -46,7 +46,6 @@ xxxx-xx-xx - version 10.8.0
 * Dev - Add wc_stripe_agentic_commerce_should_sync_product filter so adapters can exclude products from the Agentic Commerce catalog, inventory, and archive syncs
 * Dev - Move additional classes to autoloader, including email and migration classes
 * Add - Register Stripe gateway capabilities with the WordPress Abilities API for agent access (default off; opt in via the `wc_stripe_abilities_enabled` filter)
-* Update - Declare compatibility with WordPress 7.0
 
 2026-05-12 - version 10.7.0
 * Fix - Hide the "move Stripe to the top" Optimized Checkout notice when all payment methods above Stripe are disabled

--- a/readme.txt
+++ b/readme.txt
@@ -197,6 +197,5 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Add wc_stripe_agentic_commerce_should_sync_product filter so adapters can exclude products from the Agentic Commerce catalog, inventory, and archive syncs
 * Dev - Move additional classes to autoloader, including email and migration classes
 * Add - Register Stripe gateway capabilities with the WordPress Abilities API for agent access (default off; opt in via the `wc_stripe_abilities_enabled` filter)
-* Update - Declare compatibility with WordPress 7.0
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic, royho, akeda, mattyza, bor0, woothemes
 Tags: credit card, stripe, payments, woocommerce, woo
 Requires at least: 6.7
-Tested up to: 6.9.4
+Tested up to: 7.0
 Requires PHP: 7.4
 Stable tag: 10.7.0
 License: GPLv3
@@ -196,5 +196,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Add wc_stripe_agentic_commerce_should_sync_product filter so adapters can exclude products from the Agentic Commerce catalog, inventory, and archive syncs
 * Dev - Move additional classes to autoloader, including email and migration classes
 * Add - Register Stripe gateway capabilities with the WordPress Abilities API for agent access (default off; opt in via the `wc_stripe_abilities_enabled` filter)
+* Update - Declare compatibility with WordPress 7.0
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -8,7 +8,7 @@
  * Version: 10.7.0
  * Requires Plugins: woocommerce
  * Requires at least: 6.7
- * Tested up to: 6.9.4
+ * Tested up to: 7.0
  * WC requires at least: 10.5
  * WC tested up to: 10.7
  * Text Domain: woocommerce-gateway-stripe


### PR DESCRIPTION
Fixes STRIPE-<linear_issue_id>
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:

Bump `Tested up to` from `6.9.4` to `7.0` in the plugin header and `readme.txt` to declare WordPress 7.0 support.

**Resolves the failing post-merge QIT validation — the `Tested up to` major version (6.x) is no longer supported now that WordPress 7.x is current.**

<img width="944" height="268" alt="Screenshot 2026-06-02 at 17 12 18" src="https://github.com/user-attachments/assets/d84fc37a-6e61-4d43-8152-dff53b9e2f98" />

<img width="1422" height="318" alt="Screenshot 2026-06-02 at 17 12 37" src="https://github.com/user-attachments/assets/e2667f6f-4fe5-4b1c-b7e9-70d78aba130a" />

## Testing instructions

- Confirm `Tested up to: 7.0` in both `woocommerce-gateway-stripe.php` and `readme.txt`
- QIT validation passes (https://github.com/woocommerce/woocommerce-gateway-stripe/actions/runs/26845463891)

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
