### PR TITLE
Fix classic checkout blocking card/Link when the order has no billing country

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ xxxx-xx-xx - version 10.9.0
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
 * Fix - Prevent a fatal error when a Bancontact, iDEAL or Sofort payment is placed with SEPA token saving enabled through the Adaptive Pricing checkout, which left the order unpaid
+* Fix - Allow card and Link at classic checkout when the order has no billing country, instead of incorrectly blocking the payment as unavailable
 
 2026-06-08 - version 10.8.0
 * Fix - Add an order note and call action 'wc_stripe_unexpected_charge_detected' when a Stripe charge is captured for an order that was already paid via a different gateway

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -469,16 +469,20 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	 * @return bool True when no restriction is set or the country is in the supported list.
 	 */
 	public function is_available_for_billing_country( $country_code ): bool {
+		// Methods with no country restriction (e.g. card, Link) are available everywhere,
+		// including when the billing country is unknown — an empty country must not block
+		// them, or checkout fails for orders that carry no billing country.
+		if ( empty( $this->supported_billing_countries ) ) {
+			return true;
+		}
+
+		// A restricted method can't be confirmed available without knowing the country.
 		$country_code = is_string( $country_code ) ? strtoupper( $country_code ) : '';
 		if ( '' === $country_code ) {
 			return false;
 		}
 
-		if ( ! empty( $this->supported_billing_countries ) ) {
-			return in_array( $country_code, $this->supported_billing_countries, true );
-		}
-
-		return true;
+		return in_array( $country_code, $this->supported_billing_countries, true );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -472,7 +472,7 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 		// Methods with no country restriction (e.g. card, Link) are available everywhere,
 		// including when the billing country is unknown — an empty country must not block
 		// them, or checkout fails for orders that carry no billing country.
-		if ( empty( $this->supported_billing_countries ) ) {
+		if ( [] === $this->supported_billing_countries ) {
 			return true;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -161,5 +161,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
 * Fix - Prevent a fatal error when a Bancontact, iDEAL or Sofort payment is placed with SEPA token saving enabled through the Adaptive Pricing checkout, which left the order unpaid
+* Fix - Allow card and Link at classic checkout when the order has no billing country, instead of incorrectly blocking the payment as unavailable
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-test.php
@@ -1209,27 +1209,37 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 
 	public function provide_test_is_available_for_billing_country(): array {
 		return [
-			'empty list permits any country (US)' => [
+			'empty list permits any country (US)'    => [
 				[],
 				'US',
 				true,
 			],
-			'empty list permits any country (ZZ)' => [
+			'empty list permits any country (ZZ)'    => [
 				[],
 				'ZZ',
 				true,
 			],
-			'populated list matches'              => [
+			'empty list permits unknown country'     => [
+				[],
+				'',
+				true,
+			],
+			'populated list rejects unknown country' => [
+				[ 'US', 'CA' ],
+				'',
+				false,
+			],
+			'populated list matches'                 => [
 				[ 'US', 'CA' ],
 				'CA',
 				true,
 			],
-			'populated list rejects miss'         => [
+			'populated list rejects miss'            => [
 				[ 'US', 'CA' ],
 				'GB',
 				false,
 			],
-			'case-sensitive comparison'           => [
+			'case-sensitive comparison'              => [
 				[ 'US' ],
 				'us',
 				true,

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-test.php
@@ -1229,6 +1229,16 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 				'',
 				false,
 			],
+			'empty list permits null country'        => [
+				[],
+				null,
+				true,
+			],
+			'populated list rejects null country'        => [
+				[ 'US', 'CA', 'GB' ],
+				null,
+				false,
+			],
 			'populated list matches'                 => [
 				[ 'US', 'CA' ],
 				'CA',

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-test.php
@@ -1197,11 +1197,11 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 	/**
 	 * @dataProvider provide_test_is_available_for_billing_country
 	 *
-	 * @param string[] $supported_billing_countries Supported billing countries to seed on the method.
-	 * @param string   $country_code                Billing country to check.
-	 * @param bool     $expected                    Expected return value.
+	 * @param string[]    $supported_billing_countries Supported billing countries to seed on the method.
+	 * @param string|null $country_code                Billing country to check.
+	 * @param bool        $expected                    Expected return value.
 	 */
-	public function test_is_available_for_billing_country( array $supported_billing_countries, string $country_code, bool $expected ): void {
+	public function test_is_available_for_billing_country( array $supported_billing_countries, ?string $country_code, bool $expected ): void {
 		$method = $this->make_method_with_billing_countries( $supported_billing_countries );
 
 		$this->assertSame( $expected, $method->is_available_for_billing_country( $country_code ) );
@@ -1234,7 +1234,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 				null,
 				true,
 			],
-			'populated list rejects null country'        => [
+			'populated list rejects null country'    => [
 				[ 'US', 'CA', 'GB' ],
 				null,
 				false,


### PR DESCRIPTION
Fixes STRIPE-<linear_issue_id>

## Changes proposed in this Pull Request:
Classic (shortcode) checkout was failing for orders with no billing country, with the error *"The payment method type 'card' is not available in ."* (note the empty country). It hit card and Link — methods that have no country restriction at all — and aborted the payment **before** the PaymentIntent was created, so the customer couldn't complete checkout.

Root cause is in `WC_Stripe_UPE_Payment_Method::is_available_for_billing_country()` (introduced in 10.8.0). It returned `false` for **every** method when the billing country was empty:

```php
  if ( '' === $country_code ) {
      return false; // blocked even unrestricted methods like card/Link
  }
```

validate_selected_payment_method_type() then threw and stopped the payment. Because card/Link carry an empty supported_billing_countries (available everywhere), an unknown billing country should never have blocked them.

This PR reorders the check so a method with no country restriction is available regardless of the billing country (including when it's empty/unknown). Restricted methods (e.g. Klarna, BLIK) keep the previous behaviour: an unknown country still returns false, since a country-gated method can't be confirmed without one.

## Testing instructions
- Code review
- Regression check: a country-restricted method (e.g. Klarna/BLIK) with a valid supported billing country still works, and with an unsupported/empty country is still correctly blocked.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
