### PR TITLE
Reserve product Express Checkout space before render

### DIFF
--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -70,6 +70,8 @@ jQuery( function ( $ ) {
 	);
 
 	let wcStripeECEError = '';
+	const productPageReservedSpaceClass =
+		'wc-stripe-express-checkout-element--reserved-space';
 	const defaultErrorMessage = __(
 		'There was an error getting the product information.',
 		'woocommerce-gateway-stripe'
@@ -154,8 +156,35 @@ jQuery( function ( $ ) {
 			wcStripeECE.getButtonSeparator().hide();
 		},
 
+		reserveProductPageSpace: () => {
+			if ( ! getExpressCheckoutData( 'is_product_page' ) ) {
+				return;
+			}
+
+			wcStripeECE
+				.getElements()
+				.addClass( productPageReservedSpaceClass )
+				.show();
+		},
+
+		releaseProductPageSpaceIfEmpty: () => {
+			if ( ! getExpressCheckoutData( 'is_product_page' ) ) {
+				return;
+			}
+
+			const elements = wcStripeECE.getElements();
+			if ( elements.children().length ) {
+				return;
+			}
+
+			elements.removeClass( productPageReservedSpaceClass ).hide();
+			wcStripeECE.getButtonSeparator().hide();
+		},
+
 		renderButton: ( eceButton, expressPaymentType ) => {
 			if ( $( '#wc-stripe-express-checkout-element' ).length ) {
+				wcStripeECE.reserveProductPageSpace();
+
 				const containerName = `wc-stripe-express-checkout-element-${ expressPaymentType }`;
 				if ( ! $( `#${ containerName }` ).length ) {
 					$( '#wc-stripe-express-checkout-element' ).append(
@@ -170,11 +199,13 @@ jQuery( function ( $ ) {
 				eceButton.on( 'ready', ( { availablePaymentMethods } ) => {
 					if ( ! availablePaymentMethods ) {
 						$( `#${ containerName }` ).remove();
+						wcStripeECE.releaseProductPageSpaceIfEmpty();
 					}
 				} );
 
 				eceButton.on( 'loaderror', () => {
 					$( `#${ containerName }` ).remove();
+					wcStripeECE.releaseProductPageSpaceIfEmpty();
 				} );
 			}
 		},
@@ -246,6 +277,10 @@ jQuery( function ( $ ) {
 					EXPRESS_PAYMENT_METHOD_SETTING_AMAZON_PAY,
 				isLinkEnabled && EXPRESS_PAYMENT_METHOD_SETTING_LINK,
 			].filter( Boolean );
+
+			if ( expressPaymentTypes.length ) {
+				wcStripeECE.reserveProductPageSpace();
+			}
 
 			expressPaymentTypes.forEach( ( expressPaymentType ) => {
 				wcStripeECE.createExpressCheckoutElement( expressPaymentType, {

--- a/client/entrypoints/express-checkout/styles.scss
+++ b/client/entrypoints/express-checkout/styles.scss
@@ -9,8 +9,13 @@
 	flex-wrap: wrap;
 	justify-content: center;
 
+	&.wc-stripe-express-checkout-element--reserved-space {
+		min-height: 48px;
+	}
+
 	> div {
 		flex: 1;
 		min-width: 260px;
+		min-height: 48px;
 	}
 }


### PR DESCRIPTION
## Summary
- Reserves product-page Express Checkout space before Stripe finishes rendering dynamic buttons.
- Clears the reserved space again if Stripe reports no available payment methods or the element load fails.
- Adds a minimum slot height matching the default Express Checkout button height so visible content does not jump when the button appears.

Closes #4378.

## Verification
- `PATH="$HOME/.nvm/versions/node/v20.18.1/bin:$PATH" npx eslint client/entrypoints/express-checkout/index.js`
- `PATH="$HOME/.nvm/versions/node/v20.18.1/bin:$PATH" npm run test:js -- client/express-checkout/utils/__tests__/index.test.js --runInBand`
- `PATH="$HOME/.nvm/versions/node/v20.18.1/bin:$PATH" npm run build:webpack`
- Push hook: `npm run phpstan`

Existing warnings only:
- Browserslist/caniuse-lite staleness warning.
- Existing webpack asset/entrypoint size warnings.

## Layout-shift evidence
Homeboy Rigs deterministic CLS profiles reproduced the reported mechanism before this production fix:

| Profile | CLS | Layout shifts | Visible button |
| --- | ---: | ---: | --- |
| `simulated-cls` | `0.0351` | `1` | yes |
| `simulated-cls-reserved` | `0` | `0` | yes |

Those traces prove the underlying issue shape from #4378: inserting a visible Express Checkout button without reserved space causes CLS, while reserving the same final button space prevents the layout shift.

Note: running the Homeboy rig directly against this branch currently requires the benchmark fixture from #5522, which is still open. The production change here stays focused on the CLS fix rather than bundling the benchmark fixture into this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the product-page reserved-space implementation, ran targeted checks, and summarized the deterministic CLS evidence; Chris remains responsible for review and acceptance.