### PR TITLE
Add E2E tests for subscription purchases and renewals under Optimized Checkout Suite

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -46,6 +46,7 @@ xxxx-xx-xx - version 10.8.0
 * Dev - Add wc_stripe_agentic_commerce_should_sync_product filter so adapters can exclude products from the Agentic Commerce catalog, inventory, and archive syncs
 * Dev - Move additional classes to autoloader, including email and migration classes
 * Add - Register Stripe gateway capabilities with the WordPress Abilities API for agent access (default off; opt in via the `wc_stripe_abilities_enabled` filter)
+* Dev - Add e2e tests for subscriptions and Optimized Checkout Suite and support stricter payment confirmation checks
 
 2026-05-12 - version 10.7.0
 * Fix - Hide the "move Stripe to the top" Optimized Checkout notice when all payment methods above Stripe are disabled

--- a/readme.txt
+++ b/readme.txt
@@ -197,5 +197,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Add wc_stripe_agentic_commerce_should_sync_product filter so adapters can exclude products from the Agentic Commerce catalog, inventory, and archive syncs
 * Dev - Move additional classes to autoloader, including email and migration classes
 * Add - Register Stripe gateway capabilities with the WordPress Abilities API for agent access (default off; opt in via the `wc_stripe_abilities_enabled` filter)
+* Dev - Add e2e tests for subscriptions and Optimized Checkout Suite and support stricter payment confirmation checks
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/e2e/config/playwright.config.js
+++ b/tests/e2e/config/playwright.config.js
@@ -87,7 +87,7 @@ const config = {
 			testMatch: '**/*.spec.js',
 			testIgnore: [
 				'**/acss.spec.js',
-				'**/optimized-checkout.spec.js',
+				'**/*optimized-checkout.spec.js',
 				'**/blik.spec.js',
 				'**/becs.spec.js',
 				'**/isk.spec.js',
@@ -131,7 +131,7 @@ const config = {
 		},
 		{
 			name: 'optimized-checkout',
-			testMatch: '**/optimized-checkout.spec.js',
+			testMatch: '**/*optimized-checkout.spec.js',
 			dependencies: [ 'oc-setup' ],
 			use: { ...devices[ 'Desktop Chrome' ] },
 		},

--- a/tests/e2e/tests/subscriptions/subscription-purchase-optimized-checkout.spec.js
+++ b/tests/e2e/tests/subscriptions/subscription-purchase-optimized-checkout.spec.js
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'crypto';
+import config from 'config';
+import { api, payments, products, user } from '../../utils';
+
+const {
+	emptyCart,
+	clickAddToCartButton,
+	setupOptimizedCheckout,
+	fillOCDetails,
+	clickPlaceOrder,
+} = payments;
+
+let productId;
+
+test.describe( 'Optimized Checkout subscription purchase tests @subscriptions', () => {
+	test.beforeAll( async () => {
+		productId = await api.create.product( products.subscriptionData() );
+	} );
+
+	test.afterAll( async () => {
+		await api.deletePost.product( productId );
+	} );
+
+	/**
+	 * Create a fresh customer and purchase the subscription product through
+	 * the Optimized Checkout element.
+	 *
+	 * A unique customer per test is required: purchasing a subscription
+	 * auto-saves a payment token, and a customer with a saved token sees the
+	 * "Use a new payment method" selector instead of the expanded new-card
+	 * OCS element, which would hide the card iframe. Logging in (rather than
+	 * guest checkout) is needed because setupOptimizedCheckout uses a fixed
+	 * billing email that would collide across the two tests.
+	 *
+	 * @param {import('@playwright/test').Page} page         Playwright page fixture.
+	 * @param {string}                          checkoutType 'blocks' or 'shortcode'.
+	 */
+	async function purchaseSubscriptionWithOC( page, checkoutType ) {
+		const randomString = randomUUID();
+		const username =
+			randomString + '.' + config.get( 'users.customer.username' );
+
+		await api.create.customer( {
+			...config.get( 'users.customer' ),
+			...config.get( 'addresses.customer' ),
+			email: randomString + '+' + config.get( 'users.customer.email' ),
+			username,
+		} );
+
+		await user.login(
+			page,
+			username,
+			config.get( 'users.customer.password' )
+		);
+
+		// Add the subscription product to the cart, then set up the checkout
+		// without letting the helper reset the cart to the default product.
+		await emptyCart( page );
+		await page.goto( `?p=${ productId }` );
+		await clickAddToCartButton( page );
+
+		await setupOptimizedCheckout( page, checkoutType, {
+			skipCartSetup: true,
+		} );
+		await fillOCDetails( page, config.get( 'cards.basic' ), checkoutType );
+
+		await clickPlaceOrder( page );
+		await page.waitForURL( '**/checkout/order-received/**' );
+		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
+			'Order received'
+		);
+	}
+
+	test( 'customer can purchase a subscription with Optimized Checkout @smoke @blocks', async ( {
+		page,
+	} ) => {
+		await purchaseSubscriptionWithOC( page, 'blocks' );
+	} );
+
+	test( 'customer can purchase a subscription with Optimized Checkout @smoke @shortcode', async ( {
+		page,
+	} ) => {
+		await purchaseSubscriptionWithOC( page, 'shortcode' );
+	} );
+} );

--- a/tests/e2e/tests/subscriptions/subscription-purchase-optimized-checkout.spec.js
+++ b/tests/e2e/tests/subscriptions/subscription-purchase-optimized-checkout.spec.js
@@ -65,6 +65,7 @@ test.describe( 'Optimized Checkout subscription purchase tests @subscriptions', 
 		await clickAddToCartButton( page );
 
 		await setupOptimizedCheckout( page, checkoutType, {
+			timeout: 10000,
 			skipCartSetup: true,
 		} );
 		await fillOCDetails( page, config.get( 'cards.basic' ), checkoutType );

--- a/tests/e2e/tests/subscriptions/subscription-purchase-optimized-checkout.spec.js
+++ b/tests/e2e/tests/subscriptions/subscription-purchase-optimized-checkout.spec.js
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { randomUUID } from 'crypto';
 import config from 'config';
-import { api, payments, products, user } from '../../utils';
+import { admin, api, payments, products, user } from '../../utils';
 
 const {
 	emptyCart,
@@ -12,6 +12,9 @@ const {
 } = payments;
 
 let productId;
+
+// Subscription product ($9.99) + flat-rate shipping ($10.00).
+const EXPECTED_ORDER_TOTAL = '19.99';
 
 test.describe( 'Optimized Checkout subscription purchase tests @subscriptions', () => {
 	test.beforeAll( async () => {
@@ -33,10 +36,11 @@ test.describe( 'Optimized Checkout subscription purchase tests @subscriptions', 
 	 * guest checkout) is needed because setupOptimizedCheckout uses a fixed
 	 * billing email that would collide across the two tests.
 	 *
-	 * @param {import('@playwright/test').Page} page         Playwright page fixture.
-	 * @param {string}                          checkoutType 'blocks' or 'shortcode'.
+	 * @param {import('@playwright/test').Page}    page         Playwright page fixture.
+	 * @param {import('@playwright/test').Browser} browser      Playwright browser fixture.
+	 * @param {string}                             checkoutType 'blocks' or 'shortcode'.
 	 */
-	async function purchaseSubscriptionWithOC( page, checkoutType ) {
+	async function purchaseSubscriptionWithOC( page, browser, checkoutType ) {
 		const randomString = randomUUID();
 		const username =
 			randomString + '.' + config.get( 'users.customer.username' );
@@ -70,17 +74,27 @@ test.describe( 'Optimized Checkout subscription purchase tests @subscriptions', 
 		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 			'Order received'
 		);
+
+		// As the admin, confirm the order was charged the expected amount.
+		const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
+		await admin.verifyOrderChargedAmount(
+			browser,
+			orderId,
+			EXPECTED_ORDER_TOTAL
+		);
 	}
 
 	test( 'customer can purchase a subscription with Optimized Checkout @smoke @blocks', async ( {
 		page,
+		browser,
 	} ) => {
-		await purchaseSubscriptionWithOC( page, 'blocks' );
+		await purchaseSubscriptionWithOC( page, browser, 'blocks' );
 	} );
 
 	test( 'customer can purchase a subscription with Optimized Checkout @smoke @shortcode', async ( {
 		page,
+		browser,
 	} ) => {
-		await purchaseSubscriptionWithOC( page, 'shortcode' );
+		await purchaseSubscriptionWithOC( page, browser, 'shortcode' );
 	} );
 } );

--- a/tests/e2e/tests/subscriptions/subscription-renewal-optimized-checkout.spec.js
+++ b/tests/e2e/tests/subscriptions/subscription-renewal-optimized-checkout.spec.js
@@ -118,6 +118,7 @@ test.describe( 'Optimized Checkout subscription renewal tests @subscriptions', (
 			await clickAddToCartButton( page );
 
 			await setupOptimizedCheckout( page, checkoutType, {
+				timeout: 10000,
 				skipCartSetup: true,
 			} );
 			await fillOCDetails(

--- a/tests/e2e/tests/subscriptions/subscription-renewal-optimized-checkout.spec.js
+++ b/tests/e2e/tests/subscriptions/subscription-renewal-optimized-checkout.spec.js
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { randomUUID } from 'crypto';
 import config from 'config';
-import { api, payments, products, user } from '../../utils';
+import { admin, api, payments, products, user } from '../../utils';
 
 const {
 	emptyCart,
@@ -12,6 +12,9 @@ const {
 } = payments;
 
 let productId;
+
+// Subscription product ($9.99) + flat-rate shipping ($10.00).
+const EXPECTED_ORDER_TOTAL = '19.99';
 
 const relatedOrdersRow = '.woocommerce-orders-table--orders tbody tr';
 
@@ -42,6 +45,7 @@ test.describe( 'Optimized Checkout subscription renewal tests @subscriptions', (
 	 *
 	 * @param {import('@playwright/test').Page} page         Playwright page fixture.
 	 * @param {string}                          checkoutType 'blocks' or 'shortcode'.
+	 * @returns {Promise<string>} The renewal order ID.
 	 */
 	async function completeRenewal( page, checkoutType ) {
 		// Note that the selectors and UX are different for blocks and shortcode.
@@ -64,9 +68,12 @@ test.describe( 'Optimized Checkout subscription renewal tests @subscriptions', (
 			await page.locator( '#place_order' ).click();
 		}
 
+		await page.waitForURL( '**/order-received/**' );
 		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 			'Order received'
 		);
+
+		return admin.getOrderIdFromOrderReceivedUrl( page.url() );
 	}
 
 	/**
@@ -77,10 +84,11 @@ test.describe( 'Optimized Checkout subscription renewal tests @subscriptions', (
 	 * pre-existing saved token (which would collapse the new-card OCS
 	 * element). Logging in is required so the renewal can reuse the token.
 	 *
-	 * @param {import('@playwright/test').Page} page         Playwright page fixture.
-	 * @param {string}                          checkoutType 'blocks' or 'shortcode'.
+	 * @param {import('@playwright/test').Page}    page         Playwright page fixture.
+	 * @param {import('@playwright/test').Browser} browser      Playwright browser fixture.
+	 * @param {string}                             checkoutType 'blocks' or 'shortcode'.
 	 */
-	async function purchaseAndRenew( page, checkoutType ) {
+	async function purchaseAndRenew( page, browser, checkoutType ) {
 		const randomString = randomUUID();
 		const username =
 			randomString + '.' + config.get( 'users.customer.username' );
@@ -91,6 +99,8 @@ test.describe( 'Optimized Checkout subscription renewal tests @subscriptions', (
 			email: randomString + '+' + config.get( 'users.customer.email' ),
 			username,
 		} );
+
+		let purchaseOrderId, renewalOrderId;
 
 		await test.step( 'customer login', async () => {
 			await user.login(
@@ -121,6 +131,10 @@ test.describe( 'Optimized Checkout subscription renewal tests @subscriptions', (
 			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 				'Order received'
 			);
+
+			purchaseOrderId = admin.getOrderIdFromOrderReceivedUrl(
+				page.url()
+			);
 		} );
 
 		await test.step( 'customer renews the subscription', async () => {
@@ -139,7 +153,7 @@ test.describe( 'Optimized Checkout subscription renewal tests @subscriptions', (
 				await page.goto( '/checkout-shortcode/' );
 			}
 
-			await completeRenewal( page, checkoutType );
+			renewalOrderId = await completeRenewal( page, checkoutType );
 		} );
 
 		await test.step( 'renewal appears in the related orders table', async () => {
@@ -149,17 +163,32 @@ test.describe( 'Optimized Checkout subscription renewal tests @subscriptions', (
 			// Initial purchase + renewal.
 			await expect( renewalOrderRows( page ) ).toHaveCount( 2 );
 		} );
+
+		await test.step( 'admin confirms the expected amounts were charged', async () => {
+			await admin.verifyOrderChargedAmount(
+				browser,
+				purchaseOrderId,
+				EXPECTED_ORDER_TOTAL
+			);
+			await admin.verifyOrderChargedAmount(
+				browser,
+				renewalOrderId,
+				EXPECTED_ORDER_TOTAL
+			);
+		} );
 	}
 
 	test( 'customer can renew an Optimized Checkout subscription @smoke @blocks', async ( {
 		page,
+		browser,
 	} ) => {
-		await purchaseAndRenew( page, 'blocks' );
+		await purchaseAndRenew( page, browser, 'blocks' );
 	} );
 
 	test( 'customer can renew an Optimized Checkout subscription @smoke @shortcode', async ( {
 		page,
+		browser,
 	} ) => {
-		await purchaseAndRenew( page, 'shortcode' );
+		await purchaseAndRenew( page, browser, 'shortcode' );
 	} );
 } );

--- a/tests/e2e/tests/subscriptions/subscription-renewal-optimized-checkout.spec.js
+++ b/tests/e2e/tests/subscriptions/subscription-renewal-optimized-checkout.spec.js
@@ -1,0 +1,165 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'crypto';
+import config from 'config';
+import { api, payments, products, user } from '../../utils';
+
+const {
+	emptyCart,
+	clickAddToCartButton,
+	setupOptimizedCheckout,
+	fillOCDetails,
+	clickPlaceOrder,
+} = payments;
+
+let productId;
+
+const relatedOrdersRow = '.woocommerce-orders-table--orders tbody tr';
+
+/**
+ * Locate the real (non-draft) related-order rows for a subscription.
+ *
+ * We need to ignore draft order, as they can be created when
+ * visiting the blocks checkout page.
+ *
+ * @param {import('@playwright/test').Page} page Playwright page fixture.
+ * @returns {import('@playwright/test').Locator} Locator for non-draft order rows.
+ */
+const renewalOrderRows = ( page ) =>
+	page.locator( relatedOrdersRow ).filter( { hasNotText: 'Draft' } );
+
+test.describe( 'Optimized Checkout subscription renewal tests @subscriptions', () => {
+	test.beforeAll( async () => {
+		productId = await api.create.product( products.subscriptionData() );
+	} );
+
+	test.afterAll( async () => {
+		await api.deletePost.product( productId );
+	} );
+
+	/**
+	 * Select the saved payment token and submit the renewal on the given
+	 * checkout surface.
+	 *
+	 * @param {import('@playwright/test').Page} page         Playwright page fixture.
+	 * @param {string}                          checkoutType 'blocks' or 'shortcode'.
+	 */
+	async function completeRenewal( page, checkoutType ) {
+		// Note that the selectors and UX are different for blocks and shortcode.
+		if ( checkoutType === 'blocks' ) {
+			await page.click(
+				'input[id^="radio-control-wc-payment-method-saved-tokens-"]'
+			);
+			await page
+				.locator( 'text=Renew subscription' )
+				.dispatchEvent( 'click' );
+		} else {
+			const savedTokenRadio = page.locator(
+				'.woocommerce-SavedPaymentMethods-token input[id^="wc-stripe-payment-token-"]'
+			);
+			await expect( savedTokenRadio ).toBeVisible();
+			await savedTokenRadio.click();
+			// Classic checkout submit (label is relabelled "Renew
+			// subscription" by WC Subscriptions, but the id is stable).
+			await expect( page.locator( '#place_order' ) ).toBeEnabled();
+			await page.locator( '#place_order' ).click();
+		}
+
+		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
+			'Order received'
+		);
+	}
+
+	/**
+	 * Purchase a subscription through the OCS element, then renew it on the
+	 * given checkout surface.
+	 *
+	 * A unique customer per test keeps the initial purchase free of a
+	 * pre-existing saved token (which would collapse the new-card OCS
+	 * element). Logging in is required so the renewal can reuse the token.
+	 *
+	 * @param {import('@playwright/test').Page} page         Playwright page fixture.
+	 * @param {string}                          checkoutType 'blocks' or 'shortcode'.
+	 */
+	async function purchaseAndRenew( page, checkoutType ) {
+		const randomString = randomUUID();
+		const username =
+			randomString + '.' + config.get( 'users.customer.username' );
+
+		await api.create.customer( {
+			...config.get( 'users.customer' ),
+			...config.get( 'addresses.customer' ),
+			email: randomString + '+' + config.get( 'users.customer.email' ),
+			username,
+		} );
+
+		await test.step( 'customer login', async () => {
+			await user.login(
+				page,
+				username,
+				config.get( 'users.customer.password' )
+			);
+		} );
+
+		await test.step( 'customer purchases a subscription through Optimized Checkout', async () => {
+			// The initial purchase goes through the OCS payment element,
+			// which auto-saves the payment token used by the renewal below.
+			await emptyCart( page );
+			await page.goto( `?p=${ productId }` );
+			await clickAddToCartButton( page );
+
+			await setupOptimizedCheckout( page, checkoutType, {
+				skipCartSetup: true,
+			} );
+			await fillOCDetails(
+				page,
+				config.get( 'cards.basic' ),
+				checkoutType
+			);
+
+			await clickPlaceOrder( page );
+			await page.waitForURL( '**/checkout/order-received/**' );
+			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
+				'Order received'
+			);
+		} );
+
+		await test.step( 'customer renews the subscription', async () => {
+			await page.goto( `/my-account` );
+			await page.click( 'text=My Subscription' );
+
+			// Only the initial purchase order is present.
+			await expect( renewalOrderRows( page ) ).toHaveCount( 1 );
+
+			// "Renew now" adds the renewal to the cart and redirects to the
+			// checkout. Navigate to the desired checkout surface to renew
+			// there (the redirect always lands on the blocks checkout).
+			await page.click( 'text=Renew now' );
+			await page.waitForURL( '**/checkout/' );
+			if ( checkoutType === 'shortcode' ) {
+				await page.goto( '/checkout-shortcode/' );
+			}
+
+			await completeRenewal( page, checkoutType );
+		} );
+
+		await test.step( 'renewal appears in the related orders table', async () => {
+			await page.goto( `/my-account` );
+			await page.click( 'text=My Subscription' );
+
+			// Initial purchase + renewal.
+			await expect( renewalOrderRows( page ) ).toHaveCount( 2 );
+		} );
+	}
+
+	test( 'customer can renew an Optimized Checkout subscription @smoke @blocks', async ( {
+		page,
+	} ) => {
+		await purchaseAndRenew( page, 'blocks' );
+	} );
+
+	test( 'customer can renew an Optimized Checkout subscription @smoke @shortcode', async ( {
+		page,
+	} ) => {
+		await purchaseAndRenew( page, 'shortcode' );
+	} );
+} );

--- a/tests/e2e/utils/admin.js
+++ b/tests/e2e/utils/admin.js
@@ -145,3 +145,78 @@ export const initializeOptimizedCheckout = async (
 
 	await adminContext.close();
 };
+
+/**
+ * Extract the order ID from a WooCommerce "Order received" page URL.
+ *
+ * @param {string} url The order-received URL (e.g. `.../order-received/123/?key=...`).
+ * @returns {string} The order ID.
+ */
+export const getOrderIdFromOrderReceivedUrl = ( url ) =>
+	url.split( 'order-received/' )[ 1 ].split( '/?' )[ 0 ];
+
+/**
+ * Open the admin order edit page for an order and confirm the expected amount
+ * was charged.
+ *
+ * Checks the following locations to ensure we are charging the expected amount:
+ *  - The "Order Total" row
+ *  - The "Paid" (captured) row of the order details
+ *  - The sum of the "Stripe Fee" and "Stripe Payout" rows
+ *
+ * @param {Browser} browser       Playwright browser fixture.
+ * @param {string}  orderId       The WooCommerce order ID.
+ * @param {string}  expectedTotal The expected charged amount, without currency
+ *                                symbol (e.g. "19.99").
+ */
+export const verifyOrderChargedAmount = async (
+	browser,
+	orderId,
+	expectedTotal
+) => {
+	const { context, page } = await getAdminPage( browser );
+
+	try {
+		// Access via the post edit screen - we should be redirected if HPOS is enabled.
+		await page.goto( `/wp-admin/post.php?post=${ orderId }&action=edit` );
+
+		const totalElementForLabel = ( label ) =>
+			page
+				.locator( '.wc-order-totals tr' )
+				.filter( { hasText: label } )
+				.locator( '.total' );
+
+		// The order is recorded for the expected total...
+		await expect( totalElementForLabel( 'Order Total' ) ).toContainText(
+			expectedTotal
+		);
+		// ...and that total was actually captured (the "Paid" line).
+		await expect( totalElementForLabel( 'Paid' ) ).toContainText(
+			expectedTotal
+		);
+
+		// Also verify that the Stripe Fee and Stripe Payout rows are present and add up to the expected amount.
+		const stripeFeeElement = totalElementForLabel( 'Stripe Fee' );
+		const stripePayoutElement = totalElementForLabel( 'Stripe Payout' );
+
+		await expect( stripeFeeElement ).toContainText( '-' );
+		await expect( stripePayoutElement ).not.toBeEmpty();
+
+		const stripeFeeText = await stripeFeeElement.textContent();
+		const stripePayoutText = await stripePayoutElement.textContent();
+
+		// Extract the numeric amount from the text content - ignore - and currency symbol.
+		const stripeFeeAmount = parseFloat(
+			stripeFeeText.replace( /[^0-9\.]/g, '' )
+		);
+		const stripePayoutAmount = parseFloat(
+			stripePayoutText.replace( /[^0-9\.]/g, '' )
+		);
+
+		const totalAmount = stripeFeeAmount + stripePayoutAmount;
+
+		expect( totalAmount ).toBeCloseTo( parseFloat( expectedTotal ), 2 );
+	} finally {
+		await context.close();
+	}
+};

--- a/tests/e2e/utils/admin.js
+++ b/tests/e2e/utils/admin.js
@@ -153,7 +153,7 @@ export const initializeOptimizedCheckout = async (
  * @returns {string} The order ID.
  */
 export const getOrderIdFromOrderReceivedUrl = ( url ) =>
-	url.split( 'order-received/' )[ 1 ].split( '/?' )[ 0 ];
+	url.split( 'order-received/' )[ 1 ].split( '/' )[ 0 ];
 
 /**
  * Open the admin order edit page for an order and confirm the expected amount

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -731,23 +731,18 @@ export const setupOptimizedCheckout = async (
 			);
 		}
 
-		// Wait for the Stripe iframe
-		await page.waitForSelector( currentSelectors.iframe, {
+		// Stripe may inject a secondary hidden iframe that matches the selector.
+		// Ensure we're looking for the visible frame.
+		const paymentIframe = page
+			.locator( currentSelectors.iframe )
+			.filter( { visible: true } )
+			.first();
+		await paymentIframe.waitFor( {
 			state: 'visible',
 			timeout: options.timeout,
 		} );
 
-		// Get the payment frame
-		const paymentFrame = await page
-			.locator( currentSelectors.iframe )
-			.contentFrame()
-			.first();
-
-		if ( ! paymentFrame ) {
-			throw new Error(
-				`Could not find Stripe payment element frame in ${ currentSelectors.container }`
-			);
-		}
+		const paymentFrame = paymentIframe.contentFrame();
 
 		// Select the card payment method
 		await paymentFrame.getByRole( 'button', { name: 'Card' } ).click();
@@ -919,20 +914,16 @@ export const fillOCDetails = async ( page, card, checkoutType = 'blocks' ) => {
 			? '#radio-control-wc-payment-method-options-stripe__content iframe[name^="__privateStripeFrame"]'
 			: '#wc-stripe-upe-form .StripeElement iframe[name^="__privateStripeFrame"]';
 
-	// Wait for the Stripe iframe to be visible
-	await page.waitForSelector( iframeSelector, {
-		state: 'visible',
-		timeout: 10000,
-	} );
-
-	const paymentFrame = await page
+	// Stripe injects a hidden "accessory-target" iframe alongside the real
+	// payment input frame; both match the selector. Target the visible one to
+	// avoid latching onto the hidden frame.
+	const paymentIframe = page
 		.locator( iframeSelector )
-		.contentFrame()
+		.filter( { visible: true } )
 		.first();
+	await paymentIframe.waitFor( { state: 'visible', timeout: 10000 } );
 
-	if ( ! paymentFrame ) {
-		throw new Error( 'Could not find Stripe payment element frame' );
-	}
+	const paymentFrame = paymentIframe.contentFrame();
 
 	// Fill in test card details
 	await paymentFrame.locator( '[name="number"]' ).fill( card.number );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-1130
Towards STRIPE-1131

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR implements E2E tests for subscription purchases and renewals using the card payment method when Optimized Checkout Suite is enabled. (These changes address STRIPE-1130.)

In addition to the above, this PR adds new `admin.getOrderIdFromOrderReceivedUrl()` and `admin.verifyOrderChargedAmount()` helper methods to identify the order ID for and order and then use the order admin UI to verify that the expected amount was actually charged. This is a first step to rolling out this kind of check across more E2E tests, which is the goal of STRIPE-1131.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
* Inspect the new tests and helpers
* Verify that the e2e tests all pass, especially the Optimized Checkout suite

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
