### PR TITLE
Add CODEOWNERS to auto-request Quark review on all PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-features/customizing-your-repository/about-code-owners
+#
+# The Quark team is requested for review on every pull request.
+* @woocommerce/quark


### PR DESCRIPTION
## Changes proposed in this Pull Request:
Adds a `.github/CODEOWNERS` file with a single wildcard rule (`* @woocommerce/quark`) so the Quark team is automatically requested as a reviewer on every pull request opened in this repo.

No code or runtime behavior changes — this is repo tooling only.

## Testing instructions
Code review.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Internal repository configuration (CODEOWNERS) change; no user-facing code changes.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
