### PR TITLE
Fix duplicate payment tokens on My Account → Payment methods

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 xxxx-xx-xx - version 10.8.0
 * Add - Default Optimized Checkout Suite and Adaptive Pricing on for all eligible stores, with in-app notices announcing the change
+* Fix - Prevent saved Link, Cash App Pay, SEPA, Amazon Pay and Bacs Direct Debit payment methods from being duplicated when viewing My Account → Payment methods
 * Fix - Ensure the save-payment-method checkbox is unchecked when a non-reusable payment method is selected in Optimized Checkout
 * Tweak - Drop redundant "Test mode:" label from test payment instructions on Blocks checkout, which already shows a Test Mode badge
 * Fix - Resolve console errors shown when editing the Blocks checkout page

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -1060,37 +1060,28 @@ class WC_Stripe_Payment_Tokens {
 	 * @return string
 	 */
 	public function woocommerce_payment_token_class( $class, $type ) {
-		// WooCommerce derives the token class from the lowercase Stripe type ('WC_Payment_Token_' . $type).
-		// The case-sensitive Composer classmap can't resolve that against these mixed-case class names, so
-		// WC_Payment_Tokens::get() drops the tokens (and the sync then recreates them on every load). Map
-		// each type to its concrete class so the tokens resolve instead of being dropped.
+		// Replace WooCommerce's core credit card token with our own subclass.
 		if ( WC_Payment_Token_CC::class === $class ) {
 			return WC_Stripe_Payment_Token_CC::class;
 		}
-		if ( WC_Stripe_UPE_Payment_Method_ACH::STRIPE_ID === $type ) {
-			return WC_Payment_Token_ACH::class;
+
+		// WooCommerce derives the token class from the lowercase Stripe type ('WC_Payment_Token_' . $type),
+		// which the case-sensitive Composer classmap can't resolve for these mixed-case classes. Without an
+		// explicit mapping, WC_Payment_Tokens::get() drops the tokens and the sync recreates them on every load.
+		$token_classes = [
+			WC_Stripe_Payment_Methods::ACH         => WC_Payment_Token_ACH::class,
+			WC_Stripe_Payment_Methods::ACSS_DEBIT  => WC_Payment_Token_ACSS::class,
+			WC_Stripe_Payment_Methods::BECS_DEBIT  => WC_Payment_Token_Becs_Debit::class,
+			WC_Stripe_Payment_Methods::BACS_DEBIT  => WC_Payment_Token_Bacs_Debit::class,
+			WC_Stripe_Payment_Methods::LINK        => WC_Payment_Token_Link::class,
+			WC_Stripe_Payment_Methods::CASHAPP_PAY => WC_Payment_Token_CashApp::class,
+			WC_Stripe_Payment_Methods::SEPA        => WC_Payment_Token_SEPA::class,
+			WC_Stripe_Payment_Methods::AMAZON_PAY  => WC_Payment_Token_Amazon_Pay::class,
+		];
+		if ( isset( $token_classes[ $type ] ) ) {
+			return $token_classes[ $type ];
 		}
-		if ( WC_Stripe_UPE_Payment_Method_ACSS::STRIPE_ID === $type ) {
-			return WC_Payment_Token_ACSS::class;
-		}
-		if ( WC_Stripe_UPE_Payment_Method_Becs_Debit::STRIPE_ID === $type ) {
-			return WC_Payment_Token_Becs_Debit::class;
-		}
-		if ( WC_Stripe_Payment_Methods::LINK === $type ) {
-			return WC_Payment_Token_Link::class;
-		}
-		if ( WC_Stripe_Payment_Methods::CASHAPP_PAY === $type ) {
-			return WC_Payment_Token_CashApp::class;
-		}
-		if ( WC_Stripe_Payment_Methods::SEPA === $type ) {
-			return WC_Payment_Token_SEPA::class;
-		}
-		if ( WC_Stripe_Payment_Methods::AMAZON_PAY === $type ) {
-			return WC_Payment_Token_Amazon_Pay::class;
-		}
-		if ( WC_Stripe_Payment_Methods::BACS_DEBIT === $type ) {
-			return WC_Payment_Token_Bacs_Debit::class;
-		}
+
 		// Check for Klarna and make sure we don't override other plugins that may use `klarna` as the token ID.
 		if ( WC_Stripe_UPE_Payment_Method_Klarna::STRIPE_ID === $type && 'WC_Payment_Token_klarna' === $class ) {
 			return WC_Stripe_Klarna_Payment_Token::class;

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -1072,6 +1072,25 @@ class WC_Stripe_Payment_Tokens {
 		if ( WC_Stripe_UPE_Payment_Method_Becs_Debit::STRIPE_ID === $type ) {
 			return WC_Payment_Token_Becs_Debit::class;
 		}
+		// WooCommerce derives the token class from the lowercase Stripe type ('WC_Payment_Token_' . $type).
+		// The case-sensitive Composer classmap can't resolve that against these mixed-case class names, so
+		// WC_Payment_Tokens::get() drops the tokens (and the sync then recreates them on every load). Map
+		// each type to its concrete class so the tokens resolve instead of being dropped.
+		if ( WC_Stripe_Payment_Methods::LINK === $type ) {
+			return WC_Payment_Token_Link::class;
+		}
+		if ( WC_Stripe_Payment_Methods::CASHAPP_PAY === $type ) {
+			return WC_Payment_Token_CashApp::class;
+		}
+		if ( WC_Stripe_Payment_Methods::SEPA === $type ) {
+			return WC_Payment_Token_SEPA::class;
+		}
+		if ( WC_Stripe_Payment_Methods::AMAZON_PAY === $type ) {
+			return WC_Payment_Token_Amazon_Pay::class;
+		}
+		if ( WC_Stripe_Payment_Methods::BACS_DEBIT === $type ) {
+			return WC_Payment_Token_Bacs_Debit::class;
+		}
 		// Check for Klarna and make sure we don't override other plugins that may use `klarna` as the token ID.
 		if ( WC_Stripe_UPE_Payment_Method_Klarna::STRIPE_ID === $type && 'WC_Payment_Token_klarna' === $class ) {
 			return WC_Stripe_Klarna_Payment_Token::class;

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -1060,6 +1060,10 @@ class WC_Stripe_Payment_Tokens {
 	 * @return string
 	 */
 	public function woocommerce_payment_token_class( $class, $type ) {
+		// WooCommerce derives the token class from the lowercase Stripe type ('WC_Payment_Token_' . $type).
+		// The case-sensitive Composer classmap can't resolve that against these mixed-case class names, so
+		// WC_Payment_Tokens::get() drops the tokens (and the sync then recreates them on every load). Map
+		// each type to its concrete class so the tokens resolve instead of being dropped.
 		if ( WC_Payment_Token_CC::class === $class ) {
 			return WC_Stripe_Payment_Token_CC::class;
 		}
@@ -1072,10 +1076,6 @@ class WC_Stripe_Payment_Tokens {
 		if ( WC_Stripe_UPE_Payment_Method_Becs_Debit::STRIPE_ID === $type ) {
 			return WC_Payment_Token_Becs_Debit::class;
 		}
-		// WooCommerce derives the token class from the lowercase Stripe type ('WC_Payment_Token_' . $type).
-		// The case-sensitive Composer classmap can't resolve that against these mixed-case class names, so
-		// WC_Payment_Tokens::get() drops the tokens (and the sync then recreates them on every load). Map
-		// each type to its concrete class so the tokens resolve instead of being dropped.
 		if ( WC_Stripe_Payment_Methods::LINK === $type ) {
 			return WC_Payment_Token_Link::class;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -153,6 +153,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 10.8.0 - xxxx-xx-xx =
 * Add - Default Optimized Checkout Suite and Adaptive Pricing on for all eligible stores, with in-app notices announcing the change
+* Fix - Prevent saved Link, Cash App Pay, SEPA, Amazon Pay and Bacs Direct Debit payment methods from being duplicated when viewing My Account → Payment methods
 * Fix - Ensure the save-payment-method checkbox is unchecked when a non-reusable payment method is selected in Optimized Checkout
 * Tweak - Drop redundant "Test mode:" label from test payment instructions on Blocks checkout, which already shows a Test Mode badge
 * Fix - Resolve console errors shown when editing the Blocks checkout page

--- a/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
+++ b/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
@@ -487,6 +487,33 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 				'expected' => WC_Payment_Token_Becs_Debit::class,
 				'type'     => WC_Stripe_UPE_Payment_Method_Becs_Debit::STRIPE_ID,
 			],
+			// The cases below pass the lowercase class name WooCommerce derives from the token type
+			// ('WC_Payment_Token_' . $type), which is what triggers the dropped-token duplication bug.
+			'Link from lowercase type'         => [
+				'class'    => 'WC_Payment_Token_link',
+				'expected' => WC_Payment_Token_Link::class,
+				'type'     => WC_Stripe_Payment_Methods::LINK,
+			],
+			'Cash App from lowercase type'     => [
+				'class'    => 'WC_Payment_Token_cashapp',
+				'expected' => WC_Payment_Token_CashApp::class,
+				'type'     => WC_Stripe_Payment_Methods::CASHAPP_PAY,
+			],
+			'SEPA from lowercase type'         => [
+				'class'    => 'WC_Payment_Token_sepa',
+				'expected' => WC_Payment_Token_SEPA::class,
+				'type'     => WC_Stripe_Payment_Methods::SEPA,
+			],
+			'Amazon Pay from lowercase type'   => [
+				'class'    => 'WC_Payment_Token_amazon_pay',
+				'expected' => WC_Payment_Token_Amazon_Pay::class,
+				'type'     => WC_Stripe_Payment_Methods::AMAZON_PAY,
+			],
+			'Bacs Debit from lowercase type'   => [
+				'class'    => 'WC_Payment_Token_bacs_debit',
+				'expected' => WC_Payment_Token_Bacs_Debit::class,
+				'type'     => WC_Stripe_Payment_Methods::BACS_DEBIT,
+			],
 			'Klarna with overridden class'     => [
 				'class'    => 'test_klarna',
 				'expected' => 'test_klarna',


### PR DESCRIPTION
Fixes STRIPE-<linear_issue_id>
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:

Loading `My Account → Payment methods` duplicates saved Link, Cash App Pay, SEPA, Amazon Pay and Bacs Direct Debit tokens in the `wp_woocommerce_payment_tokens` table (on every load).

https://github.com/user-attachments/assets/da3b9ec4-bee7-4dc0-b89a-37361e3faf7d

Root cause:
- `WC_Payment_Tokens::get()` builds each token's class as `WC_Payment_Token_{type}` from the lowercase Stripe type (e.g. `WC_Payment_Token_link`) and silently drops the token if `class_exists()` is false. 
- Our classes are in the case-sensitive Composer classmap under mixed-case names (`WC_Payment_Token_Link`, `..._CashApp`, `..._SEPA`, etc) and aren't loaded at bootstrap, so the lookup misses and WooCommerce drops the tokens from `get_tokens()`.
- The sync (`sync_and_retrieve_customer_payment_tokens`) then can't see them and recreates them on each load. 

`woocommerce_payment_token_class(...)` already maps CC/ACH/ACSS/BECS/Klarna; this PR adds the missing mapping for the five that were missing.

_NOTE:_ This stops **new duplicates** but doesn't remove rows already accumulated. A one-time dedupe migration (keep one row per user_id+token preserving any subscription-referenced token) will be handled in a follow-up PR.

## Testing instructions

1. Enable Cash App Pay
2. As a customer save a Cash App Pay payment method (either by manually adding it from My Account or by purchasing a subscription with it)
3. Navigate to `My account > Payment methods` and verify that the new payment method is shown
4. Reload the page a couple times
5. Check the table `wp_woocommerce_payment_tokens ` in the DB (the newest rows), in `develop` several duplicates are present (same `token`); but with this branch there is only one row for the newly added payment method:
    <img width="724" height="285" alt="Screenshot 2026-06-05 at 03 31 31" src="https://github.com/user-attachments/assets/a9e09c35-cb60-4b72-a1c0-0aa340402d1e" />

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
