### PR TITLE
 Prevent Adaptive Pricing from being enabled when Stripe webhooks aren't working

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,7 +16,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Append the 3-letter currency code to the Stripe Fee and Stripe Payout amounts in WP Admin order totals when the Stripe account currency differs from the order currency
 * Fix - Only create an agentic commerce order on the site that produced the checkout, preventing duplicate or wrong-site orders when multiple stores share one Stripe account
 * Dev - Add a Code Comment Conventions section to AGENTS.md to standardize agent and contributor comment guidance
-* Fix - Disable Adaptive Pricing when webhooks are disable
+* Fix - Disable Adaptive Pricing when webhooks are disabled
 
 2026-06-11 - version 10.8.1
 * Fix - Prevent a fatal error when a Bancontact, iDEAL or Sofort payment is placed with SEPA token saving enabled through the Adaptive Pricing checkout, which left the order unpaid

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Append the 3-letter currency code to the Stripe Fee and Stripe Payout amounts in WP Admin order totals when the Stripe account currency differs from the order currency
 * Fix - Only create an agentic commerce order on the site that produced the checkout, preventing duplicate or wrong-site orders when multiple stores share one Stripe account
 * Dev - Add a Code Comment Conventions section to AGENTS.md to standardize agent and contributor comment guidance
+* Fix - Disable Adaptive Pricing when webhooks are disable
 
 2026-06-11 - version 10.8.1
 * Fix - Prevent a fatal error when a Bancontact, iDEAL or Sofort payment is placed with SEPA token saving enabled through the Adaptive Pricing checkout, which left the order unpaid

--- a/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
+++ b/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
@@ -96,6 +96,27 @@ describe( 'Optimized Checkout Element feature setting', () => {
 		} );
 	} );
 
+	it( 'disables Adaptive Pricing and explains why when webhooks are disabled', () => {
+		global.wc_stripe_settings_params = {
+			is_cs_available: true,
+			adaptive_pricing_unavailable_reason: 'webhooks-disabled',
+		};
+
+		useIsOCEnabled.mockReturnValue( [ true, jest.fn() ] );
+
+		render( <OptimizedCheckoutFeature isOCAvailable={ true } /> );
+
+		expect(
+			screen.getByText( /Adaptive Pricing requires working webhooks/i )
+		).toBeInTheDocument();
+
+		expect(
+			screen.getByLabelText(
+				'Let customers pay in their local currency with Adaptive Pricing'
+			)
+		).toBeDisabled();
+	} );
+
 	it( 'triggers the hook when changing the Adaptive Pricing setting', async () => {
 		global.wc_stripe_settings_params = {
 			is_cs_available: true,

--- a/client/settings/advanced-settings-section/optimized-checkout-feature.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-feature.js
@@ -69,6 +69,11 @@ const getAdaptivePricingUnavailableText = (
 				'Adaptive Pricing is unavailable as your account does not support settlement in your store currency.',
 				'woocommerce-gateway-stripe'
 			);
+		case 'webhooks-disabled':
+			return __(
+				'Adaptive Pricing requires working webhooks. Your Stripe webhooks are currently disabled, so it can’t be enabled.',
+				'woocommerce-gateway-stripe'
+			);
 		default:
 			return __(
 				'Adaptive Pricing is currently unavailable.',

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1190,6 +1190,10 @@ class WC_Stripe_Helper {
 			return 'account-country';
 		}
 
+		if ( ! $stripe_account->is_webhook_enabled() ) {
+			return 'webhooks-disabled';
+		}
+
 		// If we are in test mode, payout details are often missing and currency-based rules
 		// are not enforced.
 		if ( WC_Stripe_Mode::is_test() ) {

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -303,14 +303,8 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 
 			$this->clear_caches_after_key_update();
 
-			// Runs after the keys are saved: the Adaptive Pricing decision needs the account data.
 			if ( 'connect' === $type && $should_default_optimized_checkout_on ) {
 				$options['optimized_checkout_element'] = 'yes';
-				if ( WC_Stripe_Helper::is_adaptive_pricing_available_for_account() ) {
-					$options['adaptive_pricing'] = 'yes';
-				} else {
-					WC_Stripe_Logger::info( 'OAuth: Not defaulting Adaptive Pricing on; it is not available for the connected account.' );
-				}
 				WC_Stripe_Helper::update_main_stripe_settings( $options );
 			}
 
@@ -353,6 +347,19 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			} finally {
 				// Ensure we reset the key before we do anything else.
 				WC_Stripe_API::set_secret_key( '' );
+			}
+
+			// Default Adaptive Pricing on for first-time connections, now that webhooks have been
+			// configured above. AP requires a working webhook endpoint, so this decision must run after
+			// configure_webhooks()
+			if ( 'connect' === $type && $should_default_optimized_checkout_on ) {
+				if ( WC_Stripe_Helper::is_adaptive_pricing_available_for_account() ) {
+					$settings                     = WC_Stripe_Helper::get_stripe_settings();
+					$settings['adaptive_pricing'] = 'yes';
+					WC_Stripe_Helper::update_main_stripe_settings( $settings );
+				} else {
+					WC_Stripe_Logger::info( 'OAuth: Not defaulting Adaptive Pricing on; it is not available for the connected account.' );
+				}
 			}
 
 			return $result;

--- a/readme.txt
+++ b/readme.txt
@@ -171,5 +171,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Append the 3-letter currency code to the Stripe Fee and Stripe Payout amounts in WP Admin order totals when the Stripe account currency differs from the order currency
 * Fix - Only create an agentic commerce order on the site that produced the checkout, preventing duplicate or wrong-site orders when multiple stores share one Stripe account
 * Dev - Add a Code Comment Conventions section to AGENTS.md to standardize agent and contributor comment guidance
+* Fix - Disable Adaptive Pricing when webhooks are disable
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -171,6 +171,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Append the 3-letter currency code to the Stripe Fee and Stripe Payout amounts in WP Admin order totals when the Stripe account currency differs from the order currency
 * Fix - Only create an agentic commerce order on the site that produced the checkout, preventing duplicate or wrong-site orders when multiple stores share one Stripe account
 * Dev - Add a Code Comment Conventions section to AGENTS.md to standardize agent and contributor comment guidance
-* Fix - Disable Adaptive Pricing when webhooks are disable
+* Fix - Disable Adaptive Pricing when webhooks are disabled
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/admin/class-wc-stripe-settings-controller-test.php
+++ b/tests/phpunit/admin/class-wc-stripe-settings-controller-test.php
@@ -145,6 +145,9 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 				->disableOriginalConstructor()
 				->getMock();
 			$account->method( 'get_account_country' )->willReturn( $account_country );
+			// Adaptive Pricing availability now also depends on webhooks; enable them so this test
+			// isolates the country-restriction logic it covers.
+			$account->method( 'is_webhook_enabled' )->willReturn( true );
 
 			$stripe_singleton_account_backup   = WC_Stripe::get_instance()->account;
 			WC_Stripe::get_instance()->account = $account;

--- a/tests/phpunit/class-wc-stripe-connect-test.php
+++ b/tests/phpunit/class-wc-stripe-connect-test.php
@@ -62,7 +62,14 @@ class WC_Stripe_Connect_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			delete_option( 'wc_stripe_optimized_checkout_default_on' );
 		}
 
-		$this->set_stripe_account_data( [ 'country' => $account_country ] );
+		$account = $this->getMockBuilder( WC_Stripe_Account::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_cached_account_data', 'maybe_decommission_webhook', 'configure_webhooks', 'clear_cache', 'is_webhook_enabled' ] )
+			->getMock();
+		$account->method( 'get_cached_account_data' )->willReturn( [ 'country' => $account_country ] );
+		$account->method( 'maybe_decommission_webhook' )->willReturn( false );
+		$account->method( 'is_webhook_enabled' )->willReturn( true );
+		WC_Stripe::get_instance()->account = $account;
 
 		$result                 = new stdClass();
 		$result->publishableKey = 'pk_test_123'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -1743,17 +1743,37 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 * @param array  $cart_product_types Cart product types (e.g. ['simple'], ['simple','simple'], ['simple','simple','subscription']). Empty or null = empty cart.
 	 * @param bool   $expected           Expected result.
 	 * @param string $account_country    Two-letter ISO country code for the Stripe account. Defaults to 'US'.
+	 * @param bool   $webhook_enabled    Whether the Stripe webhook endpoint is enabled. Defaults to true.
 	 * @return void
 	 * @dataProvider provide_is_adaptive_pricing_supported
 	 */
-	public function test_is_adaptive_pricing_supported( bool $is_checkout, bool $has_block, string $adaptive_pricing, ?array $cart_product_types, bool $expected, string $account_country = 'US' ): void {
+	public function test_is_adaptive_pricing_supported( bool $is_checkout, bool $has_block, string $adaptive_pricing, ?array $cart_product_types, bool $expected, string $account_country = 'US', bool $webhook_enabled = true ): void {
 		$original_stripe_settings                          = WC_Stripe_Helper::get_stripe_settings();
 		$new_stripe_settings                               = $original_stripe_settings;
 		$new_stripe_settings['adaptive_pricing']           = $adaptive_pricing;
 		$new_stripe_settings['optimized_checkout_element'] = 'yes';
 		$new_stripe_settings['capture']                    = 'yes';
 		$new_stripe_settings['pmc_enabled']                = 'yes';
+		if ( $webhook_enabled ) {
+			$new_stripe_settings['webhook_data']      = [
+				'id'     => 'we_live',
+				'secret' => 'whsec_live',
+			];
+			$new_stripe_settings['test_webhook_data'] = [
+				'id'     => 'we_test',
+				'secret' => 'whsec_test',
+			];
+		}
 		WC_Stripe_Helper::update_main_stripe_settings( $new_stripe_settings );
+
+		// is_webhook_enabled() short-circuits on a cached status, so we don't hit the Stripe API here.
+		if ( $webhook_enabled ) {
+			set_transient( WC_Stripe_Account::LIVE_WEBHOOK_STATUS_OPTION, 'enabled', HOUR_IN_SECONDS );
+			set_transient( WC_Stripe_Account::TEST_WEBHOOK_STATUS_OPTION, 'enabled', HOUR_IN_SECONDS );
+		} else {
+			delete_transient( WC_Stripe_Account::LIVE_WEBHOOK_STATUS_OPTION );
+			delete_transient( WC_Stripe_Account::TEST_WEBHOOK_STATUS_OPTION );
+		}
 
 		$is_checkout_filter = function () use ( $is_checkout ) {
 			return $is_checkout;
@@ -1812,6 +1832,8 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 
 		remove_filter( 'woocommerce_is_checkout', $is_checkout_filter );
 		WC_Stripe_Helper::update_main_stripe_settings( $original_stripe_settings );
+		delete_transient( WC_Stripe_Account::LIVE_WEBHOOK_STATUS_OPTION );
+		delete_transient( WC_Stripe_Account::TEST_WEBHOOK_STATUS_OPTION );
 		\WC_Subscriptions_Product::set_is_subscription( false );
 		\WC_Subscriptions_Product::set_subscription_product_ids( [] );
 		\WC_Pre_Orders_Product::set_is_pre_order_charged_upon_release( false );
@@ -1929,6 +1951,15 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'expected'           => true,
 				'account_country'    => 'US',
 			],
+			'webhooks disabled'                         => [
+				'is_checkout'        => true,
+				'has_block'          => false,
+				'adaptive_pricing'   => 'yes',
+				'cart_product_types' => [ 'simple' ],
+				'expected'           => false,
+				'account_country'    => 'US',
+				'webhook_enabled'    => false,
+			],
 		];
 	}
 
@@ -1976,6 +2007,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 * @param bool    $test_mode       Whether Stripe test mode is enabled.
 	 * @param string  $store_currency  WooCommerce store currency code.
 	 * @param ?string $expected        Expected return value.
+	 * @param bool    $webhook_enabled Whether the Stripe webhook endpoint is enabled. Defaults to true.
 	 * @return void
 	 * @dataProvider provide_test_get_adaptive_pricing_account_unavailable_reason
 	 */
@@ -1983,12 +2015,32 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		array $account_data,
 		bool $test_mode,
 		string $store_currency,
-		?string $expected
+		?string $expected,
+		bool $webhook_enabled = true
 	): void {
 		$original_settings    = WC_Stripe_Helper::get_stripe_settings();
 		$settings             = $original_settings;
 		$settings['testmode'] = $test_mode ? 'yes' : 'no';
+		if ( $webhook_enabled ) {
+			$settings['webhook_data']      = [
+				'id'     => 'we_live',
+				'secret' => 'whsec_live',
+			];
+			$settings['test_webhook_data'] = [
+				'id'     => 'we_test',
+				'secret' => 'whsec_test',
+			];
+		}
 		WC_Stripe_Helper::update_main_stripe_settings( $settings );
+
+		// is_webhook_enabled() short-circuits on a cached status, so we don't hit the Stripe API here.
+		if ( $webhook_enabled ) {
+			set_transient( WC_Stripe_Account::LIVE_WEBHOOK_STATUS_OPTION, 'enabled', HOUR_IN_SECONDS );
+			set_transient( WC_Stripe_Account::TEST_WEBHOOK_STATUS_OPTION, 'enabled', HOUR_IN_SECONDS );
+		} else {
+			delete_transient( WC_Stripe_Account::LIVE_WEBHOOK_STATUS_OPTION );
+			delete_transient( WC_Stripe_Account::TEST_WEBHOOK_STATUS_OPTION );
+		}
 
 		$this->set_stripe_account_data( $account_data );
 
@@ -2000,6 +2052,8 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		// Cleanup.
 		update_option( 'woocommerce_currency', $original_currency );
 		WC_Stripe_Helper::update_main_stripe_settings( $original_settings );
+		delete_transient( WC_Stripe_Account::LIVE_WEBHOOK_STATUS_OPTION );
+		delete_transient( WC_Stripe_Account::TEST_WEBHOOK_STATUS_OPTION );
 
 		$this->assertSame( $expected, $actual );
 	}
@@ -2011,7 +2065,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 */
 	public function provide_test_get_adaptive_pricing_account_unavailable_reason(): array {
 		return [
-			'India account (uppercase) → account-country'                             => [
+			'India account (uppercase) → account-country'                                   => [
 				'account_data'   => [
 					'country'           => 'IN',
 					'external_accounts' => [
@@ -2024,7 +2078,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'store_currency' => 'USD',
 				'expected'       => 'account-country',
 			],
-			'India account (lowercase) → account-country'                             => [
+			'India account (lowercase) → account-country'                                   => [
 				'account_data'   => [
 					'country'           => 'in',
 					'external_accounts' => [
@@ -2037,7 +2091,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'store_currency' => 'USD',
 				'expected'       => 'account-country',
 			],
-			'India account + test mode → account-country (India checked before mode)' => [
+			'India account + test mode → account-country (India checked before mode)'       => [
 				'account_data'   => [
 					'country'           => 'IN',
 					'external_accounts' => [
@@ -2048,7 +2102,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'store_currency' => 'USD',
 				'expected'       => 'account-country',
 			],
-			'Test mode, no settlement currencies → null (currency check bypassed)'    => [
+			'Test mode, no settlement currencies → null (currency check bypassed)'          => [
 				'account_data'   => [
 					'country'           => 'US',
 					'external_accounts' => [
@@ -2059,7 +2113,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'store_currency' => 'USD',
 				'expected'       => null,
 			],
-			'Test mode, currency mismatch → null (currency check bypassed)'           => [
+			'Test mode, currency mismatch → null (currency check bypassed)'                 => [
 				'account_data'   => [
 					'country'           => 'US',
 					'external_accounts' => [
@@ -2072,7 +2126,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'store_currency' => 'USD',
 				'expected'       => null,
 			],
-			'Live mode, no settlement currencies → no-settlement-currencies'          => [
+			'Live mode, no settlement currencies → no-settlement-currencies'                => [
 				'account_data'   => [
 					'country'           => 'US',
 					'external_accounts' => [
@@ -2096,7 +2150,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'store_currency' => 'USD',
 				'expected'       => 'store-currency-not-settlement-currency',
 			],
-			'Live mode, store currency in settlement → null'                          => [
+			'Live mode, store currency in settlement → null'                                => [
 				'account_data'   => [
 					'country'           => 'US',
 					'external_accounts' => [
@@ -2109,7 +2163,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'store_currency' => 'USD',
 				'expected'       => null,
 			],
-			'Live mode, non-US account, matching currency → null'                     => [
+			'Live mode, non-US account, matching currency → null'                           => [
 				'account_data'   => [
 					'country'           => 'GB',
 					'external_accounts' => [
@@ -2121,6 +2175,32 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'test_mode'      => false,
 				'store_currency' => 'GBP',
 				'expected'       => null,
+			],
+			'Live mode, webhooks disabled → webhooks-disabled'                              => [
+				'account_data'    => [
+					'country'           => 'US',
+					'external_accounts' => [
+						'data' => [
+							[ 'currency' => 'usd' ],
+						],
+					],
+				],
+				'test_mode'       => false,
+				'store_currency'  => 'USD',
+				'expected'        => 'webhooks-disabled',
+				'webhook_enabled' => false,
+			],
+			'Test mode, webhooks disabled → webhooks-disabled (gate applies in both modes)' => [
+				'account_data'    => [
+					'country'           => 'US',
+					'external_accounts' => [
+						'data' => [],
+					],
+				],
+				'test_mode'       => true,
+				'store_currency'  => 'USD',
+				'expected'        => 'webhooks-disabled',
+				'webhook_enabled' => false,
 			],
 		];
 	}


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->


## Changes proposed in this Pull Request:

Adaptive Pricing depends on webhooks to mark orders as paid. If a store's webhooks aren't working, Stripe still charges the customer but the order will not be updated on the site and will stay in "Pending Payment" status. This PR ties Adaptive Pricing availability to webhook status so that can't happen.

<img width="1536" height="326" alt="CleanShot 2026-06-12 at 17 45 17@2x" src="https://github.com/user-attachments/assets/b30fdccd-9173-4cfb-ad31-366f5b2c7b19" />


With this change:

  - A merchant can no longer turn Adaptive Pricing on while their webhooks are disabled. 
  - For stores that already had Adaptive Pricing on, it stops being applied at checkout.
  - Adaptive Pricing default-on migration only applies when webhooks are enabled.
  - First-time onboarding still enables Adaptive Pricing as before
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. Manually bump the version to 10.8.2. 
2. Generate a build of this branch.

### (Regression) Test new merchants
1. Onboard as a new merchant using this branch.
2. Both OCS + AP should be enabled

### (Regression) Test backbook default-on migration
1. Setup a test store with Stripe 10.7.0 
2. Make sure Adaptive Pricing is disabled.
3. Upgrade to this build.
4. AP should be enabled

### Test backbook default-on migration with webhook disabled
1. Set up a test store with Stripe 10.7.0 
2. Make sure Adaptive Pricing is disabled.
3. Disable Webhooks for the site via the Stripe dashboard.
4. Upgrade to this build.
5. AP should NOT be enabled


### Test merchants who already have AP on but have webhooks disabled
1. Setup a site with a build from this branch
2. Enable AP.
3. Disable Webhooks via the Stripe dashboard.
4. AP should appear disabled on the merchant site and should not be available to shoppers.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
