### PR TITLE
Run woocommerce_gateway_description filter on UPE payment methods so descriptions can be filtered

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Append the 3-letter currency code to the Stripe Fee and Stripe Payout amounts in WP Admin order totals when the Stripe account currency differs from the order currency
 * Fix - Only create an agentic commerce order on the site that produced the checkout, preventing duplicate or wrong-site orders when multiple stores share one Stripe account
 * Dev - Add a Code Comment Conventions section to AGENTS.md to standardize agent and contributor comment guidance
+* Fix - Run the woocommerce_gateway_description filter for Stripe payment methods so third parties can add or replace their checkout descriptions
 
 2026-06-11 - version 10.8.1
 * Fix - Prevent a fatal error when a Bancontact, iDEAL or Sofort payment is placed with SEPA token saving enabled through the Adaptive Pricing checkout, which left the order unpaid

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -344,7 +344,7 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	 * @return string
 	 */
 	public function get_description() {
-		return '';
+		return apply_filters( 'woocommerce_gateway_description', '', $this->id );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -171,5 +171,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Append the 3-letter currency code to the Stripe Fee and Stripe Payout amounts in WP Admin order totals when the Stripe account currency differs from the order currency
 * Fix - Only create an agentic commerce order on the site that produced the checkout, preventing duplicate or wrong-site orders when multiple stores share one Stripe account
 * Dev - Add a Code Comment Conventions section to AGENTS.md to standardize agent and contributor comment guidance
+* Fix - Run the woocommerce_gateway_description filter for Stripe payment methods so third parties can add or replace their checkout descriptions
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-test.php
@@ -496,6 +496,30 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 	}
 
 	/**
+	 * Payment methods have no description by default, but the standard WooCommerce
+	 * `woocommerce_gateway_description` filter must still fire so third parties can add one.
+	 */
+	public function test_get_description_runs_woocommerce_gateway_description_filter() {
+		$sepa_method = $this->mock_payment_methods[ WC_Stripe_Payment_Methods::SEPA_DEBIT ];
+		$gateway_id  = WC_Stripe_UPE_Payment_Gateway::ID . '_' . $sepa_method->get_id();
+
+		// No filter hooked: the default description is empty.
+		$this->assertSame( '', $sepa_method->get_description() );
+
+		$received_id = null;
+		$filter      = function ( $description, $id ) use ( &$received_id ) {
+			$received_id = $id;
+			return 'SEPA approval can take a few days.';
+		};
+		add_filter( 'woocommerce_gateway_description', $filter, 10, 2 );
+
+		$this->assertSame( 'SEPA approval can take a few days.', $sepa_method->get_description() );
+		$this->assertSame( $gateway_id, $received_id );
+
+		remove_filter( 'woocommerce_gateway_description', $filter, 10 );
+	}
+
+	/**
 	 * Card payment method is always enabled.
 	 */
 	public function test_card_payment_method_capability_is_always_enabled() {


### PR DESCRIPTION
Fixes STRIPE-1213
Fixes #5572 

## Changes proposed in this Pull Request:
`WC_Stripe_UPE_Payment_Method::get_description()` hard-returned `''`, which short-circuited WooCommerce's `WC_Payment_Gateway::get_description()` and never fired the `woocommerce_gateway_description` filter. As a result, third parties could not add or replace the checkout description for individual Stripe payment methods (e.g. a "SEPA approval can take a few days" note on Direct Debit).

This change keeps the empty default but routes it through the standard filter, so extensions can hook in.

## Testing instructions
Code review should be sufficient.

1. Without any filter: no method description renders at checkout (unchanged).
2. Add a filter, e.g.:
```php
     add_filter( 'woocommerce_gateway_description', function ( $desc, $id ) {
         return 'stripe_sepa_debit' === $id ? 'Payment approval can take a few days.' : $desc;
     }, 10, 2 );
```
Confirm the text appears under SEPA Direct Debit on classic checkout, Blocks, and OC, and that other methods are unaffected.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
