### PR TITLE
Fix console errors on the Blocks checkout page editor

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 xxxx-xx-xx - version 10.8.0
 * Tweak - Drop redundant "Test mode:" label from test payment instructions on Blocks checkout, which already shows a Test Mode badge
+* Fix - Remove console errors on the Blocks checkout page editor caused by accessing wc.wcSettings without declaring the wc-settings dependency and an undefined wc_stripe_upe_params global
 * Fix - Prevent Stripe from rendering an unexpected "Address Line 2" field inside the Payment Element
 * Update - Ensure payment method restrictions based on account and shopper countries are up to date
 * Fix - Store transaction IDs for orders when we get charges to ensure we can refund correctly

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@
 
 xxxx-xx-xx - version 10.8.0
 * Tweak - Drop redundant "Test mode:" label from test payment instructions on Blocks checkout, which already shows a Test Mode badge
-* Fix - Remove console errors on the Blocks checkout page editor caused by accessing wc.wcSettings without declaring the wc-settings dependency and an undefined wc_stripe_upe_params global
+* Fix - Resolve console errors shown when editing the Blocks checkout page
 * Fix - Prevent Stripe from rendering an unexpected "Address Line 2" field inside the Payment Element
 * Update - Ensure payment method restrictions based on account and shopper countries are up to date
 * Fix - Store transaction IDs for orders when we get charges to ensure we can refund correctly

--- a/client/blocks/__tests__/utils.test.js
+++ b/client/blocks/__tests__/utils.test.js
@@ -1,3 +1,4 @@
+import { getSetting } from '@woocommerce/settings';
 import { render } from '@testing-library/react';
 import {
 	extractOrderAttributionData,
@@ -6,6 +7,10 @@ import {
 	shouldSetupOffSessionPayment,
 } from 'wcstripe/blocks/utils';
 import { isLinkEnabled } from 'wcstripe/stripe-utils';
+
+jest.mock( '@woocommerce/settings', () => ( {
+	getSetting: jest.fn(),
+} ) );
 
 jest.mock( 'wcstripe/stripe-utils', () => ( {
 	isLinkEnabled: jest.fn().mockReturnValue( false ),
@@ -55,12 +60,8 @@ describe( 'Blocks Utils', () => {
 		let mockGetSetting;
 
 		beforeEach( () => {
-			mockGetSetting = jest.fn();
-			global.wc = {
-				wcSettings: {
-					getSetting: mockGetSetting,
-				},
-			};
+			mockGetSetting = getSetting;
+			mockGetSetting.mockClear();
 			isLinkEnabled.mockReturnValue( false );
 		} );
 
@@ -137,12 +138,8 @@ describe( 'Blocks Utils', () => {
 		let mockGetSetting;
 
 		beforeEach( () => {
-			mockGetSetting = jest.fn().mockReturnValue( {} );
-			global.wc = {
-				wcSettings: {
-					getSetting: mockGetSetting,
-				},
-			};
+			mockGetSetting = getSetting;
+			mockGetSetting.mockReturnValue( {} );
 		} );
 
 		test( 'cart has auto renewal subscription', () => {

--- a/client/blocks/utils.js
+++ b/client/blocks/utils.js
@@ -1,5 +1,4 @@
-/* global wc */
-
+import { getSetting } from '@woocommerce/settings';
 import { isLinkEnabled } from 'wcstripe/stripe-utils';
 import { OPTIMIZED_CHECKOUT_DEFAULT_LAYOUT } from 'wcstripe/stripe-utils/constants';
 
@@ -10,7 +9,7 @@ import { OPTIMIZED_CHECKOUT_DEFAULT_LAYOUT } from 'wcstripe/stripe-utils/constan
  * @return {Object} The Stripe blocks configuration object.
  */
 export const getBlocksConfiguration = () => {
-	const stripeServerData = wc?.wcSettings?.getSetting( 'stripe_data', null );
+	const stripeServerData = getSetting( 'stripe_data', null );
 
 	if ( ! stripeServerData ) {
 		throw new Error( 'Stripe initialization data is not available' );

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -1,4 +1,5 @@
-/* global wc_stripe_upe_params, wc, wc_stripe_express_checkout_params */
+/* global wc_stripe_upe_params, wc_stripe_express_checkout_params */
+import { getSetting } from '@woocommerce/settings';
 import React from 'react';
 import { createPortal } from 'react-dom';
 import {
@@ -30,12 +31,9 @@ const getStripeServerData = () => {
 	// eslint-disable-next-line camelcase
 	if ( typeof wc_stripe_upe_params !== 'undefined' ) {
 		data = wc_stripe_upe_params; // eslint-disable-line camelcase
-	} else if (
-		typeof wc === 'object' &&
-		typeof wc.wcSettings !== 'undefined'
-	) {
-		// 'getSetting' has this data value on block checkout only.
-		data = wc.wcSettings?.getSetting( 'stripe_data' ) || null;
+	} else {
+		// 'stripe_data' is available via wc-settings on block checkout only.
+		data = getSetting( 'stripe_data', null );
 	}
 
 	if ( ! data ) {

--- a/client/styles/upe/index.js
+++ b/client/styles/upe/index.js
@@ -378,8 +378,10 @@ const DEFAULT_FONT_DOMAINS = [
  * @return {string[]} Array of permitted font domains.
  */
 const getPermittedFontDomains = () => {
-	// eslint-disable-next-line camelcase
-	if ( Array.isArray( wc_stripe_upe_params?.permittedFontDomains ) ) {
+	if (
+		undefined !== wc_stripe_upe_params && // eslint-disable-line camelcase
+		Array.isArray( wc_stripe_upe_params?.permittedFontDomains ) // eslint-disable-line camelcase
+	) {
 		return DEFAULT_FONT_DOMAINS.concat(
 			wc_stripe_upe_params.permittedFontDomains // eslint-disable-line camelcase
 		);

--- a/client/styles/upe/index.js
+++ b/client/styles/upe/index.js
@@ -379,7 +379,7 @@ const DEFAULT_FONT_DOMAINS = [
  */
 const getPermittedFontDomains = () => {
 	if (
-		undefined !== wc_stripe_upe_params && // eslint-disable-line camelcase
+		typeof wc_stripe_upe_params !== 'undefined' && // eslint-disable-line camelcase
 		Array.isArray( wc_stripe_upe_params?.permittedFontDomains ) // eslint-disable-line camelcase
 	) {
 		return DEFAULT_FONT_DOMAINS.concat(

--- a/readme.txt
+++ b/readme.txt
@@ -153,7 +153,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 10.8.0 - xxxx-xx-xx =
 * Tweak - Drop redundant "Test mode:" label from test payment instructions on Blocks checkout, which already shows a Test Mode badge
-* Fix - Remove console errors on the Blocks checkout page editor caused by accessing wc.wcSettings without declaring the wc-settings dependency and an undefined wc_stripe_upe_params global
+* Fix - Resolve console errors shown when editing the Blocks checkout page
 * Fix - Prevent Stripe from rendering an unexpected "Address Line 2" field inside the Payment Element
 * Update - Ensure payment method restrictions based on account and shopper countries are up to date
 * Fix - Store transaction IDs for orders when we get charges to ensure we can refund correctly

--- a/readme.txt
+++ b/readme.txt
@@ -153,6 +153,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 10.8.0 - xxxx-xx-xx =
 * Tweak - Drop redundant "Test mode:" label from test payment instructions on Blocks checkout, which already shows a Test Mode badge
+* Fix - Remove console errors on the Blocks checkout page editor caused by accessing wc.wcSettings without declaring the wc-settings dependency and an undefined wc_stripe_upe_params global
 * Fix - Prevent Stripe from rendering an unexpected "Address Line 2" field inside the Payment Element
 * Update - Ensure payment method restrictions based on account and shopper countries are up to date
 * Fix - Store transaction IDs for orders when we get charges to ensure we can refund correctly


### PR DESCRIPTION
## Changes proposed in this Pull Request:
Opening the Blocks checkout page in the editor logged two console errors. This PR fixes both at their source.

1. **`wc.wcSettings` accessed without declaring `wc-settings`**
The Stripe blocks scripts read `wc.wcSettings.getSetting('stripe_data')` through the raw `wc` global, so webpack never registered `wc-settings` as a script dependency. WooCommerce flagged this at runtime. Switched both `getBlocksConfiguration()` (`client/blocks/utils.js`) and `getStripeServerData()` (`client/stripe-utils/utils.js`) to import `getSetting` from `@woocommerce/settings` — the dependency-extraction plugin now adds `wc-settings` to the asset automatically.

<img width="373" height="620" alt="Screenshot 2026-06-03 at 4 37 16 PM" src="https://github.com/user-attachments/assets/da120549-eaab-46d6-ba10-3ea5896511fe" />


2. **`ReferenceError` on `wc_stripe_upe_params`**
`getPermittedFontDomains()` accessed `wc_stripe_upe_params` directly, which throws when the global isn't defined (e.g. in the editor). Added an `undefined` guard before reading it.

<img width="374" height="274" alt="Screenshot 2026-06-03 at 4 50 41 PM" src="https://github.com/user-attachments/assets/4805a008-29a9-4944-991b-6fd4138a1387" />

## Testing instructions
- In wp-admin, go to the block checkout editor.
- Verify that the above two console errors/warnings are not present.
- As a shopper, verify that the Stripe payment element is rendered correctly on block and classic checkout pages.
- Complete a checkout and verify that there is no regression.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
