### PR TITLE
Don't default Adaptive Pricing on for India-based accounts at Connect OAuth

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -47,7 +47,7 @@ xxxx-xx-xx - version 10.8.0
 * Update - Improve express checkout load times by preloading the resources
 * Tweak - Reduce JS bundle sizes by using native browser features instead of polyfills
 * Dev - Memoize the Express Checkout button visibility check within a request
-* Fix - Don't default Adaptive Pricing on when connecting a Stripe account it is unavailable for (e.g. India-based accounts)
+* Fix - Don't default Adaptive Pricing on when first connecting a Stripe account that is ineligible for Adaptive Pricing
 * Fix - Fix admin banner dismissal and display logic
 * Add - Detect Stripe API outages (network failures, timeouts, 5xx responses) and surface a wp-admin notice instead of crashing or showing misleading "couldn't connect" messages
 * Fix - Require a connected account for the target mode before switching between test and live

--- a/changelog.txt
+++ b/changelog.txt
@@ -47,6 +47,7 @@ xxxx-xx-xx - version 10.8.0
 * Update - Improve express checkout load times by preloading the resources
 * Tweak - Reduce JS bundle sizes by using native browser features instead of polyfills
 * Dev - Memoize the Express Checkout button visibility check within a request
+* Fix - Don't default Adaptive Pricing on when connecting a Stripe account it is unavailable for (e.g. India-based accounts)
 * Fix - Fix admin banner dismissal and display logic
 * Add - Detect Stripe API outages (network failures, timeouts, 5xx responses) and surface a wp-admin notice instead of crashing or showing misleading "couldn't connect" messages
 * Fix - Require a connected account for the target mode before switching between test and live

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -215,13 +215,16 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 		}
 
 		/**
-		 * Helper function to clear some important PMC caches after a key update.
+		 * Helper function to clear some important caches after a key update.
 		 */
 		public function clear_caches_after_key_update(): void {
 			// Note that we also need to update the fallback PMC details, but we can't simply wipe that data.
 
 			// Clear PMC cache after key updates.
 			WC_Stripe_Payment_Method_Configurations::clear_payment_method_configuration_cache();
+
+			// Clear the account cache; the new keys may belong to a different account.
+			WC_Stripe::get_instance()->account->clear_cache();
 		}
 
 		/**
@@ -295,8 +298,6 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			// Runs after the keys are saved: the Adaptive Pricing decision needs the account country.
 			if ( 'connect' === $type && $should_default_optimized_checkout_on ) {
 				$account = WC_Stripe::get_instance()->account;
-				// Force refresh to avoid stale data from a previous connection.
-				$account->get_cached_account_data( $mode, true );
 
 				$options['optimized_checkout_element'] = 'yes';
 				if ( WC_Stripe_Country_Code::INDIA !== strtoupper( $account->get_account_country() ) ) {

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -273,10 +273,6 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			$should_default_optimized_checkout_on       = get_option( 'wc_stripe_optimized_checkout_default_on' );
 			// Clean up the option.
 			delete_option( 'wc_stripe_optimized_checkout_default_on' );
-			if ( 'connect' === $type && $should_default_optimized_checkout_on ) {
-				$options['optimized_checkout_element'] = 'yes';
-				$options['adaptive_pricing']           = 'yes';
-			}
 			if ( 'app' === $type ) {
 				$options[ $prefix . 'refresh_token' ] = $result->refreshToken; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			}
@@ -295,6 +291,21 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			update_option( 'wc_stripe_' . $prefix . 'oauth_last_failed_at', '' );
 
 			$this->clear_caches_after_key_update();
+
+			// Runs after the keys are saved: the Adaptive Pricing decision needs the account country.
+			if ( 'connect' === $type && $should_default_optimized_checkout_on ) {
+				$account = WC_Stripe::get_instance()->account;
+				// Force refresh to avoid stale data from a previous connection.
+				$account->get_cached_account_data( $mode, true );
+
+				$options['optimized_checkout_element'] = 'yes';
+				if ( WC_Stripe_Country_Code::INDIA !== strtoupper( $account->get_account_country() ) ) {
+					$options['adaptive_pricing'] = 'yes';
+				} else {
+					WC_Stripe_Logger::info( 'OAuth: Not defaulting Adaptive Pricing on; it is not supported for India-based accounts.' );
+				}
+				WC_Stripe_Helper::update_main_stripe_settings( $options );
+			}
 
 			if ( $is_verbose_debug_mode_enabled ) {
 				WC_Stripe_Logger::debug(

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -295,15 +295,13 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 
 			$this->clear_caches_after_key_update();
 
-			// Runs after the keys are saved: the Adaptive Pricing decision needs the account country.
+			// Runs after the keys are saved: the Adaptive Pricing decision needs the account data.
 			if ( 'connect' === $type && $should_default_optimized_checkout_on ) {
-				$account = WC_Stripe::get_instance()->account;
-
 				$options['optimized_checkout_element'] = 'yes';
-				if ( WC_Stripe_Country_Code::INDIA !== strtoupper( $account->get_account_country() ) ) {
+				if ( WC_Stripe_Helper::is_adaptive_pricing_available_for_account() ) {
 					$options['adaptive_pricing'] = 'yes';
 				} else {
-					WC_Stripe_Logger::info( 'OAuth: Not defaulting Adaptive Pricing on; it is not supported for India-based accounts.' );
+					WC_Stripe_Logger::info( 'OAuth: Not defaulting Adaptive Pricing on; it is not available for the connected account.' );
 				}
 				WC_Stripe_Helper::update_main_stripe_settings( $options );
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -198,7 +198,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Improve express checkout load times by preloading the resources
 * Tweak - Reduce JS bundle sizes by using native browser features instead of polyfills
 * Dev - Memoize the Express Checkout button visibility check within a request
-* Fix - Don't default Adaptive Pricing on when connecting a Stripe account it is unavailable for (e.g. India-based accounts)
+* Fix - Don't default Adaptive Pricing on when first connecting a Stripe account that is ineligible for Adaptive Pricing
 * Fix - Fix admin banner dismissal and display logic
 * Add - Detect Stripe API outages (network failures, timeouts, 5xx responses) and surface a wp-admin notice instead of crashing or showing misleading "couldn't connect" messages
 * Fix - Require a connected account for the target mode before switching between test and live

--- a/readme.txt
+++ b/readme.txt
@@ -198,6 +198,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Improve express checkout load times by preloading the resources
 * Tweak - Reduce JS bundle sizes by using native browser features instead of polyfills
 * Dev - Memoize the Express Checkout button visibility check within a request
+* Fix - Don't default Adaptive Pricing on when connecting a Stripe account it is unavailable for (e.g. India-based accounts)
 * Fix - Fix admin banner dismissal and display logic
 * Add - Detect Stripe API outages (network failures, timeouts, 5xx responses) and surface a wp-admin notice instead of crashing or showing misleading "couldn't connect" messages
 * Fix - Require a connected account for the target mode before switching between test and live

--- a/tests/phpunit/class-wc-stripe-connect-test.php
+++ b/tests/phpunit/class-wc-stripe-connect-test.php
@@ -42,22 +42,27 @@ class WC_Stripe_Connect_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 
 	/**
 	 * Asserts that the OCS install marker is consumed during Connect OAuth: when the
-	 * marker is present and the connection type is 'connect', both Optimized Checkout
-	 * and Adaptive Pricing are defaulted to 'yes'. The marker is always cleaned up.
+	 * marker is present and the connection type is 'connect', Optimized Checkout is
+	 * defaulted to 'yes' and Adaptive Pricing is defaulted to 'yes' unless the connected
+	 * account is India-based, where Adaptive Pricing is not supported. The marker is
+	 * always cleaned up.
 	 *
 	 * @param bool   $marker_set       Whether the OCS install marker is set before save.
 	 * @param string $type             Connection type ('connect' or 'app').
+	 * @param string $account_country  Country of the connected Stripe account.
 	 * @param string $expected_oc      Expected value of optimized_checkout_element after save.
 	 * @param string $expected_ap      Expected value of adaptive_pricing after save.
 	 *
 	 * @dataProvider provide_save_stripe_keys_defaults_ocs_for_new_installs
 	 */
-	public function test_save_stripe_keys_defaults_ocs_and_adaptive_pricing_for_new_installs( bool $marker_set, string $type, string $expected_oc, string $expected_ap ): void {
+	public function test_save_stripe_keys_defaults_ocs_and_adaptive_pricing_for_new_installs( bool $marker_set, string $type, string $account_country, string $expected_oc, string $expected_ap ): void {
 		if ( $marker_set ) {
 			update_option( 'wc_stripe_optimized_checkout_default_on', 'yes' );
 		} else {
 			delete_option( 'wc_stripe_optimized_checkout_default_on' );
 		}
+
+		$this->set_stripe_account_data( [ 'country' => $account_country ] );
 
 		$result                 = new stdClass();
 		$result->publishableKey = 'pk_test_123'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
@@ -85,22 +90,32 @@ class WC_Stripe_Connect_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	public function provide_save_stripe_keys_defaults_ocs_for_new_installs(): array {
 		return [
 			'marker set + connect type defaults both OCS and Adaptive Pricing' => [
-				'marker_set'  => true,
-				'type'        => 'connect',
-				'expected_oc' => 'yes',
-				'expected_ap' => 'yes',
+				'marker_set'      => true,
+				'type'            => 'connect',
+				'account_country' => 'US',
+				'expected_oc'     => 'yes',
+				'expected_ap'     => 'yes',
+			],
+			'marker set + connect type + India account defaults OCS only'      => [
+				'marker_set'      => true,
+				'type'            => 'connect',
+				'account_country' => 'IN',
+				'expected_oc'     => 'yes',
+				'expected_ap'     => '',
 			],
 			'marker set + app type leaves both unset'                          => [
-				'marker_set'  => true,
-				'type'        => 'app',
-				'expected_oc' => '',
-				'expected_ap' => '',
+				'marker_set'      => true,
+				'type'            => 'app',
+				'account_country' => 'US',
+				'expected_oc'     => '',
+				'expected_ap'     => '',
 			],
 			'no marker + connect type leaves both unset'                       => [
-				'marker_set'  => false,
-				'type'        => 'connect',
-				'expected_oc' => '',
-				'expected_ap' => '',
+				'marker_set'      => false,
+				'type'            => 'connect',
+				'account_country' => 'US',
+				'expected_oc'     => '',
+				'expected_ap'     => '',
 			],
 		];
 	}


### PR DESCRIPTION
Towards STRIPE-1176

## Changes proposed in this Pull Request:
We are defaulting Optimized Checkout and Adaptive Pricing on for new installs at Connect OAuth time. However, Adaptive Pricing is [not supported for India-based Stripe accounts](https://docs.stripe.com/payments/currencies/localize-prices/adaptive-pricing?payment-ui=embedded-components#restrictions), and the OAuth path enabled it unconditionally — so India-based accounts also got `adaptive_pricing = 'yes'`. 

This PR moves the default-on logic in `WC_Stripe_Connect::save_stripe_keys()` to after the new keys are saved — the account country can only be fetched with the new keys — and skips the Adaptive Pricing flip when the connected account is India-based. The account data is force-refreshed before the check so a stale cache from a previous connection can't influence the decision.

## Testing instructions
- Create a new JN site.
- Build the plugin from `release/10.8.0` and install the plugin.
- Connect to a IN Stripe account.
- Notice that the OCS and AP both got auto-enabled but the AP checkbox can not be toggled.

<img width="770" height="546" alt="India frontbook 10 7" src="https://github.com/user-attachments/assets/1460a6bc-ee2d-4494-988d-4c7faa491594" />

- Now build the plugin from this branch.
- Create another new JN site and install the build of this branch.
- Connect to a IN Stripe account.
- Notice that the OCS is auto-enabled and AP is disabled with the correct message.

<img width="577" height="517" alt="Screenshot 2026-06-05 at 5 10 42 PM" src="https://github.com/user-attachments/assets/fec81835-70d0-4d31-ab13-9334deffe0fa" />

- Regression test: ensure that the default-on feature in working correctly for non-IN accounts.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
