### PR TITLE
Fix Adaptive Pricing orders stuck in pending after successful payment

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Append the 3-letter currency code to the Stripe Fee and Stripe Payout amounts in WP Admin order totals when the Stripe account currency differs from the order currency
 * Fix - Only create an agentic commerce order on the site that produced the checkout, preventing duplicate or wrong-site orders when multiple stores share one Stripe account
 * Dev - Add a Code Comment Conventions section to AGENTS.md to standardize agent and contributor comment guidance
+* Fix - Prevent Adaptive Pricing orders from being stuck in pending after a successful payment
 
 2026-06-11 - version 10.8.1
 * Fix - Prevent a fatal error when a Bancontact, iDEAL or Sofort payment is placed with SEPA token saving enabled through the Adaptive Pricing checkout, which left the order unpaid

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2299,107 +2299,99 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			exit;
 		}
 
-		$locked = $order_helper->lock_order_payment( $order );
-		if ( $locked ) {
-			WC_Stripe_Logger::info( "Skip processing checkout session redirect for order $order_id, order payment is already being processed (locked)" );
-			return;
-		}
-
-		try {
-			$checkout_session = $this->get_checkout_session_from_order( $order, true, true );
-			if ( null === $checkout_session ) {
-				// Either the order has no session id (defensive) or the Stripe API call failed.
-				// Logged downstream by get_checkout_session_from_order(). Leave the order
-				// untouched and let the webhook take over, but still strip the disambiguation
-				// query args from the address bar so a refresh doesn't loop on the API.
-				$order_helper->unlock_order_payment( $order );
-				wp_safe_redirect( wp_sanitize_redirect( $this->get_return_url( $order ) ) );
-				exit;
-			}
-
-			$status         = isset( $checkout_session->status ) ? $checkout_session->status : '';
-			$payment_intent = isset( $checkout_session->payment_intent ) && is_object( $checkout_session->payment_intent )
-				? $checkout_session->payment_intent
-				: null;
-			$payment_error  = $payment_intent && isset( $payment_intent->last_payment_error ) ? $payment_intent->last_payment_error : null;
-
-			// Success: session is complete (paid OR async-pending unpaid like Boleto).
-			// Mark the handler as having run so a refresh of the order-received page
-			// doesn't fall through into the cancel path while the webhook is still in flight,
-			// then strip the disambiguation query args from the address bar.
-			if ( 'complete' === $status ) {
-				$order_helper->update_stripe_upe_redirect_processed( $order, true );
-				$order->save();
-				$order_helper->unlock_order_payment( $order );
-				wp_safe_redirect( wp_sanitize_redirect( $this->get_return_url( $order ) ) );
-				exit;
-			}
-
-			// Anything else (open / expired) on a non-terminal order means the customer
-			// either cancelled on the redirect provider, the session expired, or there
-			// was a hard failure. Disambiguate via last_payment_error if present.
-			//
-			// NOTE: we intentionally do NOT set `_stripe_upe_redirect_processed` on these
-			// branches. The flag is order-scoped and never cleared, so setting it here
-			// would block a subsequent retry on the same order (the next return would
-			// short-circuit above and skip the bounce/notice logic). Replay protection
-			// for cancel/failure is unnecessary because these paths leave the order in
-			// a non-terminal state that is safe to re-enter.
-			$cancellation_codes = [
-				'payment_method_customer_decline',
-				'payment_intent_payment_attempt_expired',
-			];
-			$error_code         = $payment_error && isset( $payment_error->code ) ? $payment_error->code : '';
-			$error_message      = $payment_error && isset( $payment_error->message ) ? $payment_error->message : '';
-
-			// Hard failure: a real decline/error reported by the upstream payment provider.
-			// An `expired` session (Stripe's own timeout) is never a hard failure — the
-			// customer needs a fresh session to retry, regardless of any stale
-			// last_payment_error left on the intent from an earlier attempt.
-			$is_hard_failure = 'expired' !== $status
-				&& ! empty( $error_code )
-				&& ! in_array( $error_code, $cancellation_codes, true );
-
-			if ( $is_hard_failure ) {
-				WC_Stripe_Logger::error(
-					'Checkout session redirect failed for order: ' . $order_id,
-					[
-						'session_status' => $status,
-						'error_code'     => $error_code,
-						'error_message'  => $error_message,
-					]
-				);
-
-				/* translators: localized Stripe error message */
-				$order->update_status( OrderStatus::FAILED, sprintf( __( 'Stripe payment failed: %s', 'woocommerce-gateway-stripe' ), $error_message ) );
-
-				wc_add_notice( $error_message, 'error' );
-			} else {
-				WC_Stripe_Logger::info(
-					'Checkout session redirect cancelled for order: ' . $order_id,
-					[
-						'session_status' => $status,
-						'error_code'     => $error_code,
-						'error_message'  => $error_message,
-					]
-				);
-
-				wc_add_notice(
-					__( 'Your payment was cancelled. Please try again or use a different payment method.', 'woocommerce-gateway-stripe' ),
-					'notice'
-				);
-			}
-
-			// No explicit $order->save() needed here: the hard-failure branch calls
-			// update_status() which persists internally; the cancel branch has no
-			// order mutation.
-			$redirect_url = $is_pay_for_order ? $order->get_checkout_payment_url() : wc_get_checkout_url();
-			$order_helper->unlock_order_payment( $order );
-			wp_safe_redirect( wp_sanitize_redirect( $redirect_url ) );
+		// No payment lock needed: this path only routes the browser and never settles the order,
+		// and duplicate returns are already idempotent via the terminal-status short-circuit and
+		// the `_stripe_upe_redirect_processed` flag above. Taking it also risks harm — if the
+		// checkout.session.* webhook arrives while we hold it across the Stripe call below, the
+		// webhook can't settle the order and a paid order is left stuck pending.
+		$checkout_session = $this->get_checkout_session_from_order( $order, true, true );
+		if ( null === $checkout_session ) {
+			// Either the order has no session id (defensive) or the Stripe API call failed.
+			// Logged downstream by get_checkout_session_from_order(). Leave the order
+			// untouched and let the webhook take over, but still strip the disambiguation
+			// query args from the address bar so a refresh doesn't loop on the API.
+			wp_safe_redirect( wp_sanitize_redirect( $this->get_return_url( $order ) ) );
 			exit;
-		} finally {
-			$order_helper->unlock_order_payment( $order );
 		}
+
+		$status         = isset( $checkout_session->status ) ? $checkout_session->status : '';
+		$payment_intent = isset( $checkout_session->payment_intent ) && is_object( $checkout_session->payment_intent )
+			? $checkout_session->payment_intent
+			: null;
+		$payment_error  = $payment_intent && isset( $payment_intent->last_payment_error ) ? $payment_intent->last_payment_error : null;
+
+		// Success: session is complete (paid OR async-pending unpaid like Boleto).
+		// Mark the handler as having run so a refresh of the order-received page
+		// doesn't fall through into the cancel path while the webhook is still in flight,
+		// then strip the disambiguation query args from the address bar.
+		if ( 'complete' === $status ) {
+			$order_helper->update_stripe_upe_redirect_processed( $order, true );
+			$order->save();
+			wp_safe_redirect( wp_sanitize_redirect( $this->get_return_url( $order ) ) );
+			exit;
+		}
+
+		// Anything else (open / expired) on a non-terminal order means the customer
+		// either cancelled on the redirect provider, the session expired, or there
+		// was a hard failure. Disambiguate via last_payment_error if present.
+		//
+		// NOTE: we intentionally do NOT set `_stripe_upe_redirect_processed` on these
+		// branches. The flag is order-scoped and never cleared, so setting it here
+		// would block a subsequent retry on the same order (the next return would
+		// short-circuit above and skip the bounce/notice logic). Replay protection
+		// for cancel/failure is unnecessary because these paths leave the order in
+		// a non-terminal state that is safe to re-enter.
+		$cancellation_codes = [
+			'payment_method_customer_decline',
+			'payment_intent_payment_attempt_expired',
+		];
+		$error_code         = $payment_error && isset( $payment_error->code ) ? $payment_error->code : '';
+		$error_message      = $payment_error && isset( $payment_error->message ) ? $payment_error->message : '';
+
+		// Hard failure: a real decline/error reported by the upstream payment provider.
+		// An `expired` session (Stripe's own timeout) is never a hard failure — the
+		// customer needs a fresh session to retry, regardless of any stale
+		// last_payment_error left on the intent from an earlier attempt.
+		$is_hard_failure = 'expired' !== $status
+			&& ! empty( $error_code )
+			&& ! in_array( $error_code, $cancellation_codes, true );
+
+		if ( $is_hard_failure ) {
+			WC_Stripe_Logger::error(
+				'Checkout session redirect failed for order: ' . $order_id,
+				[
+					'session_status' => $status,
+					'error_code'     => $error_code,
+					'error_message'  => $error_message,
+				]
+			);
+
+			/* translators: localized Stripe error message */
+			$order->update_status( OrderStatus::FAILED, sprintf( __( 'Stripe payment failed: %s', 'woocommerce-gateway-stripe' ), $error_message ) );
+
+			wc_add_notice( $error_message, 'error' );
+		} else {
+			WC_Stripe_Logger::info(
+				'Checkout session redirect cancelled for order: ' . $order_id,
+				[
+					'session_status' => $status,
+					'error_code'     => $error_code,
+					'error_message'  => $error_message,
+				]
+			);
+
+			wc_add_notice(
+				__( 'Your payment was cancelled. Please try again or use a different payment method.', 'woocommerce-gateway-stripe' ),
+				'notice'
+			);
+		}
+
+		// No explicit $order->save() needed here: the hard-failure branch calls
+		// update_status() which persists internally; the cancel branch has no
+		// order mutation.
+		$redirect_url = $is_pay_for_order ? $order->get_checkout_payment_url() : wc_get_checkout_url();
+		wp_safe_redirect( wp_sanitize_redirect( $redirect_url ) );
+		exit;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -171,5 +171,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Append the 3-letter currency code to the Stripe Fee and Stripe Payout amounts in WP Admin order totals when the Stripe account currency differs from the order currency
 * Fix - Only create an agentic commerce order on the site that produced the checkout, preventing duplicate or wrong-site orders when multiple stores share one Stripe account
 * Dev - Add a Code Comment Conventions section to AGENTS.md to standardize agent and contributor comment guidance
+* Fix - Prevent Adaptive Pricing orders from being stuck in pending after a successful payment
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-1216

## Changes proposed in this Pull Request:
With Adaptive Pricing (Checkout Sessions on OCS), a successfully paid order could stay stuck in `pending`.

The order-received redirect handler (`process_checkout_session_redirect`) is UX-only — it just routes the browser and never settles the order. But it was acquiring the order payment lock and holding it across a ~1s Stripe API call. When the `checkout.session.completed` webhook (the path that actually settles the order) arrived in that window, it couldn't get the lock and silently dropped settlement. The redirect handler then released the lock without settling either — so the paid order was never marked `processing`.
  
This is a edge case but realistic race that I encountered during testing another PR.
  
**Fix:** the redirect handler no longer takes the payment lock. It doesn't need it — it never settles the order, and duplicate returns are already idempotent via the terminal-status short-circuit and the `_stripe_upe_redirect_processed` flag. The change is a net removal of the locking machinery from that handler; the webhook now settles unobstructed.
  
  ## Testing instructions
  
  1. Enable Adaptive Pricing and use the optimized checkout.
  2. Place an order with local currency (AP)
  3. Complete payment and let it redirect to the order-received page.
  4. Confirm the order moves to **Processing** (not stuck in Pending), the payment intent/charge are recorded, and the "Local currency purchase via Adaptive Pricing" order note is present.
  5. Also verify the non-success paths still behave: cancelling on a redirect-based method bounces back to checkout with a notice, and a hard decline marks the order Failed.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
