### PR TITLE
 Use order currency for Express Checkout on the Pay for Order page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -54,6 +54,7 @@ xxxx-xx-xx - version 10.8.0
 * Dev - Add e2e tests for subscriptions and Optimized Checkout Suite and support stricter payment confirmation checks
 * Fix - Restore "Refund via Gateway" button and Stripe dashboard transaction link for Amazon Pay orders by keeping Amazon Pay registered in the gateway list on order edit and refund pages
 * Fix - Correct Amazon Pay button preview rendering in the Full Site Editor block cart and checkout pages
+* Fix - Express Checkout (Apple Pay / Google Pay) now uses the order's currency instead of the store base currency on the Pay for Order page
 
 2026-05-12 - version 10.7.0
 * Fix - Hide the "move Stripe to the top" Optimized Checkout notice when all payment methods above Stripe are disabled

--- a/changelog.txt
+++ b/changelog.txt
@@ -57,7 +57,7 @@ xxxx-xx-xx - version 10.8.0
 * Dev - Add e2e tests for subscriptions and Optimized Checkout Suite and support stricter payment confirmation checks
 * Fix - Restore "Refund via Gateway" button and Stripe dashboard transaction link for Amazon Pay orders by keeping Amazon Pay registered in the gateway list on order edit and refund pages
 * Fix - Correct Amazon Pay button preview rendering in the Full Site Editor block cart and checkout pages
-* Fix - Express Checkout (Apple Pay / Google Pay) now uses the order's currency instead of the store base currency on the Pay for Order page
+* Fix - Use the order's currency instead of the store base currency on the Pay for Order page for the Express Checkout Element
 
 2026-05-12 - version 10.7.0
 * Fix - Hide the "move Stripe to the top" Optimized Checkout notice when all payment methods above Stripe are disabled

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -542,6 +542,7 @@ jQuery( function ( $ ) {
 
 				const {
 					total: { amount: total },
+					currency,
 					displayItems,
 					order,
 					orderDetails,
@@ -560,6 +561,7 @@ jQuery( function ( $ ) {
 				wcStripeECE.startExpressCheckout( {
 					total,
 					currency:
+						currency ??
 						getExpressCheckoutData( 'checkout' ).currency_code,
 					appearance: getExpressCheckoutButtonAppearance(),
 					locale: getExpressCheckoutData( 'stripe' )?.locale ?? 'en',

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -296,7 +296,7 @@ class WC_Stripe_Express_Checkout_Element {
 		if ( ! wp_script_is( 'wc_stripe_express_checkout', 'registered' ) ) {
 			$this->register_express_checkout_script();
 		}
-		$currency = get_woocommerce_currency();
+		$currency = $order->get_currency();
 		$data     = [];
 		$items    = [];
 
@@ -379,6 +379,7 @@ class WC_Stripe_Express_Checkout_Element {
 			],
 		];
 		$data['displayItems']   = $items;
+		$data['currency']       = strtolower( $currency );
 		$data['needs_shipping'] = false; // This should be already entered/prepared.
 		$data['total']          = [
 			'label'   => $this->express_checkout_helper->get_total_label(),

--- a/readme.txt
+++ b/readme.txt
@@ -205,5 +205,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Add e2e tests for subscriptions and Optimized Checkout Suite and support stricter payment confirmation checks
 * Fix - Restore "Refund via Gateway" button and Stripe dashboard transaction link for Amazon Pay orders by keeping Amazon Pay registered in the gateway list on order edit and refund pages
 * Fix - Correct Amazon Pay button preview rendering in the Full Site Editor block cart and checkout pages
+* Fix - Express Checkout (Apple Pay / Google Pay) now uses the order's currency instead of the store base currency on the Pay for Order page
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -208,6 +208,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Add e2e tests for subscriptions and Optimized Checkout Suite and support stricter payment confirmation checks
 * Fix - Restore "Refund via Gateway" button and Stripe dashboard transaction link for Amazon Pay orders by keeping Amazon Pay registered in the gateway list on order edit and refund pages
 * Fix - Correct Amazon Pay button preview rendering in the Full Site Editor block cart and checkout pages
-* Fix - Express Checkout (Apple Pay / Google Pay) now uses the order's currency instead of the store base currency on the Pay for Order page
+* Fix - Use the order's currency instead of the store base currency on the Pay for Order page for the Express Checkout Element
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-element-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-element-test.php
@@ -918,4 +918,78 @@ class WC_Stripe_Express_Checkout_Element_Test extends WP_UnitTestCase {
 			],
 		];
 	}
+
+	/**
+	 * The Pay for Order page must localize the express checkout payload using the order's
+	 * currency, not the store base currency. Otherwise the Apple Pay / Google Pay wallet
+	 * sheet shows the wrong currency (and, for zero-decimal currencies, the wrong amount)
+	 * whenever the order currency differs from the store base. See STRIPE-1195.
+	 *
+	 * @param string $store_currency  Store base currency option value.
+	 * @param string $order_currency  The order's currency.
+	 * @param int    $expected_amount Expected `total.amount` in Stripe's smallest unit.
+	 *
+	 * @return void
+	 * @dataProvider provide_test_localize_pay_for_order_uses_order_currency
+	 */
+	public function test_localize_pay_for_order_uses_order_currency( $store_currency, $order_currency, $expected_amount ) {
+		// Start from a clean script registration so we read only this call's localized data.
+		wp_deregister_script( 'wc_stripe_express_checkout' );
+
+		update_option( 'woocommerce_currency', $store_currency );
+
+		// Order total is 50 from the helper; give it a currency that may differ from the store base.
+		$order = WC_Helper_Order::create_order( 1, null, [ 'currency' => $order_currency ] );
+
+		$this->element->localize_pay_for_order_page_scripts( $order );
+
+		$params = $this->get_localized_pay_for_order_params();
+
+		$this->assertSame( strtolower( $order_currency ), $params['currency'] );
+		$this->assertSame( $expected_amount, $params['total']['amount'] );
+	}
+
+	/**
+	 * Data provider for `test_localize_pay_for_order_uses_order_currency`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_localize_pay_for_order_uses_order_currency() {
+		return [
+			// Order total 50, two-decimal currency differing from store base -> 5000 (cents).
+			'order currency differs from store base' => [
+				'store_currency'  => 'GBP',
+				'order_currency'  => 'AUD',
+				'expected_amount' => 5000,
+			],
+			// Zero-decimal order currency on a two-decimal store: amount must stay 50, not 5000.
+			'zero-decimal order currency'            => [
+				'store_currency'  => 'GBP',
+				'order_currency'  => 'JPY',
+				'expected_amount' => 50,
+			],
+			// Control: order currency equal to store base still works.
+			'order currency equals store base'       => [
+				'store_currency'  => 'USD',
+				'order_currency'  => 'USD',
+				'expected_amount' => 5000,
+			],
+		];
+	}
+
+	/**
+	 * Decode the localized `wcStripeExpressCheckoutPayForOrderParams` payload back into an array.
+	 *
+	 * `wp_localize_script` stores it as `var wcStripeExpressCheckoutPayForOrderParams = {json};`.
+	 *
+	 * @return array
+	 */
+	private function get_localized_pay_for_order_params() {
+		$data  = wp_scripts()->get_data( 'wc_stripe_express_checkout', 'data' );
+		$start = strpos( $data, '{' );
+		$end   = strrpos( $data, '}' );
+		$json  = substr( $data, $start, $end - $start + 1 );
+
+		return json_decode( $json, true );
+	}
 }


### PR DESCRIPTION
Fixes STRIPE-1195

## Changes proposed in this Pull Request:
- `includes/payment-methods/class-wc-stripe-express-checkout-element.php` — `localize_pay_for_order_page_scripts()` now uses `$order->get_currency()` instead of `get_woocommerce_currency()`, and adds a `currency` key to the localized `wcStripeExpressCheckoutPayForOrderParams` payload. Using the order currency also corrects the itemization/total amounts, since `WC_Stripe_Helper::get_stripe_amount()` relies on the currency for zero-decimal handling (e.g. JPY).
- `client/entrypoints/express-checkout/index.js` — the pay-for-order branch now prefers the payload's `currency`, falling back to the global checkout `currency_code` when it's absent.

## Testing instructions
- Set your store currency to Euro.
- Enable Google/Apple Pay
- As an admin, create an order with a product and an existing user.
- Get the pay for order link from the order edit page (`Customer payment page`)
- Now change the store currency to AUD.
- Go to the pay for order page.
- The order details section should have Euro in the line items and subtotal.
- Click the ECE button.
- In `develop` notice that the currency on the ECE modal is AUD.

<img width="620" height="605" alt="Screenshot 2026-06-04 at 10 38 13 PM" src="https://github.com/user-attachments/assets/3253cf8a-e1ce-43c0-9270-4ada49346d0c" />

- In this branch, the currency on the ECE modal should be Euro (order currency).

<img width="620" height="605" alt="Screenshot 2026-06-04 at 10 56 57 PM" src="https://github.com/user-attachments/assets/2424850a-a36d-41de-8715-6ba8bb9e3dea" />


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
