### PR TITLE
Fix the Adaptive Pricing checkbox's disabled state when toggling Optimized Checkout Suite

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -51,6 +51,7 @@ xxxx-xx-xx - version 10.8.0
 * Dev - Move additional classes to autoloader, including email and migration classes
 * Add - Register Stripe gateway capabilities with the WordPress Abilities API for agent access (default off; opt in via the `wc_stripe_abilities_enabled` filter)
 * Dev - Add e2e tests for subscriptions and Optimized Checkout Suite and support stricter payment confirmation checks
+ * Fix - Keep the Adaptive Pricing setting in sync with the Optimized Checkout Suite toggle without requiring a page refresh
 
 2026-05-12 - version 10.7.0
 * Fix - Hide the "move Stripe to the top" Optimized Checkout notice when all payment methods above Stripe are disabled

--- a/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
+++ b/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
@@ -116,10 +116,10 @@ describe( 'Optimized Checkout Element feature setting', () => {
 			'Let customers pay in their local currency with Adaptive Pricing'
 		);
 
-		// It should appear unchecked (not stuck "on") and be disabled while OCS is off...
+		// It should appear unchecked (not stuck "on") and be disabled while OCS is off.
 		expect( adaptivePricingCheckbox ).not.toBeChecked();
 		expect( adaptivePricingCheckbox ).toBeDisabled();
-		// ...and we never mutate the saved Adaptive Pricing value, so it can be restored when OCS is re-enabled.
+		// The saved Adaptive Pricing value is not mutated, so it can be restored when OCS is re-enabled.
 		expect( setAdaptivePricingEnabledMock ).not.toHaveBeenCalled();
 	} );
 
@@ -141,6 +141,31 @@ describe( 'Optimized Checkout Element feature setting', () => {
 
 		expect( adaptivePricingCheckbox ).toBeChecked();
 		expect( adaptivePricingCheckbox ).toBeEnabled();
+	} );
+
+	it( 'shows Adaptive Pricing as unchecked and disabled when the account does not support it, even with OCS enabled', () => {
+		global.wc_stripe_settings_params = {
+			is_cs_available: true,
+			adaptive_pricing_unavailable_reason: 'account-country',
+		};
+
+		// OCS enabled and a saved value of true, but the account-level reason blocks Adaptive Pricing.
+		useIsOCEnabled.mockReturnValue( [ true, jest.fn() ] );
+		const setAdaptivePricingEnabledMock = jest.fn();
+		useIsAdaptivePricingEnabled.mockReturnValue( [
+			true,
+			setAdaptivePricingEnabledMock,
+		] );
+
+		render( <OptimizedCheckoutFeature isOCAvailable={ true } /> );
+
+		const adaptivePricingCheckbox = screen.getByLabelText(
+			'Let customers pay in their local currency with Adaptive Pricing'
+		);
+
+		expect( adaptivePricingCheckbox ).not.toBeChecked();
+		expect( adaptivePricingCheckbox ).toBeDisabled();
+		expect( setAdaptivePricingEnabledMock ).not.toHaveBeenCalled();
 	} );
 
 	it( 'triggers the hook when changing the Adaptive Pricing setting', async () => {

--- a/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
+++ b/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
@@ -96,6 +96,53 @@ describe( 'Optimized Checkout Element feature setting', () => {
 		} );
 	} );
 
+	it( 'shows Adaptive Pricing as unchecked and disabled when OCS is off, without clearing the saved value', () => {
+		global.wc_stripe_settings_params = {
+			is_cs_available: true,
+			adaptive_pricing_unavailable_reason: null,
+		};
+
+		// OCS is off but Adaptive Pricing was previously enabled (saved value is true).
+		useIsOCEnabled.mockReturnValue( [ false, jest.fn() ] );
+		const setAdaptivePricingEnabledMock = jest.fn();
+		useIsAdaptivePricingEnabled.mockReturnValue( [
+			true,
+			setAdaptivePricingEnabledMock,
+		] );
+
+		render( <OptimizedCheckoutFeature isOCAvailable={ true } /> );
+
+		const adaptivePricingCheckbox = screen.getByLabelText(
+			'Let customers pay in their local currency with Adaptive Pricing'
+		);
+
+		// It should appear unchecked (not stuck "on") and be disabled while OCS is off...
+		expect( adaptivePricingCheckbox ).not.toBeChecked();
+		expect( adaptivePricingCheckbox ).toBeDisabled();
+		// ...and we never mutate the saved Adaptive Pricing value, so it can be restored when OCS is re-enabled.
+		expect( setAdaptivePricingEnabledMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'restores the saved Adaptive Pricing value once OCS is enabled', () => {
+		global.wc_stripe_settings_params = {
+			is_cs_available: true,
+			adaptive_pricing_unavailable_reason: null,
+		};
+
+		// OCS enabled and Adaptive Pricing previously enabled.
+		useIsOCEnabled.mockReturnValue( [ true, jest.fn() ] );
+		useIsAdaptivePricingEnabled.mockReturnValue( [ true, jest.fn() ] );
+
+		render( <OptimizedCheckoutFeature isOCAvailable={ true } /> );
+
+		const adaptivePricingCheckbox = screen.getByLabelText(
+			'Let customers pay in their local currency with Adaptive Pricing'
+		);
+
+		expect( adaptivePricingCheckbox ).toBeChecked();
+		expect( adaptivePricingCheckbox ).toBeEnabled();
+	} );
+
 	it( 'triggers the hook when changing the Adaptive Pricing setting', async () => {
 		global.wc_stripe_settings_params = {
 			is_cs_available: true,

--- a/client/settings/advanced-settings-section/optimized-checkout-feature.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-feature.js
@@ -158,6 +158,13 @@ const OptimizedCheckoutFeature = ( { isOCAvailable } ) => {
 		);
 	}, [ adaptivePricingUnavailableReason, isOCAvailable, isOCEnabled ] );
 
+	// Adaptive Pricing is a sub-feature of Optimized Checkout Suite: it cannot be used unless OCS is
+	// available and enabled (and the account supports it). When unavailable, the checkbox is disabled.
+	const isAdaptivePricingUnavailable =
+		! isOCAvailable ||
+		! isOCEnabled ||
+		adaptivePricingUnavailableReason !== null;
+
 	return (
 		<>
 			<h4 ref={ headingRef }>
@@ -224,17 +231,16 @@ const OptimizedCheckoutFeature = ( { isOCAvailable } ) => {
 			) }
 			<h4>{ __( 'Adaptive Pricing', 'woocommerce-gateway-stripe' ) }</h4>
 			<CheckboxControl
-				disabled={
-					! isOCAvailable ||
-					! isOCEnabled ||
-					adaptivePricingUnavailableReason !== null
-				}
+				disabled={ isAdaptivePricingUnavailable }
 				label={ __(
 					'Let customers pay in their local currency with Adaptive Pricing',
 					'woocommerce-gateway-stripe'
 				) }
 				help={ adaptivePricingHelp }
-				checked={ isAdaptivePricingEnabled }
+				// Show the checkbox as unchecked whenever Adaptive Pricing is unavailable.
+				checked={
+					! isAdaptivePricingUnavailable && isAdaptivePricingEnabled
+				}
 				onChange={ setIsAdaptivePricingEnabled }
 			/>
 		</>

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -215,14 +215,8 @@ class WC_Stripe_Settings_Controller {
 			// Show the Stripe Tax banner only if OC is enabled
 			&& $is_oc_enabled;
 
-		$is_checkout_sessions_available      = false;
-		$adaptive_pricing_unavailable_reason = 'disabled';
-		if ( WC_Stripe_Feature_Flags::is_checkout_sessions_available() ) {
-			$adaptive_pricing_unavailable_reason = WC_Stripe_Helper::get_adaptive_pricing_account_unavailable_reason();
-			if ( null === $adaptive_pricing_unavailable_reason ) {
-				$is_checkout_sessions_available = true;
-			}
-		}
+		$adaptive_pricing_unavailable_reason = WC_Stripe_Helper::get_adaptive_pricing_account_unavailable_reason();
+		$is_checkout_sessions_available      = null === $adaptive_pricing_unavailable_reason;
 
 		$params = [
 			'time'                                  => time(),

--- a/readme.txt
+++ b/readme.txt
@@ -202,5 +202,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Move additional classes to autoloader, including email and migration classes
 * Add - Register Stripe gateway capabilities with the WordPress Abilities API for agent access (default off; opt in via the `wc_stripe_abilities_enabled` filter)
 * Dev - Add e2e tests for subscriptions and Optimized Checkout Suite and support stricter payment confirmation checks
+ * Fix - Keep the Adaptive Pricing setting in sync with the Optimized Checkout Suite toggle without requiring a page refresh
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/admin/class-wc-stripe-settings-controller-test.php
+++ b/tests/phpunit/admin/class-wc-stripe-settings-controller-test.php
@@ -116,15 +116,12 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 	 */
 	public function test_admin_scripts_sets_checkout_sessions_availability_with_country_restrictions(
 		string $account_country,
-		bool $is_checkout_sessions_feature_available,
-		bool $expected_checkout_sessions_availability
+		bool $expected_checkout_sessions_availability,
+		?string $expected_adaptive_pricing_unavailable_reason
 	): void {
 		global $current_tab, $current_section;
 
 		$wp_scripts_backup = $GLOBALS['wp_scripts'];
-		$feature_filter    = static function () use ( $is_checkout_sessions_feature_available ) {
-			return $is_checkout_sessions_feature_available;
-		};
 
 		try {
 			// Avoid stacked `wp_localize_script` output from prior data-provider runs breaking JSON extraction.
@@ -169,8 +166,6 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 
 			$controller = new WC_Stripe_Settings_Controller( $account, $gateway );
 
-			add_filter( 'wc_stripe_is_checkout_sessions_available', $feature_filter );
-
 			$controller->admin_scripts( 'woocommerce_page_wc-settings' );
 
 			$localized_data = wp_scripts()->get_data( 'woocommerce_stripe_admin', 'data' );
@@ -185,23 +180,23 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 			$this->assertIsArray( $params );
 			$expected_cs_param = $expected_checkout_sessions_availability ? '1' : '';
 			$this->assertSame( $expected_cs_param, $params['is_cs_available'] );
+			$this->assertSame( $expected_adaptive_pricing_unavailable_reason, $params['adaptive_pricing_unavailable_reason'] );
 			$this->assertSame( 'accordion', $params['oc_layout'] );
 		} finally {
 			if ( isset( $stripe_singleton_account_backup ) ) {
 				WC_Stripe::get_instance()->account = $stripe_singleton_account_backup;
 			}
 			$GLOBALS['wp_scripts'] = $wp_scripts_backup;
-			remove_filter( 'wc_stripe_is_checkout_sessions_available', $feature_filter );
 			unset( $current_tab, $current_section );
 		}
 	}
 
 	public function provide_test_admin_scripts_checkout_sessions_country_restrictions(): array {
 		return [
-			'US account + feature available'   => [ 'US', true, true ],
-			'IN account + feature available'   => [ 'IN', true, false ],
-			'DE account + feature available'   => [ 'DE', true, true ],
-			'US account + feature unavailable' => [ 'US', false, false ],
+			// [ account country, expected is_cs_available, expected AP unavailable reason ]
+			'US account (supported)'     => [ 'US', true, null ],
+			'DE account (supported)'     => [ 'DE', true, null ],
+			'IN account (not supported)' => [ 'IN', false, 'account-country' ],
 		];
 	}
 }


### PR DESCRIPTION
Similar to STRIPE-1090

## Changes proposed in this Pull Request:
This PR addresses two small UX issues with the adaptive pricing checkbox.

 1. **AP stayed disabled after enabling OCS (until refresh).** The AP "unavailable
     reason" was derived from `is_checkout_sessions_available()`, which returns
     `false` whenever OCS is off — so it was baked in as `'disabled'` at page load
     and never re-evaluated when OCS was ticked. It now derives only from
     account-level availability (`get_adaptive_pricing_account_unavailable_reason()`).
     The OCS on/off gating stays the React app's job (it already reacts to
     `isOCEnabled`), so the AP checkbox enables the moment OCS is enabled. No change
     to the shared `is_checkout_sessions_available()` feature flag and no
     checkout-time impact.

  2. **AP was stuck "checked but disabled" after disabling OCS.** When OCS was
     unchecked with AP already on, the AP checkbox went disabled but stayed
     visually checked — looking "on" with no way to click it off. The displayed
     `checked` state is now derived from the same condition that disables the
     checkbox, so a disabled AP checkbox always reads as unchecked. The saved value
     is intentionally left untouched (it's inert at checkout, since AP runtime-gates
     on OCS), so re-enabling OCS immediately restores the merchant's previous AP
     choice.

## Testing instructions
- At first make sure OCS and AP both checkboxes are disabled (refresh the page if you made these changes just now)
- Now enable the OCS checkbox.
- In `develop` notice that the AP checkbox is still disabled and you can not check/uncheck it. Refresh the page and then you'll be able to toggle the AP checkbox.

<img width="1126" height="485" alt="Screenshot 2026-06-04 at 4 54 25 PM" src="https://github.com/user-attachments/assets/c64da7cb-a69b-44f0-b811-9d13ead3331c" />

- In this branch, the AP checkbox should be unblocked to toggle.
- Now enable OCS and AP both and save the settings. 
- Now uncheck the OCS checkbox. 
- In `develop`, notice that AP checkbox is still checked but you can not toggle it anymore.

<img width="1103" height="350" alt="Screenshot 2026-06-04 at 4 55 03 PM" src="https://github.com/user-attachments/assets/8cb18388-860c-4901-bb58-97a0b961f08b" />

- In this branch, the AP checkbox should be unblocked to toggle.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
