### PR TITLE
Fix Adaptive Pricing orders stuck in pending by re-queueing the settlement webhook when the order is locked

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ xxxx-xx-xx - version 10.9.0
 * Dev - Add a Code Comment Conventions section to AGENTS.md to standardize agent and contributor comment guidance
 * Fix - Disable Adaptive Pricing when webhooks are disabled
 * Fix - Run the woocommerce_gateway_description filter for Stripe payment methods so third parties can add or replace their checkout descriptions
+* Fix - Prevent Adaptive Pricing orders from being stuck in pending after a successful payment
 
 2026-06-11 - version 10.8.1
 * Fix - Prevent a fatal error when a Bancontact, iDEAL or Sofort payment is placed with SEPA token saving enabled through the Adaptive Pricing checkout, which left the order unpaid

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -61,6 +61,17 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	protected $deferred_webhook_delay = 2 * MINUTE_IN_SECONDS;
 
 	/**
+	 * How long to wait before retrying a webhook that lost the order-payment lock race.
+	 *
+	 * The order-received redirect handler holds the lock only across a single Stripe API
+	 * call (~1s), so a short backoff settles the order quickly instead of leaving it pending
+	 * for the full deferred delay. Kept well above the typical hold to avoid a busy re-queue loop.
+	 *
+	 * @var int
+	 */
+	protected $locked_order_retry_delay = 10;
+
+	/**
 	 * The Action Scheduler hook to use when retrying a webhook.
 	 *
 	 * @var string
@@ -1465,10 +1476,12 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @param stdClass $webhook_notification The webhook payload received from Stripe.
 	 * @param array    $additional_data      Additional data to pass to the scheduled job.
+	 * @param int|null $delay                Seconds to wait before retrying. Defaults to $deferred_webhook_delay.
 	 */
-	protected function defer_webhook_processing( $webhook_notification, $additional_data ) {
+	protected function defer_webhook_processing( $webhook_notification, $additional_data, $delay = null ) {
+		$delay = null === $delay ? $this->deferred_webhook_delay : $delay;
 		$this->action_scheduler_service->schedule_job(
-			time() + $this->deferred_webhook_delay,
+			time() + $delay,
 			$this->deferred_webhook_action,
 			[
 				'type'         => $webhook_notification->type,
@@ -1554,7 +1567,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					break;
 				case 'checkout.session.completed':
 				case 'checkout.session.async_payment_succeeded':
-					$this->handle_checkout_session_success( $notification );
+					// If the order is still locked, this re-queues itself again; don't fire the
+					// action now — the next retry fires it once settlement actually runs.
+					if ( $this->handle_checkout_session_success( $notification ) ) {
+						return;
+					}
 					break;
 				case 'checkout.session.expired':
 				case 'checkout.session.async_payment_failed':
@@ -1801,18 +1818,19 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return true;
 		}
 
-		// If order exists, process the webhook immediately.
-		$this->handle_checkout_session_success( $notification );
-		return false;
+		// The order exists, so process the webhook immediately — unless it re-queues itself because the
+		// order is locked, in which case propagate that signal so the caller skips firing the
+		// `wc_stripe_webhook_received` action before settlement actually happens.
+		return $this->handle_checkout_session_success( $notification );
 	}
 
 	/**
 	 * Handles a deferred checkout session success event.
 	 *
 	 * @param object        $notification The Stripe notification containing the checkout session data.
-	 * @return void
+	 * @return bool True if the event was re-queued for async processing, false if handled inline.
 	 */
-	protected function handle_checkout_session_success( object $notification ): void {
+	protected function handle_checkout_session_success( object $notification ): bool {
 		$checkout_session = $notification->data->object;
 
 		$session_id = $checkout_session->id;
@@ -1828,7 +1846,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				'Checkout session is already being processed.',
 				[ 'session_id' => $session_id ]
 			);
-			return;
+			return false;
 		}
 		WC_Stripe_Database_Cache::set( $lock_key, time(), 5 * MINUTE_IN_SECONDS );
 
@@ -1844,7 +1862,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					'Completed Adaptive Pricing checkout session has no matching order: ' . $checkout_session->id
 				);
 				WC_Stripe_Database_Cache::delete( $lock_key );
-				return;
+				return false;
 			}
 
 			try {
@@ -1854,7 +1872,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			} finally {
 				WC_Stripe_Database_Cache::delete( $lock_key );
 			}
-			return;
+			return false;
 		}
 
 		WC_Stripe_Database_Cache::delete( $lock_key );
@@ -1874,7 +1892,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		);
 
 		if ( ! $order->has_status( $allowed_payment_processing_statuses ) ) {
-			return;
+			return false;
 		}
 
 		// Set the order being processed for the `wc_stripe_webhook_received` action later.
@@ -1885,10 +1903,12 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		// Lock the order. The order-received redirect handler briefly holds this same lock across a
 		// Stripe API call without settling; dropping the event here would leave a paid order stuck
 		// pending. Re-queue instead so settlement runs once the lock is released — the lock's 5-minute
-		// TTL guarantees a wedged holder clears, so the retry terminates.
+		// TTL guarantees a wedged holder clears, so the retry terminates. Return the deferred signal so
+		// the caller skips firing `wc_stripe_webhook_received` now: settlement hasn't happened yet, and
+		// the retry fires the action itself once it does.
 		if ( $order_helper->lock_order_payment( $order ) ) {
-			$this->defer_webhook_processing( $notification, [ 'session_id' => $session_id ] );
-			return;
+			$this->defer_webhook_processing( $notification, [ 'session_id' => $session_id ], $this->locked_order_retry_delay );
+			return true;
 		}
 
 		try {
@@ -1925,7 +1945,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 			if ( ! $intent ) {
 				WC_Stripe_Logger::error( 'Could not find intent for order: ' . $order->get_id() );
-				return;
+				return false;
 			}
 
 			$payment_method_id = is_object( $intent->payment_method ) ? $intent->payment_method->id : $intent->payment_method;
@@ -2018,6 +2038,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			// Unlock the order
 			$order_helper->unlock_order_payment( $order );
 		}
+
+		return false;
 	}
 
 	/**

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1861,8 +1861,12 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		$order_helper = WC_Stripe_Order_Helper::get_instance();
 
-		// Lock the order
+		// Lock the order. The order-received redirect handler briefly holds this same lock across a
+		// Stripe API call without settling; dropping the event here would leave a paid order stuck
+		// pending. Re-queue instead so settlement runs once the lock is released — the lock's 5-minute
+		// TTL guarantees a wedged holder clears, so the retry terminates.
 		if ( $order_helper->lock_order_payment( $order ) ) {
+			$this->defer_webhook_processing( $notification, [ 'session_id' => $session_id ] );
 			return;
 		}
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3255,8 +3255,9 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$webhook_notification of method WC_Stripe_Webhook_Handler\:\:defer_webhook_processing\(\) expects stdClass, object given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 3
 			path: includes/class-wc-stripe-webhook-handler.php
+
 
 		-
 			message: '#^Parameter \#2 \$request_body of method WC_Stripe_Webhook_Handler\:\:validate_request\(\) expects array, string\|false given\.$#'

--- a/readme.txt
+++ b/readme.txt
@@ -173,5 +173,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Add a Code Comment Conventions section to AGENTS.md to standardize agent and contributor comment guidance
 * Fix - Disable Adaptive Pricing when webhooks are disabled
 * Fix - Run the woocommerce_gateway_description filter for Stripe payment methods so third parties can add or replace their checkout descriptions
+* Fix - Prevent Adaptive Pricing orders from being stuck in pending after a successful payment
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -797,7 +797,10 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 				$this->callback(
 					function ( $timestamp ) use ( $start ) {
 						$this->assertIsInt( $timestamp );
-						$this->assertGreaterThanOrEqual( $start + 2 * MINUTE_IN_SECONDS, $timestamp );
+						// The lock clears in ~1s, so the retry uses a short dedicated backoff rather than
+						// the 2-minute deferred delay — the order must not sit pending that long.
+						$this->assertGreaterThanOrEqual( $start + 10, $timestamp );
+						$this->assertLessThan( $start + MINUTE_IN_SECONDS, $timestamp );
 
 						return true;
 					}
@@ -820,6 +823,63 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 
 		// Settlement is deferred to the retry, so the order must still be unsettled.
 		$this->assertTrue( wc_get_order( $order->get_id() )->has_status( OrderStatus::PENDING ) );
+	}
+
+	/**
+	 * Regression: when the order is locked and settlement is re-queued, process_webhook must NOT fire
+	 * wc_stripe_webhook_received on this live pass. Settlement hasn't happened yet; the action fires
+	 * once from the retry. Firing here would double-dispatch and run before the payment settles.
+	 *
+	 * @return void
+	 */
+	public function test_process_webhook_skips_received_action_when_order_payment_locked(): void {
+		$checkout_session_id = 'cs_test_locked_no_action';
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::PENDING );
+		$order->save();
+		WC_Stripe_Order_Helper::get_instance()->update_stripe_checkout_session_id( $order, $checkout_session_id );
+		$order->save_meta_data();
+
+		WC_Stripe_Database_Cache::delete( 'checkout_session_lock_' . $checkout_session_id );
+		WC_Stripe_Database_Cache::delete( 'checkout_session_' . $checkout_session_id );
+
+		$order_helper = $this->createPartialMock(
+			WC_Stripe_Order_Helper::class,
+			[ 'lock_order_payment', 'unlock_order_payment' ]
+		);
+		$order_helper->method( 'lock_order_payment' )->willReturn( true );
+		$order_helper->method( 'unlock_order_payment' );
+		WC_Stripe_Order_Helper::set_instance( $order_helper );
+
+		$notification = (object) [
+			'type' => 'checkout.session.completed',
+			'data' => (object) [
+				'object' => (object) [
+					'id'             => $checkout_session_id,
+					'payment_intent' => 'pi_test_locked_no_action',
+				],
+			],
+		];
+
+		$handler = new WC_Stripe_Webhook_Handler();
+		$prop    = new ReflectionProperty( WC_Stripe_Webhook_Handler::class, 'action_scheduler_service' );
+		$prop->setAccessible( true );
+		$prop->setValue( $handler, $this->createMock( WC_Stripe_Action_Scheduler_Service::class ) );
+
+		$fired    = 0;
+		$listener = function () use ( &$fired ) {
+			++$fired;
+		};
+		add_action( 'wc_stripe_webhook_received', $listener );
+
+		try {
+			$handler->process_webhook( wp_json_encode( $notification ) );
+		} finally {
+			remove_action( 'wc_stripe_webhook_received', $listener );
+		}
+
+		$this->assertSame( 0, $fired, 'wc_stripe_webhook_received must not fire while settlement is deferred.' );
 	}
 
 	/**

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -751,6 +751,78 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Regression: when the order is found but its payment lock is held by a concurrent process
+	 * (e.g. the order-received redirect handler holding it across a Stripe API call), settlement
+	 * must be re-queued, otherwise the paid order is left stuck pending.
+	 *
+	 * @return void
+	 */
+	public function test_handle_checkout_session_success_requeues_when_order_payment_locked(): void {
+		$checkout_session_id = 'cs_test_locked_requeue';
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::PENDING );
+		$order->save();
+		WC_Stripe_Order_Helper::get_instance()->update_stripe_checkout_session_id( $order, $checkout_session_id );
+		$order->save_meta_data();
+
+		// Clear per-session caches so the handler doesn't short-circuit on a stale lock entry.
+		WC_Stripe_Database_Cache::delete( 'checkout_session_lock_' . $checkout_session_id );
+		WC_Stripe_Database_Cache::delete( 'checkout_session_' . $checkout_session_id );
+
+		// Simulate a concurrent process holding the order payment lock.
+		$order_helper = $this->createPartialMock(
+			WC_Stripe_Order_Helper::class,
+			[ 'lock_order_payment', 'unlock_order_payment' ]
+		);
+		$order_helper->method( 'lock_order_payment' )->willReturn( true );
+		$order_helper->method( 'unlock_order_payment' );
+		WC_Stripe_Order_Helper::set_instance( $order_helper );
+
+		$notification = (object) [
+			'type' => 'checkout.session.completed',
+			'data' => (object) [
+				'object' => (object) [
+					'id'             => $checkout_session_id,
+					'payment_intent' => 'pi_test_locked',
+				],
+			],
+		];
+
+		$start          = time();
+		$mock_scheduler = $this->createMock( WC_Stripe_Action_Scheduler_Service::class );
+		$mock_scheduler->expects( $this->once() )
+			->method( 'schedule_job' )
+			->with(
+				$this->callback(
+					function ( $timestamp ) use ( $start ) {
+						$this->assertIsInt( $timestamp );
+						$this->assertGreaterThanOrEqual( $start + 2 * MINUTE_IN_SECONDS, $timestamp );
+
+						return true;
+					}
+				),
+				'wc_stripe_deferred_webhook',
+				$this->callback(
+					function ( $args ) use ( $checkout_session_id ) {
+						return 'checkout.session.completed' === ( $args['type'] ?? '' )
+							&& ( $args['data']['session_id'] ?? '' ) === $checkout_session_id;
+					}
+				)
+			);
+
+		$handler = new WC_Stripe_Webhook_Handler();
+		$prop    = new ReflectionProperty( WC_Stripe_Webhook_Handler::class, 'action_scheduler_service' );
+		$prop->setAccessible( true );
+		$prop->setValue( $handler, $mock_scheduler );
+
+		$handler->process_checkout_session_success( $notification );
+
+		// Settlement is deferred to the retry, so the order must still be unsettled.
+		$this->assertTrue( wc_get_order( $order->get_id() )->has_status( OrderStatus::PENDING ) );
+	}
+
+	/**
 	 * Deferred checkout session success events should run handle_checkout_session_success when the job executes.
 	 *
 	 * @param string $event_type Stripe event type.


### PR DESCRIPTION
Fixes STRIPE-1216

## Changes proposed in this Pull Request:

With Adaptive Pricing (Checkout Sessions on OCS), a successfully paid order could stay stuck in pending.

The order-received redirect handler (process_checkout_session_redirect) is UX-only — it just routes the browser and never settles the order. But it was acquiring the order payment lock and holding it across a ~1s Stripe API call. When the checkout.session.completed webhook (the path that actually settles the order) arrived in that window, it couldn't get the lock and silently dropped settlement. The redirect handler then released the lock without settling either — so the paid order was never marked processing.

This is a edge case but realistic race that I encountered during testing another PR.

 **Fix:** when the order is locked, the webhook now re-queues itself (via Action Scheduler) instead of dropping the event. The lock holder releases within ~1s, so the retry acquires the lock and settles the order — nothing is lost. The lock's existing 5-minute TTL guarantees a wedged holder clears, so the retry always terminates (no retry counter needed). This keeps the redirect handler's lock in place; the only change is making the webhook resilient to contention rather than giving up.

## Testing instructions

- Enable Adaptive Pricing and use the optimized checkout.
- Place an order with local currency (AP)
- Complete payment and let it redirect to the order-received page.
- Confirm the order moves to **Processing** (not stuck in Pending), the payment intent/charge are recorded, and the "Local currency purchase via Adaptive Pricing" order note is present.
- Also verify the non-success paths still behave: cancelling on a redirect-based method bounces back to checkout with a notice, and a hard decline marks the order Failed.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
