### PR TITLE
Send the billing address to Stripe for "Pay for Order" orders

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -67,6 +67,7 @@ xxxx-xx-xx - version 10.8.0
 * Fix - Correct Amazon Pay button preview rendering in the Full Site Editor block cart and checkout pages
 * Fix - Use the order's currency instead of the store base currency on the Pay for Order page for the Express Checkout Element
 * Fix - Update the order description and metadata on the payment intent after an Adaptive Pricing payment completes
+* Fix - Send the billing address to Stripe on the Pay for Order page so payments aren't incorrectly blocked by Stripe Radar rules
 
 2026-05-12 - version 10.7.0
 * Fix - Hide the "move Stripe to the top" Optimized Checkout notice when all payment methods above Stripe are disabled

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 xxxx-xx-xx - version 10.9.0
 * Fix - Prevent unnecessary Stripe payment method creation when shortcode checkout has empty required fields
+* Fix - Send the billing address to Stripe on the Pay for Order page so payments aren't incorrectly blocked by Stripe Radar rules
 
 2026-06-08 - version 10.8.0
 * Fix - Add an order note and call action 'wc_stripe_unexpected_charge_detected' when a Stripe charge is captured for an order that was already paid via a different gateway
@@ -65,7 +66,6 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Restore "Refund via Gateway" button and Stripe dashboard transaction link for Amazon Pay orders by keeping Amazon Pay registered in the gateway list on order edit and refund pages
 * Fix - Correct Amazon Pay button preview rendering in the Full Site Editor block cart and checkout pages
 * Fix - Update the order description and metadata on the payment intent after an Adaptive Pricing payment completes
-* Fix - Send the billing address to Stripe on the Pay for Order page so payments aren't incorrectly blocked by Stripe Radar rules
 
 2026-05-12 - version 10.7.0
 * Fix - Hide the "move Stripe to the top" Optimized Checkout notice when all payment methods above Stripe are disabled

--- a/client/classic/upe/__tests__/payment-processing.test.js
+++ b/client/classic/upe/__tests__/payment-processing.test.js
@@ -7,6 +7,7 @@ jest.mock( 'wcstripe/stripe-utils', () => ( {
 	appendPaymentMethodIdToForm: jest.fn(),
 	appendSetupIntentToForm: jest.fn(),
 	getAdditionalSetupIntentData: jest.fn().mockReturnValue( {} ),
+	getBillingDetailsForDeferredFlow: jest.fn().mockReturnValue( null ),
 	getDefaultValues: jest.fn().mockReturnValue( {} ),
 	getExcludedPaymentMethodTypes: jest.fn().mockReturnValue( [] ),
 	getPaymentMethodTypes: jest.fn().mockReturnValue( [ 'card' ] ),
@@ -173,14 +174,17 @@ const createMockApi = ( checkoutElements ) => {
 	};
 };
 
-const createMockForm = ( { savePaymentMethodChecked = false } = {} ) => {
+const createMockForm = ( {
+	savePaymentMethodChecked = false,
+	name = 'checkout',
+} = {} ) => {
 	const f = {};
 	f.addClass = jest.fn( () => f );
 	f.removeClass = jest.fn( () => f );
 	f.block = jest.fn( () => f );
 	f.unblock = jest.fn( () => f );
 	f.trigger = jest.fn( () => f );
-	f.attr = jest.fn( () => 'checkout' );
+	f.attr = jest.fn( () => name );
 	f.serialize = jest.fn( () => 'billing_first_name=John' );
 	f.append = jest.fn();
 	f.find = jest.fn( () => ( {
@@ -263,6 +267,96 @@ describe( 'payment-processing', () => {
 					stripeUtils.appendPaymentMethodIdToForm
 				).toHaveBeenCalledWith( form, 'pm_test_123' );
 				expect( form.trigger ).toHaveBeenCalledWith( 'submit' );
+			} );
+
+			it( 'on a deferred flow (non-checkout form), creates the payment method with billing_details from getBillingDetailsForDeferredFlow', async () => {
+				const billingDetails = {
+					name: 'John Doe',
+					email: 'john@example.com',
+					phone: '+1234567890',
+					address: {
+						country: 'US',
+						line1: '123 Main St',
+						city: 'New York',
+						state: 'NY',
+						postal_code: '10001',
+					},
+				};
+				stripeUtils.getBillingDetailsForDeferredFlow.mockReturnValue(
+					billingDetails
+				);
+
+				const checkoutElements = createMockElements();
+				const api = createMockApi( checkoutElements );
+				api._stripe.elements.mockReturnValue( api._standardElements );
+
+				const dom = document.createElement( 'div' );
+				dom.dataset.paymentMethodType = 'card';
+				await paymentProcessing.mountStripePaymentElement( api, dom );
+
+				// The pay-for-order form is #order_review, not named 'checkout'.
+				const form = createMockForm( { name: 'order_review' } );
+				paymentProcessing.processPayment( api, form, 'card' );
+				await flushPromises();
+
+				expect( api._stripe.createPaymentMethod ).toHaveBeenCalledWith(
+					{
+						elements: api._standardElements,
+						params: { billing_details: billingDetails },
+					}
+				);
+			} );
+
+			it( 'on a deferred flow with no usable billing data, omits billing_details', async () => {
+				stripeUtils.getBillingDetailsForDeferredFlow.mockReturnValue(
+					null
+				);
+
+				const checkoutElements = createMockElements();
+				const api = createMockApi( checkoutElements );
+				api._stripe.elements.mockReturnValue( api._standardElements );
+
+				const dom = document.createElement( 'div' );
+				dom.dataset.paymentMethodType = 'card';
+				await paymentProcessing.mountStripePaymentElement( api, dom );
+
+				const form = createMockForm( { name: 'order_review' } );
+				paymentProcessing.processPayment( api, form, 'card' );
+				await flushPromises();
+
+				expect( api._stripe.createPaymentMethod ).toHaveBeenCalledWith(
+					{
+						elements: api._standardElements,
+						params: {},
+					}
+				);
+			} );
+
+			it( 'on the checkout form, ignores getBillingDetailsForDeferredFlow', async () => {
+				stripeUtils.getBillingDetailsForDeferredFlow.mockReturnValue( {
+					email: 'deferred@example.com',
+				} );
+
+				const checkoutElements = createMockElements();
+				const api = createMockApi( checkoutElements );
+				api._stripe.elements.mockReturnValue( api._standardElements );
+
+				const dom = document.createElement( 'div' );
+				dom.dataset.paymentMethodType = 'card';
+				await paymentProcessing.mountStripePaymentElement( api, dom );
+
+				const form = createMockForm( { name: 'checkout' } );
+				paymentProcessing.processPayment( api, form, 'card' );
+				await flushPromises();
+
+				const callArg =
+					api._stripe.createPaymentMethod.mock.calls[ 0 ][ 0 ];
+				// On checkout, billing_details are read from the DOM, not the
+				// deferred-flow helper.
+				expect( callArg.params.billing_details ).toBeDefined();
+				expect( callArg.params.billing_details.email ).not.toBe(
+					'deferred@example.com'
+				);
 			} );
 
 			it( 'shows an error and does not submit when hasLoadError is true', async () => {

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -17,6 +17,7 @@ import {
 	validateBlikCode,
 	getExcludedPaymentMethodTypes,
 	getUserDataForCheckoutSession,
+	getBillingDetailsForDeferredFlow,
 } from '../../stripe-utils';
 import {
 	initializeUPEAppearance,
@@ -552,6 +553,16 @@ function createStripePaymentMethod(
 				},
 			},
 		};
+	} else {
+		// On the deferred-payment flows the form is not a checkout form, so billing
+		// fields are not present in the DOM. Forward the order/customer billing
+		// data from the server.
+		const billingDetails = getBillingDetailsForDeferredFlow();
+		if ( billingDetails ) {
+			params = {
+				billing_details: billingDetails,
+			};
+		}
 	}
 
 	// BLIK uses a controlled form instead of Stripe Elements.

--- a/client/stripe-utils/__tests__/utils.test.js
+++ b/client/stripe-utils/__tests__/utils.test.js
@@ -1,6 +1,7 @@
 import {
 	getFontSizeBase,
 	getDefaultValues,
+	getBillingDetailsForDeferredFlow,
 	getHiddenBillingFields,
 } from '../utils';
 import { initializeUPEAppearance } from '../upe-appearance';
@@ -252,6 +253,102 @@ describe( 'utils', () => {
 					},
 				} );
 			} );
+		} );
+	} );
+
+	describe( 'getBillingDetailsForDeferredFlow', () => {
+		const globalValues = global.wc_stripe_upe_params;
+
+		afterEach( () => {
+			global.wc_stripe_upe_params = globalValues;
+		} );
+
+		it.each( [ 'isOrderPay', 'isChangingPayment', 'isAddPaymentMethod' ] )(
+			'returns billing_details from customerBillingData when %s is true',
+			( flag ) => {
+				global.wc_stripe_upe_params = {
+					[ flag ]: true,
+					customerBillingData: {
+						name: 'John Doe',
+						email: 'john@example.com',
+						phone: '+1234567890',
+						address: {
+							country: 'us', // lowercase, should be uppercased
+							line1: '123 Main St',
+							line2: 'Apt 4B',
+							city: 'New York',
+							state: 'NY',
+							postal_code: '10001',
+						},
+					},
+				};
+
+				expect( getBillingDetailsForDeferredFlow() ).toEqual( {
+					name: 'John Doe',
+					email: 'john@example.com',
+					phone: '+1234567890',
+					address: {
+						country: 'US',
+						line1: '123 Main St',
+						line2: 'Apt 4B',
+						city: 'New York',
+						state: 'NY',
+						postal_code: '10001',
+					},
+				} );
+			}
+		);
+
+		it( 'omits empty address fields, trims values, and uppercases the country', () => {
+			global.wc_stripe_upe_params = {
+				isOrderPay: true,
+				customerBillingData: {
+					name: '  John Doe  ',
+					email: '  john@example.com  ',
+					phone: '',
+					address: {
+						country: 'gb',
+						line1: '10 Downing St',
+						line2: '',
+						city: '',
+						state: '',
+						postal_code: 'SW1A 2AA',
+					},
+				},
+			};
+
+			expect( getBillingDetailsForDeferredFlow() ).toEqual( {
+				name: 'John Doe',
+				email: 'john@example.com',
+				address: {
+					country: 'GB',
+					line1: '10 Downing St',
+					postal_code: 'SW1A 2AA',
+				},
+			} );
+		} );
+
+		it( 'returns null on standard checkout', () => {
+			global.wc_stripe_upe_params = {
+				isCheckout: true,
+				customerBillingData: {
+					email: 'john@example.com',
+				},
+			};
+
+			expect( getBillingDetailsForDeferredFlow() ).toBeNull();
+		} );
+
+		it( 'returns null when customer email is missing', () => {
+			global.wc_stripe_upe_params = {
+				isOrderPay: true,
+				customerBillingData: {
+					name: 'John Doe',
+					address: { line1: '123 Main St' },
+				},
+			};
+
+			expect( getBillingDetailsForDeferredFlow() ).toBeNull();
 		} );
 	} );
 

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -520,15 +520,6 @@ export const appendCheckoutSessionIdToForm = ( form, checkoutSessionId ) => {
 };
 
 /**
- * Craft the defaultValues parameter, used to pre-fill
- * user email and phone number for Link in the Payment Element.
- * On order pay and change payment method pages, also preloads all billing details
- * from the customer billing data passed from the server.
- *
- * @param {boolean} forCheckoutSession Whether the default values are for a Checkout Session.
- * @return {Object} The defaultValues object for the Payment Element.
- */
-/**
  * Returns true when the current page is one of the deferred-payment flows
  * (order pay, change payment method, or add payment method).
  *

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -528,69 +528,94 @@ export const appendCheckoutSessionIdToForm = ( form, checkoutSessionId ) => {
  * @param {boolean} forCheckoutSession Whether the default values are for a Checkout Session.
  * @return {Object} The defaultValues object for the Payment Element.
  */
-export const getDefaultValues = ( forCheckoutSession = false ) => {
+/**
+ * Returns true when the current page is one of the deferred-payment flows
+ * (order pay, change payment method, or add payment method).
+ *
+ * @return {boolean} Whether the current page is a deferred-payment flow.
+ */
+const isDeferredPaymentFlow = () => {
 	const stripeServerData = getStripeServerData();
-	const isOrderPay = stripeServerData?.isOrderPay;
-	const isChangingPayment = stripeServerData?.isChangingPayment;
-	const isAddPaymentMethod = stripeServerData?.isAddPaymentMethod;
+	return Boolean(
+		stripeServerData?.isOrderPay ||
+			stripeServerData?.isChangingPayment ||
+			stripeServerData?.isAddPaymentMethod
+	);
+};
 
+/**
+ * Normalizes the server-localized customer billing data into a billing details
+ * object (`{ name, email, phone, address }`) suitable for both the Payment
+ * Element `defaultValues` and the `createPaymentMethod` `billing_details` param.
+ *
+ * @return {Object|null} Normalized billing details, or null when unavailable.
+ */
+const buildCustomerBillingDetails = () => {
+	const billingData = getStripeServerData()?.customerBillingData;
+
+	if ( ! billingData || ! billingData.email?.trim() ) {
+		return null;
+	}
+
+	// Build address object, only including non-empty values.
+	const address = {};
+	const country = billingData.address?.country?.trim();
+	if ( country ) {
+		// Country must be uppercase ISO 3166-1 alpha-2 code for Stripe.
+		address.country = country.toUpperCase();
+	}
+	const line1 = billingData.address?.line1?.trim();
+	if ( line1 ) {
+		address.line1 = line1;
+	}
+	const line2 = billingData.address?.line2?.trim();
+	if ( line2 ) {
+		address.line2 = line2;
+	}
+	const city = billingData.address?.city?.trim();
+	if ( city ) {
+		address.city = city;
+	}
+	const state = billingData.address?.state?.trim();
+	if ( state ) {
+		address.state = state;
+	}
+	const postalCode = billingData.address?.postal_code?.trim();
+	if ( postalCode ) {
+		address.postal_code = postalCode;
+	}
+
+	return {
+		name: billingData.name?.trim() || undefined,
+		email: billingData.email.trim(),
+		phone: billingData.phone?.trim() || undefined,
+		...( Object.keys( address ).length > 0 ? { address } : {} ),
+	};
+};
+
+export const getDefaultValues = ( forCheckoutSession = false ) => {
 	// On order pay, change payment method, and add payment method pages, use billing data from customer.
-	if ( isOrderPay || isChangingPayment || isAddPaymentMethod ) {
-		const billingData = stripeServerData?.customerBillingData;
+	if ( isDeferredPaymentFlow() ) {
+		const billingDetails = buildCustomerBillingDetails();
 
-		if ( billingData && billingData.email?.trim() ) {
-			// Build address object, only including non-empty values
-			const address = {};
-			const country = billingData.address?.country?.trim();
-			if ( country ) {
-				// Country must be uppercase ISO 3166-1 alpha-2 code for Stripe
-				address.country = country.toUpperCase();
-			}
-			const line1 = billingData.address?.line1?.trim();
-			if ( line1 ) {
-				address.line1 = line1;
-			}
-			const line2 = billingData.address?.line2?.trim();
-			if ( line2 ) {
-				address.line2 = line2;
-			}
-			const city = billingData.address?.city?.trim();
-			if ( city ) {
-				address.city = city;
-			}
-			const state = billingData.address?.state?.trim();
-			if ( state ) {
-				address.state = state;
-			}
-			const postalCode = billingData.address?.postal_code?.trim();
-			if ( postalCode ) {
-				address.postal_code = postalCode;
-			}
-
+		if ( billingDetails ) {
 			if ( forCheckoutSession ) {
 				return {
 					defaultValues: {
 						billingAddress: {
-							name: billingData.name?.trim() || undefined,
-							...( Object.keys( address ).length > 0
-								? { address }
+							name: billingDetails.name,
+							...( billingDetails.address
+								? { address: billingDetails.address }
 								: {} ),
 						},
-						phoneNumber: billingData.phone?.trim() || undefined,
+						phoneNumber: billingDetails.phone,
 					},
 				};
 			}
 
 			return {
 				defaultValues: {
-					billingDetails: {
-						name: billingData.name?.trim() || undefined,
-						email: billingData.email.trim(),
-						phone: billingData.phone?.trim() || undefined,
-						...( Object.keys( address ).length > 0
-							? { address }
-							: {} ),
-					},
+					billingDetails,
 				},
 			};
 		}
@@ -618,6 +643,26 @@ export const getDefaultValues = ( forCheckoutSession = false ) => {
 			},
 		},
 	};
+};
+
+/**
+ * Returns the `billing_details` object to pass to Stripe's `createPaymentMethod`
+ * on the deferred-payment flows.
+ *
+ * On these flows the form is not a checkout form, so billing fields are not
+ * present in the DOM. The order/customer billing data is localized server-side
+ * as `customerBillingData`; we forward it explicitly so the full address reaches
+ * the PaymentMethod.
+ *
+ * @return {Object|null} A `billing_details` object, or null when not a deferred
+ *                       flow or when no usable customer billing data exists.
+ */
+export const getBillingDetailsForDeferredFlow = () => {
+	if ( ! isDeferredPaymentFlow() ) {
+		return null;
+	}
+
+	return buildCustomerBillingDetails();
 };
 
 /**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -666,24 +666,21 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 
 		$is_pay_for_order = parent::is_valid_pay_for_order_endpoint();
 
-		// Pass billing details from user's customer data for preloading Payment Element fields in Pay for Order, Change Payment Method, and Add Payment Method pages.
+		// Pass billing details for preloading Payment Element fields and for Radar AVS
+		// checks on the Pay for Order, Change Payment Method, and Add Payment Method pages.
 		if ( is_wc_endpoint_url( 'add-payment-method' ) || $is_pay_for_order || $is_change_payment_method ) {
-			// Get billing details from the current user's customer data instead of the order.
-			$customer = WC()->customer;
-			if ( $customer ) {
-				$stripe_params['customerBillingData'] = [
-					'name'    => trim( $customer->get_billing_first_name() . ' ' . $customer->get_billing_last_name() ),
-					'email'   => $customer->get_billing_email(),
-					'phone'   => $customer->get_billing_phone(),
-					'address' => [
-						'country'     => $customer->get_billing_country(),
-						'line1'       => $customer->get_billing_address_1(),
-						'line2'       => $customer->get_billing_address_2(),
-						'city'        => $customer->get_billing_city(),
-						'state'       => $customer->get_billing_state(),
-						'postal_code' => $customer->get_billing_postcode(),
-					],
-				];
+			// On the pay-for-order page, the order (loaded only for the order-key-validated
+			// endpoint) is the billing source; elsewhere the logged-in customer is.
+			$pay_for_order_order = null;
+			if ( $is_pay_for_order ) {
+				$order               = wc_get_order( absint( get_query_var( 'order-pay' ) ) );
+				$pay_for_order_order = $order instanceof WC_Order ? $order : null;
+			}
+
+			$customer     = WC()->customer instanceof WC_Customer ? WC()->customer : null;
+			$billing_data = $this->get_deferred_flow_billing_data( $is_pay_for_order, $pay_for_order_order, $customer );
+			if ( null !== $billing_data ) {
+				$stripe_params['customerBillingData'] = $billing_data;
 			}
 		}
 
@@ -745,6 +742,52 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		}
 
 		return array_merge( $stripe_params, WC_Stripe_Helper::get_localized_messages() );
+	}
+
+	/**
+	 * Resolves the billing data to localize for the deferred-payment flows (pay for order,
+	 * change payment method, add payment method).
+	 *
+	 * On the pay-for order page, we try to source the billing data from the order, as it's likely the merchant has pre-filled them.
+	 * Failing that, we fall back to the customer data, which may be available for the logged in users.
+	 *
+	 * @param bool             $is_pay_for_order Whether the current page is the validated pay-for-order endpoint.
+	 * @param WC_Order|null    $order            The order being paid, or null when not pay-for-order/unavailable.
+	 * @param WC_Customer|null $customer         The current customer, or null when unavailable.
+	 * @return array|null The billing data array, or null when no usable source exists.
+	 */
+	public function get_deferred_flow_billing_data( bool $is_pay_for_order, ?WC_Order $order, ?WC_Customer $customer ): ?array {
+		if ( $is_pay_for_order && $order instanceof WC_Order && '' !== trim( (string) $order->get_billing_email() ) ) {
+			return $this->build_billing_data_from_source( $order );
+		}
+
+		if ( $customer instanceof WC_Customer ) {
+			return $this->build_billing_data_from_source( $customer );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Builds the billing data array from a billing source.
+	 *
+	 * @param WC_Order|WC_Customer $source The object to read billing details from.
+	 * @return array The billing data array.
+	 */
+	private function build_billing_data_from_source( $source ): array {
+		return [
+			'name'    => trim( $source->get_billing_first_name() . ' ' . $source->get_billing_last_name() ),
+			'email'   => $source->get_billing_email(),
+			'phone'   => $source->get_billing_phone(),
+			'address' => [
+				'country'     => $source->get_billing_country(),
+				'line1'       => $source->get_billing_address_1(),
+				'line2'       => $source->get_billing_address_2(),
+				'city'        => $source->get_billing_city(),
+				'state'       => $source->get_billing_state(),
+				'postal_code' => $source->get_billing_postcode(),
+			],
+		];
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -218,5 +218,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Correct Amazon Pay button preview rendering in the Full Site Editor block cart and checkout pages
 * Fix - Use the order's currency instead of the store base currency on the Pay for Order page for the Express Checkout Element
 * Fix - Update the order description and metadata on the payment intent after an Adaptive Pricing payment completes
+* Fix - Send the billing address to Stripe on the Pay for Order page so payments aren't incorrectly blocked by Stripe Radar rules
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -703,6 +703,106 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * The billing source for the deferred-payment flows is selected all-or-nothing:
+	 * the order on a validated pay-for-order page (so guests still get full address
+	 * details), otherwise the customer, with a wholesale fallback to the customer when
+	 * the order has no usable billing email.
+	 *
+	 * @dataProvider provide_deferred_flow_billing_data_scenarios
+	 *
+	 * @param bool   $is_pay_for_order Whether the page is the validated pay-for-order endpoint.
+	 * @param bool   $order_has_email  Whether the order carries a billing email.
+	 * @param bool   $with_customer    Whether a customer is available as a source.
+	 * @param string $expected_source  Expected source: 'order', 'customer', or 'none'.
+	 */
+	public function test_get_deferred_flow_billing_data( bool $is_pay_for_order, bool $order_has_email, bool $with_customer, string $expected_source ) {
+		$order_billing    = [
+			'name'    => 'Order Buyer',
+			'email'   => 'order-buyer@example.com',
+			'phone'   => '+15551234567',
+			'address' => [
+				'country'     => 'US',
+				'line1'       => '123 Order St',
+				'line2'       => 'Suite 5',
+				'city'        => 'Orderville',
+				'state'       => 'CA',
+				'postal_code' => '90001',
+			],
+		];
+		$customer_billing = [
+			'name'    => 'Cust Omer',
+			'email'   => 'customer@example.com',
+			'phone'   => '+447700900000',
+			'address' => [
+				'country'     => 'GB',
+				'line1'       => '999 Customer Ave',
+				'line2'       => 'Flat 2',
+				'city'        => 'London',
+				'state'       => 'LND',
+				'postal_code' => 'SW1A 2AA',
+			],
+		];
+
+		// A bare (unsaved) order keeps the test free of the DB and of helper-seeded defaults.
+		$order = new WC_Order();
+		$order->set_billing_first_name( 'Order' );
+		$order->set_billing_last_name( 'Buyer' );
+		$order->set_billing_phone( $order_billing['phone'] );
+		$order->set_billing_country( $order_billing['address']['country'] );
+		$order->set_billing_address_1( $order_billing['address']['line1'] );
+		$order->set_billing_address_2( $order_billing['address']['line2'] );
+		$order->set_billing_city( $order_billing['address']['city'] );
+		$order->set_billing_state( $order_billing['address']['state'] );
+		$order->set_billing_postcode( $order_billing['address']['postal_code'] );
+		if ( $order_has_email ) {
+			$order->set_billing_email( $order_billing['email'] );
+		}
+
+		$customer = null;
+		if ( $with_customer ) {
+			$customer = new WC_Customer();
+			$customer->set_billing_first_name( 'Cust' );
+			$customer->set_billing_last_name( 'Omer' );
+			$customer->set_billing_email( $customer_billing['email'] );
+			$customer->set_billing_phone( $customer_billing['phone'] );
+			$customer->set_billing_country( $customer_billing['address']['country'] );
+			$customer->set_billing_address_1( $customer_billing['address']['line1'] );
+			$customer->set_billing_address_2( $customer_billing['address']['line2'] );
+			$customer->set_billing_city( $customer_billing['address']['city'] );
+			$customer->set_billing_state( $customer_billing['address']['state'] );
+			$customer->set_billing_postcode( $customer_billing['address']['postal_code'] );
+		}
+
+		$result = $this->mock_gateway->get_deferred_flow_billing_data( $is_pay_for_order, $order, $customer );
+
+		switch ( $expected_source ) {
+			case 'order':
+				$this->assertSame( $order_billing, $result );
+				break;
+			case 'customer':
+				// Asserting the whole array proves the fallback is all-or-nothing: no order field leaks in.
+				$this->assertSame( $customer_billing, $result );
+				break;
+			default:
+				$this->assertNull( $result );
+		}
+	}
+
+	/**
+	 * Data provider for test_get_deferred_flow_billing_data.
+	 *
+	 * @return array<string, array{0: bool, 1: bool, 2: bool, 3: string}>
+	 */
+	public function provide_deferred_flow_billing_data_scenarios(): array {
+		return [
+			'pay-for-order uses the order when it has an email'                    => [ true, true, true, 'order' ],
+			'pay-for-order falls back to the customer when the order has no email' => [ true, false, true, 'customer' ],
+			'change/add payment method uses the customer even with an order'       => [ false, true, true, 'customer' ],
+			'returns null when neither order nor customer is usable'               => [ true, false, false, 'none' ],
+		];
+	}
+
+	/**
 	 * Test basic checkout process_payment flow with deferred intent.
 	 *
 	 * @dataProvider provide_process_payment_deferred_intent_returns_valid_response


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-952

## Changes proposed in this Pull Request:

On the Pay for Order page, the billing address was not sent to Stripe when creating the PaymentMethod. This can result in failed orders if there are Radar rules that check for billing address data. This PR fixes this by addressing the following two underlying causes.

- In the frontend, billing details were only attached to `createPaymentMethod` when it's a checkout form. The Pay for Order form is `#order_review`, so no `billing_details` were sent. The Payment Element's `defaultValues` were pre-filled, but Stripe's card element never collects the hidden address fields (line1/city/state), so they never reached the PaymentMethod.
- The billing data localized to the page was always sourced from the customer profile, which is empty for a **guest** paying a merchant-created order, so the address the merchant entered on the order never reached the page. In this PR for pay-for-order orders, we try to source the billing address from the order data. If that's not available, we fallback to the customer data.




<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. In the Stripe Dashboard (test mode) -> **Radar -> Rules**, add a **Block** rule: `Block if :address_line1_check: in ('fail', 'not_provided')`.
2. In WooCommerce admin, create a **manual order**: add a product, set a customer billing address 
3. Copy the **Customer payment page** link
4. Open that link in a logged-out / incognito window and place the order
5. **Expected:** the payment succeeds. Radar should not block this.
6. **Before this fix** the same payment is blocked by the Radar rule.
7. Regression - confirm standard checkout still works: place a normal order from the cart and verify billing details are still sent and payment succeeds.
8. Regression - confirm a logged-in customer paying for their own order via Pay for Order still succeeds with the address sent. In this case, the address set in the customer account should be used.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
