### PR TITLE
Consolidate Stripe API version to a single constant (STRIPE-981)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 xxxx-xx-xx - version 10.9.0
 * Fix - Prevent unnecessary Stripe payment method creation when shortcode checkout has empty required fields
+* Update - Use a single Stripe API version across the plugin, replacing the temporary per-request version override used by Agentic Commerce
 
 2026-06-08 - version 10.8.0
 * Fix - Add an order note and call action 'wc_stripe_unexpected_charge_detected' when a Stripe charge is captured for an order that was already paid via a different gateway

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -294,7 +294,7 @@ class WC_Stripe_Account {
 		$request = [
 			'enabled_events' => self::WEBHOOK_EVENTS,
 			'url'            => WC_Stripe_Helper::get_webhook_url(),
-			'api_version'    => self::get_webhooks_api_version(),
+			'api_version'    => WC_Stripe_API::STRIPE_API_VERSION,
 		];
 
 		$response = WC_Stripe_API::request( $request, 'webhook_endpoints', 'POST' );
@@ -434,28 +434,7 @@ class WC_Stripe_Account {
 	 * @return bool True if API version differs, false if they match.
 	 */
 	private function does_webhooks_api_version_differ( $existing_webhook ): bool {
-		return self::get_webhooks_api_version() !== $existing_webhook->api_version; // @phpstan-ignore property.notFound
-	}
-
-	/**
-	 * Returns the API version for the webhooks.
-	 *
-	 * @return string The API version.
-	 */
-	private static function get_webhooks_api_version(): string {
-		$version = WC_Stripe_API::STRIPE_API_VERSION;
-
-		/**
-		 * Agentic Commerce uses a different API version for webhooks.
-		 *
-		 * This method should be removed once we switch to
-		 * AGENTIC_COMMERCE_API_VERSION or higher.
-		 */
-		if ( WC_Stripe_Feature_Flags::is_agentic_commerce_enabled() ) {
-			$version = WC_Stripe_API::AGENTIC_COMMERCE_API_VERSION;
-		}
-
-		return $version;
+		return WC_Stripe_API::STRIPE_API_VERSION !== $existing_webhook->api_version; // @phpstan-ignore property.notFound
 	}
 
 	/**

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -17,6 +17,13 @@ class WC_Stripe_API {
 	public const STRIPE_API_VERSION = '2025-12-15.preview';
 
 	/**
+	 * Stripe API version previously used only for Agentic Commerce requests.
+	 *
+	 * @deprecated 10.9.0 The plugin now uses a single API version everywhere; use STRIPE_API_VERSION instead.
+	 */
+	public const AGENTIC_COMMERCE_API_VERSION = self::STRIPE_API_VERSION;
+
+	/**
 	 * The invalid API key error count cache key.
 	 *
 	 * @var string

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -13,9 +13,8 @@ class WC_Stripe_API {
 	/**
 	 * Stripe API Endpoint
 	 */
-	public const ENDPOINT                     = 'https://api.stripe.com/v1/';
-	public const STRIPE_API_VERSION           = '2025-09-30.clover';
-	public const AGENTIC_COMMERCE_API_VERSION = '2025-12-15.preview';
+	public const ENDPOINT           = 'https://api.stripe.com/v1/';
+	public const STRIPE_API_VERSION = '2025-12-15.preview';
 
 	/**
 	 * The invalid API key error count cache key.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -2303,109 +2303,98 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			]
 		);
 
-		// Temporarily override the API version to get the right fields.
-		$override_version = function ( $headers ) {
-			$headers['Stripe-Version'] = WC_Stripe_API::AGENTIC_COMMERCE_API_VERSION;
-			return $headers;
-		};
-		add_filter( 'wc_stripe_request_headers', $override_version );
+		$url         = $this->build_checkout_session_retrieve_url(
+			$notification->data->object->id,
+			WC_Stripe_Agentic_Checkout_Session::get_fields_to_expand()
+		);
+		$raw_session = WC_Stripe_API::retrieve( $url );
+
+		if ( is_wp_error( $raw_session ) || ! is_object( $raw_session ) ) {
+			WC_Stripe_Logger::error(
+				'Failed to retrieve checkout session with expand params.',
+				[
+					'url'   => $url,
+					'error' => is_wp_error( $raw_session ) ? $raw_session->get_error_message() : 'Unexpected response from Stripe API.',
+				]
+			);
+			return;
+		}
+
+		assert( $raw_session instanceof stdClass );
+		$session = new WC_Stripe_Agentic_Checkout_Session( $raw_session );
+
+		if ( ! $session->is_agentic() ) {
+			WC_Stripe_Logger::info(
+				'Checkout session is not agentic, skipping agentic processing: ' . $session->get_id()
+			);
+			return;
+		}
+
+		$payment_intent_id = $session->get_payment_intent_id();
+		if ( null === $payment_intent_id || empty( $payment_intent_id ) ) {
+			WC_Stripe_Logger::error(
+				'Checkout session is missing the payment intent id.',
+				[
+					'session_id' => $session->get_id(),
+				]
+			);
+			return;
+		}
 
 		try {
-			$url         = $this->build_checkout_session_retrieve_url(
-				$notification->data->object->id,
-				WC_Stripe_Agentic_Checkout_Session::get_fields_to_expand()
+			$order_mapper         = new WC_Stripe_Agentic_Commerce_Order_Mapper();
+			$order                = $order_mapper->create_order_from_checkout_session( $session );
+			$this->resolved_order = $order;
+
+			WC_Stripe_Logger::info(
+				'Agentic order created from checkout session.',
+				[
+					'session_id' => $session->get_id(),
+					'order_id'   => $order->get_id(),
+				]
 			);
-			$raw_session = WC_Stripe_API::retrieve( $url );
 
-			if ( is_wp_error( $raw_session ) || ! is_object( $raw_session ) ) {
-				WC_Stripe_Logger::error(
-					'Failed to retrieve checkout session with expand params.',
-					[
-						'url'   => $url,
-						'error' => is_wp_error( $raw_session ) ? $raw_session->get_error_message() : 'Unexpected response from Stripe API.',
-					]
-				);
-				return;
+			/**
+			 * Fires after an agentic commerce order is created from a checkout session.
+			 *
+			 * @since 10.6.0
+			 * @param WC_Order                           $order   The created order.
+			 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
+			 */
+			do_action( 'wc_stripe_agentic_order_created', $order, $session );
+		} catch ( Throwable $e ) {
+			// Cap trace length to avoid overwhelming log handlers that may
+			// truncate or reject very large context fields.
+			$trace = $e->getTraceAsString();
+			if ( strlen( $trace ) > 4000 ) {
+				$trace = substr( $trace, 0, 4000 ) . '... [truncated]';
 			}
 
-			assert( $raw_session instanceof stdClass );
-			$session = new WC_Stripe_Agentic_Checkout_Session( $raw_session );
+			WC_Stripe_Logger::error(
+				'Failed to create agentic order from checkout session.',
+				[
+					'session_id' => $session->get_id(),
+					'error'      => $e->getMessage(),
+					'exception'  => get_class( $e ),
+					'file'       => $e->getFile(),
+					'line'       => $e->getLine(),
+					'trace'      => $trace,
+				]
+			);
 
-			if ( ! $session->is_agentic() ) {
-				WC_Stripe_Logger::info(
-					'Checkout session is not agentic, skipping agentic processing: ' . $session->get_id()
-				);
-				return;
-			}
+			/**
+			 * Fires when agentic commerce order creation fails.
+			 *
+			 * @since 10.6.0
+			 * @param Throwable                          $e       The throwable that was thrown.
+			 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
+			 */
+			do_action( 'wc_stripe_agentic_order_creation_failed', $e, $session );
 
-			$payment_intent_id = $session->get_payment_intent_id();
-			if ( null === $payment_intent_id || empty( $payment_intent_id ) ) {
-				WC_Stripe_Logger::error(
-					'Checkout session is missing the payment intent id.',
-					[
-						'session_id' => $session->get_id(),
-					]
-				);
-				return;
-			}
-
-			try {
-				$order_mapper         = new WC_Stripe_Agentic_Commerce_Order_Mapper();
-				$order                = $order_mapper->create_order_from_checkout_session( $session );
-				$this->resolved_order = $order;
-
-				WC_Stripe_Logger::info(
-					'Agentic order created from checkout session.',
-					[
-						'session_id' => $session->get_id(),
-						'order_id'   => $order->get_id(),
-					]
-				);
-
-				/**
-				 * Fires after an agentic commerce order is created from a checkout session.
-				 *
-				 * @since 10.6.0
-				 * @param WC_Order                           $order   The created order.
-				 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
-				 */
-				do_action( 'wc_stripe_agentic_order_created', $order, $session );
-			} catch ( Throwable $e ) {
-				// Cap trace length to avoid overwhelming log handlers that may
-				// truncate or reject very large context fields.
-				$trace = $e->getTraceAsString();
-				if ( strlen( $trace ) > 4000 ) {
-					$trace = substr( $trace, 0, 4000 ) . '... [truncated]';
-				}
-
-				WC_Stripe_Logger::error(
-					'Failed to create agentic order from checkout session.',
-					[
-						'session_id' => $session->get_id(),
-						'error'      => $e->getMessage(),
-						'exception'  => get_class( $e ),
-						'file'       => $e->getFile(),
-						'line'       => $e->getLine(),
-						'trace'      => $trace,
-					]
-				);
-
-				/**
-				 * Fires when agentic commerce order creation fails.
-				 *
-				 * @since 10.6.0
-				 * @param Throwable                          $e       The throwable that was thrown.
-				 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
-				 */
-				do_action( 'wc_stripe_agentic_order_creation_failed', $e, $session );
-
-				// Re-throw so Action Scheduler marks the job as failed. The inner
-				// catch exists to log with full context and fire the failure hook;
-				// swallowing here would make AS report the run as complete.
-				throw $e;
-			}
-		} finally {
-			remove_filter( 'wc_stripe_request_headers', $override_version );
+			// Re-throw so Action Scheduler marks the job as failed. The inner
+			// catch exists to log with full context and fire the failure hook;
+			// swallowing here would make AS report the run as complete.
+			throw $e;
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -157,5 +157,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 10.9.0 - xxxx-xx-xx =
 * Fix - Prevent unnecessary Stripe payment method creation when shortcode checkout has empty required fields
+* Update - Use a single Stripe API version across the plugin, replacing the temporary per-request version override used by Agentic Commerce
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-account-test.php
+++ b/tests/phpunit/class-wc-stripe-account-test.php
@@ -539,39 +539,6 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that webhook reconfiguration is triggered when the agentic flag
-	 * causes the desired API version to differ from the existing webhook.
-	 */
-	public function test_reconfigure_webhooks_on_update_with_agentic_flag_enabled() {
-		add_filter( 'wc_stripe_is_agentic_commerce_enabled', '__return_true' );
-
-		try {
-			// Mock a webhook that has current events but the non-agentic API version.
-			$outdated_webhook = (object) [
-				'id'             => 'we_123',
-				'url'            => WC_Stripe_Helper::get_webhook_url(),
-				'enabled_events' => WC_Stripe_Account::WEBHOOK_EVENTS,
-				'api_version'    => \WC_Stripe_API::STRIPE_API_VERSION,
-				'status'         => 'enabled',
-			];
-
-			$this->account = $this->getMockBuilder( WC_Stripe_Account::class )
-				->setConstructorArgs( [ $this->mock_connect, WC_Helper_Stripe_Api::class ] )
-				->onlyMethods( [ 'get_existing_webhook', 'configure_webhooks' ] )
-				->getMock();
-
-			$this->account->method( 'get_existing_webhook' )->willReturn( $outdated_webhook );
-			$this->account->expects( $this->once() )
-				->method( 'configure_webhooks' )
-				->with( $this->equalTo( 'test' ) );
-
-			$this->account->maybe_reconfigure_webhooks_on_update();
-		} finally {
-			remove_filter( 'wc_stripe_is_agentic_commerce_enabled', '__return_true' );
-		}
-	}
-
-	/**
 	 * Test webhook reconfiguration on update with existing webhooks that are up to date.
 	 */
 	public function test_reconfigure_webhooks_on_update_with_current_webhooks() {

--- a/tests/phpunit/class-wc-stripe-webhook-handler-agentic-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-agentic-test.php
@@ -382,28 +382,9 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the wc_stripe_request_headers filter is always removed after processing,
-	 * even when an error occurs before order creation.
+	 * Tests that the Stripe API version header is applied during the retrieve call.
 	 */
-	public function test_request_headers_filter_is_removed_after_processing_failure() {
-		$this->assertFalse( has_filter( 'wc_stripe_request_headers' ) );
-
-		$session_id   = 'cs_test_filter_cleanup';
-		$notification = $this->build_notification( $session_id );
-		$this->mock_stripe_api_error();
-
-		// Immediate phase: defers the webhook.
-		$this->handler->process_checkout_session_success( $notification );
-		// Deferred phase: API error → filter must still be cleaned up.
-		$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
-
-		$this->assertFalse( has_filter( 'wc_stripe_request_headers' ) );
-	}
-
-	/**
-	 * Tests that the Stripe API version override header is applied during the retrieve call.
-	 */
-	public function test_api_version_override_applied() {
+	public function test_api_version_header_applied() {
 		$captured_headers  = null;
 		$this->http_filter = function ( $preempt, $parsed_args ) use ( &$captured_headers ) {
 			$captured_headers = $parsed_args['headers'] ?? [];
@@ -421,10 +402,10 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 
 		// Immediate phase: defers the webhook.
 		$this->handler->process_checkout_session_success( $notification );
-		// Deferred phase: API retrieve call must include the Stripe-Version override
-		// header. The stub session references a non-existent product, so the mapper
-		// fails and re-throws — that's fine for this test; we only care that the
-		// override filter was applied before the HTTP call.
+		// Deferred phase: API retrieve call must include the Stripe-Version header.
+		// The stub session references a non-existent product, so the mapper fails and
+		// re-throws — that's fine for this test; we only care that the version header
+		// was sent on the HTTP call.
 		$mapper_threw = null;
 		try {
 			$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
@@ -435,7 +416,7 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 
 		$this->assertNotNull( $captured_headers );
 		$this->assertArrayHasKey( 'Stripe-Version', $captured_headers );
-		$this->assertEquals( WC_Stripe_API::AGENTIC_COMMERCE_API_VERSION, $captured_headers['Stripe-Version'] );
+		$this->assertEquals( WC_Stripe_API::STRIPE_API_VERSION, $captured_headers['Stripe-Version'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes STRIPE-981

## Changes proposed in this Pull Request:

Agentic Commerce shipped behind a temporary `AGENTIC_COMMERCE_API_VERSION` constant that overrode the Stripe request/webhook version in two places. Maintaining a second version risked webhook-version drift and reliability issues if it were ever bumped independently. With the feature ready to ship, this consolidates to a **single API version (`2025-12-15.preview`) used throughout the plugin** and removes the temporary override machinery.

What this change does:

- **`includes/class-wc-stripe-api.php`** — `STRIPE_API_VERSION` is now `2025-12-15.preview`. `AGENTIC_COMMERCE_API_VERSION` is kept as a **deprecated alias** of `STRIPE_API_VERSION` (not removed), so any external consumers referencing it keep working.
- **`includes/class-wc-stripe-account.php`** — removed the temporary private `get_webhooks_api_version()` helper (its docblock already flagged it for removal once we switched versions). `configure_webhooks()` and `does_webhooks_api_version_differ()` reference `STRIPE_API_VERSION` directly.
- **`includes/class-wc-stripe-webhook-handler.php`** — removed the temporary `wc_stripe_request_headers` override filter (closure + `add_filter`/`remove_filter`) and its `try/finally` around agentic checkout-session retrieval; the global version now equals the agentic version, so the override is redundant. The large line count is whitespace de-indentation — `git diff -w` shows only the override removal.

The unrelated `WC_Stripe_Agentic_Commerce_Files_Api_Delivery::API_VERSION` (`2025-09-30.clover;udap_beta=v1`, the Files API / UDAP-beta feed-delivery version) is intentionally left untouched.

**How can this code break?** Every Stripe API call plugin-wide now uses `2025-12-15.preview` rather than `2025-09-30.clover`. A behavioral difference in any endpoint between those two versions would surface across all flows (cards, express checkout, webhooks), not just Agentic Commerce.

**What are we doing to make sure it doesn't break?** The agentic flows already used this version for their webhook/retrieve calls, so it's a proven version for Stripe. Static analysis (PHPStan level 8) and PHPCS pass; PHPUnit covers webhook reconfiguration and the agentic version header. Reviewers should validate the non-agentic flows below.

## Testing instructions

1. Confirm `WC_Stripe_API::STRIPE_API_VERSION` resolves to `2025-12-15.preview` and `WC_Stripe_API::AGENTIC_COMMERCE_API_VERSION` returns the same value.
2. With a Stripe account connected, trigger webhook (re)configuration (e.g. re-save Stripe settings) and confirm the webhook endpoint is created/updated with `api_version` `2025-12-15.preview` and no errors are logged.
3. Run a classic-checkout card payment and a Blocks/express-checkout payment; confirm both complete successfully (validates the global version bump on non-agentic flows).
4. With Agentic Commerce enabled, process a `checkout.session.completed` webhook and confirm the order is created as before.
5. Run the related PHPUnit suites: `class-wc-stripe-webhook-handler-agentic-test.php` and `class-wc-stripe-account-test.php`.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

Update - Use a single Stripe API version across the plugin, replacing the temporary per-request version override used by Agentic Commerce

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

*Drafted with AI; reviewed by me.*