### PR TITLE
Fix Adaptive Pricing checkout sessions being misclassified as agentic in webhooks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,7 +10,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Send the billing address to Stripe on the Pay for Order page so payments aren't incorrectly blocked by Stripe Radar rules
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
-* Fix - Stop treating a completed Adaptive Pricing checkout session as an agentic session in webhook processing, which could drop the payment when agentic commerce is disabled
+* Fix - Correctly distinguish Adaptive Pricing checkout sessions from agentic ones in webhooks so their payments aren't dropped
 * Add - Stripe admin pages to the WordPress Command Palette
 * Fix - Prevent a possible fatal error when saving the payment method on a subscription order
 * Dev - Use clsx library instead of classnames

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ xxxx-xx-xx - version 10.9.0
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
 * Fix - Prevent a fatal error when a Bancontact, iDEAL or Sofort payment is placed with SEPA token saving enabled through the Adaptive Pricing checkout, which left the order unpaid
+* Fix - Stop treating a completed Adaptive Pricing checkout session as an agentic session in webhook processing, which could drop the payment when agentic commerce is disabled
 
 2026-06-08 - version 10.8.0
 * Fix - Add an order note and call action 'wc_stripe_unexpected_charge_detected' when a Stripe charge is captured for an order that was already paid via a different gateway

--- a/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
+++ b/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
@@ -11,8 +11,6 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler {
 	/**
 	 * Checkout session metadata value identifying an Adaptive Pricing checkout.
 	 *
-	 * Set on the session at creation and read back in the webhook handler so a
-	 * completed Adaptive Pricing session is never mistaken for an agentic one.
 	 *
 	 * @var string
 	 */

--- a/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
+++ b/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
@@ -11,7 +11,6 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler {
 	/**
 	 * Checkout session metadata value identifying an Adaptive Pricing checkout.
 	 *
-	 *
 	 * @var string
 	 */
 	public const ADAPTIVE_PRICING_CHECKOUT_TYPE = 'adaptive_pricing_checkout';

--- a/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
+++ b/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
@@ -9,6 +9,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Stripe_Checkout_Sessions_Ajax_Handler {
 	/**
+	 * Checkout session metadata value identifying an Adaptive Pricing checkout.
+	 *
+	 * Set on the session at creation and read back in the webhook handler so a
+	 * completed Adaptive Pricing session is never mistaken for an agentic one.
+	 *
+	 * @var string
+	 */
+	public const ADAPTIVE_PRICING_CHECKOUT_TYPE = 'adaptive_pricing_checkout';
+
+	/**
 	 * Initialize hooks.
 	 *
 	 * @return void
@@ -42,6 +52,9 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler {
 				'mode'                          => 'payment',
 				'adaptive_pricing'              => [
 					'enabled' => 'true',
+				],
+				'metadata'                      => [
+					'checkout_type' => self::ADAPTIVE_PRICING_CHECKOUT_TYPE,
 				],
 			];
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1730,6 +1730,18 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		// Look for an order. If one does not exists, this is probably an agentic hook.
 		$order = WC_Stripe_Helper::get_order_by_checkout_session_id( $checkout_session->id );
 		if ( ! $order instanceof \WC_Order ) {
+			// An Adaptive Pricing session is tagged at creation. It is never agentic,
+			// so don't route it into the agentic handler — that would silently drop a
+			// paid session whenever agentic commerce is disabled.
+			$checkout_type = $checkout_session->metadata->checkout_type ?? '';
+			if ( WC_Stripe_Checkout_Sessions_Ajax_Handler::ADAPTIVE_PRICING_CHECKOUT_TYPE === $checkout_type ) {
+				WC_Stripe_Logger::warning(
+					'Completed Adaptive Pricing checkout session has no matching order: ' . $checkout_session->id
+				);
+				WC_Stripe_Database_Cache::delete( $lock_key );
+				return;
+			}
+
 			try {
 				$this->handle_agentic_checkout_session( $notification );
 			} finally {

--- a/readme.txt
+++ b/readme.txt
@@ -165,8 +165,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Send the billing address to Stripe on the Pay for Order page so payments aren't incorrectly blocked by Stripe Radar rules
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
-* Fix - Prevent a fatal error when a Bancontact, iDEAL or Sofort payment is placed with SEPA token saving enabled through the Adaptive Pricing checkout, which left the order unpaid
-* Fix - Stop treating a completed Adaptive Pricing checkout session as an agentic session in webhook processing, which could drop the payment when agentic commerce is disabled
+* Fix - Correctly distinguish Adaptive Pricing checkout sessions from agentic ones in webhooks so their payments aren't dropped
 * Add - Stripe admin pages to the WordPress Command Palette
 * Fix - Prevent a possible fatal error when saving the payment method on a subscription order
 * Dev - Use clsx library instead of classnames

--- a/readme.txt
+++ b/readme.txt
@@ -161,5 +161,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
 * Fix - Prevent a fatal error when a Bancontact, iDEAL or Sofort payment is placed with SEPA token saving enabled through the Adaptive Pricing checkout, which left the order unpaid
+* Fix - Stop treating a completed Adaptive Pricing checkout session as an agentic session in webhook processing, which could drop the payment when agentic commerce is disabled
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-webhook-handler-agentic-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-agentic-test.php
@@ -110,6 +110,44 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * An Adaptive Pricing session with no matching order must not be routed to the
+	 * agentic handler — otherwise a paid AP session is silently dropped (and, with
+	 * agentic enabled, wrongly processed as agentic).
+	 */
+	public function test_adaptive_pricing_session_without_order_is_not_treated_as_agentic() {
+		$session_id                           = 'cs_test_adaptive_pricing';
+		$notification                         = $this->build_notification( $session_id );
+		$notification->data->object->metadata = (object) [
+			'checkout_type' => WC_Stripe_Checkout_Sessions_Ajax_Handler::ADAPTIVE_PRICING_CHECKOUT_TYPE,
+		];
+
+		// Flag (and stub) any agentic retrieval of the session from Stripe. With the
+		// guard in place this must never be reached for an Adaptive Pricing session.
+		$retrieved         = false;
+		$this->http_filter = function ( $preempt, $args, $url ) use ( &$retrieved, $session_id ) {
+			if ( str_starts_with( $url, 'https://api.stripe.com/v1/checkout/sessions/' ) ) {
+				$retrieved = true;
+				return [
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'body'     => wp_json_encode( (object) [ 'id' => $session_id ] ),
+				];
+			}
+			return $preempt;
+		};
+		add_filter( 'pre_http_request', $this->http_filter, 10, 3 );
+
+		// Immediate phase defers; deferred phase must skip the agentic path.
+		$this->handler->process_checkout_session_success( $notification );
+		$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
+
+		$this->assertFalse( $retrieved, 'Adaptive Pricing session must not trigger agentic session retrieval.' );
+		$this->assertNull( $this->get_resolved_order( $this->handler ) );
+	}
+
+	/**
 	 * Tests that a session with empty network_business_profile is skipped.
 	 */
 	public function test_skips_session_with_empty_network_business_profile() {


### PR DESCRIPTION
Fixes STRIPE-<linear_issue_id>

## Changes proposed in this Pull Request:
In `handle_checkout_session_success()`, when a `checkout.session.completed` event couldn't be matched to a WooCommerce order, the handler assumed the session was **agentic** and routed it to `handle_agentic_checkout_session()`. That handler returns early when agentic commerce is disabled (`Agentic commerce is disabled, skipping…`) — *before* ever checking whether the session is actually agentic. So a paid Adaptive Pricing session whose order lookup was missed was discarded. (Worse, with agentic commerce *enabled*, it would have been run through the agentic order mapper and produced an incorrect order.)

 - Tag Adaptive Pricing checkout sessions with `metadata.checkout_type = adaptive_pricing_checkout` at creation, and promote the value to a shared `public const` so the producer (AJAX handler) and consumer (webhook handler) can't drift.
- In the webhook handler, before routing an order-less completed session to the agentic path, read `metadata->checkout_type`. An Adaptive Pricing session is never agentic, so log a warning and return instead of misrouting it.

## Testing instructions
1. Enable Adaptive Pricing / Optimized Checkout on a Stripe account, with **agentic commerce disabled**.
2. Simulate the edge case where a completed Adaptive Pricing `checkout.session.completed` webhook arrives with no matching WooCommerce order (e.g. the order wasn't created/linked) (comment out the order update with cs ID in `process_payment_with_checkout_session` method)
3. **Before this PR:** the log shows `Agentic commerce is disabled, skipping agentic checkout session: cs_…` and the session is dropped.
4. **With this PR:** the log instead shows `Completed Adaptive Pricing checkout session has no matching order: cs_…` and the agentic path is not invoked.
5. Regression check — a normal Adaptive Pricing checkout (order created during payment) still completes and is marked paid; a genuine agentic session (agentic commerce enabled) still processes as before.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
