### PR TITLE
Update the order description and metadata on the payment intent after an Adaptive Pricing payment completes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -65,6 +65,7 @@ xxxx-xx-xx - version 10.8.0
 * Fix - Restore "Refund via Gateway" button and Stripe dashboard transaction link for Amazon Pay orders by keeping Amazon Pay registered in the gateway list on order edit and refund pages
 * Fix - Correct Amazon Pay button preview rendering in the Full Site Editor block cart and checkout pages
 * Fix - Use the order's currency instead of the store base currency on the Pay for Order page for the Express Checkout Element
+* Fix - Update the order description and metadata on the payment intent after an Adaptive Pricing payment completes
 
 2026-05-12 - version 10.7.0
 * Fix - Hide the "move Stripe to the top" Optimized Checkout notice when all payment methods above Stripe are disabled

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -485,8 +485,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$post_data['currency']                 = strtolower( $order->get_currency() );
 		$post_data['amount']                   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $post_data['currency'] );
 
-		/* translators: 1) blog name 2) order number */
-		$post_data['description'] = sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() );
+		$post_data['description'] = WC_Stripe_Helper::get_payment_intent_description( $order );
 		$billing_email            = $order->get_billing_email();
 		$billing_first_name       = $order->get_billing_first_name();
 		$billing_last_name        = $order->get_billing_last_name();

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -127,6 +127,18 @@ class WC_Stripe_Helper {
 	}
 
 	/**
+	 * Builds the description sent to Stripe for an order's payment or setup intent.
+	 *
+	 * @since 10.8.0
+	 * @param WC_Order $order The order the intent belongs to.
+	 * @return string The intent description. Format: "{blog name} - Order {order number}".
+	 */
+	public static function get_payment_intent_description( $order ): string {
+		/* translators: 1) blog name 2) order number */
+		return sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() );
+	}
+
+	/**
 	 * Converts a Stripe amount (smallest currency unit) to WooCommerce amount.
 	 *
 	 * @param int    $stripe_amount Amount in Stripe's smallest unit (e.g. cents).

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -509,8 +509,7 @@ class WC_Stripe_Intent_Controller {
 		if ( $intent_id ) {
 			$request = [
 				'metadata'    => $gateway->get_metadata_from_order( $order ),
-				/* translators: 1) blog name 2) order number */
-				'description' => sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ),
+				'description' => WC_Stripe_Helper::get_payment_intent_description( $order ),
 			];
 
 			$is_setup_intent = substr( $intent_id, 0, 4 ) === 'seti';
@@ -893,8 +892,7 @@ class WC_Stripe_Intent_Controller {
 				'confirm'              => 'true',
 				'currency'             => $payment_information['currency'],
 				'customer'             => $payment_information['customer'],
-				/* translators: 1) blog name 2) order number */
-				'description'          => sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ),
+				'description'          => WC_Stripe_Helper::get_payment_intent_description( $order ),
 				'metadata'             => $payment_information['metadata'],
 				'payment_method_types' => $payment_method_types,
 			]

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1860,6 +1860,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 						],
 					]
 				);
+			} else {
+				WC_Stripe_Logger::error( 'Empty intent ID, so cannot add order details and metadata.' );
 			}
 		} catch ( Exception $e ) {
 			WC_Stripe_Logger::error(

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1860,14 +1860,16 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 			// Schedule a job to store the order description and remaining metadata on the payment intent.
 			// The session is created from the cart before the order exists, so neither could be set at creation.
-			$this->action_scheduler_service->schedule_job(
-				time() + $this->process_payment_intent_metadata_delay,
-				$this->process_payment_intent_metadata_action,
-				[
-					'payment_intent_id' => $intent->id,
-					'order_id'          => $order->get_id(),
-				]
-			);
+			if ( ! empty( $intent_id ) ) {
+				$this->action_scheduler_service->schedule_job(
+					time() + $this->process_payment_intent_metadata_delay,
+					$this->process_payment_intent_metadata_action,
+					[
+						'payment_intent_id' => $intent_id,
+						'order_id'          => $order->get_id(),
+					]
+				);
+			}
 		} catch ( Exception $e ) {
 			WC_Stripe_Logger::error(
 				'Error processing checkout session for order: ' . $order->get_id(),

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -65,7 +65,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 	/**
 	 * The legacy Action Scheduler hook that updated checkout session metadata after a webhook.
-	 * Kept registered so jobs queued before the switch to {@see $process_payment_intent_metadata_action} still drain.
+	 * Kept registered so jobs queued before the switch to {@see $process_payment_intent_metadata_action} still run to completion.
 	 *
 	 * @deprecated 10.8.0 Replaced by {@see $process_payment_intent_metadata_action}.
 	 *
@@ -1572,15 +1572,15 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Processes the checkout session metadata update event to store additional metadata on the checkout session object.
 	 *
-	 * @deprecated 10.8.0 Replaced by {@see process_payment_intent_metadata()}; kept so jobs queued before the switch still drain.
+	 * @deprecated 10.8.0 Replaced by {@see process_payment_intent_metadata()}; kept so jobs queued before the switch still run to completion.
 	 *
 	 * @param string $checkout_session_id The checkout session ID.
 	 * @param array $metadata The metadata from the checkout session.
 	 * @return void
 	 */
 	public function process_checkout_session_metadata( string $checkout_session_id, array $metadata ): void {
-		wc_deprecated_function( __METHOD__, '10.8.0', 'process_payment_intent_metadata' );
-
+		// No runtime deprecation notice yet: legacy jobs queued before the 10.8.0 switch can still run in this
+		// release, and we don't want to emit notices for those. The notice will be added in a future release.
 		try {
 			$response = WC_Stripe_API::request( [ 'metadata' => $metadata ], 'checkout/sessions/' . $checkout_session_id, 'POST' );
 			if ( ! empty( $response->error->message ) ) {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -50,14 +50,24 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	protected $deferred_webhook_action = 'wc_stripe_deferred_webhook';
 
 	/**
-	 * How long to wait before processing checkout session metadata after a webhook.
+	 * How long to wait before updating the payment intent description and metadata after a webhook.
 	 *
 	 * @var int
 	 */
-	protected $process_checkout_session_metadata_delay = 2 * MINUTE_IN_SECONDS;
+	protected $process_payment_intent_metadata_delay = 2 * MINUTE_IN_SECONDS;
 
 	/**
-	 * The Action Scheduler hook to use when processing checkout session metadata after a webhook.
+	 * The Action Scheduler hook to use when updating the payment intent description and metadata after a webhook.
+	 *
+	 * @var string
+	 */
+	protected $process_payment_intent_metadata_action = 'wc_stripe_process_payment_intent_metadata';
+
+	/**
+	 * The legacy Action Scheduler hook that updated checkout session metadata after a webhook.
+	 * Kept registered so jobs queued before the switch to {@see $process_payment_intent_metadata_action} still drain.
+	 *
+	 * @deprecated 10.8.0 Replaced by {@see $process_payment_intent_metadata_action}.
 	 *
 	 * @var string
 	 */
@@ -93,6 +103,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		WC_Stripe_Webhook_State::get_monitoring_began_at();
 
 		add_action( $this->deferred_webhook_action, [ $this, 'process_deferred_webhook' ], 10, 3 );
+		add_action( $this->process_payment_intent_metadata_action, [ $this, 'process_payment_intent_metadata' ], 10, 2 );
 		add_action( $this->process_checkout_session_metadata_action, [ $this, 'process_checkout_session_metadata' ], 10, 2 );
 	}
 
@@ -1536,13 +1547,57 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
+	 * Updates a Checkout Session payment intent with the order description and metadata.
+	 *
+	 * @since 10.8.0
+	 *
+	 * @param string $payment_intent_id The payment intent ID.
+	 * @param int    $order_id          The order ID.
+	 * @return void
+	 */
+	public function process_payment_intent_metadata( string $payment_intent_id, int $order_id ): void {
+		$order = wc_get_order( $order_id );
+		if ( ! $order instanceof WC_Order ) {
+			WC_Stripe_Logger::error( 'Could not find order to update payment intent description and metadata.', [ 'order_id' => $order_id ] );
+			return;
+		}
+
+		$request = [
+			/* translators: 1) blog name 2) order number */
+			'description' => sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ),
+			'metadata'    => [
+				'order_id'   => $order->get_order_number(),
+				'order_key'  => $order->get_order_key(),
+				'signature'  => $this->get_order_signature( $order ),
+				'tax_amount' => WC_Stripe_Helper::get_stripe_amount( $order->get_total_tax(), strtolower( $order->get_currency() ) ),
+			],
+		];
+
+		try {
+			$response = WC_Stripe_API::request( $request, 'payment_intents/' . $payment_intent_id, 'POST' );
+			if ( ! empty( $response->error->message ) ) {
+				throw new WC_Stripe_Exception( $response->error->message );
+			}
+		} catch ( Exception $e ) {
+			WC_Stripe_Logger::error( 'Failed to update payment intent description and metadata: ' . $e->getMessage() );
+
+			// This will be caught by Action Scheduler and logged as an error.
+			throw $e;
+		}
+	}
+
+	/**
 	 * Processes the checkout session metadata update event to store additional metadata on the checkout session object.
+	 *
+	 * @deprecated 10.8.0 Replaced by {@see process_payment_intent_metadata()}; kept so jobs queued before the switch still drain.
 	 *
 	 * @param string $checkout_session_id The checkout session ID.
 	 * @param array $metadata The metadata from the checkout session.
 	 * @return void
 	 */
 	public function process_checkout_session_metadata( string $checkout_session_id, array $metadata ): void {
+		wc_deprecated_function( __METHOD__, '10.8.0', 'process_payment_intent_metadata' );
+
 		try {
 			$response = WC_Stripe_API::request( [ 'metadata' => $metadata ], 'checkout/sessions/' . $checkout_session_id, 'POST' );
 			if ( ! empty( $response->error->message ) ) {
@@ -1803,18 +1858,14 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			$charge->is_webhook_response = true;
 			$this->process_response( $charge, $order );
 
-			// Schedule a job to store the remaining metadata to the checkout session.
+			// Schedule a job to store the order description and remaining metadata on the payment intent.
+			// The session is created from the cart before the order exists, so neither could be set at creation.
 			$this->action_scheduler_service->schedule_job(
-				time() + $this->process_checkout_session_metadata_delay,
-				$this->process_checkout_session_metadata_action,
+				time() + $this->process_payment_intent_metadata_delay,
+				$this->process_payment_intent_metadata_action,
 				[
-					'checkout_session_id' => $checkout_session->id,
-					'metadata'            => [
-						'order_id'   => $order->get_order_number(),
-						'order_key'  => $order->get_order_key(),
-						'signature'  => $this->get_order_signature( $order ),
-						'tax_amount' => WC_Stripe_Helper::get_stripe_amount( $order->get_total_tax(), strtolower( $order->get_currency() ) ),
-					],
+					'payment_intent_id' => $intent->id,
+					'order_id'          => $order->get_id(),
 				]
 			);
 		} catch ( Exception $e ) {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1552,27 +1552,10 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @since 10.8.0
 	 *
 	 * @param string $payment_intent_id The payment intent ID.
-	 * @param int    $order_id          The order ID.
+	 * @param array  $request           The request payload (description and metadata) computed at scheduling time.
 	 * @return void
 	 */
-	public function process_payment_intent_metadata( string $payment_intent_id, int $order_id ): void {
-		$order = wc_get_order( $order_id );
-		if ( ! $order instanceof WC_Order ) {
-			WC_Stripe_Logger::error( 'Could not find order to update payment intent description and metadata.', [ 'order_id' => $order_id ] );
-			return;
-		}
-
-		$request = [
-			/* translators: 1) blog name 2) order number */
-			'description' => sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ),
-			'metadata'    => [
-				'order_id'   => $order->get_order_number(),
-				'order_key'  => $order->get_order_key(),
-				'signature'  => $this->get_order_signature( $order ),
-				'tax_amount' => WC_Stripe_Helper::get_stripe_amount( $order->get_total_tax(), strtolower( $order->get_currency() ) ),
-			],
-		];
-
+	public function process_payment_intent_metadata( string $payment_intent_id, array $request ): void {
 		try {
 			$response = WC_Stripe_API::request( $request, 'payment_intents/' . $payment_intent_id, 'POST' );
 			if ( ! empty( $response->error->message ) ) {
@@ -1866,7 +1849,16 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					$this->process_payment_intent_metadata_action,
 					[
 						'payment_intent_id' => $intent_id,
-						'order_id'          => $order->get_id(),
+						'request'           => [
+							/* translators: 1) blog name 2) order number */
+							'description' => sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ),
+							'metadata'    => [
+								'order_id'   => $order->get_order_number(),
+								'order_key'  => $order->get_order_key(),
+								'signature'  => $this->get_order_signature( $order ),
+								'tax_amount' => WC_Stripe_Helper::get_stripe_amount( $order->get_total_tax(), strtolower( $order->get_currency() ) ),
+							],
+						],
 					]
 				);
 			}

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1850,8 +1850,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					[
 						'payment_intent_id' => $intent_id,
 						'request'           => [
-							/* translators: 1) blog name 2) order number */
-							'description' => sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ),
+							'description' => WC_Stripe_Helper::get_payment_intent_description( $order ),
 							'metadata'    => [
 								'order_id'   => $order->get_order_number(),
 								'order_key'  => $order->get_order_key(),

--- a/readme.txt
+++ b/readme.txt
@@ -216,5 +216,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Restore "Refund via Gateway" button and Stripe dashboard transaction link for Amazon Pay orders by keeping Amazon Pay registered in the gateway list on order edit and refund pages
 * Fix - Correct Amazon Pay button preview rendering in the Full Site Editor block cart and checkout pages
 * Fix - Use the order's currency instead of the store base currency on the Pay for Order page for the Express Checkout Element
+* Fix - Update the order description and metadata on the payment intent after an Adaptive Pricing payment completes
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -392,6 +392,16 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
+	 * Test for `get_payment_intent_description`.
+	 */
+	public function test_get_payment_intent_description(): void {
+		$order = WC_Helper_Order::create_order();
+
+		$expected = sprintf( '%1$s - Order %2$s', wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() );
+		$this->assertSame( $expected, WC_Stripe_Helper::get_payment_intent_description( $order ) );
+	}
+
+	/**
 	 * Test for `get_woocommerce_amount_from_stripe_amount` (Stripe → WooCommerce amount conversion).
 	 *
 	 * @param int|string $stripe_amount Stripe amount in smallest unit (cents, etc.).

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -1673,8 +1673,6 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_process_checkout_session_metadata_success(): void {
-		$this->setExpectedDeprecated( 'WC_Stripe_Webhook_Handler::process_checkout_session_metadata' );
-
 		$checkout_session_id = 'cs_test_abc123';
 		$metadata            = [
 			'order_id'   => '100',
@@ -1720,8 +1718,6 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_process_checkout_session_metadata_api_error_response(): void {
-		$this->setExpectedDeprecated( 'WC_Stripe_Webhook_Handler::process_checkout_session_metadata' );
-
 		$checkout_session_id = 'cs_test_abc123';
 		$metadata            = [
 			'order_id'   => '100',
@@ -1793,6 +1789,9 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			}
 			$request_captured = true;
 			$this->assertEquals( 'POST', $parsed_args['method'] );
+			$this->assertIsArray( $parsed_args['body'] );
+			$this->assertArrayHasKey( 'description', $parsed_args['body'] );
+			$this->assertArrayHasKey( 'metadata', $parsed_args['body'] );
 			$this->assertEquals( $request['description'], $parsed_args['body']['description'] );
 			$this->assertEquals( $request['metadata'], $parsed_args['body']['metadata'] );
 			return [
@@ -1893,6 +1892,9 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			],
 		];
 
+		// Capture a fixed baseline before scheduling so the timestamp assertion can't race a 1-second rollover.
+		$scheduled_at = time();
+
 		// Mock the action scheduler service.
 		$mock_scheduler = $this->createMock( WC_Stripe_Action_Scheduler_Service::class );
 		$scheduled_args = null;
@@ -1900,9 +1902,9 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			->method( 'schedule_job' )
 			->with(
 				$this->callback(
-					function ( $timestamp ) {
+					function ( $timestamp ) use ( $scheduled_at ) {
 						$this->assertIsInt( $timestamp, 'Expected timestamp to be an integer.' );
-						$this->assertGreaterThanOrEqual( time() + 2 * MINUTE_IN_SECONDS, $timestamp, 'Expected timestamp to be in the future.' );
+						$this->assertGreaterThanOrEqual( $scheduled_at + 2 * MINUTE_IN_SECONDS, $timestamp, 'Expected timestamp to be in the future.' );
 
 						return true;
 					}
@@ -1911,7 +1913,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 				$this->callback(
 					function ( $args ) use ( &$scheduled_args ) {
 						$scheduled_args = $args;
-						return isset( $args['payment_intent_id'] ) && isset( $args['request'] );
+						return isset( $args['payment_intent_id'] ) && isset( $args['request'] ) && is_array( $args['request'] );
 					}
 				)
 			);
@@ -2113,7 +2115,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 				'wc_stripe_process_payment_intent_metadata',
 				$this->callback(
 					function ( $args ) {
-						return isset( $args['payment_intent_id'] ) && isset( $args['request'] );
+						return isset( $args['payment_intent_id'] ) && isset( $args['request'] ) && is_array( $args['request'] );
 					}
 				)
 			);

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -1775,24 +1775,26 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	public function test_process_payment_intent_metadata_success(): void {
 		$payment_intent_id = 'pi_test_abc123';
 
-		$order = WC_Helper_Order::create_order();
-		$order->save();
-
-		$expected_description = sprintf( '%1$s - Order %2$s', wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() );
+		$request = [
+			'description' => 'Test Blog - Order 100',
+			'metadata'    => [
+				'order_id'   => '100',
+				'order_key'  => 'wc_order_test123',
+				'signature'  => '100:abc123hash',
+				'tax_amount' => 250,
+			],
+		];
 
 		$request_captured = false;
-		$pre_http_filter  = function ( $return_value, $parsed_args, $url ) use ( $payment_intent_id, $order, $expected_description, &$request_captured ) {
+		$pre_http_filter  = function ( $return_value, $parsed_args, $url ) use ( $payment_intent_id, $request, &$request_captured ) {
 			$expected_url = WC_Stripe_API::ENDPOINT . 'payment_intents/' . $payment_intent_id;
 			if ( $url !== $expected_url ) {
 				return $return_value;
 			}
 			$request_captured = true;
 			$this->assertEquals( 'POST', $parsed_args['method'] );
-			$this->assertEquals( $expected_description, $parsed_args['body']['description'] );
-			$this->assertEquals( $order->get_order_number(), $parsed_args['body']['metadata']['order_id'] );
-			$this->assertEquals( $order->get_order_key(), $parsed_args['body']['metadata']['order_key'] );
-			$this->assertNotEmpty( $parsed_args['body']['metadata']['signature'] );
-			$this->assertArrayHasKey( 'tax_amount', $parsed_args['body']['metadata'] );
+			$this->assertEquals( $request['description'], $parsed_args['body']['description'] );
+			$this->assertEquals( $request['metadata'], $parsed_args['body']['metadata'] );
 			return [
 				'headers'  => [],
 				'body'     => wp_json_encode( [ 'id' => $payment_intent_id ] ),
@@ -1808,7 +1810,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		add_filter( 'pre_http_request', $pre_http_filter, 10, 3 );
 
 		$handler = new WC_Stripe_Webhook_Handler();
-		$handler->process_payment_intent_metadata( $payment_intent_id, $order->get_id() );
+		$handler->process_payment_intent_metadata( $payment_intent_id, $request );
 
 		remove_filter( 'pre_http_request', $pre_http_filter );
 
@@ -1821,9 +1823,6 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_process_payment_intent_metadata_api_error_response(): void {
-		$order = WC_Helper_Order::create_order();
-		$order->save();
-
 		$error_message   = 'No such payment intent.';
 		$pre_http_filter = function () use ( $error_message ) {
 			return [
@@ -1849,7 +1848,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$handler = new WC_Stripe_Webhook_Handler();
 		$caught  = null;
 		try {
-			$handler->process_payment_intent_metadata( 'pi_test_abc123', $order->get_id() );
+			$handler->process_payment_intent_metadata( 'pi_test_abc123', [ 'metadata' => [ 'order_id' => '100' ] ] );
 		} catch ( Exception $e ) {
 			$caught = $e;
 		}
@@ -1859,28 +1858,6 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$this->assertNotNull( $caught, 'Expected an exception to be thrown.' );
 		$this->assertInstanceOf( \WC_Stripe_Exception::class, $caught, 'Expected an instance of WC_Stripe_Exception.' );
 		$this->assertSame( $error_message, $caught->getMessage() );
-	}
-
-	/**
-	 * Test that `process_payment_intent_metadata` makes no API request when the order does not exist.
-	 *
-	 * @return void
-	 */
-	public function test_process_payment_intent_metadata_missing_order(): void {
-		$request_captured = false;
-		$pre_http_filter  = function ( $return_value ) use ( &$request_captured ) {
-			$request_captured = true;
-			return $return_value;
-		};
-
-		add_filter( 'pre_http_request', $pre_http_filter, 10, 3 );
-
-		$handler = new WC_Stripe_Webhook_Handler();
-		$handler->process_payment_intent_metadata( 'pi_test_abc123', 0 );
-
-		remove_filter( 'pre_http_request', $pre_http_filter );
-
-		$this->assertFalse( $request_captured, 'Expected no API request to be made.' );
 	}
 
 	/**
@@ -1934,7 +1911,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 				$this->callback(
 					function ( $args ) use ( &$scheduled_args ) {
 						$scheduled_args = $args;
-						return isset( $args['payment_intent_id'] ) && isset( $args['order_id'] );
+						return isset( $args['payment_intent_id'] ) && isset( $args['request'] );
 					}
 				)
 			);
@@ -1960,10 +1937,14 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 
 		$this->mock_webhook_handler->process_checkout_session_success( $notification );
 
-		// Verify the job is scheduled with the intent and order it should update.
+		// Verify the job is scheduled with the intent and the full payload snapshot.
 		$this->assertNotNull( $scheduled_args );
 		$this->assertEquals( 'pi_test_abc', $scheduled_args['payment_intent_id'] );
-		$this->assertEquals( $order->get_id(), $scheduled_args['order_id'] );
+		$this->assertEquals( sprintf( '%1$s - Order %2$s', wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ), $scheduled_args['request']['description'] );
+		$this->assertEquals( $order->get_order_number(), $scheduled_args['request']['metadata']['order_id'] );
+		$this->assertEquals( $order->get_order_key(), $scheduled_args['request']['metadata']['order_key'] );
+		$this->assertNotEmpty( $scheduled_args['request']['metadata']['signature'] );
+		$this->assertIsInt( $scheduled_args['request']['metadata']['tax_amount'] );
 	}
 
 	/**
@@ -2132,7 +2113,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 				'wc_stripe_process_payment_intent_metadata',
 				$this->callback(
 					function ( $args ) {
-						return isset( $args['payment_intent_id'] ) && isset( $args['order_id'] );
+						return isset( $args['payment_intent_id'] ) && isset( $args['request'] );
 					}
 				)
 			);

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -1962,7 +1962,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 
 		// Verify the job is scheduled with the intent and order it should update.
 		$this->assertNotNull( $scheduled_args );
-		$this->assertEquals( self::MOCK_PAYMENT_INTENT['id'], $scheduled_args['payment_intent_id'] );
+		$this->assertEquals( 'pi_test_abc', $scheduled_args['payment_intent_id'] );
 		$this->assertEquals( $order->get_id(), $scheduled_args['order_id'] );
 	}
 

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -1673,6 +1673,8 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_process_checkout_session_metadata_success(): void {
+		$this->setExpectedDeprecated( 'WC_Stripe_Webhook_Handler::process_checkout_session_metadata' );
+
 		$checkout_session_id = 'cs_test_abc123';
 		$metadata            = [
 			'order_id'   => '100',
@@ -1718,6 +1720,8 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_process_checkout_session_metadata_api_error_response(): void {
+		$this->setExpectedDeprecated( 'WC_Stripe_Webhook_Handler::process_checkout_session_metadata' );
+
 		$checkout_session_id = 'cs_test_abc123';
 		$metadata            = [
 			'order_id'   => '100',
@@ -1764,11 +1768,127 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that `process_checkout_session` schedules the metadata job with the correct arguments.
+	 * Test that `process_payment_intent_metadata` updates the intent with the order description and metadata.
 	 *
 	 * @return void
 	 */
-	public function test_process_checkout_session_schedules_metadata_job(): void {
+	public function test_process_payment_intent_metadata_success(): void {
+		$payment_intent_id = 'pi_test_abc123';
+
+		$order = WC_Helper_Order::create_order();
+		$order->save();
+
+		$expected_description = sprintf( '%1$s - Order %2$s', wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() );
+
+		$request_captured = false;
+		$pre_http_filter  = function ( $return_value, $parsed_args, $url ) use ( $payment_intent_id, $order, $expected_description, &$request_captured ) {
+			$expected_url = WC_Stripe_API::ENDPOINT . 'payment_intents/' . $payment_intent_id;
+			if ( $url !== $expected_url ) {
+				return $return_value;
+			}
+			$request_captured = true;
+			$this->assertEquals( 'POST', $parsed_args['method'] );
+			$this->assertEquals( $expected_description, $parsed_args['body']['description'] );
+			$this->assertEquals( $order->get_order_number(), $parsed_args['body']['metadata']['order_id'] );
+			$this->assertEquals( $order->get_order_key(), $parsed_args['body']['metadata']['order_key'] );
+			$this->assertNotEmpty( $parsed_args['body']['metadata']['signature'] );
+			$this->assertArrayHasKey( 'tax_amount', $parsed_args['body']['metadata'] );
+			return [
+				'headers'  => [],
+				'body'     => wp_json_encode( [ 'id' => $payment_intent_id ] ),
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'cookies'  => [],
+				'filename' => null,
+			];
+		};
+
+		add_filter( 'pre_http_request', $pre_http_filter, 10, 3 );
+
+		$handler = new WC_Stripe_Webhook_Handler();
+		$handler->process_payment_intent_metadata( $payment_intent_id, $order->get_id() );
+
+		remove_filter( 'pre_http_request', $pre_http_filter );
+
+		$this->assertTrue( $request_captured, 'Expected the API request to be made.' );
+	}
+
+	/**
+	 * Test that `process_payment_intent_metadata` throws an exception when the API returns an error response.
+	 *
+	 * @return void
+	 */
+	public function test_process_payment_intent_metadata_api_error_response(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->save();
+
+		$error_message   = 'No such payment intent.';
+		$pre_http_filter = function () use ( $error_message ) {
+			return [
+				'headers'  => [],
+				'body'     => wp_json_encode(
+					[
+						'error' => [
+							'message' => $error_message,
+						],
+					]
+				),
+				'response' => [
+					'code'    => 404,
+					'message' => 'Not Found',
+				],
+				'cookies'  => [],
+				'filename' => null,
+			];
+		};
+
+		add_filter( 'pre_http_request', $pre_http_filter, 10, 3 );
+
+		$handler = new WC_Stripe_Webhook_Handler();
+		$caught  = null;
+		try {
+			$handler->process_payment_intent_metadata( 'pi_test_abc123', $order->get_id() );
+		} catch ( Exception $e ) {
+			$caught = $e;
+		}
+
+		remove_filter( 'pre_http_request', $pre_http_filter );
+
+		$this->assertNotNull( $caught, 'Expected an exception to be thrown.' );
+		$this->assertInstanceOf( \WC_Stripe_Exception::class, $caught, 'Expected an instance of WC_Stripe_Exception.' );
+		$this->assertSame( $error_message, $caught->getMessage() );
+	}
+
+	/**
+	 * Test that `process_payment_intent_metadata` makes no API request when the order does not exist.
+	 *
+	 * @return void
+	 */
+	public function test_process_payment_intent_metadata_missing_order(): void {
+		$request_captured = false;
+		$pre_http_filter  = function ( $return_value ) use ( &$request_captured ) {
+			$request_captured = true;
+			return $return_value;
+		};
+
+		add_filter( 'pre_http_request', $pre_http_filter, 10, 3 );
+
+		$handler = new WC_Stripe_Webhook_Handler();
+		$handler->process_payment_intent_metadata( 'pi_test_abc123', 0 );
+
+		remove_filter( 'pre_http_request', $pre_http_filter );
+
+		$this->assertFalse( $request_captured, 'Expected no API request to be made.' );
+	}
+
+	/**
+	 * Test that `process_checkout_session` schedules the payment intent metadata job with the correct arguments.
+	 *
+	 * @return void
+	 */
+	public function test_process_checkout_session_schedules_payment_intent_metadata_job(): void {
 		$checkout_session_id = 'cs_test_schedule123';
 
 		// Create an order and associate it with the checkout session.
@@ -1810,15 +1930,11 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 						return true;
 					}
 				),
-				'wc_stripe_process_checkout_session_metadata',
+				'wc_stripe_process_payment_intent_metadata',
 				$this->callback(
-					function ( $args ) use ( $checkout_session_id, &$scheduled_args ) {
+					function ( $args ) use ( &$scheduled_args ) {
 						$scheduled_args = $args;
-						return isset( $args['checkout_session_id'] ) && $args['checkout_session_id'] === $checkout_session_id
-							&& isset( $args['metadata']['order_id'] )
-							&& isset( $args['metadata']['order_key'] )
-							&& isset( $args['metadata']['signature'] )
-							&& isset( $args['metadata']['tax_amount'] );
+						return isset( $args['payment_intent_id'] ) && isset( $args['order_id'] );
 					}
 				)
 			);
@@ -1844,13 +1960,10 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 
 		$this->mock_webhook_handler->process_checkout_session_success( $notification );
 
-		// Verify the metadata contains the correct order data.
+		// Verify the job is scheduled with the intent and order it should update.
 		$this->assertNotNull( $scheduled_args );
-		$this->assertEquals( $checkout_session_id, $scheduled_args['checkout_session_id'] );
-		$this->assertEquals( $order->get_order_number(), $scheduled_args['metadata']['order_id'] );
-		$this->assertEquals( $order->get_order_key(), $scheduled_args['metadata']['order_key'] );
-		$this->assertNotEmpty( $scheduled_args['metadata']['signature'] );
-		$this->assertIsInt( $scheduled_args['metadata']['tax_amount'] );
+		$this->assertEquals( self::MOCK_PAYMENT_INTENT['id'], $scheduled_args['payment_intent_id'] );
+		$this->assertEquals( $order->get_id(), $scheduled_args['order_id'] );
 	}
 
 	/**
@@ -2016,10 +2129,10 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			->method( 'schedule_job' )
 			->with(
 				$this->isType( 'int' ),
-				'wc_stripe_process_checkout_session_metadata',
+				'wc_stripe_process_payment_intent_metadata',
 				$this->callback(
-					function ( $args ) use ( $checkout_session_id ) {
-						return isset( $args['checkout_session_id'] ) && $checkout_session_id === $args['checkout_session_id'];
+					function ( $args ) {
+						return isset( $args['payment_intent_id'] ) && isset( $args['order_id'] );
 					}
 				)
 			);

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -1893,7 +1893,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		];
 
 		// Capture a fixed baseline before scheduling so the timestamp assertion can't race a 1-second rollover.
-		$scheduled_at = time();
+		$test_start_time = time();
 
 		// Mock the action scheduler service.
 		$mock_scheduler = $this->createMock( WC_Stripe_Action_Scheduler_Service::class );
@@ -1902,9 +1902,14 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			->method( 'schedule_job' )
 			->with(
 				$this->callback(
-					function ( $timestamp ) use ( $scheduled_at ) {
+					function ( $timestamp ) use ( $test_start_time ) {
 						$this->assertIsInt( $timestamp, 'Expected timestamp to be an integer.' );
-						$this->assertGreaterThanOrEqual( $scheduled_at + 2 * MINUTE_IN_SECONDS, $timestamp, 'Expected timestamp to be in the future.' );
+
+						// The timestamp is captured between the test's start and now, so bound it on both sides
+						// to assert it lands exactly 2 minutes out rather than some arbitrary point after.
+						$current_time = time();
+						$this->assertGreaterThanOrEqual( $test_start_time + 2 * MINUTE_IN_SECONDS, $timestamp, 'Expected timestamp to be at least 2 minutes in the future.' );
+						$this->assertLessThanOrEqual( $current_time + 2 * MINUTE_IN_SECONDS, $timestamp, 'Expected timestamp to be at most 2 minutes in the future.' );
 
 						return true;
 					}


### PR DESCRIPTION
## Changes proposed in this Pull Request:
Adaptive Pricing routes through Stripe Checkout Sessions instead of a directly-created PaymentIntent. The session is created in includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php:26, and its build_payment_intent_data() (line 167) only passes metadata, no description. 
So, on the Stripe transaction page, the payment intent ID is set as the description. 
When we pay with the payment intent API, the description is set as `WooCommerce Stripe Dev - Order <order_id>`. But during the checkout session creation we do not have the order ID or any other order meta.

When we receive a checkout session completed event, we update the checkout session metadata with the order meta but the checkout session API does not take the `description` field. Only way to update the description is the payment intent API.

In this PR, I have changed the API call to use payment intents API instead of checkout session API to update the metadata when the checkout session completed event is received. Now we are able to update the description in the same API call.

## Testing instructions
- Enable OCS and Adaptive Pricing.
- As a shopper, place an order using card in your local currency.
- Wait for a while and check the order as an admin.
- Order should be in processing status.
- Check the corresponding transaction in Stripe dashboard.
- The transaction should include the description and all the metadata.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
