### PR TITLE
Prevent fatal when saving redirect APMs as SEPA tokens in Adaptive Pricing webhook

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 xxxx-xx-xx - version 10.9.0
 * Fix - Prevent unnecessary Stripe payment method creation when shortcode checkout has empty required fields
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
+* Fix - Prevent a fatal error when saving Bancontact, iDEAL or Sofort payments as SEPA tokens through the Adaptive Pricing checkout, so the order completes normally
 
 2026-06-08 - version 10.8.0
 * Fix - Add an order note and call action 'wc_stripe_unexpected_charge_detected' when a Stripe charge is captured for an order that was already paid via a different gateway

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Prevent unnecessary Stripe payment method creation when shortcode checkout has empty required fields
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
 * Fix - Prevent a fatal error when saving Bancontact, iDEAL or Sofort payments as SEPA tokens through the Adaptive Pricing checkout, so the order completes normally
+* Fix - Generate and save a reusable SEPA token when a shopper opts to save a Bancontact, iDEAL or Sofort payment through the Adaptive Pricing checkout
 
 2026-06-08 - version 10.8.0
 * Fix - Add an order note and call action 'wc_stripe_unexpected_charge_detected' when a Stripe charge is captured for an order that was already paid via a different gateway

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,8 +3,7 @@
 xxxx-xx-xx - version 10.9.0
 * Fix - Prevent unnecessary Stripe payment method creation when shortcode checkout has empty required fields
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
-* Fix - Prevent a fatal error when saving Bancontact, iDEAL or Sofort payments as SEPA tokens through the Adaptive Pricing checkout, so the order completes normally
-* Fix - Generate and save a reusable SEPA token when a shopper opts to save a Bancontact, iDEAL or Sofort payment through the Adaptive Pricing checkout
+* Fix - Fix saving Bancontact, iDEAL and Sofort payments as reusable SEPA tokens through the Adaptive Pricing checkout, which previously caused a fatal error and left the order unpaid
 
 2026-06-08 - version 10.8.0
 * Fix - Add an order note and call action 'wc_stripe_unexpected_charge_detected' when a Stripe charge is captured for an order that was already paid via a different gateway

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,7 +5,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Send the billing address to Stripe on the Pay for Order page so payments aren't incorrectly blocked by Stripe Radar rules
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
-* Fix - Fix saving Bancontact, iDEAL and Sofort payments as reusable SEPA tokens through the Adaptive Pricing checkout, which previously caused a fatal error and left the order unpaid
+* Fix - Prevent a fatal error when a Bancontact, iDEAL or Sofort payment is placed with SEPA token saving enabled through the Adaptive Pricing checkout, which left the order unpaid
 
 2026-06-08 - version 10.8.0
 * Fix - Add an order note and call action 'wc_stripe_unexpected_charge_detected' when a Stripe charge is captured for an order that was already paid via a different gateway

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1812,7 +1812,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				$order_helper->update_stripe_source_id( $order, $payment_method_id );
 			}
 
-			// Fetch the charge once; reused below to process the response and to resolve any reusable SEPA mandate.
+			// Fetch the charge once; reused below.
 			$charge = $this->get_latest_charge_from_intent( $intent );
 
 			// Save payment method to store if the customer requested it during checkout.
@@ -1821,17 +1821,15 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 				$payment_method_object = is_object( $intent->payment_method ) ? $intent->payment_method : WC_Stripe_API::retrieve( 'payment_methods/' . $payment_method_id );
 				if ( $upe_gateway instanceof WC_Stripe_UPE_Payment_Gateway && ! is_wp_error( $payment_method_object ) && empty( $payment_method_object->error ) && ! empty( $payment_method_object ) ) {
-					// Redirect-based APMs (Bancontact, iDEAL, Sofort) are returned as their own PaymentMethod
-					// type but are saved as SEPA tokens. Convert to the generated SEPA debit PM before saving,
-					// mirroring the deferred-intent flow. Returns null when Stripe did not generate a reusable
-					// mandate, in which case there is nothing to save (and we avoid a fatal on set_fingerprint()).
+					// Redirect APMs saved as SEPA tokens need converting to their generated SEPA debit PM;
+					// null means no reusable mandate was generated, so there is nothing to save.
 					$payment_method_to_save = $upe_gateway->get_reusable_payment_method_for_saving( $payment_method_object, $charge );
 
 					if ( $payment_method_to_save instanceof stdClass && ! empty( $payment_method_to_save->type ) ) {
 						$upe_gateway->handle_saving_payment_method( $order, $payment_method_to_save, $payment_method_to_save->type );
 					}
 
-					// Clear the flag so it does not run again on webhook retries (even when nothing was saved).
+					// Clear the flag so retries don't re-run this, even when nothing was saved.
 					$order_helper->delete_should_save_stripe_payment_method( $order );
 				}
 			}

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1821,11 +1821,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 				$payment_method_object = is_object( $intent->payment_method ) ? $intent->payment_method : WC_Stripe_API::retrieve( 'payment_methods/' . $payment_method_id );
 				if ( $upe_gateway instanceof WC_Stripe_UPE_Payment_Gateway && ! is_wp_error( $payment_method_object ) && empty( $payment_method_object->error ) && ! empty( $payment_method_object ) ) {
-					// Redirect APMs saved as SEPA tokens need converting to their generated SEPA debit PM;
-					// null means no reusable mandate was generated, so there is nothing to save.
+					// Get the payment method details that should be saved. That may be different from the
+					// original payment method, e.g. for Bancontact and iDEAL/Wero, which are saved as SEPA.
 					$payment_method_to_save = $upe_gateway->get_reusable_payment_method_for_saving( $payment_method_object, $charge );
 
-					if ( $payment_method_to_save instanceof stdClass && ! empty( $payment_method_to_save->type ) ) {
+					if ( is_object( $payment_method_to_save ) && ! empty( $payment_method_to_save->type ) ) {
 						$upe_gateway->handle_saving_payment_method( $order, $payment_method_to_save, $payment_method_to_save->type );
 					}
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1812,15 +1812,26 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				$order_helper->update_stripe_source_id( $order, $payment_method_id );
 			}
 
+			// Fetch the charge once; reused below to process the response and to resolve any reusable SEPA mandate.
+			$charge = $this->get_latest_charge_from_intent( $intent );
+
 			// Save payment method to store if the customer requested it during checkout.
 			if ( $order_helper->get_should_save_stripe_payment_method( $order ) && ! empty( $payment_method_id ) ) {
 				$upe_gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
 
 				$payment_method_object = is_object( $intent->payment_method ) ? $intent->payment_method : WC_Stripe_API::retrieve( 'payment_methods/' . $payment_method_id );
-				if ( ! is_wp_error( $payment_method_object ) && empty( $payment_method_object->error ) && ! empty( $payment_method_object ) ) {
-					$upe_gateway->handle_saving_payment_method( $order, $payment_method_object, $payment_method_object->type );
+				if ( $upe_gateway instanceof WC_Stripe_UPE_Payment_Gateway && ! is_wp_error( $payment_method_object ) && empty( $payment_method_object->error ) && ! empty( $payment_method_object ) ) {
+					// Redirect-based APMs (Bancontact, iDEAL, Sofort) are returned as their own PaymentMethod
+					// type but are saved as SEPA tokens. Convert to the generated SEPA debit PM before saving,
+					// mirroring the deferred-intent flow. Returns null when Stripe did not generate a reusable
+					// mandate, in which case there is nothing to save (and we avoid a fatal on set_fingerprint()).
+					$payment_method_to_save = $upe_gateway->get_reusable_payment_method_for_saving( $payment_method_object, $charge );
 
-					// Clear the flag so it does not run again on webhook retries.
+					if ( $payment_method_to_save instanceof stdClass && ! empty( $payment_method_to_save->type ) ) {
+						$upe_gateway->handle_saving_payment_method( $order, $payment_method_to_save, $payment_method_to_save->type );
+					}
+
+					// Clear the flag so it does not run again on webhook retries (even when nothing was saved).
 					$order_helper->delete_should_save_stripe_payment_method( $order );
 				}
 			}
@@ -1835,8 +1846,6 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			}
 
 			$order->save();
-
-			$charge = $this->get_latest_charge_from_intent( $intent );
 
 			$charge->is_webhook_response = true;
 			$this->process_response( $charge, $order );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1525,9 +1525,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Sets setup_future_usage on the session so Stripe mints a reusable SEPA mandate for redirect-based
-	 * APMs (Bancontact, iDEAL, Sofort). Best-effort — failures are logged and swallowed so they cannot
-	 * block checkout.
+	 * Sets `setup_future_usage` to `off_session` for the checkout session, which will
+	 * ensure the payment method is saved. This is necessary for payment methods that "convert"
+	 * to SEPA debits when saved, including Bancontact and iDEAL/Wero.
+	 * Note that failures are logged and ignored so we don't prevent any other processing.
 	 *
 	 * @param string $checkout_session_id The Stripe Checkout Session ID.
 	 * @param string $payment_method_type The Stripe payment method type (e.g. 'bancontact').

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3778,6 +3778,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			return null;
 		}
 
+		/**
+		 * Decoded Stripe API JSON objects are always stdClass.
+		 *
+		 * @var stdClass $generated_payment_method
+		 */
 		return $generated_payment_method;
 	}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1438,29 +1438,40 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		$order_helper = WC_Stripe_Order_Helper::get_instance();
 		$order_helper->update_stripe_checkout_session_id( $order, $checkout_session_id );
 
-		// Persist the 'save-payment-method' flag so the webhook handler can create the token once payment is completed.
-		$upe_payment_method = $this->payment_methods[ $selected_payment_type ] ?? null;
-		if ( $save_payment_method && $upe_payment_method && $upe_payment_method->get_id() === $upe_payment_method->get_retrievable_type() ) {
-			$order_helper->update_should_save_stripe_payment_method( $order, true );
-		}
-
-		// Eagerly set the payment method title from the customer's selection so the order
-		// reflects the right method as soon as it lands on the order-received page, even if
-		// the checkout.session.completed webhook is delayed. Prefer the type the customer
-		// actually picked inside the Stripe Element (sent via the hidden
-		// `wc_stripe_selected_upe_payment_type` input by the Optimized Checkout JS) over
-		// the gateway-derived `$selected_payment_type`, which for Optimized Checkout is
-		// always 'card' and would otherwise resolve to the OC pseudo-method's "Stripe"
-		// title. The webhook handler will reaffirm/refine this once the actual payment
-		// method type is known from the intent.
+		// Resolve the payment method the customer actually picked inside the Stripe Element. For
+		// Optimized Checkout the gateway-derived `$selected_payment_type` is always 'card', so prefer
+		// the type sent via the hidden `wc_stripe_selected_upe_payment_type` input by the Optimized
+		// Checkout JS when it is present and known.
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$selected_upe_payment_type = isset( $_POST['wc_stripe_selected_upe_payment_type'] )
 			? sanitize_text_field( wp_unslash( $_POST['wc_stripe_selected_upe_payment_type'] ) )
 			: '';
 
-		$title_payment_type = ( ! empty( $selected_upe_payment_type ) && isset( $this->payment_methods[ $selected_upe_payment_type ] ) )
+		$resolved_payment_type   = ( ! empty( $selected_upe_payment_type ) && isset( $this->payment_methods[ $selected_upe_payment_type ] ) )
 			? $selected_upe_payment_type
 			: $selected_payment_type;
+		$resolved_payment_method = $this->payment_methods[ $resolved_payment_type ] ?? null;
+
+		// Persist the 'save-payment-method' flag so the webhook handler can create the token once payment is completed.
+		if ( $save_payment_method && $resolved_payment_method && $resolved_payment_method->is_reusable() ) {
+			$order_helper->update_should_save_stripe_payment_method( $order, true );
+
+			// Redirect-based APMs that are tokenized as SEPA (Bancontact, iDEAL, Sofort) only generate a
+			// reusable SEPA mandate when the Checkout Session asks for it via setup_future_usage. The save
+			// checkbox alone (saved_payment_method_options.payment_method_save) does not mint a
+			// `generated_sepa_debit` for these methods, so the save flag would otherwise be meaningless.
+			// Request it on the session before the client confirms it. Best-effort: a failure must not block
+			// checkout — the order still completes, and the webhook safely skips saving when no mandate exists.
+			if ( $resolved_payment_method->get_id() !== $resolved_payment_method->get_retrievable_type() ) {
+				$this->set_setup_future_usage_on_checkout_session( $checkout_session_id, $resolved_payment_method->get_id() );
+			}
+		}
+
+		// Eagerly set the payment method title from the customer's selection so the order reflects the
+		// right method as soon as it lands on the order-received page, even if the
+		// checkout.session.completed webhook is delayed. The webhook handler will reaffirm/refine this
+		// once the actual payment method type is known from the intent.
+		$title_payment_type = $resolved_payment_type;
 
 		if ( isset( $this->payment_methods[ $title_payment_type ] ) ) {
 			$this->set_payment_method_title_for_order( $order, $title_payment_type );
@@ -1478,6 +1489,38 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			'result'   => 'success',
 			'redirect' => $this->get_return_url_for_checkout_session( $order ),
 		];
+	}
+
+	/**
+	 * Requests a reusable SEPA mandate for the Checkout Session by setting setup_future_usage on the
+	 * selected payment method.
+	 *
+	 * Used for redirect-based APMs that are tokenized as SEPA (Bancontact, iDEAL, Sofort): Stripe only
+	 * mints a `generated_sepa_debit` when the session asks for it. Runs server-side before the client
+	 * confirms the session. Best-effort — any failure is logged and swallowed so it cannot block checkout.
+	 *
+	 * @param string $checkout_session_id   The Stripe Checkout Session ID.
+	 * @param string $payment_method_type   The Stripe payment method type (e.g. 'bancontact').
+	 *
+	 * @return void
+	 */
+	private function set_setup_future_usage_on_checkout_session( string $checkout_session_id, string $payment_method_type ): void {
+		try {
+			$response = WC_Stripe_API::request(
+				[
+					'payment_method_options' => [
+						$payment_method_type => [ 'setup_future_usage' => 'off_session' ],
+					],
+				],
+				"checkout/sessions/$checkout_session_id"
+			);
+
+			if ( ! empty( $response->error ) ) {
+				WC_Stripe_Logger::error( 'Unable to set setup_future_usage on checkout session ' . $checkout_session_id . ': ' . wp_json_encode( $response->error ) );
+			}
+		} catch ( Exception $e ) {
+			WC_Stripe_Logger::error( 'Exception while setting setup_future_usage on checkout session ' . $checkout_session_id . ': ' . $e->getMessage() );
+		}
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1438,10 +1438,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		$order_helper = WC_Stripe_Order_Helper::get_instance();
 		$order_helper->update_stripe_checkout_session_id( $order, $checkout_session_id );
 
-		// Resolve the payment method the customer actually picked inside the Stripe Element. For
-		// Optimized Checkout the gateway-derived `$selected_payment_type` is always 'card', so prefer
-		// the type sent via the hidden `wc_stripe_selected_upe_payment_type` input by the Optimized
-		// Checkout JS when it is present and known.
+		// Resolve the method the customer actually picked: for Optimized Checkout the gateway type is
+		// always 'card', so prefer the hidden `wc_stripe_selected_upe_payment_type` input when present.
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$selected_upe_payment_type = isset( $_POST['wc_stripe_selected_upe_payment_type'] )
 			? sanitize_text_field( wp_unslash( $_POST['wc_stripe_selected_upe_payment_type'] ) )
@@ -1456,21 +1454,15 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		if ( $save_payment_method && $resolved_payment_method && $resolved_payment_method->is_reusable() ) {
 			$order_helper->update_should_save_stripe_payment_method( $order, true );
 
-			// Redirect-based APMs that are tokenized as SEPA (Bancontact, iDEAL, Sofort) only generate a
-			// reusable SEPA mandate when the Checkout Session asks for it via setup_future_usage. The save
-			// checkbox alone (saved_payment_method_options.payment_method_save) does not mint a
-			// `generated_sepa_debit` for these methods, so the save flag would otherwise be meaningless.
-			// Request it on the session before the client confirms it. Best-effort: a failure must not block
-			// checkout — the order still completes, and the webhook safely skips saving when no mandate exists.
+			// Redirect APMs saved as SEPA tokens only get a reusable mandate when the session requests
+			// setup_future_usage; the save checkbox alone does not. Set it before the client confirms.
 			if ( $resolved_payment_method->get_id() !== $resolved_payment_method->get_retrievable_type() ) {
 				$this->set_setup_future_usage_on_checkout_session( $checkout_session_id, $resolved_payment_method->get_id() );
 			}
 		}
 
-		// Eagerly set the payment method title from the customer's selection so the order reflects the
-		// right method as soon as it lands on the order-received page, even if the
-		// checkout.session.completed webhook is delayed. The webhook handler will reaffirm/refine this
-		// once the actual payment method type is known from the intent.
+		// Eagerly set the title from the customer's selection so the order-received page is correct even
+		// if the checkout.session.completed webhook is delayed; the webhook reaffirms it later.
 		$title_payment_type = $resolved_payment_type;
 
 		if ( isset( $this->payment_methods[ $title_payment_type ] ) ) {
@@ -3724,8 +3716,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			return $payment_method_object;
 		}
 
-		// Conversion required: locate the generated SEPA debit PM on the charge. If Stripe did not
-		// generate one (e.g. the Checkout Session never set setup_future_usage), there is nothing to save.
+		// Locate the generated SEPA debit PM on the charge; absent it, there is nothing to save.
 		$generated_payment_method_id = is_object( $charge ) ? ( $charge->payment_method_details->{$type}->generated_sepa_debit ?? null ) : null;
 		if ( empty( $generated_payment_method_id ) ) {
 			return null;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3751,7 +3751,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 *                       resolved for payment methods that have been converted to SEPA or similar.
 	 */
 	public function get_reusable_payment_method_for_saving( stdClass $payment_method_object, $charge ) {
-		$type     = $payment_method_object->type ?? '';
+		$type = $payment_method_object->type ?? '';
 		if ( '' === $type ) {
 			return $payment_method_object;
 		}
@@ -3774,7 +3774,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		}
 
 		$generated_payment_method = WC_Stripe_API::retrieve( 'payment_methods/' . $generated_payment_method_id );
-		if ( empty( $generated_payment_method ) || is_wp_error( $generated_payment_method ) || ! $generated_payment_method instanceof stdClass || ! empty( $generated_payment_method->error ) ) {
+		if ( empty( $generated_payment_method ) || is_wp_error( $generated_payment_method ) || ! is_object( $generated_payment_method ) || ! empty( $generated_payment_method->error ) ) {
 			return null;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1454,15 +1454,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		if ( $save_payment_method && $resolved_payment_method && $resolved_payment_method->is_reusable() ) {
 			$order_helper->update_should_save_stripe_payment_method( $order, true );
 
-			// Redirect APMs saved as SEPA tokens only get a reusable mandate when the session requests
-			// setup_future_usage; the save checkbox alone does not. Set it before the client confirms.
+			// Payment methods that are saved as a different payment method need to have
+			// `setup_future_usage` specified to request that the payment method be saved.
 			if ( $resolved_payment_method->get_id() !== $resolved_payment_method->get_retrievable_type() ) {
 				$this->set_setup_future_usage_on_checkout_session( $checkout_session_id, $resolved_payment_method->get_id() );
 			}
 		}
 
-		// Eagerly set the title from the customer's selection so the order-received page is correct even
-		// if the checkout.session.completed webhook is delayed; the webhook reaffirms it later.
 		$title_payment_type = $resolved_payment_type;
 
 		if ( isset( $this->payment_methods[ $title_payment_type ] ) ) {
@@ -3697,15 +3695,16 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Resolves the PaymentMethod to save as a reusable token. Redirect-based APMs saved as SEPA
-	 * (Bancontact, iDEAL, Sofort) are returned as their own type; their reusable mandate lives on the
-	 * charge as `payment_method_details.<type>.generated_sepa_debit`.
+	 * Resolves the PaymentMethod that should be saved as a token.
 	 *
-	 * @param stdClass           $payment_method_object The PaymentMethod used for the payment.
+	 * Payment methods that are saved as secondary types need special logic to get the saved payment
+	 * method details. This primarily occurs for Bancontact and iDEAL/Wero, which are saved as SEPA tokens.
+	 *
+	 * @param stdClass           $payment_method_object The PaymentMethod object used for the payment.
 	 * @param object|string|null $charge                The latest charge from the intent, if available.
 	 *
-	 * @return stdClass|null The generated SEPA debit PM when a conversion is required, the original
-	 *                       object when none is needed, or null when no reusable mandate was generated.
+	 * @return stdClass|null The payment method to save, or null. The payment method may need to be
+	 *                       resolved for payment methods that have been converted to SEPA or similar.
 	 */
 	public function get_reusable_payment_method_for_saving( stdClass $payment_method_object, $charge ) {
 		$type     = $payment_method_object->type ?? '';
@@ -3716,14 +3715,18 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			return $payment_method_object;
 		}
 
-		// Locate the generated SEPA debit PM on the charge; absent it, there is nothing to save.
-		$generated_payment_method_id = is_object( $charge ) ? ( $charge->payment_method_details->{$type}->generated_sepa_debit ?? null ) : null;
+		// Only SEPA-tokenized methods expose their reusable mandate as `generated_sepa_debit` on the charge.
+		$generated_payment_method_id = null;
+		if ( WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID === $instance->get_retrievable_type() ) {
+			$generated_payment_method_id = is_object( $charge ) ? ( $charge->payment_method_details->{$type}->generated_sepa_debit ?? null ) : null;
+		}
+
 		if ( empty( $generated_payment_method_id ) ) {
 			return null;
 		}
 
 		$generated_payment_method = WC_Stripe_API::retrieve( 'payment_methods/' . $generated_payment_method_id );
-		if ( is_wp_error( $generated_payment_method ) || ! empty( $generated_payment_method->error ) || empty( $generated_payment_method ) ) {
+		if ( empty( $generated_payment_method ) || is_wp_error( $generated_payment_method ) || ! $generated_payment_method instanceof stdClass || ! empty( $generated_payment_method->error ) ) {
 			return null;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1494,9 +1494,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		$resolved_payment_method = $this->payment_methods[ $resolved_payment_type ] ?? null;
 
 		// Persist the 'save-payment-method' flag so the webhook handler can create the token once payment is completed.
-		// Saving itself is requested client-side: the session is created with
-		// `saved_payment_method_options.payment_method_save` enabled and the save checkbox state is
-		// passed to `checkout.confirm()`, which makes Stripe set `setup_future_usage` on the intent.
+		// Saving itself is requested client-side via `checkout.confirm( { savePaymentMethod } )`, which Stripe
+		// only honors for cards: Checkout Sessions cannot request `setup_future_usage` for methods that convert
+		// to SEPA (Bancontact, iDEAL, Sofort), so for those no reusable method is generated and the webhook
+		// skips token creation.
 		if ( $save_payment_method && $resolved_payment_method && $resolved_payment_method->is_reusable() ) {
 			$order_helper->update_should_save_stripe_payment_method( $order, true );
 		}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3667,6 +3667,48 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
+	 * Resolves the PaymentMethod object that should be saved as a reusable token.
+	 *
+	 * Redirect-based APMs whose retrievable type differs from their own type (Bancontact, iDEAL,
+	 * Sofort — all saved as SEPA tokens) are returned by Stripe as their own PaymentMethod type,
+	 * which has no `sepa_debit` child. The reusable mandate is exposed on the charge as
+	 * `payment_method_details.<type>.generated_sepa_debit`. This mirrors the conversion already done
+	 * in the deferred-intent flow (see process_upe_redirect_payment) so the Adaptive Pricing /
+	 * Checkout Sessions webhook path does not pass a non-SEPA-shaped object to a SEPA token.
+	 *
+	 * @param stdClass             $payment_method_object The PaymentMethod object used for the payment.
+	 * @param object|string|null   $charge                The latest charge from the intent, if available.
+	 *
+	 * @return stdClass|null The PaymentMethod to save: the generated SEPA debit PM when a conversion
+	 *                       is required and a mandate was generated; the original object when no
+	 *                       conversion is needed; or null when a conversion is required but Stripe did
+	 *                       not generate a reusable mandate (nothing to save).
+	 */
+	public function get_reusable_payment_method_for_saving( stdClass $payment_method_object, $charge ) {
+		$type     = $payment_method_object->type ?? '';
+		$instance = '' !== $type ? $this->get_payment_method_instance( $type ) : null;
+
+		// No conversion needed when the method is saved under its own type (e.g. card, sepa_debit).
+		if ( ! $instance instanceof WC_Stripe_UPE_Payment_Method || $instance->get_id() === $instance->get_retrievable_type() ) {
+			return $payment_method_object;
+		}
+
+		// Conversion required: locate the generated SEPA debit PM on the charge. If Stripe did not
+		// generate one (e.g. the Checkout Session never set setup_future_usage), there is nothing to save.
+		$generated_payment_method_id = is_object( $charge ) ? ( $charge->payment_method_details->{$type}->generated_sepa_debit ?? null ) : null;
+		if ( empty( $generated_payment_method_id ) ) {
+			return null;
+		}
+
+		$generated_payment_method = WC_Stripe_API::retrieve( 'payment_methods/' . $generated_payment_method_id );
+		if ( is_wp_error( $generated_payment_method ) || ! empty( $generated_payment_method->error ) || empty( $generated_payment_method ) ) {
+			return null;
+		}
+
+		return $generated_payment_method;
+	}
+
+	/**
 	 * Set the payment metadata for payment method id.
 	 *
 	 * @param WC_Order $order The order.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3683,13 +3683,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Save the selected payment method information to the order and as a payment token for the user.
 	 *
-	 * @param WC_Order $order                 The WC order for which we're saving the payment method.
-	 * @param object   $payment_method_object The payment method object retrieved from Stripe.
-	 * @param string   $payment_method_type   The payment method type, like `card`, `sepa_debit`, etc.
+	 * @param WC_Order $order                  The WC order for which we're saving the payment method.
+	 * @param stdClass $payment_method_object  The payment method object retrieved from Stripe.
+	 * @param string   $payment_method_type    The payment method type, like `card`, `sepa_debit`, etc.
 	 *
 	 * @return void
 	 */
-	public function handle_saving_payment_method( WC_Order $order, object $payment_method_object, string $payment_method_type ): void {
+	public function handle_saving_payment_method( WC_Order $order, stdClass $payment_method_object, string $payment_method_type ): void {
 		$user     = $this->get_user_from_order( $order );
 		$customer = new WC_Stripe_Customer( $user->ID );
 		$customer->clear_cache();
@@ -3747,7 +3747,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 * @param stdClass           $payment_method_object The PaymentMethod object used for the payment.
 	 * @param object|string|null $charge                The latest charge from the intent, if available.
 	 *
-	 * @return object|null The payment method to save, or null. The payment method may need to be
+	 * @return stdClass|null The payment method to save, or null. The payment method may need to be
 	 *                       resolved for payment methods that have been converted to SEPA or similar.
 	 */
 	public function get_reusable_payment_method_for_saving( stdClass $payment_method_object, $charge ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3747,7 +3747,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 * @param stdClass           $payment_method_object The PaymentMethod object used for the payment.
 	 * @param object|string|null $charge                The latest charge from the intent, if available.
 	 *
-	 * @return stdClass|null The payment method to save, or null. The payment method may need to be
+	 * @return object|null The payment method to save, or null. The payment method may need to be
 	 *                       resolved for payment methods that have been converted to SEPA or similar.
 	 */
 	public function get_reusable_payment_method_for_saving( stdClass $payment_method_object, $charge ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1494,14 +1494,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		$resolved_payment_method = $this->payment_methods[ $resolved_payment_type ] ?? null;
 
 		// Persist the 'save-payment-method' flag so the webhook handler can create the token once payment is completed.
+		// Saving itself is requested client-side: the session is created with
+		// `saved_payment_method_options.payment_method_save` enabled and the save checkbox state is
+		// passed to `checkout.confirm()`, which makes Stripe set `setup_future_usage` on the intent.
 		if ( $save_payment_method && $resolved_payment_method && $resolved_payment_method->is_reusable() ) {
 			$order_helper->update_should_save_stripe_payment_method( $order, true );
-
-			// Payment methods that are saved as a different payment method need to have
-			// `setup_future_usage` specified to request that the payment method be saved.
-			if ( $resolved_payment_method->get_id() !== $resolved_payment_method->get_retrievable_type() ) {
-				$this->set_setup_future_usage_on_checkout_session( $checkout_session_id, $resolved_payment_method->get_id() );
-			}
 		}
 
 		$title_payment_type = $resolved_payment_type;
@@ -1522,34 +1519,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			'result'   => 'success',
 			'redirect' => $this->get_return_url_for_checkout_session( $order ),
 		];
-	}
-
-	/**
-	 * Sets `setup_future_usage` to `off_session` for the checkout session, which will
-	 * ensure the payment method is saved. This is necessary for payment methods that "convert"
-	 * to SEPA debits when saved, including Bancontact and iDEAL/Wero.
-	 * Note that failures are logged and ignored so we don't prevent any other processing.
-	 *
-	 * @param string $checkout_session_id The Stripe Checkout Session ID.
-	 * @param string $payment_method_type The Stripe payment method type (e.g. 'bancontact').
-	 */
-	private function set_setup_future_usage_on_checkout_session( string $checkout_session_id, string $payment_method_type ): void {
-		try {
-			$response = WC_Stripe_API::request(
-				[
-					'payment_method_options' => [
-						$payment_method_type => [ 'setup_future_usage' => 'off_session' ],
-					],
-				],
-				"checkout/sessions/$checkout_session_id"
-			);
-
-			if ( ! empty( $response->error ) ) {
-				WC_Stripe_Logger::error( 'Unable to set setup_future_usage on checkout session ' . $checkout_session_id . ': ' . wp_json_encode( $response->error ) );
-			}
-		} catch ( Exception $e ) {
-			WC_Stripe_Logger::error( 'Exception while setting setup_future_usage on checkout session ' . $checkout_session_id . ': ' . $e->getMessage() );
-		}
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3752,7 +3752,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 */
 	public function get_reusable_payment_method_for_saving( stdClass $payment_method_object, $charge ) {
 		$type     = $payment_method_object->type ?? '';
-		$instance = '' !== $type ? $this->get_payment_method_instance( $type ) : null;
+		if ( '' === $type ) {
+			return $payment_method_object;
+		}
+
+		$instance = $this->get_payment_method_instance( $type );
 
 		// No conversion needed when the method is saved under its own type (e.g. card, sepa_debit).
 		if ( ! $instance instanceof WC_Stripe_UPE_Payment_Method || $instance->get_id() === $instance->get_retrievable_type() ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3683,13 +3683,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Save the selected payment method information to the order and as a payment token for the user.
 	 *
-	 * @param WC_Order $order                  The WC order for which we're saving the payment method.
-	 * @param stdClass $payment_method_object  The payment method object retrieved from Stripe.
-	 * @param string   $payment_method_type    The payment method type, like `card`, `sepa_debit`, etc.
+	 * @param WC_Order $order                 The WC order for which we're saving the payment method.
+	 * @param object   $payment_method_object The payment method object retrieved from Stripe.
+	 * @param string   $payment_method_type   The payment method type, like `card`, `sepa_debit`, etc.
 	 *
 	 * @return void
 	 */
-	public function handle_saving_payment_method( WC_Order $order, stdClass $payment_method_object, string $payment_method_type ): void {
+	public function handle_saving_payment_method( WC_Order $order, object $payment_method_object, string $payment_method_type ): void {
 		$user     = $this->get_user_from_order( $order );
 		$customer = new WC_Stripe_Customer( $user->ID );
 		$customer->clear_cache();

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1492,17 +1492,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Requests a reusable SEPA mandate for the Checkout Session by setting setup_future_usage on the
-	 * selected payment method.
+	 * Sets setup_future_usage on the session so Stripe mints a reusable SEPA mandate for redirect-based
+	 * APMs (Bancontact, iDEAL, Sofort). Best-effort — failures are logged and swallowed so they cannot
+	 * block checkout.
 	 *
-	 * Used for redirect-based APMs that are tokenized as SEPA (Bancontact, iDEAL, Sofort): Stripe only
-	 * mints a `generated_sepa_debit` when the session asks for it. Runs server-side before the client
-	 * confirms the session. Best-effort — any failure is logged and swallowed so it cannot block checkout.
-	 *
-	 * @param string $checkout_session_id   The Stripe Checkout Session ID.
-	 * @param string $payment_method_type   The Stripe payment method type (e.g. 'bancontact').
-	 *
-	 * @return void
+	 * @param string $checkout_session_id The Stripe Checkout Session ID.
+	 * @param string $payment_method_type The Stripe payment method type (e.g. 'bancontact').
 	 */
 	private function set_setup_future_usage_on_checkout_session( string $checkout_session_id, string $payment_method_type ): void {
 		try {
@@ -3710,22 +3705,15 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Resolves the PaymentMethod object that should be saved as a reusable token.
+	 * Resolves the PaymentMethod to save as a reusable token. Redirect-based APMs saved as SEPA
+	 * (Bancontact, iDEAL, Sofort) are returned as their own type; their reusable mandate lives on the
+	 * charge as `payment_method_details.<type>.generated_sepa_debit`.
 	 *
-	 * Redirect-based APMs whose retrievable type differs from their own type (Bancontact, iDEAL,
-	 * Sofort — all saved as SEPA tokens) are returned by Stripe as their own PaymentMethod type,
-	 * which has no `sepa_debit` child. The reusable mandate is exposed on the charge as
-	 * `payment_method_details.<type>.generated_sepa_debit`. This mirrors the conversion already done
-	 * in the deferred-intent flow (see process_upe_redirect_payment) so the Adaptive Pricing /
-	 * Checkout Sessions webhook path does not pass a non-SEPA-shaped object to a SEPA token.
+	 * @param stdClass           $payment_method_object The PaymentMethod used for the payment.
+	 * @param object|string|null $charge                The latest charge from the intent, if available.
 	 *
-	 * @param stdClass             $payment_method_object The PaymentMethod object used for the payment.
-	 * @param object|string|null   $charge                The latest charge from the intent, if available.
-	 *
-	 * @return stdClass|null The PaymentMethod to save: the generated SEPA debit PM when a conversion
-	 *                       is required and a mandate was generated; the original object when no
-	 *                       conversion is needed; or null when a conversion is required but Stripe did
-	 *                       not generate a reusable mandate (nothing to save).
+	 * @return stdClass|null The generated SEPA debit PM when a conversion is required, the original
+	 *                       object when none is needed, or null when no reusable mandate was generated.
 	 */
 	public function get_reusable_payment_method_for_saving( stdClass $payment_method_object, $charge ) {
 		$type     = $payment_method_object->type ?? '';

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -544,6 +544,17 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	 * @return WC_Payment_Token_SEPA
 	 */
 	public function create_payment_token_for_user( $user_id, $payment_method ) {
+		// Guard against non-SEPA-shaped PaymentMethods (e.g. a raw Bancontact/iDEAL/Sofort object reaching
+		// this SEPA token path). Without a SEPA fingerprint there is nothing reusable to tokenize, and
+		// set_fingerprint() would fatal on null. Fail with a catchable exception instead of a TypeError.
+		$sepa_debit = $payment_method->sepa_debit ?? null;
+		if ( ! is_object( $sepa_debit ) || ! isset( $sepa_debit->fingerprint ) ) {
+			throw new WC_Stripe_Exception(
+				sprintf( 'Cannot create a SEPA payment token from payment method %s: missing sepa_debit fingerprint.', $payment_method->id ?? 'unknown' ),
+				__( "We're not able to save this payment method. Please try again.", 'woocommerce-gateway-stripe' )
+			);
+		}
+
 		$token = new WC_Payment_Token_SEPA();
 		$token->set_last4( $payment_method->sepa_debit->last4 );
 		$token->set_gateway_id( $this->id );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -544,9 +544,8 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	 * @return WC_Payment_Token_SEPA
 	 */
 	public function create_payment_token_for_user( $user_id, $payment_method ) {
-		// Guard against non-SEPA-shaped PaymentMethods (e.g. a raw Bancontact/iDEAL/Sofort object reaching
-		// this SEPA token path). Without a SEPA fingerprint there is nothing reusable to tokenize, and
-		// set_fingerprint() would fatal on null. Fail with a catchable exception instead of a TypeError.
+		// Guard against non-SEPA-shaped PaymentMethods so set_fingerprint() throws a catchable exception
+		// instead of fataling on null.
 		$sepa_debit = $payment_method->sepa_debit ?? null;
 		if ( ! is_object( $sepa_debit ) || ! isset( $sepa_debit->fingerprint ) ) {
 			throw new WC_Stripe_Exception(

--- a/readme.txt
+++ b/readme.txt
@@ -158,7 +158,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 = 10.9.0 - xxxx-xx-xx =
 * Fix - Prevent unnecessary Stripe payment method creation when shortcode checkout has empty required fields
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
-* Fix - Prevent a fatal error when saving Bancontact, iDEAL or Sofort payments as SEPA tokens through the Adaptive Pricing checkout, so the order completes normally
-* Fix - Generate and save a reusable SEPA token when a shopper opts to save a Bancontact, iDEAL or Sofort payment through the Adaptive Pricing checkout
+* Fix - Fix saving Bancontact, iDEAL and Sofort payments as reusable SEPA tokens through the Adaptive Pricing checkout, which previously caused a fatal error and left the order unpaid
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -159,5 +159,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Prevent unnecessary Stripe payment method creation when shortcode checkout has empty required fields
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
 * Fix - Prevent a fatal error when saving Bancontact, iDEAL or Sofort payments as SEPA tokens through the Adaptive Pricing checkout, so the order completes normally
+* Fix - Generate and save a reusable SEPA token when a shopper opts to save a Bancontact, iDEAL or Sofort payment through the Adaptive Pricing checkout
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -158,5 +158,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 = 10.9.0 - xxxx-xx-xx =
 * Fix - Prevent unnecessary Stripe payment method creation when shortcode checkout has empty required fields
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
+* Fix - Prevent a fatal error when saving Bancontact, iDEAL or Sofort payments as SEPA tokens through the Adaptive Pricing checkout, so the order completes normally
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -160,6 +160,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Send the billing address to Stripe on the Pay for Order page so payments aren't incorrectly blocked by Stripe Radar rules
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
-* Fix - Fix saving Bancontact, iDEAL and Sofort payments as reusable SEPA tokens through the Adaptive Pricing checkout, which previously caused a fatal error and left the order unpaid
+* Fix - Prevent a fatal error when a Bancontact, iDEAL or Sofort payment is placed with SEPA token saving enabled through the Adaptive Pricing checkout, which left the order unpaid
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -2082,6 +2082,144 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Redirect-based APMs that are saved as SEPA tokens (Bancontact, iDEAL, Sofort) must not fatal in
+	 * the Adaptive Pricing / Checkout Sessions webhook when the save-payment-method flag is set.
+	 *
+	 * Stripe returns the APM PaymentMethod (no `sepa_debit` child). The handler must convert it to the
+	 * charge's `generated_sepa_debit` PaymentMethod before saving — and skip saving entirely when Stripe
+	 * did not generate a reusable mandate — instead of passing a non-SEPA object to set_fingerprint().
+	 *
+	 * Regression for STRIPE-1205.
+	 *
+	 * @dataProvider provider_checkout_session_apm_sepa_save
+	 *
+	 * @param string  $payment_method_type   Redirect APM type (e.g. 'bancontact', 'ideal', 'sofort').
+	 * @param ?string $generated_sepa_debit  The generated SEPA debit PM id on the charge, or null.
+	 * @param bool    $expect_token_saved    Whether a SEPA token should be saved for the user.
+	 * @return void
+	 */
+	public function test_process_checkout_session_success_saves_apm_as_sepa_token( string $payment_method_type, ?string $generated_sepa_debit, bool $expect_token_saved ): void {
+		$checkout_session_id = 'cs_test_apm_' . $payment_method_type;
+		$generated_pm_id     = 'pm_generated_sepa_' . $payment_method_type;
+
+		$user_id = self::factory()->user->create();
+
+		$order = WC_Helper_Order::create_order( $user_id );
+		$order->set_status( OrderStatus::PENDING );
+		$order->save();
+
+		$order_helper = WC_Stripe_Order_Helper::get_instance();
+		$order_helper->update_stripe_checkout_session_id( $order, $checkout_session_id );
+		$order_helper->update_should_save_stripe_payment_method( $order, true );
+		$order->save_meta_data();
+
+		$notification = (object) [
+			'type' => 'checkout.session.completed',
+			'data' => (object) [
+				'object' => (object) [
+					'id'             => $checkout_session_id,
+					'payment_intent' => 'pi_test_' . $payment_method_type,
+				],
+			],
+		];
+
+		// The APM PaymentMethod as Stripe returns it: its own type, no sepa_debit child.
+		$payment_method_object = (object) [
+			'id'   => 'pm_mock_' . $payment_method_type,
+			'type' => $payment_method_type,
+		];
+
+		// The charge exposes the reusable mandate (or null) via payment_method_details.<type>.generated_sepa_debit.
+		$charge = (object) [
+			'id'                     => 'ch_mock_' . $payment_method_type,
+			'captured'               => true,
+			'status'                 => 'succeeded',
+			'payment_method_details' => (object) [
+				$payment_method_type => (object) [
+					'generated_sepa_debit' => $generated_sepa_debit,
+				],
+			],
+		];
+
+		// Intercept the generated SEPA PaymentMethod retrieval and return a SEPA-shaped object.
+		$pre_http_filter = function ( $return_value, $parsed_args, $url ) use ( $generated_pm_id ) {
+			if ( WC_Stripe_API::ENDPOINT . 'payment_methods/' . $generated_pm_id !== $url ) {
+				return $return_value;
+			}
+			return [
+				'headers'  => [],
+				'body'     => wp_json_encode(
+					[
+						'id'         => $generated_pm_id,
+						'type'       => WC_Stripe_Payment_Methods::SEPA_DEBIT,
+						'customer'   => 'cus_mock_apm',
+						'sepa_debit' => [
+							'last4'       => '7061',
+							'fingerprint' => 'Fxxxxxxxxxxxxxxx',
+						],
+					]
+				),
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'cookies'  => [],
+				'filename' => null,
+			];
+		};
+		add_filter( 'pre_http_request', $pre_http_filter, 10, 3 );
+
+		$mock_scheduler = $this->createMock( WC_Stripe_Action_Scheduler_Service::class );
+		$mock_scheduler->expects( $this->once() )->method( 'schedule_job' );
+
+		$handler = $this->getMockBuilder( WC_Stripe_Webhook_Handler::class )
+			->setMethods( [ 'get_intent_from_order', 'get_latest_charge_from_intent', 'process_response' ] )
+			->getMock();
+
+		$handler->method( 'get_intent_from_order' )
+			->willReturn( (object) array_merge( self::MOCK_PAYMENT_INTENT, [ 'payment_method' => $payment_method_object ] ) );
+		$handler->method( 'get_latest_charge_from_intent' )->willReturn( $charge );
+		$handler->method( 'process_response' );
+
+		$prop = new ReflectionProperty( WC_Stripe_Webhook_Handler::class, 'action_scheduler_service' );
+		$prop->setAccessible( true );
+		$prop->setValue( $handler, $mock_scheduler );
+
+		// Must not fatal.
+		$handler->process_checkout_session_success( $notification );
+
+		remove_filter( 'pre_http_request', $pre_http_filter );
+
+		// The save flag is always cleared so webhook retries do not loop.
+		$this->assertFalse( $order_helper->get_should_save_stripe_payment_method( wc_get_order( $order->get_id() ) ) );
+
+		$tokens = WC_Payment_Tokens::get_customer_tokens( $user_id );
+		if ( $expect_token_saved ) {
+			$this->assertCount( 1, $tokens );
+			$token = array_shift( $tokens );
+			$this->assertInstanceOf( WC_Payment_Token_SEPA::class, $token );
+			$this->assertSame( $generated_pm_id, $token->get_token() );
+			$this->assertSame( '7061', $token->get_last4() );
+		} else {
+			$this->assertCount( 0, $tokens );
+		}
+	}
+
+	/**
+	 * Data provider for `test_process_checkout_session_success_saves_apm_as_sepa_token`.
+	 *
+	 * @return array[]
+	 */
+	public function provider_checkout_session_apm_sepa_save(): array {
+		return [
+			'bancontact with generated mandate' => [ WC_Stripe_Payment_Methods::BANCONTACT, 'pm_generated_sepa_bancontact', true ],
+			'ideal with generated mandate'      => [ WC_Stripe_Payment_Methods::IDEAL, 'pm_generated_sepa_ideal', true ],
+			'sofort with generated mandate'     => [ WC_Stripe_Payment_Methods::SOFORT, 'pm_generated_sepa_sofort', true ],
+			'bancontact without mandate'        => [ WC_Stripe_Payment_Methods::BANCONTACT, null, false ],
+		];
+	}
+
+	/**
 	 * Test that `checkout.session.async_payment_succeeded` processes on-hold orders.
 	 *
 	 * @return void

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -1939,6 +1939,132 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * When saving a redirect-based APM that is tokenized as SEPA (Bancontact, iDEAL, Sofort) through the
+	 * Adaptive Pricing / Checkout Sessions flow, the gateway must ask Stripe for a reusable SEPA mandate by
+	 * setting payment_method_options.<method>.setup_future_usage = off_session on the session before the
+	 * client confirms it, and must persist the save-payment-method flag on the order.
+	 *
+	 * Part of STRIPE-1205.
+	 */
+	public function test_process_payment_with_checkout_session_requests_setup_future_usage_for_redirect_apm() {
+		$session_id = 'cs_test_sfu_bancontact';
+
+		$_POST['wc_stripe_checkout_session_id'] = $session_id;
+		$_POST['payment_method']                = WC_Stripe_UPE_Payment_Gateway::ID;
+		$_POST['wc-stripe-payment-method']      = WC_Stripe_UPE_Payment_Gateway::ID;
+		// Optimized Checkout reports 'card' as the gateway type; the real method is sent separately.
+		$_POST['wc_stripe_selected_upe_payment_type'] = WC_Stripe_Payment_Methods::BANCONTACT;
+		$_POST['wc-stripe-new-payment-method']        = 'true';
+
+		// Saved cards must be enabled for the save-payment-method checkbox to take effect.
+		$this->mock_gateway->saved_cards = true;
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_payment_method( WC_Stripe_UPE_Payment_Gateway::ID );
+		$order->set_status( OrderStatus::PENDING );
+		$order->save();
+
+		$captured_body   = null;
+		$pre_http_filter = function ( $return_value, $parsed_args, $url ) use ( $session_id, &$captured_body ) {
+			if ( WC_Stripe_API::ENDPOINT . 'checkout/sessions/' . $session_id !== $url ) {
+				return $return_value;
+			}
+			$captured_body = $parsed_args['body'];
+			return [
+				'headers'  => [],
+				'body'     => wp_json_encode( [ 'id' => $session_id ] ),
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'cookies'  => [],
+				'filename' => null,
+			];
+		};
+		add_filter( 'pre_http_request', $pre_http_filter, 10, 3 );
+
+		try {
+			$result = $this->mock_gateway->process_payment( $order->get_id() );
+		} finally {
+			remove_filter( 'pre_http_request', $pre_http_filter );
+			unset(
+				$_POST['wc_stripe_checkout_session_id'],
+				$_POST['payment_method'],
+				$_POST['wc-stripe-payment-method'],
+				$_POST['wc_stripe_selected_upe_payment_type'],
+				$_POST['wc-stripe-new-payment-method']
+			);
+		}
+
+		$this->assertSame( 'success', $result['result'] );
+
+		// The session must have been updated with setup_future_usage for the selected redirect APM.
+		$this->assertIsArray( $captured_body, 'Expected the checkout session to be updated.' );
+		$this->assertSame(
+			'off_session',
+			$captured_body['payment_method_options'][ WC_Stripe_Payment_Methods::BANCONTACT ]['setup_future_usage'] ?? null
+		);
+
+		// The save flag must be persisted so the webhook can save the generated SEPA mandate.
+		$this->assertTrue(
+			WC_Stripe_Order_Helper::get_instance()->get_should_save_stripe_payment_method( wc_get_order( $order->get_id() ) )
+		);
+	}
+
+	/**
+	 * The setup_future_usage session update must NOT run for methods saved under their own type (e.g.
+	 * card), since they do not need a generated SEPA mandate.
+	 *
+	 * Part of STRIPE-1205.
+	 */
+	public function test_process_payment_with_checkout_session_skips_setup_future_usage_for_card() {
+		$session_id = 'cs_test_sfu_card';
+
+		$_POST['wc_stripe_checkout_session_id']       = $session_id;
+		$_POST['payment_method']                      = WC_Stripe_UPE_Payment_Gateway::ID;
+		$_POST['wc-stripe-payment-method']            = WC_Stripe_UPE_Payment_Gateway::ID;
+		$_POST['wc_stripe_selected_upe_payment_type'] = WC_Stripe_Payment_Methods::CARD;
+		$_POST['wc-stripe-new-payment-method']        = 'true';
+
+		$this->mock_gateway->saved_cards = true;
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_payment_method( WC_Stripe_UPE_Payment_Gateway::ID );
+		$order->set_status( OrderStatus::PENDING );
+		$order->save();
+
+		$session_update_called = false;
+		$pre_http_filter       = function ( $return_value, $parsed_args, $url ) use ( $session_id, &$session_update_called ) {
+			if ( WC_Stripe_API::ENDPOINT . 'checkout/sessions/' . $session_id === $url ) {
+				$session_update_called = true;
+			}
+			return $return_value;
+		};
+		add_filter( 'pre_http_request', $pre_http_filter, 10, 3 );
+
+		try {
+			$result = $this->mock_gateway->process_payment( $order->get_id() );
+		} finally {
+			remove_filter( 'pre_http_request', $pre_http_filter );
+			unset(
+				$_POST['wc_stripe_checkout_session_id'],
+				$_POST['payment_method'],
+				$_POST['wc-stripe-payment-method'],
+				$_POST['wc_stripe_selected_upe_payment_type'],
+				$_POST['wc-stripe-new-payment-method']
+			);
+		}
+
+		$this->assertSame( 'success', $result['result'] );
+		$this->assertFalse( $session_update_called, 'Card payments must not trigger a setup_future_usage session update.' );
+
+		// The save flag is still persisted for card (reusable, saved under its own type).
+		$this->assertTrue(
+			WC_Stripe_Order_Helper::get_instance()->get_should_save_stripe_payment_method( wc_get_order( $order->get_id() ) )
+		);
+	}
+
+	/**
 	 * Test the success short-circuit: an order already in `processing` status must
 	 * not trigger any Stripe API call and must redirect to the clean order-received
 	 * URL (stripping the disambiguation query args from the address bar).

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -2052,7 +2052,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		$_POST['wc_stripe_checkout_session_id'] = $session_id;
 		$_POST['payment_method']                = WC_Stripe_UPE_Payment_Gateway::ID;
 		$_POST['wc-stripe-payment-method']      = WC_Stripe_UPE_Payment_Gateway::ID;
-		// Optimized Checkout reports 'card' as the gateway type; the real method is sent separately.
+		// Optimized Checkout reports 'card' as the gateway type; the real method is sent in `wc_stripe_selected_upe_payment_type`.
 		$_POST['wc_stripe_selected_upe_payment_type'] = WC_Stripe_Payment_Methods::BANCONTACT;
 		$_POST['wc-stripe-new-payment-method']        = 'true';
 

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -2039,93 +2039,27 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
-	 * When saving a redirect-based APM that is tokenized as SEPA (Bancontact, iDEAL, Sofort) through the
-	 * Adaptive Pricing / Checkout Sessions flow, the gateway must ask Stripe for a reusable SEPA mandate by
-	 * setting payment_method_options.<method>.setup_future_usage = off_session on the session before the
-	 * client confirms it, and must persist the save-payment-method flag on the order.
+	 * Saving through the Adaptive Pricing / Checkout Sessions flow must persist the save-payment-method
+	 * flag on the order without any server-side session update: saving is requested client-side via
+	 * `checkout.confirm()`, and the Checkout Session update API does not accept `payment_method_options`.
 	 *
 	 * Part of STRIPE-1205.
+	 *
+	 * @dataProvider provide_checkout_session_save_payment_method_types
+	 *
+	 * @param string $payment_method_type The UPE payment method type selected at checkout.
 	 */
-	public function test_process_payment_with_checkout_session_requests_setup_future_usage_for_redirect_apm() {
-		$session_id = 'cs_test_sfu_bancontact';
+	public function test_process_payment_with_checkout_session_persists_save_flag_without_session_update( string $payment_method_type ) {
+		$session_id = 'cs_test_save_' . $payment_method_type;
 
 		$_POST['wc_stripe_checkout_session_id'] = $session_id;
 		$_POST['payment_method']                = WC_Stripe_UPE_Payment_Gateway::ID;
 		$_POST['wc-stripe-payment-method']      = WC_Stripe_UPE_Payment_Gateway::ID;
 		// Optimized Checkout reports 'card' as the gateway type; the real method is sent in `wc_stripe_selected_upe_payment_type`.
-		$_POST['wc_stripe_selected_upe_payment_type'] = WC_Stripe_Payment_Methods::BANCONTACT;
+		$_POST['wc_stripe_selected_upe_payment_type'] = $payment_method_type;
 		$_POST['wc-stripe-new-payment-method']        = 'true';
 
 		// Saved cards must be enabled for the save-payment-method checkbox to take effect.
-		$this->mock_gateway->saved_cards = true;
-
-		$order = WC_Helper_Order::create_order();
-		$order->set_payment_method( WC_Stripe_UPE_Payment_Gateway::ID );
-		$order->set_status( OrderStatus::PENDING );
-		$order->save();
-
-		$captured_body   = null;
-		$pre_http_filter = function ( $return_value, $parsed_args, $url ) use ( $session_id, &$captured_body ) {
-			if ( WC_Stripe_API::ENDPOINT . 'checkout/sessions/' . $session_id !== $url ) {
-				return $return_value;
-			}
-			$captured_body = $parsed_args['body'];
-			return [
-				'headers'  => [],
-				'body'     => wp_json_encode( [ 'id' => $session_id ] ),
-				'response' => [
-					'code'    => 200,
-					'message' => 'OK',
-				],
-				'cookies'  => [],
-				'filename' => null,
-			];
-		};
-		add_filter( 'pre_http_request', $pre_http_filter, 10, 3 );
-
-		try {
-			$result = $this->mock_gateway->process_payment( $order->get_id() );
-		} finally {
-			remove_filter( 'pre_http_request', $pre_http_filter );
-			unset(
-				$_POST['wc_stripe_checkout_session_id'],
-				$_POST['payment_method'],
-				$_POST['wc-stripe-payment-method'],
-				$_POST['wc_stripe_selected_upe_payment_type'],
-				$_POST['wc-stripe-new-payment-method']
-			);
-		}
-
-		$this->assertSame( 'success', $result['result'] );
-
-		// The session must have been updated with setup_future_usage for the selected redirect APM.
-		$this->assertIsArray( $captured_body, 'Expected the checkout session to be updated.' );
-		$this->assertSame(
-			'off_session',
-			$captured_body['payment_method_options'][ WC_Stripe_Payment_Methods::BANCONTACT ]['setup_future_usage'] ?? null
-		);
-
-		// The save flag must be persisted so the webhook can save the generated SEPA mandate.
-		$this->assertTrue(
-			WC_Stripe_Order_Helper::get_instance()->get_should_save_stripe_payment_method( wc_get_order( $order->get_id() ) )
-		);
-	}
-
-	/**
-	 * The setup_future_usage session update must NOT run for methods saved under their own type (e.g.
-	 * card), since they do not need a generated SEPA mandate.
-	 *
-	 * Part of STRIPE-1205.
-	 */
-	public function test_process_payment_with_checkout_session_skips_setup_future_usage_for_card() {
-		$session_id = 'cs_test_sfu_card';
-
-		$_POST['wc_stripe_checkout_session_id']       = $session_id;
-		$_POST['payment_method']                      = WC_Stripe_UPE_Payment_Gateway::ID;
-		$_POST['wc-stripe-payment-method']            = WC_Stripe_UPE_Payment_Gateway::ID;
-		$_POST['wc_stripe_selected_upe_payment_type'] = WC_Stripe_Payment_Methods::CARD;
-		$_POST['wc-stripe-new-payment-method']        = 'true';
-
 		$this->mock_gateway->saved_cards = true;
 
 		$order = WC_Helper_Order::create_order();
@@ -2156,12 +2090,24 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		}
 
 		$this->assertSame( 'success', $result['result'] );
-		$this->assertFalse( $session_update_called, 'Card payments must not trigger a setup_future_usage session update.' );
+		$this->assertFalse( $session_update_called, 'Saving a payment method must not trigger a checkout session update.' );
 
-		// The save flag is still persisted for card (reusable, saved under its own type).
+		// The save flag must be persisted so the webhook can save the payment method (or its generated SEPA mandate).
 		$this->assertTrue(
 			WC_Stripe_Order_Helper::get_instance()->get_should_save_stripe_payment_method( wc_get_order( $order->get_id() ) )
 		);
+	}
+
+	/**
+	 * Provides payment method types for the checkout session save-payment-method test.
+	 *
+	 * @return array[]
+	 */
+	public function provide_checkout_session_save_payment_method_types(): array {
+		return [
+			'redirect APM tokenized as SEPA (bancontact)' => [ WC_Stripe_Payment_Methods::BANCONTACT ],
+			'method saved under its own type (card)'      => [ WC_Stripe_Payment_Methods::CARD ],
+		];
 	}
 
 	/**

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-test.php
@@ -905,6 +905,29 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 	}
 
 	/**
+	 * The base SEPA token path must fail safely (catchable exception) instead of fataling with a
+	 * TypeError when handed a non-SEPA-shaped PaymentMethod.
+	 *
+	 * Regression for the Adaptive Pricing / Checkout Sessions webhook crash where a raw Bancontact
+	 * PaymentMethod (no `sepa_debit` child) reached create_payment_token_for_user() and
+	 * set_fingerprint( null ) fataled.
+	 *
+	 * @return void
+	 */
+	public function test_create_payment_token_for_user_throws_on_missing_sepa_fingerprint() {
+		$payment_method = new WC_Stripe_UPE_Payment_Method_Sepa();
+
+		// A raw Bancontact PaymentMethod has no sepa_debit child.
+		$bancontact_payment_method = (object) [
+			'id'   => 'pm_mock_bancontact',
+			'type' => WC_Stripe_Payment_Methods::BANCONTACT,
+		];
+
+		$this->expectException( WC_Stripe_Exception::class );
+		$payment_method->create_payment_token_for_user( 1, $bancontact_payment_method );
+	}
+
+	/**
 	 * Test for `update_payment_token` method.
 	 *
 	 * @return void


### PR DESCRIPTION
Fixes STRIPE-1205

## Changes proposed in this Pull Request:

With Optimized Checkout + Adaptive Pricing enabled (defaults since 10.7.0) and "save as SEPA token" enabled for Bancontact, saving a Bancontact payment through the Checkout Sessions flow triggered a fatal `TypeError` in the `checkout.session.completed` webhook. The order was left stuck at **Pending payment** and Stripe kept retrying the same fatal. The same applies to iDEAL and Sofort.

**Why it broke:** the AP webhook save path passed the raw Bancontact PaymentMethod (`type=bancontact`, no `sepa_debit` child) into the base SEPA token path, which dereferenced `$pm->sepa_debit->fingerprint` → `null`; PHP 8's strict typing on `set_fingerprint( string $fingerprint )` fataled. The deferred-intent / subscription flow already handled this by detecting `get_id() !== get_retrievable_type()` and fetching the charge's `generated_sepa_debit`; the Checkout Sessions path was missing that conversion.

**The fix:**
- Webhook handler: convert the PaymentMethod via a new gateway helper before saving; skip the save when no reusable mandate exists; clear the save flag unconditionally so webhook retries don't loop.
- UPE gateway: new `get_reusable_payment_method_for_saving()` mirroring the deferred-intent conversion.
- Base payment method: `create_payment_token_for_user()` now throws a catchable exception instead of fataling with a `TypeError` on a non-SEPA-shaped PaymentMethod.

**Known limitation (out of scope):** with the Checkout Sessions (Adaptive Pricing) flow, Stripe currently provides no way to mint the reusable SEPA mandate for these methods, so ticking the save checkbox does not produce a token. Verified against the Stripe test API (pinned version `2025-09-30.clover`):

- Session **update** with `payment_method_options` → `parameter_unknown` (this is what an earlier revision of this PR attempted; it never worked).
- Session **creation** with `payment_method_options[bancontact][setup_future_usage]=off_session` → `Invalid …: must be none`.
- Session **creation** with `payment_intent_data[setup_future_usage]=off_session` → ``unsupported for payment method `bancontact` ``.
- Client-side `checkout.confirm( { savePaymentMethod } )` only supports cards per [Stripe's docs](https://docs.stripe.com/payments/checkout/save-during-payment?payment-ui=checkout-form).

A follow-up PR hides the save checkbox for these methods in the Checkout Sessions flow so shoppers aren't offered a save that can't happen.

**How can this code break / what prevents it:** the webhook conversion safely skips saving when `generated_sepa_debit` is `null`, so the fatal cannot recur even when no mandate is generated. Behavior change is scoped to the three SEPA-tokenized redirect APMs; methods saved under their own type (card, SEPA, etc.) are unaffected.

## Testing instructions

Prerequisites:
1. WooCommerce > Settings > Payments > Stripe > Advanced: turn **Optimized Checkout Suite** ON and **Adaptive Pricing** ON.
2. Enable **Bancontact**, and enable "Save Bancontact payments as SEPA Direct Debit tokens".
3. Store currency **EUR**; use the **Block** checkout.

Steps:
1. Log in as an existing customer, add a non-subscription product to the cart, go to checkout.
2. Select **Bancontact**, tick **"Save payment information to my account for future purchases."**, place the order, and complete the Stripe-hosted authorization.
3. Confirm the order moves to **Processing/Completed** (it must NOT get stuck at "Pending payment", and there must be no fatal in the logs). Per the limitation above, no SEPA token is created — the logs should show the save being skipped, not a fatal.
4. Repeat without ticking the save box: the order completes normally and no token is saved.
5. Regression: a card payment through the same AP/OC checkout still saves normally; a Bancontact payment with the SEPA-tokens setting OFF completes normally and saves nothing.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

* Fix - Prevent a fatal error when a Bancontact, iDEAL or Sofort payment is placed with SEPA token saving enabled through the Adaptive Pricing checkout, which left the order unpaid

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Drafted with AI; reviewed by me.*
