### PR TITLE
Update the text in OCS-only banner

### DIFF
--- a/client/settings/payment-settings/promotional-banner/ocs-only-banner.js
+++ b/client/settings/payment-settings/promotional-banner/ocs-only-banner.js
@@ -35,7 +35,7 @@ export const OCSOnlyBanner = ( { setShowPromotionalBanner } ) => {
 					</BannerTitle>
 					<BannerIntro>
 						{ __(
-							'Your checkout dynamically displays the payment methods most likely to drive conversions.',
+							"Your checkout is optimized for sales by dynamically displaying the most relevant payment methods you've enabled for each customer.",
 							'woocommerce-gateway-stripe'
 						) }
 					</BannerIntro>


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Context: p1780670902026769/1779354973.383469-slack-C06ETDR8APN

## Changes proposed in this Pull Request:

This is a text update to the OCS-only promotional banner that gets displayed when only OCS is defaulted on for backbook merchants as a part of the 10.8.0 migration

<img width="1594" height="402" alt="CleanShot 2026-06-05 at 10 21 10@2x" src="https://github.com/user-attachments/assets/d5ace258-04e4-41b2-9986-d4bf5592d59c" />

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

Code inspection is enough. If you want to force the banner, you can do it by adding `return OCS_ONLY_BANNER;` to the top of [this](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/24943c05b022199800fc0f6e6a0aa709f6d20b5b/client/settings/payment-settings/promotional-banner/get-promotional-banner-type.js#L25) function.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This is a text change to an unreleased banner

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)