### PR TITLE
Fix state mapping for Morocco

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.8.0
+* Fix - Add empty state mapping for Morocco in express checkout
 * Fix - Ensure the save-payment-method checkbox is unchecked when a non-reusable payment method is selected in Optimized Checkout
 * Tweak - Drop redundant "Test mode:" label from test payment instructions on Blocks checkout, which already shows a Test Mode badge
 * Fix - Resolve console errors shown when editing the Blocks checkout page

--- a/includes/constants/class-wc-stripe-express-checkout-button-states.php
+++ b/includes/constants/class-wc-stripe-express-checkout-button-states.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *    1. WC provides a dropdown list of states, but there's no state field in Chrome for the following countries:
  *        AO (Angola), BD (Bangladesh), BG (Bulgaria), BJ (Benin), BO (Bolivia), DO (Dominican Republic),
  *        DZ (Algeria), GH (Ghana), GT (Guatemala), HU (Hungary), KE (Kenya), LA (Laos),
- *        LR (Liberia), LT (Lithuania), MD (Moldova), NA (Namibia), NP (Nepal), PK (Pakistan),
+ *        LR (Liberia), LT (Lithuania), MA (Morocco), MD (Moldova), NA (Namibia), NP (Nepal), PK (Pakistan),
  *        PY (Paraguay), RO (Romania), TZ (Tanzania), UG (Uganda), UM (United States Minor Outlying Islands),
  *        ZA (South Africa), ZM (Zambia).
  *    2. Chrome does not provide a dropdown list of states for 161 countries in total, out of the 249 countries WC supports,
@@ -650,6 +650,8 @@ class WC_Stripe_Express_Checkout_Button_States {
 		'LT' => [],
 		// Luxembourg.
 		'LU' => [],
+		// Morocco.
+		'MA' => [],
 		// Moldova.
 		'MD' => [],
 		// Martinique.

--- a/readme.txt
+++ b/readme.txt
@@ -152,6 +152,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.8.0 - xxxx-xx-xx =
+* Fix - Add empty state mapping for Morocco in express checkout
 * Fix - Ensure the save-payment-method checkbox is unchecked when a non-reusable payment method is selected in Optimized Checkout
 * Tweak - Drop redundant "Test mode:" label from test payment instructions on Blocks checkout, which already shows a Test Mode badge
 * Fix - Resolve console errors shown when editing the Blocks checkout page


### PR DESCRIPTION
Fixes STRIPE-1084

## Changes proposed in this Pull Request:
The mapping for Morocco was missing in includes/constants/class-wc-stripe-payment-request-button-states.php. The state field is not required for Lithuania in Google/Apple Pay.

## Testing instructions
Code review should be sufficient.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
