### PR TITLE
Add more checks for order completion in e2e tests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ xxxx-xx-xx - version 10.9.0
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
 * Dev - Use clsx library instead of classnames
 * Fix - Append the 3-letter currency code to the Stripe Fee and Stripe Payout amounts in WP Admin order totals when the Stripe account currency differs from the order currency
+* Dev - Add more robust purchase checks in e2e tests
 
 2026-06-11 - version 10.8.1
 * Fix - Prevent a fatal error when a Bancontact, iDEAL or Sofort payment is placed with SEPA token saving enabled through the Adaptive Pricing checkout, which left the order unpaid

--- a/readme.txt
+++ b/readme.txt
@@ -164,5 +164,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
 * Dev - Use clsx library instead of classnames
 * Fix - Append the 3-letter currency code to the Stripe Fee and Stripe Payout amounts in WP Admin order totals when the Stripe account currency differs from the order currency
+* Dev - Add more robust purchase checks in e2e tests
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/e2e/tests/checkout/blocks/lpms/ach.spec.js
+++ b/tests/e2e/tests/checkout/blocks/lpms/ach.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 import { randomUUID } from 'crypto';
 import config from 'config';
 import { admin, payments, api, user } from '../../../../utils';
@@ -9,6 +9,7 @@ const {
 	setupBlocksCheckout,
 	fillACHBankDetails,
 	setupACHCheckout,
+	waitForOrderReceivedPage,
 } = payments;
 
 test.describe( 'ACH payment tests @blocks', () => {
@@ -49,10 +50,7 @@ test.describe( 'ACH payment tests @blocks', () => {
 		await fillACHBankDetails( page );
 
 		await page.locator( 'text=Place order' ).click();
-		await page.waitForURL( '**/checkout/order-received/**' );
-		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-			'Order received'
-		);
+		await waitForOrderReceivedPage( page );
 	} );
 
 	test( 'customer can save and reuse ACH payment method @smoke', async ( {
@@ -74,10 +72,7 @@ test.describe( 'ACH payment tests @blocks', () => {
 				.click();
 
 			await page.locator( 'text=Place order' ).click();
-			await page.waitForURL( '**/checkout/order-received/**' );
-			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-				'Order received'
-			);
+			await waitForOrderReceivedPage( page );
 		} );
 
 		// Second order - Use saved payment method
@@ -94,10 +89,7 @@ test.describe( 'ACH payment tests @blocks', () => {
 				.click();
 
 			await page.locator( 'text=Place order' ).click();
-			await page.waitForURL( '**/checkout/order-received/**' );
-			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-				'Order received'
-			);
+			await waitForOrderReceivedPage( page );
 		} );
 	} );
 } );

--- a/tests/e2e/tests/checkout/blocks/lpms/acss.spec.js
+++ b/tests/e2e/tests/checkout/blocks/lpms/acss.spec.js
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import { randomUUID } from 'crypto';
 import config from 'config';
 import { payments, api, user } from '../../../../utils';

--- a/tests/e2e/tests/checkout/blocks/lpms/acss.spec.js
+++ b/tests/e2e/tests/checkout/blocks/lpms/acss.spec.js
@@ -1,7 +1,7 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 import { randomUUID } from 'crypto';
 import config from 'config';
-import { admin, payments, api, user } from '../../../../utils';
+import { payments, api, user } from '../../../../utils';
 
 const {
 	clickPlaceOrder,
@@ -10,6 +10,7 @@ const {
 	setupBlocksCheckout,
 	setupACSSCheckout,
 	fillACSSDetails,
+	waitForOrderReceivedPage,
 } = payments;
 
 test.describe( 'ACSS payment tests @blocks @acss', () => {
@@ -45,10 +46,7 @@ test.describe( 'ACSS payment tests @blocks @acss', () => {
 		).toBeVisible();
 		await clickPlaceOrder( page );
 		await fillACSSDetails( page );
-		await page.waitForURL( '**/checkout/order-received/**' );
-		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-			'Order received'
-		);
+		await waitForOrderReceivedPage( page );
 	} );
 
 	test( 'customer can save and reuse ACSS payment method @smoke', async ( {
@@ -65,10 +63,7 @@ test.describe( 'ACSS payment tests @blocks @acss', () => {
 			await page.getByLabel( 'Save payment information' ).click();
 			await clickPlaceOrder( page );
 			await fillACSSDetails( page );
-			await page.waitForURL( '**/checkout/order-received/**' );
-			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-				'Order received'
-			);
+			await waitForOrderReceivedPage( page );
 		} );
 
 		// Second order - Use saved payment method.
@@ -84,10 +79,7 @@ test.describe( 'ACSS payment tests @blocks @acss', () => {
 				.filter( { hasText: 'STRIPE TEST BANK ending in' } )
 				.click();
 			await clickPlaceOrder( page );
-			await page.waitForURL( '**/checkout/order-received/**' );
-			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-				'Order received'
-			);
+			await waitForOrderReceivedPage( page );
 		} );
 	} );
 } );

--- a/tests/e2e/tests/checkout/blocks/lpms/becs.spec.js
+++ b/tests/e2e/tests/checkout/blocks/lpms/becs.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 import { randomUUID } from 'crypto';
 import config from 'config';
 import { payments, api, user } from '../../../../utils';
@@ -9,6 +9,7 @@ const {
 	setupBlocksCheckout,
 	setupBECSCheckout,
 	fillBECSDetails,
+	waitForOrderReceivedPage,
 } = payments;
 
 test.describe( 'BECS payment tests @blocks @becs', () => {
@@ -39,10 +40,7 @@ test.describe( 'BECS payment tests @blocks @becs', () => {
 		await setupBECSCheckout( page, 'blocks' );
 		await fillBECSDetails( page );
 		await page.locator( 'text=Place order' ).click();
-		await page.waitForURL( '**/checkout/order-received/**' );
-		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-			'Order received'
-		);
+		await waitForOrderReceivedPage( page );
 	} );
 
 	test( 'customer can save and reuse BECS payment method @smoke', async ( {
@@ -59,10 +57,7 @@ test.describe( 'BECS payment tests @blocks @becs', () => {
 			await fillBECSDetails( page );
 			await page.getByLabel( 'Save payment information' ).click();
 			await page.locator( 'text=Place order' ).click();
-			await page.waitForURL( '**/checkout/order-received/**' );
-			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-				'Order received'
-			);
+			await waitForOrderReceivedPage( page );
 		} );
 
 		// Second order - Use saved payment method.
@@ -86,10 +81,7 @@ test.describe( 'BECS payment tests @blocks @becs', () => {
 				.filter( { hasText: 'BECS Direct Debit ending in' } )
 				.click();
 			await page.locator( 'text=Place order' ).click();
-			await page.waitForURL( '**/checkout/order-received/**' );
-			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-				'Order received'
-			);
+			await waitForOrderReceivedPage( page );
 		} );
 	} );
 } );

--- a/tests/e2e/tests/checkout/blocks/lpms/blik.spec.js
+++ b/tests/e2e/tests/checkout/blocks/lpms/blik.spec.js
@@ -1,9 +1,15 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 import { randomUUID } from 'crypto';
 import config from 'config';
 import { payments, api } from '../../../../utils';
 
-const { emptyCart, setupCart, setupBlocksCheckout, fillBLIKDetails } = payments;
+const {
+	emptyCart,
+	setupCart,
+	setupBlocksCheckout,
+	fillBLIKDetails,
+	waitForOrderReceivedPage,
+} = payments;
 
 test.describe( 'BLIK payment tests @blocks @blik', () => {
 	let username, userEmail;
@@ -39,9 +45,6 @@ test.describe( 'BLIK payment tests @blocks @blik', () => {
 		await page.getByLabel( /blik/i ).check();
 		await fillBLIKDetails( page );
 		await page.locator( 'text=Place order' ).click();
-		await page.waitForURL( '**/checkout/order-received/**' );
-		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-			'Order received'
-		);
+		await waitForOrderReceivedPage( page );
 	} );
 } );

--- a/tests/e2e/tests/checkout/blocks/normal-card.spec.js
+++ b/tests/e2e/tests/checkout/blocks/normal-card.spec.js
@@ -9,6 +9,7 @@ const {
 	setupBlocksCheckout,
 	clickPlaceOrder,
 	getCartTotal,
+	waitForOrderReceivedPageAndConfirmExpectedTotal,
 } = payments;
 
 test( 'customer can checkout with a normal credit card @smoke @blocks', async ( {
@@ -27,13 +28,10 @@ test( 'customer can checkout with a normal credit card @smoke @blocks', async ( 
 	const expectedTotal = await getCartTotal( page );
 
 	await clickPlaceOrder( page );
-	await page.waitForURL( '**/checkout/order-received/**' );
 
-	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-		'Order received'
+	await waitForOrderReceivedPageAndConfirmExpectedTotal(
+		browser,
+		page,
+		expectedTotal
 	);
-
-	// As the admin, confirm the order was charged the expected amount.
-	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
-	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );

--- a/tests/e2e/tests/checkout/blocks/normal-card.spec.js
+++ b/tests/e2e/tests/checkout/blocks/normal-card.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import config from 'config';
-import { payments } from '../../../utils';
+import { admin, payments } from '../../../utils';
 
 const {
 	emptyCart,
@@ -8,10 +8,12 @@ const {
 	fillCreditCardDetails,
 	setupBlocksCheckout,
 	clickPlaceOrder,
+	getCartTotal,
 } = payments;
 
 test( 'customer can checkout with a normal credit card @smoke @blocks', async ( {
 	page,
+	browser,
 } ) => {
 	await emptyCart( page );
 	await setupCart( page );
@@ -21,10 +23,17 @@ test( 'customer can checkout with a normal credit card @smoke @blocks', async ( 
 	);
 
 	await fillCreditCardDetails( page, config.get( 'cards.basic' ) );
+
+	const expectedTotal = await getCartTotal( page );
+
 	await clickPlaceOrder( page );
 	await page.waitForURL( '**/checkout/order-received/**' );
 
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 		'Order received'
 	);
+
+	// As the admin, confirm the order was charged the expected amount.
+	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
+	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );

--- a/tests/e2e/tests/checkout/blocks/optimized-checkout.spec.js
+++ b/tests/e2e/tests/checkout/blocks/optimized-checkout.spec.js
@@ -11,6 +11,7 @@ const {
 	fillOCDetails,
 	clickPlaceOrder,
 	getCartTotal,
+	waitForOrderReceivedPageAndConfirmExpectedTotal,
 } = payments;
 
 test.describe( 'Optimized Checkout payment tests @blocks', () => {
@@ -47,13 +48,12 @@ test.describe( 'Optimized Checkout payment tests @blocks', () => {
 		const expectedTotal = await getCartTotal( page );
 
 		await clickPlaceOrder( page );
-		await page.waitForURL( '**/checkout/order-received/**' );
-		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-			'Order received'
-		);
 
-		const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
-		await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
+		await waitForOrderReceivedPageAndConfirmExpectedTotal(
+			browser,
+			page,
+			expectedTotal
+		);
 	} );
 
 	test( 'customer can save and reuse Optimized Checkout payment method @smoke', async ( {
@@ -80,17 +80,10 @@ test.describe( 'Optimized Checkout payment tests @blocks', () => {
 				const expectedTotal = await getCartTotal( page );
 
 				await clickPlaceOrder( page );
-				await page.waitForURL( '**/checkout/order-received/**' );
-				await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-					'Order received'
-				);
 
-				const orderId = admin.getOrderIdFromOrderReceivedUrl(
-					page.url()
-				);
-				await admin.verifyOrderChargedAmount(
+				await waitForOrderReceivedPageAndConfirmExpectedTotal(
 					browser,
-					orderId,
+					page,
 					expectedTotal
 				);
 			} );
@@ -111,17 +104,10 @@ test.describe( 'Optimized Checkout payment tests @blocks', () => {
 				const expectedTotal = await getCartTotal( page );
 
 				await clickPlaceOrder( page );
-				await page.waitForURL( '**/checkout/order-received/**' );
-				await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-					'Order received'
-				);
 
-				const orderId = admin.getOrderIdFromOrderReceivedUrl(
-					page.url()
-				);
-				await admin.verifyOrderChargedAmount(
+				await waitForOrderReceivedPageAndConfirmExpectedTotal(
 					browser,
-					orderId,
+					page,
 					expectedTotal
 				);
 			} );

--- a/tests/e2e/tests/checkout/blocks/optimized-checkout.spec.js
+++ b/tests/e2e/tests/checkout/blocks/optimized-checkout.spec.js
@@ -10,6 +10,7 @@ const {
 	setupBlocksCheckout,
 	fillOCDetails,
 	clickPlaceOrder,
+	getCartTotal,
 } = payments;
 
 test.describe( 'Optimized Checkout payment tests @blocks', () => {
@@ -38,14 +39,21 @@ test.describe( 'Optimized Checkout payment tests @blocks', () => {
 
 	test( 'customer can pay with Optimized Checkout @smoke', async ( {
 		page,
+		browser,
 	} ) => {
 		await setupOptimizedCheckout( page, 'blocks' );
 		await fillOCDetails( page, config.get( 'cards.basic' ) );
+
+		const expectedTotal = await getCartTotal( page );
+
 		await clickPlaceOrder( page );
 		await page.waitForURL( '**/checkout/order-received/**' );
 		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 			'Order received'
 		);
+
+		const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
+		await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 	} );
 
 	test( 'customer can save and reuse Optimized Checkout payment method @smoke', async ( {
@@ -68,10 +76,22 @@ test.describe( 'Optimized Checkout payment tests @blocks', () => {
 				await setupOptimizedCheckout( page, 'blocks' );
 				await page.getByLabel( 'Save payment information' ).click();
 				await fillOCDetails( page, config.get( 'cards.basic' ) );
+
+				const expectedTotal = await getCartTotal( page );
+
 				await clickPlaceOrder( page );
 				await page.waitForURL( '**/checkout/order-received/**' );
 				await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 					'Order received'
+				);
+
+				const orderId = admin.getOrderIdFromOrderReceivedUrl(
+					page.url()
+				);
+				await admin.verifyOrderChargedAmount(
+					browser,
+					orderId,
+					expectedTotal
 				);
 			} );
 
@@ -87,10 +107,22 @@ test.describe( 'Optimized Checkout payment tests @blocks', () => {
 					.locator( 'label' )
 					.filter( { hasText: 'Visa ending in 4242 (expires' } )
 					.click();
+
+				const expectedTotal = await getCartTotal( page );
+
 				await clickPlaceOrder( page );
 				await page.waitForURL( '**/checkout/order-received/**' );
 				await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 					'Order received'
+				);
+
+				const orderId = admin.getOrderIdFromOrderReceivedUrl(
+					page.url()
+				);
+				await admin.verifyOrderChargedAmount(
+					browser,
+					orderId,
+					expectedTotal
 				);
 			} );
 		} finally {

--- a/tests/e2e/tests/checkout/blocks/pre-order-product.spec.js
+++ b/tests/e2e/tests/checkout/blocks/pre-order-product.spec.js
@@ -4,8 +4,12 @@ import config from 'config';
 import { api, payments, products } from '../../../utils';
 import { isPluginInstalled } from '../../../utils/plugin-utils';
 
-const { setupBlocksCheckout, fillCreditCardDetails, clickAddToCartButton } =
-	payments;
+const {
+	setupBlocksCheckout,
+	fillCreditCardDetails,
+	clickAddToCartButton,
+	waitForOrderReceivedPage,
+} = payments;
 
 let productId;
 
@@ -45,9 +49,6 @@ test( 'customer can purchase a pre-order product @blocks @pre-orders', async ( {
 	await fillCreditCardDetails( page, config.get( 'cards.no-3ds' ) );
 
 	await page.locator( 'text="Place pre-order now"' ).click();
-	await page.waitForURL( '**/checkout/order-received/**' );
 
-	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-		'Order received'
-	);
+	await waitForOrderReceivedPage( page );
 } );

--- a/tests/e2e/tests/checkout/blocks/retries.spec.js
+++ b/tests/e2e/tests/checkout/blocks/retries.spec.js
@@ -90,7 +90,7 @@ test( 'customer can retry payment, with changed billing details @smoke', async (
 	// Change billing details
 	await page.getByLabel( 'ZIP Code' ).fill( '12345' );
 
-	// Get cart total after changing the zip/post code.
+	// Get cart total after changing the zip/post code to ensure current taxes and shipping are applied.
 	const expectedTotal = await getCartTotal( page );
 
 	// Retry the payment

--- a/tests/e2e/tests/checkout/blocks/retries.spec.js
+++ b/tests/e2e/tests/checkout/blocks/retries.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import config from 'config';
-import { payments } from '../../../utils';
+import { admin, payments } from '../../../utils';
 
 const {
 	emptyCart,
@@ -10,6 +10,7 @@ const {
 	handleCheckout3DSChallenge,
 	clickPlaceOrder,
 	handleCheckoutCashAppPay,
+	getCartTotal,
 } = payments;
 
 test.beforeAll( 'enable Cash App Pay', async ( { browser } ) => {
@@ -44,7 +45,10 @@ test.beforeEach( async ( { page } ) => {
  */
 test( 'customer can retry payment, with a different card @smoke', async ( {
 	page,
+	browser,
 } ) => {
+	const expectedTotal = await getCartTotal( page );
+
 	await fillCreditCardDetails( page, config.get( 'cards.declined' ) );
 	await clickPlaceOrder( page );
 
@@ -62,6 +66,9 @@ test( 'customer can retry payment, with a different card @smoke', async ( {
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 		'Order received'
 	);
+
+	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
+	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );
 
 /**
@@ -72,7 +79,10 @@ test( 'customer can retry payment, with a different card @smoke', async ( {
  */
 test( 'customer can retry payment, with changed billing details @smoke', async ( {
 	page,
+	browser,
 } ) => {
+	const expectedTotal = await getCartTotal( page );
+
 	await fillCreditCardDetails( page, config.get( 'cards.3ds' ) );
 	await clickPlaceOrder( page );
 
@@ -95,6 +105,9 @@ test( 'customer can retry payment, with changed billing details @smoke', async (
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 		'Order received'
 	);
+
+	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
+	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );
 
 /**
@@ -120,4 +133,7 @@ test( 'customer can retry payment, using a different payment method @smoke', asy
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 		'Order received'
 	);
+
+	// No charged-amount verification here: Cash App Pay is not a synchronous
+	// card capture, so the order has no "Paid"/Stripe Fee/Payout rows to check.
 } );

--- a/tests/e2e/tests/checkout/blocks/retries.spec.js
+++ b/tests/e2e/tests/checkout/blocks/retries.spec.js
@@ -81,8 +81,6 @@ test( 'customer can retry payment, with changed billing details @smoke', async (
 	page,
 	browser,
 } ) => {
-	const expectedTotal = await getCartTotal( page );
-
 	await fillCreditCardDetails( page, config.get( 'cards.3ds' ) );
 	await clickPlaceOrder( page );
 
@@ -91,6 +89,9 @@ test( 'customer can retry payment, with changed billing details @smoke', async (
 
 	// Change billing details
 	await page.getByLabel( 'ZIP Code' ).fill( '12345' );
+
+	// Get cart total after changing the zip/post code.
+	const expectedTotal = await getCartTotal( page );
 
 	// Retry the payment
 	await clickPlaceOrder( page );

--- a/tests/e2e/tests/checkout/blocks/retries.spec.js
+++ b/tests/e2e/tests/checkout/blocks/retries.spec.js
@@ -11,6 +11,7 @@ const {
 	clickPlaceOrder,
 	handleCheckoutCashAppPay,
 	getCartTotal,
+	waitForOrderReceivedPageAndConfirmExpectedTotal,
 } = payments;
 
 test.beforeAll( 'enable Cash App Pay', async ( { browser } ) => {
@@ -60,15 +61,12 @@ test( 'customer can retry payment, with a different card @smoke', async ( {
 	// Change to a working card
 	await fillCreditCardDetails( page, config.get( 'cards.basic' ) );
 	await clickPlaceOrder( page );
-	await page.waitForURL( '**/order-received/**' );
 
-	// Expect the order to succeed
-	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-		'Order received'
+	await waitForOrderReceivedPageAndConfirmExpectedTotal(
+		browser,
+		page,
+		expectedTotal
 	);
-
-	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
-	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );
 
 /**
@@ -99,16 +97,11 @@ test( 'customer can retry payment, with changed billing details @smoke', async (
 	// Complete the 3DS challenge
 	await handleCheckout3DSChallenge( page );
 
-	// Expect the order to succeed
-	await page.waitForURL( '**/order-received/**' );
-
-	// Expect the order to succeed
-	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-		'Order received'
+	await waitForOrderReceivedPageAndConfirmExpectedTotal(
+		browser,
+		page,
+		expectedTotal
 	);
-
-	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
-	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );
 
 /**
@@ -130,10 +123,7 @@ test( 'customer can retry payment, using a different payment method @smoke', asy
 	await handleCheckoutCashAppPay( page, '.wcstripe-payment-element' );
 
 	// Expect the order to succeed
-	await page.waitForURL( '**/order-received/**' );
-	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-		'Order received'
-	);
+	await waitForOrderReceivedPage( page );
 
 	// No charged-amount verification here: Cash App Pay is not a synchronous
 	// card capture, so the order has no "Paid"/Stripe Fee/Payout rows to check.

--- a/tests/e2e/tests/checkout/blocks/retries.spec.js
+++ b/tests/e2e/tests/checkout/blocks/retries.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import config from 'config';
-import { admin, payments } from '../../../utils';
+import { payments } from '../../../utils';
 
 const {
 	emptyCart,
@@ -11,6 +11,7 @@ const {
 	clickPlaceOrder,
 	handleCheckoutCashAppPay,
 	getCartTotal,
+	waitForOrderReceivedPage,
 	waitForOrderReceivedPageAndConfirmExpectedTotal,
 } = payments;
 

--- a/tests/e2e/tests/checkout/blocks/saved-card.spec.js
+++ b/tests/e2e/tests/checkout/blocks/saved-card.spec.js
@@ -3,8 +3,13 @@ import { randomUUID } from 'crypto';
 import config from 'config';
 import { payments, api, user, admin } from '../../../utils';
 
-const { emptyCart, setupCart, setupBlocksCheckout, fillCreditCardDetails } =
-	payments;
+const {
+	emptyCart,
+	setupCart,
+	setupBlocksCheckout,
+	fillCreditCardDetails,
+	getCartTotal,
+} = payments;
 
 let username, userEmail;
 
@@ -54,11 +59,20 @@ test( 'customer can checkout with a saved card @smoke @blocks', async ( {
 				)
 				.click();
 
+			const expectedTotal = await getCartTotal( page );
+
 			await page.locator( 'text=Place order' ).click();
 
 			await page.waitForNavigation();
 			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 				'Order received'
+			);
+
+			const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
+			await admin.verifyOrderChargedAmount(
+				browser,
+				orderId,
+				expectedTotal
 			);
 		} );
 
@@ -80,11 +94,20 @@ test( 'customer can checkout with a saved card @smoke @blocks', async ( {
 				)
 				.click();
 
+			const expectedTotal = await getCartTotal( page );
+
 			await page.locator( 'text=Place order' ).click();
 
 			await page.waitForNavigation();
 			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 				'Order received'
+			);
+
+			const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
+			await admin.verifyOrderChargedAmount(
+				browser,
+				orderId,
+				expectedTotal
 			);
 		} );
 	} finally {

--- a/tests/e2e/tests/checkout/blocks/saved-card.spec.js
+++ b/tests/e2e/tests/checkout/blocks/saved-card.spec.js
@@ -9,6 +9,7 @@ const {
 	setupBlocksCheckout,
 	fillCreditCardDetails,
 	getCartTotal,
+	waitForOrderReceivedPageAndConfirmExpectedTotal,
 } = payments;
 
 let username, userEmail;
@@ -63,15 +64,9 @@ test( 'customer can checkout with a saved card @smoke @blocks', async ( {
 
 			await page.locator( 'text=Place order' ).click();
 
-			await page.waitForNavigation();
-			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-				'Order received'
-			);
-
-			const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
-			await admin.verifyOrderChargedAmount(
+			await waitForOrderReceivedPageAndConfirmExpectedTotal(
 				browser,
-				orderId,
+				page,
 				expectedTotal
 			);
 		} );
@@ -98,15 +93,9 @@ test( 'customer can checkout with a saved card @smoke @blocks', async ( {
 
 			await page.locator( 'text=Place order' ).click();
 
-			await page.waitForNavigation();
-			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-				'Order received'
-			);
-
-			const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
-			await admin.verifyOrderChargedAmount(
+			await waitForOrderReceivedPageAndConfirmExpectedTotal(
 				browser,
-				orderId,
+				page,
 				expectedTotal
 			);
 		} );

--- a/tests/e2e/tests/checkout/blocks/sca-card.spec.js
+++ b/tests/e2e/tests/checkout/blocks/sca-card.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import config from 'config';
-import { payments } from '../../../utils';
+import { admin, payments } from '../../../utils';
 
 const {
 	emptyCart,
@@ -9,10 +9,12 @@ const {
 	fillCreditCardDetails,
 	clickPlaceOrder,
 	handleCheckout3DSChallenge,
+	getCartTotal,
 } = payments;
 
 test( 'customer can checkout with a SCA card @smoke @blocks', async ( {
 	page,
+	browser,
 } ) => {
 	await emptyCart( page );
 	await setupCart( page );
@@ -21,6 +23,9 @@ test( 'customer can checkout with a SCA card @smoke @blocks', async ( {
 		config.get( 'addresses.customer.billing' )
 	);
 	await fillCreditCardDetails( page, config.get( 'cards.3ds' ) );
+
+	const expectedTotal = await getCartTotal( page );
+
 	await clickPlaceOrder( page );
 
 	await handleCheckout3DSChallenge( page );
@@ -30,4 +35,8 @@ test( 'customer can checkout with a SCA card @smoke @blocks', async ( {
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 		'Order received'
 	);
+
+	// As the admin, confirm the order was charged the expected amount.
+	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
+	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );

--- a/tests/e2e/tests/checkout/blocks/sca-card.spec.js
+++ b/tests/e2e/tests/checkout/blocks/sca-card.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import config from 'config';
-import { admin, payments } from '../../../utils';
+import { payments } from '../../../utils';
 
 const {
 	emptyCart,
@@ -10,6 +10,7 @@ const {
 	clickPlaceOrder,
 	handleCheckout3DSChallenge,
 	getCartTotal,
+	waitForOrderReceivedPageAndConfirmExpectedTotal,
 } = payments;
 
 test( 'customer can checkout with a SCA card @smoke @blocks', async ( {
@@ -30,13 +31,9 @@ test( 'customer can checkout with a SCA card @smoke @blocks', async ( {
 
 	await handleCheckout3DSChallenge( page );
 
-	await page.waitForURL( '**/checkout/order-received/**' );
-
-	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-		'Order received'
+	await waitForOrderReceivedPageAndConfirmExpectedTotal(
+		browser,
+		page,
+		expectedTotal
 	);
-
-	// As the admin, confirm the order was charged the expected amount.
-	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
-	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );

--- a/tests/e2e/tests/checkout/blocks/subscription-product.spec.js
+++ b/tests/e2e/tests/checkout/blocks/subscription-product.spec.js
@@ -1,10 +1,14 @@
 import { test, expect } from '@playwright/test';
 import { randomUUID } from 'crypto';
 import config from 'config';
-import { api, payments, products } from '../../../utils';
+import { admin, api, payments, products } from '../../../utils';
 
-const { setupBlocksCheckout, fillCreditCardDetails, clickAddToCartButton } =
-	payments;
+const {
+	setupBlocksCheckout,
+	fillCreditCardDetails,
+	clickAddToCartButton,
+	getCartTotal,
+} = payments;
 
 let productId;
 
@@ -18,6 +22,7 @@ test.afterAll( async () => {
 
 test( 'customer can purchase a subscription product @smoke @blocks @subscriptions', async ( {
 	page,
+	browser,
 } ) => {
 	await page.goto( `?p=${ productId }` );
 	await clickAddToCartButton( page );
@@ -35,10 +40,16 @@ test( 'customer can purchase a subscription product @smoke @blocks @subscription
 	await setupBlocksCheckout( page, customerData );
 	await fillCreditCardDetails( page, config.get( 'cards.no-3ds' ) );
 
+	const expectedTotal = await getCartTotal( page );
+
 	await page.locator( 'text=Place order' ).click();
 	await page.waitForURL( '**/checkout/order-received/**' );
 
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 		'Order received'
 	);
+
+	// As the admin, confirm the order was charged the expected amount.
+	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
+	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );

--- a/tests/e2e/tests/checkout/blocks/subscription-product.spec.js
+++ b/tests/e2e/tests/checkout/blocks/subscription-product.spec.js
@@ -1,13 +1,14 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 import { randomUUID } from 'crypto';
 import config from 'config';
-import { admin, api, payments, products } from '../../../utils';
+import { api, payments, products } from '../../../utils';
 
 const {
 	setupBlocksCheckout,
 	fillCreditCardDetails,
 	clickAddToCartButton,
 	getCartTotal,
+	waitForOrderReceivedPageAndConfirmExpectedTotal,
 } = payments;
 
 let productId;
@@ -43,13 +44,10 @@ test( 'customer can purchase a subscription product @smoke @blocks @subscription
 	const expectedTotal = await getCartTotal( page );
 
 	await page.locator( 'text=Place order' ).click();
-	await page.waitForURL( '**/checkout/order-received/**' );
 
-	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-		'Order received'
+	await waitForOrderReceivedPageAndConfirmExpectedTotal(
+		browser,
+		page,
+		expectedTotal
 	);
-
-	// As the admin, confirm the order was charged the expected amount.
-	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
-	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );

--- a/tests/e2e/tests/checkout/shortcode/lpms/ach.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/lpms/ach.spec.js
@@ -10,6 +10,7 @@ const {
 	setupShortcodeCheckout,
 	setupACHCheckout,
 	fillACHBankDetails,
+	waitForOrderReceivedPage,
 } = payments;
 
 test.describe( 'ACH payment tests @shortcode', () => {
@@ -50,10 +51,7 @@ test.describe( 'ACH payment tests @shortcode', () => {
 		await fillACHBankDetails( page );
 
 		await page.locator( 'text=Place order' ).click();
-		await page.waitForURL( '**/checkout/order-received/**' );
-		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-			'Order received'
-		);
+		await waitForOrderReceivedPage( page );
 	} );
 
 	test( 'customer can save and reuse ACH payment method @smoke', async ( {
@@ -76,10 +74,7 @@ test.describe( 'ACH payment tests @shortcode', () => {
 				.click();
 
 			await clickPlaceOrder( page );
-			await page.waitForURL( '**/checkout/order-received/**' );
-			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-				'Order received'
-			);
+			await waitForOrderReceivedPage( page );
 		} );
 
 		// Second order - Use saved payment method
@@ -102,10 +97,7 @@ test.describe( 'ACH payment tests @shortcode', () => {
 				.click();
 
 			await clickPlaceOrder( page );
-			await page.waitForURL( '**/checkout/order-received/**' );
-			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-				'Order received'
-			);
+			await waitForOrderReceivedPage( page );
 		} );
 	} );
 } );

--- a/tests/e2e/tests/checkout/shortcode/lpms/acss.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/lpms/acss.spec.js
@@ -10,6 +10,7 @@ const {
 	setupShortcodeCheckout,
 	setupACSSCheckout,
 	fillACSSDetails,
+	waitForOrderReceivedPage,
 } = payments;
 
 test.describe( 'ACSS payment tests @shortcode @acss', () => {
@@ -45,10 +46,7 @@ test.describe( 'ACSS payment tests @shortcode @acss', () => {
 		).toBeVisible();
 		await clickPlaceOrder( page );
 		await fillACSSDetails( page );
-		await page.waitForURL( '**/checkout/order-received/**' );
-		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-			'Order received'
-		);
+		await waitForOrderReceivedPage( page );
 	} );
 
 	test( 'customer can save and reuse ACSS payment method @smoke', async ( {
@@ -69,10 +67,7 @@ test.describe( 'ACSS payment tests @shortcode @acss', () => {
 				.dispatchEvent( 'click' );
 			await clickPlaceOrder( page );
 			await fillACSSDetails( page );
-			await page.waitForURL( '**/checkout/order-received/**' );
-			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-				'Order received'
-			);
+			await waitForOrderReceivedPage( page );
 		} );
 
 		// Second order - Use saved payment method.
@@ -94,10 +89,7 @@ test.describe( 'ACSS payment tests @shortcode @acss', () => {
 				.first()
 				.dispatchEvent( 'click' );
 			await clickPlaceOrder( page );
-			await page.waitForURL( '**/checkout/order-received/**' );
-			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-				'Order received'
-			);
+			await waitForOrderReceivedPage( page );
 		} );
 	} );
 } );

--- a/tests/e2e/tests/checkout/shortcode/lpms/becs.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/lpms/becs.spec.js
@@ -10,6 +10,7 @@ const {
 	setupShortcodeCheckout,
 	setupBECSCheckout,
 	fillBECSDetails,
+	waitForOrderReceivedPage,
 } = payments;
 
 test.describe( 'BECS payment tests @shortcode @becs', () => {
@@ -40,10 +41,7 @@ test.describe( 'BECS payment tests @shortcode @becs', () => {
 		await setupBECSCheckout( page, 'shortcode' );
 		await fillBECSDetails( page, 'shortcode' );
 		await clickPlaceOrder( page );
-		await page.waitForURL( '**/checkout/order-received/**' );
-		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-			'Order received'
-		);
+		await waitForOrderReceivedPage( page );
 	} );
 
 	test( 'customer can save and reuse BECS payment method @smoke', async ( {
@@ -62,10 +60,7 @@ test.describe( 'BECS payment tests @shortcode @becs', () => {
 				.check();
 			await fillBECSDetails( page, 'shortcode' );
 			await clickPlaceOrder( page );
-			await page.waitForURL( '**/checkout/order-received/**' );
-			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-				'Order received'
-			);
+			await waitForOrderReceivedPage( page );
 		} );
 
 		// Second order - Use saved payment method.
@@ -87,10 +82,7 @@ test.describe( 'BECS payment tests @shortcode @becs', () => {
 				.first()
 				.click();
 			await clickPlaceOrder( page );
-			await page.waitForURL( '**/checkout/order-received/**' );
-			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-				'Order received'
-			);
+			await waitForOrderReceivedPage( page );
 		} );
 	} );
 

--- a/tests/e2e/tests/checkout/shortcode/lpms/blik.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/lpms/blik.spec.js
@@ -1,9 +1,14 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 import config from 'config';
 import { payments } from '../../../../utils';
 
-const { emptyCart, setupCart, setupShortcodeCheckout, fillBLIKDetails } =
-	payments;
+const {
+	emptyCart,
+	setupCart,
+	setupShortcodeCheckout,
+	fillBLIKDetails,
+	waitForOrderReceivedPage,
+} = payments;
 
 test.describe( 'BLIK payment tests @shortcode @blik', () => {
 	test( 'customer can pay with BLIK', async ( { page } ) => {
@@ -16,9 +21,6 @@ test.describe( 'BLIK payment tests @shortcode @blik', () => {
 		await page.getByText( 'BLIK', { exact: true } ).click();
 		await fillBLIKDetails( page );
 		await page.locator( 'text=Place order' ).click();
-		await page.waitForURL( '**/checkout/order-received/**' );
-		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-			'Order received'
-		);
+		await waitForOrderReceivedPage( page );
 	} );
 } );

--- a/tests/e2e/tests/checkout/shortcode/normal-card.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/normal-card.spec.js
@@ -1,6 +1,6 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 import config from 'config';
-import { admin, payments } from '../../../utils';
+import { payments } from '../../../utils';
 
 const {
 	emptyCart,
@@ -8,6 +8,7 @@ const {
 	setupShortcodeCheckout,
 	fillCreditCardDetailsShortcode,
 	getCartTotal,
+	waitForOrderReceivedPageAndConfirmExpectedTotal,
 } = payments;
 
 test( 'customer can checkout with a normal credit card @smoke', async ( {
@@ -25,13 +26,10 @@ test( 'customer can checkout with a normal credit card @smoke', async ( {
 	const expectedTotal = await getCartTotal( page );
 
 	await page.locator( 'text=Place order' ).dispatchEvent( 'click' );
-	await page.waitForNavigation();
 
-	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-		'Order received'
+	await waitForOrderReceivedPageAndConfirmExpectedTotal(
+		browser,
+		page,
+		expectedTotal
 	);
-
-	// As the admin, confirm the order was charged the expected amount.
-	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
-	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );

--- a/tests/e2e/tests/checkout/shortcode/normal-card.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/normal-card.spec.js
@@ -1,16 +1,18 @@
 import { test, expect } from '@playwright/test';
 import config from 'config';
-import { payments } from '../../../utils';
+import { admin, payments } from '../../../utils';
 
 const {
 	emptyCart,
 	setupCart,
 	setupShortcodeCheckout,
 	fillCreditCardDetailsShortcode,
+	getCartTotal,
 } = payments;
 
 test( 'customer can checkout with a normal credit card @smoke', async ( {
 	page,
+	browser,
 } ) => {
 	await emptyCart( page );
 	await setupCart( page );
@@ -19,10 +21,17 @@ test( 'customer can checkout with a normal credit card @smoke', async ( {
 		config.get( 'addresses.customer.billing' )
 	);
 	await fillCreditCardDetailsShortcode( page, config.get( 'cards.basic' ) );
+
+	const expectedTotal = await getCartTotal( page );
+
 	await page.locator( 'text=Place order' ).dispatchEvent( 'click' );
 	await page.waitForNavigation();
 
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 		'Order received'
 	);
+
+	// As the admin, confirm the order was charged the expected amount.
+	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
+	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );

--- a/tests/e2e/tests/checkout/shortcode/optimized-checkout.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/optimized-checkout.spec.js
@@ -10,6 +10,7 @@ const {
 	setupOptimizedCheckout,
 	fillOCDetails,
 	clickPlaceOrder,
+	getCartTotal,
 } = payments;
 
 test.describe( 'Optimized Checkout payment tests @shortcode', () => {
@@ -38,14 +39,21 @@ test.describe( 'Optimized Checkout payment tests @shortcode', () => {
 
 	test( 'customer can pay with Optimized Checkout @smoke', async ( {
 		page,
+		browser,
 	} ) => {
 		await setupOptimizedCheckout( page, 'shortcode' );
 		await fillOCDetails( page, config.get( 'cards.basic' ), 'shortcode' );
+
+		const expectedTotal = await getCartTotal( page );
+
 		await clickPlaceOrder( page );
 		await page.waitForURL( '**/checkout/order-received/**' );
 		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 			'Order received'
 		);
+
+		const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
+		await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 	} );
 
 	test( 'customer can save and reuse Optimized Checkout payment method @smoke', async ( {
@@ -81,10 +89,22 @@ test.describe( 'Optimized Checkout payment tests @shortcode', () => {
 					config.get( 'cards.basic' ),
 					'shortcode'
 				);
+
+				const expectedTotal = await getCartTotal( page );
+
 				await clickPlaceOrder( page );
 				await page.waitForURL( '**/checkout/order-received/**' );
 				await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 					'Order received'
+				);
+
+				const orderId = admin.getOrderIdFromOrderReceivedUrl(
+					page.url()
+				);
+				await admin.verifyOrderChargedAmount(
+					browser,
+					orderId,
+					expectedTotal
 				);
 			} );
 
@@ -101,10 +121,22 @@ test.describe( 'Optimized Checkout payment tests @shortcode', () => {
 				);
 				await expect( savedTokenRadio ).toBeVisible();
 				await savedTokenRadio.click();
+
+				const expectedTotal = await getCartTotal( page );
+
 				await clickPlaceOrder( page );
 				await page.waitForURL( '**/checkout/order-received/**' );
 				await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 					'Order received'
+				);
+
+				const orderId = admin.getOrderIdFromOrderReceivedUrl(
+					page.url()
+				);
+				await admin.verifyOrderChargedAmount(
+					browser,
+					orderId,
+					expectedTotal
 				);
 			} );
 		} finally {

--- a/tests/e2e/tests/checkout/shortcode/optimized-checkout.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/optimized-checkout.spec.js
@@ -11,6 +11,7 @@ const {
 	fillOCDetails,
 	clickPlaceOrder,
 	getCartTotal,
+	waitForOrderReceivedPageAndConfirmExpectedTotal,
 } = payments;
 
 test.describe( 'Optimized Checkout payment tests @shortcode', () => {
@@ -47,13 +48,12 @@ test.describe( 'Optimized Checkout payment tests @shortcode', () => {
 		const expectedTotal = await getCartTotal( page );
 
 		await clickPlaceOrder( page );
-		await page.waitForURL( '**/checkout/order-received/**' );
-		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-			'Order received'
-		);
 
-		const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
-		await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
+		await waitForOrderReceivedPageAndConfirmExpectedTotal(
+			browser,
+			page,
+			expectedTotal
+		);
 	} );
 
 	test( 'customer can save and reuse Optimized Checkout payment method @smoke', async ( {
@@ -93,17 +93,10 @@ test.describe( 'Optimized Checkout payment tests @shortcode', () => {
 				const expectedTotal = await getCartTotal( page );
 
 				await clickPlaceOrder( page );
-				await page.waitForURL( '**/checkout/order-received/**' );
-				await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-					'Order received'
-				);
 
-				const orderId = admin.getOrderIdFromOrderReceivedUrl(
-					page.url()
-				);
-				await admin.verifyOrderChargedAmount(
+				await waitForOrderReceivedPageAndConfirmExpectedTotal(
 					browser,
-					orderId,
+					page,
 					expectedTotal
 				);
 			} );
@@ -125,17 +118,10 @@ test.describe( 'Optimized Checkout payment tests @shortcode', () => {
 				const expectedTotal = await getCartTotal( page );
 
 				await clickPlaceOrder( page );
-				await page.waitForURL( '**/checkout/order-received/**' );
-				await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-					'Order received'
-				);
 
-				const orderId = admin.getOrderIdFromOrderReceivedUrl(
-					page.url()
-				);
-				await admin.verifyOrderChargedAmount(
+				await waitForOrderReceivedPageAndConfirmExpectedTotal(
 					browser,
-					orderId,
+					page,
 					expectedTotal
 				);
 			} );

--- a/tests/e2e/tests/checkout/shortcode/pre-order-product.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/pre-order-product.spec.js
@@ -8,6 +8,7 @@ const {
 	setupShortcodeCheckout,
 	fillCreditCardDetailsShortcode,
 	clickAddToCartButton,
+	waitForOrderReceivedPage,
 } = payments;
 
 let productId;
@@ -52,9 +53,5 @@ test( 'customer can purchase a pre-order product @pre-orders', async ( {
 	} );
 	await expect( placePreOrderButton ).toBeEnabled();
 	await placePreOrderButton.dispatchEvent( 'click' );
-	await page.waitForURL( '**/checkout/order-received/**' );
-
-	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-		'Order received'
-	);
+	await waitForOrderReceivedPage( page );
 } );

--- a/tests/e2e/tests/checkout/shortcode/retries.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/retries.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import config from 'config';
-import { admin, payments } from '../../../utils';
+import { payments } from '../../../utils';
 
 const {
 	emptyCart,
@@ -11,6 +11,8 @@ const {
 	clickPlaceOrder,
 	handleCheckoutCashAppPay,
 	getCartTotal,
+	waitForOrderReceivedPage,
+	waitForOrderReceivedPageAndConfirmExpectedTotal,
 } = payments;
 
 test.beforeAll( 'enable Cash App Pay', async ( { browser } ) => {
@@ -61,15 +63,12 @@ test( 'customer can retry payment, with a different card @smoke', async ( {
 	// Change to a working card, and retry the payment.
 	await fillCreditCardDetailsShortcode( page, config.get( 'cards.basic' ) );
 	await clickPlaceOrder( page );
-	await page.waitForURL( '**/order-received/**' );
 
-	// Expect the order to succeed
-	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-		'Order received'
+	await waitForOrderReceivedPageAndConfirmExpectedTotal(
+		browser,
+		page,
+		expectedTotal
 	);
-
-	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
-	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );
 
 /**
@@ -100,16 +99,11 @@ test( 'customer can retry payment, with changed billing details @smoke', async (
 	// Complete the 3DS challenge
 	await handleCheckout3DSChallenge( page );
 
-	// Expect the order to succeed
-	await page.waitForURL( '**/order-received/**' );
-
-	// Expect the order to succeed
-	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-		'Order received'
+	await waitForOrderReceivedPageAndConfirmExpectedTotal(
+		browser,
+		page,
+		expectedTotal
 	);
-
-	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
-	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );
 
 /**
@@ -132,10 +126,7 @@ test( 'customer can retry payment, using a different payment method @smoke', asy
 	await handleCheckoutCashAppPay( page );
 
 	// Expect the order to succeed
-	await page.waitForURL( '**/order-received/**' );
-	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-		'Order received'
-	);
+	await waitForOrderReceivedPage( page );
 
 	// No charged-amount verification here: Cash App Pay is not a synchronous
 	// card capture, so the order has no "Paid"/Stripe Fee/Payout rows to check.

--- a/tests/e2e/tests/checkout/shortcode/retries.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/retries.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import config from 'config';
-import { payments } from '../../../utils';
+import { admin, payments } from '../../../utils';
 
 const {
 	emptyCart,
@@ -10,6 +10,7 @@ const {
 	handleCheckout3DSChallenge,
 	clickPlaceOrder,
 	handleCheckoutCashAppPay,
+	getCartTotal,
 } = payments;
 
 test.beforeAll( 'enable Cash App Pay', async ( { browser } ) => {
@@ -44,7 +45,10 @@ test.beforeEach( async ( { page } ) => {
  */
 test( 'customer can retry payment, with a different card @smoke', async ( {
 	page,
+	browser,
 } ) => {
+	const expectedTotal = await getCartTotal( page );
+
 	await fillCreditCardDetailsShortcode(
 		page,
 		config.get( 'cards.declined' )
@@ -63,6 +67,9 @@ test( 'customer can retry payment, with a different card @smoke', async ( {
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 		'Order received'
 	);
+
+	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
+	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );
 
 /**
@@ -73,7 +80,10 @@ test( 'customer can retry payment, with a different card @smoke', async ( {
  */
 test( 'customer can retry payment, with changed billing details @smoke', async ( {
 	page,
+	browser,
 } ) => {
+	const expectedTotal = await getCartTotal( page );
+
 	await fillCreditCardDetailsShortcode( page, config.get( 'cards.3ds' ) );
 	await clickPlaceOrder( page );
 
@@ -96,6 +106,9 @@ test( 'customer can retry payment, with changed billing details @smoke', async (
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 		'Order received'
 	);
+
+	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
+	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );
 
 /**
@@ -122,6 +135,9 @@ test( 'customer can retry payment, using a different payment method @smoke', asy
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 		'Order received'
 	);
+
+	// No charged-amount verification here: Cash App Pay is not a synchronous
+	// card capture, so the order has no "Paid"/Stripe Fee/Payout rows to check.
 } );
 
 /**

--- a/tests/e2e/tests/checkout/shortcode/retries.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/retries.spec.js
@@ -82,8 +82,6 @@ test( 'customer can retry payment, with changed billing details @smoke', async (
 	page,
 	browser,
 } ) => {
-	const expectedTotal = await getCartTotal( page );
-
 	await fillCreditCardDetailsShortcode( page, config.get( 'cards.3ds' ) );
 	await clickPlaceOrder( page );
 
@@ -92,6 +90,9 @@ test( 'customer can retry payment, with changed billing details @smoke', async (
 
 	// Change billing details
 	await page.fill( '#billing_postcode', '12345' );
+
+	// Get cart total after changing the zip/post code.
+	const expectedTotal = await getCartTotal( page );
 
 	// Retry the payment
 	await clickPlaceOrder( page );

--- a/tests/e2e/tests/checkout/shortcode/retries.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/retries.spec.js
@@ -91,7 +91,7 @@ test( 'customer can retry payment, with changed billing details @smoke', async (
 	// Change billing details
 	await page.fill( '#billing_postcode', '12345' );
 
-	// Get cart total after changing the zip/post code.
+	// Get cart total after changing the zip/post code to ensure current taxes and shipping are applied.
 	const expectedTotal = await getCartTotal( page );
 
 	// Retry the payment

--- a/tests/e2e/tests/checkout/shortcode/saved-card.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/saved-card.spec.js
@@ -9,6 +9,7 @@ const {
 	setupShortcodeCheckout,
 	fillCreditCardDetailsShortcode,
 	getCartTotal,
+	waitForOrderReceivedPageAndConfirmExpectedTotal,
 } = payments;
 
 let username, userEmail;
@@ -62,15 +63,9 @@ test( 'customer can checkout with a saved card @smoke', async ( {
 
 			await page.locator( 'text=Place order' ).dispatchEvent( 'click' );
 
-			await page.waitForNavigation();
-			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-				'Order received'
-			);
-
-			const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
-			await admin.verifyOrderChargedAmount(
+			await waitForOrderReceivedPageAndConfirmExpectedTotal(
 				browser,
-				orderId,
+				page,
 				expectedTotal
 			);
 		} );
@@ -91,15 +86,9 @@ test( 'customer can checkout with a saved card @smoke', async ( {
 
 			await page.locator( 'text=Place order' ).dispatchEvent( 'click' );
 
-			await page.waitForNavigation();
-			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-				'Order received'
-			);
-
-			const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
-			await admin.verifyOrderChargedAmount(
+			await waitForOrderReceivedPageAndConfirmExpectedTotal(
 				browser,
-				orderId,
+				page,
 				expectedTotal
 			);
 		} );

--- a/tests/e2e/tests/checkout/shortcode/saved-card.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/saved-card.spec.js
@@ -8,6 +8,7 @@ const {
 	setupCart,
 	setupShortcodeCheckout,
 	fillCreditCardDetailsShortcode,
+	getCartTotal,
 } = payments;
 
 let username, userEmail;
@@ -57,11 +58,20 @@ test( 'customer can checkout with a saved card @smoke', async ( {
 			// check box to save payment method.
 			await page.locator( '#wc-stripe-new-payment-method' ).click();
 
+			const expectedTotal = await getCartTotal( page );
+
 			await page.locator( 'text=Place order' ).dispatchEvent( 'click' );
 
 			await page.waitForNavigation();
 			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 				'Order received'
+			);
+
+			const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
+			await admin.verifyOrderChargedAmount(
+				browser,
+				orderId,
+				expectedTotal
 			);
 		} );
 
@@ -77,11 +87,20 @@ test( 'customer can checkout with a saved card @smoke', async ( {
 				)
 			).toHaveCount( 1 );
 
+			const expectedTotal = await getCartTotal( page );
+
 			await page.locator( 'text=Place order' ).dispatchEvent( 'click' );
 
 			await page.waitForNavigation();
 			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 				'Order received'
+			);
+
+			const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
+			await admin.verifyOrderChargedAmount(
+				browser,
+				orderId,
+				expectedTotal
 			);
 		} );
 	} finally {

--- a/tests/e2e/tests/checkout/shortcode/sca-card.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/sca-card.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import config from 'config';
-import { payments } from '../../../utils';
+import { admin, payments } from '../../../utils';
 
 const {
 	emptyCart,
@@ -8,9 +8,13 @@ const {
 	setupShortcodeCheckout,
 	fillCreditCardDetailsShortcode,
 	handleCheckout3DSChallenge,
+	getCartTotal,
 } = payments;
 
-test( 'customer can checkout with a SCA card @smoke', async ( { page } ) => {
+test( 'customer can checkout with a SCA card @smoke', async ( {
+	page,
+	browser,
+} ) => {
 	await emptyCart( page );
 	await setupCart( page );
 	await setupShortcodeCheckout(
@@ -18,6 +22,9 @@ test( 'customer can checkout with a SCA card @smoke', async ( { page } ) => {
 		config.get( 'addresses.customer.billing' )
 	);
 	await fillCreditCardDetailsShortcode( page, config.get( 'cards.3ds' ) );
+
+	const expectedTotal = await getCartTotal( page );
+
 	await page.locator( 'text=Place order' ).dispatchEvent( 'click' );
 
 	// Complete the 3DS challenge
@@ -28,4 +35,8 @@ test( 'customer can checkout with a SCA card @smoke', async ( { page } ) => {
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 		'Order received'
 	);
+
+	// As the admin, confirm the order was charged the expected amount.
+	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
+	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );

--- a/tests/e2e/tests/checkout/shortcode/sca-card.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/sca-card.spec.js
@@ -1,6 +1,6 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 import config from 'config';
-import { admin, payments } from '../../../utils';
+import { payments } from '../../../utils';
 
 const {
 	emptyCart,
@@ -9,6 +9,7 @@ const {
 	fillCreditCardDetailsShortcode,
 	handleCheckout3DSChallenge,
 	getCartTotal,
+	waitForOrderReceivedPageAndConfirmExpectedTotal,
 } = payments;
 
 test( 'customer can checkout with a SCA card @smoke', async ( {
@@ -30,13 +31,9 @@ test( 'customer can checkout with a SCA card @smoke', async ( {
 	// Complete the 3DS challenge
 	await handleCheckout3DSChallenge( page );
 
-	await page.waitForURL( '**/checkout/order-received/**' );
-
-	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-		'Order received'
+	await waitForOrderReceivedPageAndConfirmExpectedTotal(
+		browser,
+		page,
+		expectedTotal
 	);
-
-	// As the admin, confirm the order was charged the expected amount.
-	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
-	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );

--- a/tests/e2e/tests/checkout/shortcode/subscription-product.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/subscription-product.spec.js
@@ -1,12 +1,13 @@
 import { test, expect } from '@playwright/test';
 import { randomUUID } from 'crypto';
 import config from 'config';
-import { api, payments, products } from '../../../utils';
+import { admin, api, payments, products } from '../../../utils';
 
 const {
 	setupShortcodeCheckout,
 	fillCreditCardDetailsShortcode,
 	clickAddToCartButton,
+	getCartTotal,
 } = payments;
 
 let productId;
@@ -21,6 +22,7 @@ test.afterAll( async () => {
 
 test( 'customer can purchase a subscription product @smoke @subscriptions', async ( {
 	page,
+	browser,
 } ) => {
 	await page.goto( `?p=${ productId }` );
 	await clickAddToCartButton( page );
@@ -38,10 +40,16 @@ test( 'customer can purchase a subscription product @smoke @subscriptions', asyn
 	await setupShortcodeCheckout( page, customerData );
 	await fillCreditCardDetailsShortcode( page, config.get( 'cards.basic' ) );
 
+	const expectedTotal = await getCartTotal( page );
+
 	await page.locator( 'text=Place order' ).click();
 	await page.waitForURL( '**/checkout/order-received/**' );
 
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 		'Order received'
 	);
+
+	// As the admin, confirm the order was charged the expected amount.
+	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
+	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );

--- a/tests/e2e/tests/checkout/shortcode/subscription-product.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/subscription-product.spec.js
@@ -1,13 +1,14 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 import { randomUUID } from 'crypto';
 import config from 'config';
-import { admin, api, payments, products } from '../../../utils';
+import { api, payments, products } from '../../../utils';
 
 const {
 	setupShortcodeCheckout,
 	fillCreditCardDetailsShortcode,
 	clickAddToCartButton,
 	getCartTotal,
+	waitForOrderReceivedPageAndConfirmExpectedTotal,
 } = payments;
 
 let productId;
@@ -43,13 +44,10 @@ test( 'customer can purchase a subscription product @smoke @subscriptions', asyn
 	const expectedTotal = await getCartTotal( page );
 
 	await page.locator( 'text=Place order' ).click();
-	await page.waitForURL( '**/checkout/order-received/**' );
 
-	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-		'Order received'
+	await waitForOrderReceivedPageAndConfirmExpectedTotal(
+		browser,
+		page,
+		expectedTotal
 	);
-
-	// As the admin, confirm the order was charged the expected amount.
-	const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
-	await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 } );

--- a/tests/e2e/tests/orders/full-refund.spec.js
+++ b/tests/e2e/tests/orders/full-refund.spec.js
@@ -1,13 +1,14 @@
 import stripe from 'stripe';
 import { test, expect } from '@playwright/test';
 import config from 'config';
-import { api, payments } from '../../utils';
+import { admin, api, payments } from '../../utils';
 
 const {
 	emptyCart,
 	setupCart,
 	setupShortcodeCheckout,
 	fillCreditCardDetailsShortcode,
+	getCartTotal,
 } = payments;
 
 test( 'merchant can issue a full refund @smoke', async ( { browser } ) => {
@@ -33,6 +34,9 @@ test( 'merchant can issue a full refund @smoke', async ( { browser } ) => {
 			userPage,
 			config.get( 'cards.basic' )
 		);
+
+		const expectedTotal = await getCartTotal( userPage );
+
 		await userPage.locator( 'text=Place order' ).dispatchEvent( 'click' );
 		await userPage.waitForURL( '**/checkout/order-received/**' );
 
@@ -40,10 +44,12 @@ test( 'merchant can issue a full refund @smoke', async ( { browser } ) => {
 			'Order received'
 		);
 
-		const orderUrl = await userPage.url();
-		orderId = orderUrl.split( 'order-received/' )[ 1 ].split( '/?' )[ 0 ];
+		orderId = admin.getOrderIdFromOrderReceivedUrl( userPage.url() );
 
 		await userPage.close();
+
+		// Confirm the order was charged the expected amount before refunding.
+		await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 	} );
 
 	await test.step( 'merchant issue a full refund in the dashboard', async () => {

--- a/tests/e2e/tests/orders/full-refund.spec.js
+++ b/tests/e2e/tests/orders/full-refund.spec.js
@@ -9,6 +9,7 @@ const {
 	setupShortcodeCheckout,
 	fillCreditCardDetailsShortcode,
 	getCartTotal,
+	getOrderIdFromOrderReceivedUrl,
 	waitForOrderReceivedPageAndConfirmExpectedTotal,
 } = payments;
 
@@ -46,6 +47,8 @@ test( 'merchant can issue a full refund @smoke', async ( { browser } ) => {
 			userPage,
 			expectedTotal
 		);
+
+		orderId = getOrderIdFromOrderReceivedUrl( userPage.url() );
 
 		await userPage.close();
 	} );

--- a/tests/e2e/tests/orders/full-refund.spec.js
+++ b/tests/e2e/tests/orders/full-refund.spec.js
@@ -1,7 +1,7 @@
 import stripe from 'stripe';
 import { test, expect } from '@playwright/test';
 import config from 'config';
-import { admin, api, payments } from '../../utils';
+import { api, payments } from '../../utils';
 
 const {
 	emptyCart,
@@ -9,6 +9,7 @@ const {
 	setupShortcodeCheckout,
 	fillCreditCardDetailsShortcode,
 	getCartTotal,
+	waitForOrderReceivedPageAndConfirmExpectedTotal,
 } = payments;
 
 test( 'merchant can issue a full refund @smoke', async ( { browser } ) => {
@@ -38,18 +39,15 @@ test( 'merchant can issue a full refund @smoke', async ( { browser } ) => {
 		const expectedTotal = await getCartTotal( userPage );
 
 		await userPage.locator( 'text=Place order' ).dispatchEvent( 'click' );
-		await userPage.waitForURL( '**/checkout/order-received/**' );
-
-		await expect( userPage.locator( 'h1.entry-title' ) ).toHaveText(
-			'Order received'
-		);
-
-		orderId = admin.getOrderIdFromOrderReceivedUrl( userPage.url() );
-
-		await userPage.close();
 
 		// Confirm the order was charged the expected amount before refunding.
-		await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
+		await waitForOrderReceivedPageAndConfirmExpectedTotal(
+			browser,
+			userPage,
+			expectedTotal
+		);
+
+		await userPage.close();
 	} );
 
 	await test.step( 'merchant issue a full refund in the dashboard', async () => {

--- a/tests/e2e/tests/subscriptions/subscription-purchase-optimized-checkout.spec.js
+++ b/tests/e2e/tests/subscriptions/subscription-purchase-optimized-checkout.spec.js
@@ -1,7 +1,7 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 import { randomUUID } from 'crypto';
 import config from 'config';
-import { admin, api, payments, products, user } from '../../utils';
+import { api, payments, products, user } from '../../utils';
 
 const {
 	emptyCart,
@@ -10,6 +10,7 @@ const {
 	fillOCDetails,
 	clickPlaceOrder,
 	getCartTotal,
+	waitForOrderReceivedPageAndConfirmExpectedTotal,
 } = payments;
 
 let productId;
@@ -71,14 +72,12 @@ test.describe( 'Optimized Checkout subscription purchase tests @subscriptions', 
 		const expectedTotal = await getCartTotal( page );
 
 		await clickPlaceOrder( page );
-		await page.waitForURL( '**/checkout/order-received/**' );
-		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-			'Order received'
-		);
 
-		// As the admin, confirm the order was charged the expected amount.
-		const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
-		await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
+		await waitForOrderReceivedPageAndConfirmExpectedTotal(
+			browser,
+			page,
+			expectedTotal
+		);
 	}
 
 	test( 'customer can purchase a subscription with Optimized Checkout @smoke @blocks', async ( {

--- a/tests/e2e/tests/subscriptions/subscription-purchase-optimized-checkout.spec.js
+++ b/tests/e2e/tests/subscriptions/subscription-purchase-optimized-checkout.spec.js
@@ -9,12 +9,10 @@ const {
 	setupOptimizedCheckout,
 	fillOCDetails,
 	clickPlaceOrder,
+	getCartTotal,
 } = payments;
 
 let productId;
-
-// Subscription product ($9.99) + flat-rate shipping ($10.00).
-const EXPECTED_ORDER_TOTAL = '19.99';
 
 test.describe( 'Optimized Checkout subscription purchase tests @subscriptions', () => {
 	test.beforeAll( async () => {
@@ -70,6 +68,8 @@ test.describe( 'Optimized Checkout subscription purchase tests @subscriptions', 
 		} );
 		await fillOCDetails( page, config.get( 'cards.basic' ), checkoutType );
 
+		const expectedTotal = await getCartTotal( page );
+
 		await clickPlaceOrder( page );
 		await page.waitForURL( '**/checkout/order-received/**' );
 		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
@@ -78,11 +78,7 @@ test.describe( 'Optimized Checkout subscription purchase tests @subscriptions', 
 
 		// As the admin, confirm the order was charged the expected amount.
 		const orderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
-		await admin.verifyOrderChargedAmount(
-			browser,
-			orderId,
-			EXPECTED_ORDER_TOTAL
-		);
+		await admin.verifyOrderChargedAmount( browser, orderId, expectedTotal );
 	}
 
 	test( 'customer can purchase a subscription with Optimized Checkout @smoke @blocks', async ( {

--- a/tests/e2e/tests/subscriptions/subscription-renewal-optimized-checkout.spec.js
+++ b/tests/e2e/tests/subscriptions/subscription-renewal-optimized-checkout.spec.js
@@ -10,6 +10,8 @@ const {
 	fillOCDetails,
 	clickPlaceOrder,
 	getCartTotal,
+	getOrderIdFromOrderReceivedUrl,
+	waitForOrderReceivedPage,
 } = payments;
 
 let productId;
@@ -66,12 +68,9 @@ test.describe( 'Optimized Checkout subscription renewal tests @subscriptions', (
 			await page.locator( '#place_order' ).click();
 		}
 
-		await page.waitForURL( '**/order-received/**' );
-		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-			'Order received'
-		);
+		await waitForOrderReceivedPage( page );
 
-		return admin.getOrderIdFromOrderReceivedUrl( page.url() );
+		return getOrderIdFromOrderReceivedUrl( page.url() );
 	}
 
 	/**
@@ -128,14 +127,9 @@ test.describe( 'Optimized Checkout subscription renewal tests @subscriptions', (
 			purchaseTotal = await getCartTotal( page );
 
 			await clickPlaceOrder( page );
-			await page.waitForURL( '**/checkout/order-received/**' );
-			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-				'Order received'
-			);
+			await waitForOrderReceivedPage( page );
 
-			purchaseOrderId = admin.getOrderIdFromOrderReceivedUrl(
-				page.url()
-			);
+			purchaseOrderId = getOrderIdFromOrderReceivedUrl( page.url() );
 		} );
 
 		await test.step( 'customer renews the subscription', async () => {

--- a/tests/e2e/tests/subscriptions/subscription-renewal-optimized-checkout.spec.js
+++ b/tests/e2e/tests/subscriptions/subscription-renewal-optimized-checkout.spec.js
@@ -9,12 +9,10 @@ const {
 	setupOptimizedCheckout,
 	fillOCDetails,
 	clickPlaceOrder,
+	getCartTotal,
 } = payments;
 
 let productId;
-
-// Subscription product ($9.99) + flat-rate shipping ($10.00).
-const EXPECTED_ORDER_TOTAL = '19.99';
 
 const relatedOrdersRow = '.woocommerce-orders-table--orders tbody tr';
 
@@ -100,7 +98,7 @@ test.describe( 'Optimized Checkout subscription renewal tests @subscriptions', (
 			username,
 		} );
 
-		let purchaseOrderId, renewalOrderId;
+		let purchaseOrderId, renewalOrderId, purchaseTotal, renewalTotal;
 
 		await test.step( 'customer login', async () => {
 			await user.login(
@@ -126,6 +124,8 @@ test.describe( 'Optimized Checkout subscription renewal tests @subscriptions', (
 				config.get( 'cards.basic' ),
 				checkoutType
 			);
+
+			purchaseTotal = await getCartTotal( page );
 
 			await clickPlaceOrder( page );
 			await page.waitForURL( '**/checkout/order-received/**' );
@@ -154,6 +154,9 @@ test.describe( 'Optimized Checkout subscription renewal tests @subscriptions', (
 				await page.goto( '/checkout-shortcode/' );
 			}
 
+			// Capture the renewal total shown to the shopper before renewing.
+			renewalTotal = await getCartTotal( page );
+
 			renewalOrderId = await completeRenewal( page, checkoutType );
 		} );
 
@@ -169,12 +172,12 @@ test.describe( 'Optimized Checkout subscription renewal tests @subscriptions', (
 			await admin.verifyOrderChargedAmount(
 				browser,
 				purchaseOrderId,
-				EXPECTED_ORDER_TOTAL
+				purchaseTotal
 			);
 			await admin.verifyOrderChargedAmount(
 				browser,
 				renewalOrderId,
-				EXPECTED_ORDER_TOTAL
+				renewalTotal
 			);
 		} );
 	}

--- a/tests/e2e/tests/subscriptions/subscription-renewal.spec.js
+++ b/tests/e2e/tests/subscriptions/subscription-renewal.spec.js
@@ -1,12 +1,13 @@
 import { test, expect } from '@playwright/test';
 import { randomUUID } from 'crypto';
 import config from 'config';
-import { api, payments, products, user } from '../../utils';
+import { admin, api, payments, products, user } from '../../utils';
 
 const {
 	setupShortcodeCheckout,
 	fillCreditCardDetailsShortcode,
 	clickAddToCartButton,
+	getCartTotal,
 } = payments;
 
 let productId;
@@ -36,7 +37,10 @@ test.afterAll( async () => {
 
 test( 'customer can renew a subscription @smoke @subscriptions', async ( {
 	page,
+	browser,
 } ) => {
+	let purchaseOrderId, renewalOrderId, purchaseTotal, renewalTotal;
+
 	await test.step( 'customer login', async () => {
 		await user.login(
 			page,
@@ -55,11 +59,15 @@ test( 'customer can renew a subscription @smoke @subscriptions', async ( {
 			config.get( 'cards.basic' )
 		);
 
+		purchaseTotal = await getCartTotal( page );
+
 		await page.locator( 'text=Place order' ).click();
 
 		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 			'Order received'
 		);
+
+		purchaseOrderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
 	} );
 
 	await test.step( 'customer renews the subscription', async () => {
@@ -73,6 +81,10 @@ test( 'customer can renew a subscription @smoke @subscriptions', async ( {
 
 		await page.click( 'text=Renew now' );
 		await page.waitForURL( '**/checkout/' );
+
+		// Capture the renewal total shown to the shopper before renewing.
+		renewalTotal = await getCartTotal( page );
+
 		await page.click(
 			'input[id^="radio-control-wc-payment-method-saved-tokens-"]'
 		);
@@ -82,6 +94,8 @@ test( 'customer can renew a subscription @smoke @subscriptions', async ( {
 		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 			'Order received'
 		);
+
+		renewalOrderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
 	} );
 
 	await test.step( 'check for new entry in the related orders table', async () => {
@@ -92,5 +106,18 @@ test( 'customer can renew a subscription @smoke @subscriptions', async ( {
 		await expect(
 			page.locator( '.woocommerce-orders-table--orders tbody tr' )
 		).toHaveCount( 2 );
+	} );
+
+	await test.step( 'admin confirms the expected amounts were charged', async () => {
+		await admin.verifyOrderChargedAmount(
+			browser,
+			purchaseOrderId,
+			purchaseTotal
+		);
+		await admin.verifyOrderChargedAmount(
+			browser,
+			renewalOrderId,
+			renewalTotal
+		);
 	} );
 } );

--- a/tests/e2e/tests/subscriptions/subscription-renewal.spec.js
+++ b/tests/e2e/tests/subscriptions/subscription-renewal.spec.js
@@ -62,6 +62,7 @@ test( 'customer can renew a subscription @smoke @subscriptions', async ( {
 		purchaseTotal = await getCartTotal( page );
 
 		await page.locator( 'text=Place order' ).click();
+		await page.waitForURL( '**/checkout/order-received/**' );
 
 		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 			'Order received'
@@ -91,6 +92,7 @@ test( 'customer can renew a subscription @smoke @subscriptions', async ( {
 		await page
 			.locator( 'text=Renew subscription' )
 			.dispatchEvent( 'click' );
+		await page.waitForURL( '**/order-received/**' );
 		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 			'Order received'
 		);

--- a/tests/e2e/tests/subscriptions/subscription-renewal.spec.js
+++ b/tests/e2e/tests/subscriptions/subscription-renewal.spec.js
@@ -8,6 +8,8 @@ const {
 	fillCreditCardDetailsShortcode,
 	clickAddToCartButton,
 	getCartTotal,
+	waitForOrderReceivedPage,
+	getOrderIdFromOrderReceivedUrl,
 } = payments;
 
 let productId;
@@ -62,13 +64,9 @@ test( 'customer can renew a subscription @smoke @subscriptions', async ( {
 		purchaseTotal = await getCartTotal( page );
 
 		await page.locator( 'text=Place order' ).click();
-		await page.waitForURL( '**/checkout/order-received/**' );
+		await waitForOrderReceivedPage( page );
 
-		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-			'Order received'
-		);
-
-		purchaseOrderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
+		purchaseOrderId = getOrderIdFromOrderReceivedUrl( page.url() );
 	} );
 
 	await test.step( 'customer renews the subscription', async () => {
@@ -92,12 +90,9 @@ test( 'customer can renew a subscription @smoke @subscriptions', async ( {
 		await page
 			.locator( 'text=Renew subscription' )
 			.dispatchEvent( 'click' );
-		await page.waitForURL( '**/order-received/**' );
-		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-			'Order received'
-		);
+		await waitForOrderReceivedPage( page );
 
-		renewalOrderId = admin.getOrderIdFromOrderReceivedUrl( page.url() );
+		renewalOrderId = getOrderIdFromOrderReceivedUrl( page.url() );
 	} );
 
 	await test.step( 'check for new entry in the related orders table', async () => {

--- a/tests/e2e/utils/admin.js
+++ b/tests/e2e/utils/admin.js
@@ -147,15 +147,6 @@ export const initializeOptimizedCheckout = async (
 };
 
 /**
- * Extract the order ID from a WooCommerce "Order received" page URL.
- *
- * @param {string} url The order-received URL (e.g. `.../order-received/123/?key=...`).
- * @returns {string} The order ID.
- */
-export const getOrderIdFromOrderReceivedUrl = ( url ) =>
-	url.split( 'order-received/' )[ 1 ].split( '/' )[ 0 ];
-
-/**
  * Open the admin order edit page for an order and confirm the expected amount
  * was charged.
  *

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -1156,7 +1156,8 @@ export const setupKlarnaCheckout = async ( page, checkoutType = 'blocks' ) => {
 };
 
 /**
- * Extract the order ID from a WooCommerce "Order received" page URL.
+ * Helper method to extract the order ID from a WooCommerce "Order received" page URL.
+ * This is used to discover a recently purchased order ID from the order-received page URL.
  *
  * @param {string} url The order-received URL (e.g. `.../order-received/123/?key=...`).
  * @returns {string} The order ID.

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -91,6 +91,23 @@ export async function setupCart(
 }
 
 /**
+ * Get the current cart total from the WooCommerce Store Cart API.
+ *
+ * Must be called before placing the order while the cart still has items.
+ *
+ * @param {Page} page Playwright page fixture.
+ * @returns {Promise<string>} The cart total without currency symbol (e.g. "19.99").
+ */
+export async function getCartTotal( page ) {
+	const response = await page.request.get( '/wp-json/wc/store/v1/cart' );
+	const { total_price: totalPrice, currency_minor_unit: minorUnit } = (
+		await response.json()
+	).totals;
+
+	return ( parseInt( totalPrice, 10 ) / 10 ** minorUnit ).toFixed( 2 );
+}
+
+/**
  * Wait for Stripe iframe to be fully loaded and ready for interaction.
  * This helper addresses common race conditions with Stripe Elements.
  *

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test';
 import config from 'config';
+import { verifyOrderChargedAmount } from './admin';
 
 /**
  * Click the primary add to cart button for the current page.
@@ -1151,5 +1152,41 @@ export const setupKlarnaCheckout = async ( page, checkoutType = 'blocks' ) => {
 				)
 				.getByTestId( 'next-action-text' )
 		).toBeVisible();
+
+		/**
+		 * Extract the order ID from a WooCommerce "Order received" page URL.
+		 *
+		 * @param {string} url The order-received URL (e.g. `.../order-received/123/?key=...`).
+		 * @returns {string} The order ID.
+		 */
+		export const getOrderIdFromOrderReceivedUrl = ( url ) =>
+			url.split( 'order-received/' )[ 1 ].split( '/' )[ 0 ];
+
+		export const waitForOrderReceivedPage = async ( page ) => {
+			await page.waitForURL( '**/checkout/order-received/**' );
+
+			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
+				'Order received'
+			);
+		};
+
+		/**
+		 * Wait for the order received page to load and optionally confirm the expected total amount was charged.
+		 *
+		 * @param {Browser} browser       Playwright browser fixture.
+		 * @param {Page}    page          Playwright page fixture.
+		 * @param {string}  expectedTotal The expected total amount of the order.
+		 */
+		export const waitForOrderReceivedPageAndConfirmExpectedTotal = async (
+			browser,
+			page,
+			expectedTotal
+		) => {
+			await waitForOrderReceivedPage( page );
+
+			const orderId = getOrderIdFromOrderReceivedUrl( page.url() );
+
+			await verifyOrderChargedAmount( browser, orderId, expectedTotal );
+		};
 	}
 };

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -100,6 +100,13 @@ export async function setupCart(
  */
 export async function getCartTotal( page ) {
 	const response = await page.request.get( '/wp-json/wc/store/v1/cart' );
+	if ( ! response.ok() ) {
+		const responseText = await response.text();
+		throw new Error(
+			`Failed to fetch cart total: ${ response.status() } ${ response.statusText() } -- ${ responseText }`
+		);
+	}
+
 	const { total_price: totalPrice, currency_minor_unit: minorUnit } = (
 		await response.json()
 	).totals;

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -211,12 +211,17 @@ export async function retryWithBackoff( fn, options = {} ) {
  * @param {Object} card The CC info in the format provided on the test-data.
  */
 export async function fillCreditCardDetails( page, card ) {
-	// Get first frame, as Stripe can include a secondary bank search iframe.
-	const form = await page
-		.frameLocator(
+	// Stripe may inject a second iframe for bank details, so
+	// we require a visible frame to avoid picking the wrong one.
+	const paymentIframe = page
+		.locator(
 			'.wcstripe-payment-element iframe[name^="__privateStripeFrame"]'
 		)
+		.filter( { visible: true } )
 		.first();
+	await paymentIframe.waitFor( { state: 'visible', timeout: 10000 } );
+
+	const form = paymentIframe.contentFrame();
 
 	await form.locator( '[name="number"]' ).fill( card.number );
 

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -111,7 +111,9 @@ export async function getCartTotal( page ) {
 		await response.json()
 	).totals;
 
-	return ( parseInt( totalPrice, 10 ) / 10 ** minorUnit ).toFixed( 2 );
+	return ( parseInt( totalPrice, 10 ) / 10 ** minorUnit ).toFixed(
+		minorUnit
+	);
 }
 
 /**

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -1152,41 +1152,41 @@ export const setupKlarnaCheckout = async ( page, checkoutType = 'blocks' ) => {
 				)
 				.getByTestId( 'next-action-text' )
 		).toBeVisible();
-
-		/**
-		 * Extract the order ID from a WooCommerce "Order received" page URL.
-		 *
-		 * @param {string} url The order-received URL (e.g. `.../order-received/123/?key=...`).
-		 * @returns {string} The order ID.
-		 */
-		export const getOrderIdFromOrderReceivedUrl = ( url ) =>
-			url.split( 'order-received/' )[ 1 ].split( '/' )[ 0 ];
-
-		export const waitForOrderReceivedPage = async ( page ) => {
-			await page.waitForURL( '**/checkout/order-received/**' );
-
-			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
-				'Order received'
-			);
-		};
-
-		/**
-		 * Wait for the order received page to load and optionally confirm the expected total amount was charged.
-		 *
-		 * @param {Browser} browser       Playwright browser fixture.
-		 * @param {Page}    page          Playwright page fixture.
-		 * @param {string}  expectedTotal The expected total amount of the order.
-		 */
-		export const waitForOrderReceivedPageAndConfirmExpectedTotal = async (
-			browser,
-			page,
-			expectedTotal
-		) => {
-			await waitForOrderReceivedPage( page );
-
-			const orderId = getOrderIdFromOrderReceivedUrl( page.url() );
-
-			await verifyOrderChargedAmount( browser, orderId, expectedTotal );
-		};
 	}
+};
+
+/**
+ * Extract the order ID from a WooCommerce "Order received" page URL.
+ *
+ * @param {string} url The order-received URL (e.g. `.../order-received/123/?key=...`).
+ * @returns {string} The order ID.
+ */
+export const getOrderIdFromOrderReceivedUrl = ( url ) =>
+	url.split( 'order-received/' )[ 1 ].split( '/' )[ 0 ];
+
+export const waitForOrderReceivedPage = async ( page ) => {
+	await page.waitForURL( '**/checkout/order-received/**' );
+
+	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
+		'Order received'
+	);
+};
+
+/**
+ * Wait for the order received page to load and optionally confirm the expected total amount was charged.
+ *
+ * @param {Browser} browser       Playwright browser fixture.
+ * @param {Page}    page          Playwright page fixture.
+ * @param {string}  expectedTotal The expected total amount of the order.
+ */
+export const waitForOrderReceivedPageAndConfirmExpectedTotal = async (
+	browser,
+	page,
+	expectedTotal
+) => {
+	await waitForOrderReceivedPage( page );
+
+	const orderId = getOrderIdFromOrderReceivedUrl( page.url() );
+
+	await verifyOrderChargedAmount( browser, orderId, expectedTotal );
 };

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -194,9 +194,12 @@ export async function retryWithBackoff( fn, options = {} ) {
  * @param {Object} card The CC info in the format provided on the test-data.
  */
 export async function fillCreditCardDetails( page, card ) {
-	const form = await page.frameLocator(
-		'.wcstripe-payment-element iframe[name^="__privateStripeFrame"]'
-	);
+	// Get first frame, as Stripe can include a secondary bank search iframe.
+	const form = await page
+		.frameLocator(
+			'.wcstripe-payment-element iframe[name^="__privateStripeFrame"]'
+		)
+		.first();
 
 	await form.locator( '[name="number"]' ).fill( card.number );
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Towards STRIPE-1131
Related to #5518

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR builds on the early work in #5518 to verify that orders have been successfully processed and have the expected amounts across more of our e2e test suite. That first PR only implemented the checks for Optimized Checkout Suite tests involving subscriptions, while this PR rolls out the checks across more of our tests.

In addition to the existing code, this PR also uses the Store Cart API to dynamically get the expected purchase price based on the current cart contents, which we then use as the expected order total after completing the purchase.

Furthermore, this PR also rolls out two helper methods to support simpler, more consistent tests:
 * `waitForOrderReceivedPage()` - wait for the order received page to be loaded and confirm the order was successful
 * `waitForOrderReceivedPageAndConfirmExpectedTotal()` - wait for the order received page, confirm the order was successful, and then call `getOrderIdFromOrderReceivedUrl()` and `verifyOrderChargedAmount()` helpers to verify the charge was successful and for the correct amount.

As a minor improvement, this PR also adds a stricter selector for the credit card iframe used in block checkout, as I noticed that Stripe may generate a second iframe to search for bank details for US accounts when Link is enabled, and the `FrameLocator` API results in failures when multiple elements are returned.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

* Code inspection
* Verify that the e2e tests are passing

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
