### PR TITLE
Update status of Adaptive Payment failed orders promptly

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,7 +10,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Send the billing address to Stripe on the Pay for Order page so payments aren't incorrectly blocked by Stripe Radar rules
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
-* Fix - Stop treating a completed Adaptive Pricing checkout session as an agentic session in webhook processing, which could drop the payment when agentic commerce is disabled
+* Fix - Correctly distinguish Adaptive Pricing checkout sessions from agentic ones in webhooks so their payments aren't dropped
 * Add - Stripe admin pages to the WordPress Command Palette
 * Fix - Prevent a possible fatal error when saving the payment method on a subscription order
 * Dev - Use clsx library instead of classnames

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ xxxx-xx-xx - version 10.9.0
 * Dev - Add a Code Comment Conventions section to AGENTS.md to standardize agent and contributor comment guidance
 * Fix - Disable Adaptive Pricing when webhooks are disabled
 * Fix - Run the woocommerce_gateway_description filter for Stripe payment methods so third parties can add or replace their checkout descriptions
+* Fix - Mark Adaptive Pricing orders as failed promptly when a payment is declined, instead of leaving them in Pending Payment
 
 2026-06-11 - version 10.8.1
 * Fix - Prevent a fatal error when a Bancontact, iDEAL or Sofort payment is placed with SEPA token saving enabled through the Adaptive Pricing checkout, which left the order unpaid

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ xxxx-xx-xx - version 10.9.0
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
 * Fix - Prevent a fatal error when a Bancontact, iDEAL or Sofort payment is placed with SEPA token saving enabled through the Adaptive Pricing checkout, which left the order unpaid
+* Fix - Stop treating a completed Adaptive Pricing checkout session as an agentic session in webhook processing, which could drop the payment when agentic commerce is disabled
 
 2026-06-08 - version 10.8.0
 * Fix - Add an order note and call action 'wc_stripe_unexpected_charge_detected' when a Stripe charge is captured for an order that was already paid via a different gateway

--- a/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
+++ b/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
@@ -180,8 +180,9 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler {
 	private function build_payment_intent_data(): array {
 		$data     = [];
 		$metadata = [
-			'site_url'     => esc_url_raw( get_site_url() ),
-			'payment_type' => 'single',
+			'site_url'      => esc_url_raw( get_site_url() ),
+			'payment_type'  => 'single',
+			'checkout_type' => self::ADAPTIVE_PRICING_CHECKOUT_TYPE,
 		];
 
 		/** Documented in includes/abstracts/abstract-wc-stripe-payment-gateway.php */

--- a/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
+++ b/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php
@@ -9,6 +9,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Stripe_Checkout_Sessions_Ajax_Handler {
 	/**
+	 * Checkout session metadata value identifying an Adaptive Pricing checkout.
+	 *
+	 * Set on the session at creation and read back in the webhook handler so a
+	 * completed Adaptive Pricing session is never mistaken for an agentic one.
+	 *
+	 * @var string
+	 */
+	public const ADAPTIVE_PRICING_CHECKOUT_TYPE = 'adaptive_pricing_checkout';
+
+	/**
 	 * Initialize hooks.
 	 *
 	 * @return void
@@ -42,6 +52,9 @@ class WC_Stripe_Checkout_Sessions_Ajax_Handler {
 				'mode'                          => 'payment',
 				'adaptive_pricing'              => [
 					'enabled' => 'true',
+				],
+				'metadata'                      => [
+					'checkout_type' => self::ADAPTIVE_PRICING_CHECKOUT_TYPE,
 				],
 			];
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1730,6 +1730,18 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		// Look for an order. If one does not exists, this is probably an agentic hook.
 		$order = WC_Stripe_Helper::get_order_by_checkout_session_id( $checkout_session->id );
 		if ( ! $order instanceof \WC_Order ) {
+			// An Adaptive Pricing session is tagged at creation. It is never agentic,
+			// so don't route it into the agentic handler — that would silently drop a
+			// paid session whenever agentic commerce is disabled.
+			$checkout_type = $checkout_session->metadata->checkout_type ?? '';
+			if ( WC_Stripe_Checkout_Sessions_Ajax_Handler::ADAPTIVE_PRICING_CHECKOUT_TYPE === $checkout_type ) {
+				WC_Stripe_Logger::warning(
+					'Completed Adaptive Pricing checkout session has no matching order: ' . $checkout_session->id
+				);
+				WC_Stripe_Database_Cache::delete( $lock_key );
+				return;
+			}
+
 			try {
 				$this->handle_agentic_checkout_session( $notification );
 			} finally {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -2314,6 +2314,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			$session    = $sessions->data[0] ?? null;
 			$session_id = isset( $session->id ) ? (string) $session->id : '';
 			if ( '' === $session_id ) {
+				WC_Stripe_Logger::warning( 'No checkout session found for intent ' . $intent_id . '; order left unresolved.' );
 				return null;
 			}
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1255,6 +1255,15 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$intent = $notification->data->object;
 		$order  = $this->get_order_from_intent( $intent );
 
+		$checkout_type = $intent->metadata->checkout_type ?? '';
+
+		// For AP, attempt to find the order via the checkout session.
+		if ( ! $order
+			&& 'payment_intent.payment_failed' === $notification->type
+			&& WC_Stripe_Checkout_Sessions_Ajax_Handler::ADAPTIVE_PRICING_CHECKOUT_TYPE === $checkout_type ) {
+			$order = $this->get_order_by_intent_checkout_session( isset( $intent->id ) ? (string) $intent->id : '' );
+		}
+
 		if ( ! $order ) {
 			WC_Stripe_Logger::warning( 'Could not find order via intent ID: ' . $intent->id );
 			return;
@@ -2287,6 +2296,33 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		// Fall back to finding the order via the intent ID.
 		return WC_Stripe_Helper::get_order_by_intent_id( $intent->id );
+	}
+
+	/**
+	 * Resolves the order behind a PaymentIntent via its Checkout Session.
+	 *
+	 * @param string $intent_id PaymentIntent ID from the failed event.
+	 * @return WC_Order|null
+	 */
+	private function get_order_by_intent_checkout_session( string $intent_id ): ?WC_Order {
+		if ( '' === $intent_id ) {
+			return null;
+		}
+
+		try {
+			$sessions   = WC_Stripe_API::request( [], 'checkout/sessions?payment_intent=' . $intent_id . '&limit=1', 'GET' );
+			$session    = $sessions->data[0] ?? null;
+			$session_id = isset( $session->id ) ? (string) $session->id : '';
+			if ( '' === $session_id ) {
+				return null;
+			}
+
+			$order = WC_Stripe_Helper::get_order_by_checkout_session_id( $session_id );
+			return $order instanceof WC_Order ? $order : null;
+		} catch ( Exception $e ) {
+			WC_Stripe_Logger::warning( 'Unable to resolve order from checkout session for intent ' . $intent_id . ': ' . $e->getMessage() );
+			return null;
+		}
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -174,5 +174,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Add a Code Comment Conventions section to AGENTS.md to standardize agent and contributor comment guidance
 * Fix - Disable Adaptive Pricing when webhooks are disabled
 * Fix - Run the woocommerce_gateway_description filter for Stripe payment methods so third parties can add or replace their checkout descriptions
+* Fix - Mark Adaptive Pricing orders as failed promptly when a payment is declined, instead of leaving them in Pending Payment
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -165,8 +165,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Send the billing address to Stripe on the Pay for Order page so payments aren't incorrectly blocked by Stripe Radar rules
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
-* Fix - Prevent a fatal error when a Bancontact, iDEAL or Sofort payment is placed with SEPA token saving enabled through the Adaptive Pricing checkout, which left the order unpaid
-* Fix - Stop treating a completed Adaptive Pricing checkout session as an agentic session in webhook processing, which could drop the payment when agentic commerce is disabled
+* Fix - Correctly distinguish Adaptive Pricing checkout sessions from agentic ones in webhooks so their payments aren't dropped
 * Add - Stripe admin pages to the WordPress Command Palette
 * Fix - Prevent a possible fatal error when saving the payment method on a subscription order
 * Dev - Use clsx library instead of classnames

--- a/readme.txt
+++ b/readme.txt
@@ -161,5 +161,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
 * Fix - Prevent a fatal error when a Bancontact, iDEAL or Sofort payment is placed with SEPA token saving enabled through the Adaptive Pricing checkout, which left the order unpaid
+* Fix - Stop treating a completed Adaptive Pricing checkout session as an agentic session in webhook processing, which could drop the payment when agentic commerce is disabled
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-webhook-handler-agentic-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-agentic-test.php
@@ -110,6 +110,44 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * An Adaptive Pricing session with no matching order must not be routed to the
+	 * agentic handler — otherwise a paid AP session is silently dropped (and, with
+	 * agentic enabled, wrongly processed as agentic).
+	 */
+	public function test_adaptive_pricing_session_without_order_is_not_treated_as_agentic() {
+		$session_id                           = 'cs_test_adaptive_pricing';
+		$notification                         = $this->build_notification( $session_id );
+		$notification->data->object->metadata = (object) [
+			'checkout_type' => WC_Stripe_Checkout_Sessions_Ajax_Handler::ADAPTIVE_PRICING_CHECKOUT_TYPE,
+		];
+
+		// Flag (and stub) any agentic retrieval of the session from Stripe. With the
+		// guard in place this must never be reached for an Adaptive Pricing session.
+		$retrieved         = false;
+		$this->http_filter = function ( $preempt, $args, $url ) use ( &$retrieved, $session_id ) {
+			if ( str_starts_with( $url, 'https://api.stripe.com/v1/checkout/sessions/' ) ) {
+				$retrieved = true;
+				return [
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'body'     => wp_json_encode( (object) [ 'id' => $session_id ] ),
+				];
+			}
+			return $preempt;
+		};
+		add_filter( 'pre_http_request', $this->http_filter, 10, 3 );
+
+		// Immediate phase defers; deferred phase must skip the agentic path.
+		$this->handler->process_checkout_session_success( $notification );
+		$this->handler->process_deferred_webhook( 'checkout.session.completed', [ 'session_id' => $session_id ], $notification );
+
+		$this->assertFalse( $retrieved, 'Adaptive Pricing session must not trigger agentic session retrieval.' );
+		$this->assertNull( $this->get_resolved_order( $this->handler ) );
+	}
+
+	/**
 	 * Tests that a session with empty network_business_profile is skipped.
 	 */
 	public function test_skips_session_with_empty_network_business_profile() {

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -952,6 +952,148 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Builds a pre_http_request stub for the "list Checkout Sessions by PaymentIntent" lookup.
+	 *
+	 * @param string      $intent_id           PaymentIntent the failed event references.
+	 * @param string|null $checkout_session_id Session to return, or null to simulate no match.
+	 * @param bool        $called              Set to true when the lookup endpoint is hit.
+	 * @return callable
+	 */
+	private function stub_checkout_session_lookup( string $intent_id, ?string $checkout_session_id, &$called = false ) {
+		return function ( $return_value, $parsed_args, $url ) use ( $intent_id, $checkout_session_id, &$called ) {
+			$expected_url = WC_Stripe_API::ENDPOINT . 'checkout/sessions?payment_intent=' . $intent_id . '&limit=1';
+			if ( $url !== $expected_url ) {
+				return $return_value;
+			}
+			$called = true;
+			$data   = null === $checkout_session_id ? [] : [
+				[
+					'id'             => $checkout_session_id,
+					'payment_intent' => $intent_id,
+				],
+			];
+			return [
+				'headers'  => [],
+				'body'     => wp_json_encode(
+					[
+						'object' => 'list',
+						'data'   => $data,
+					]
+				),
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'cookies'  => [],
+				'filename' => null,
+			];
+		};
+	}
+
+	/**
+	 * Adaptive Pricing declines leave the order linked only to its Checkout Session — the failed
+	 * intent carries no order metadata and the intent ID isn't stored on the order. The handler runs
+	 * the (extra) session lookup only for intents flagged as Checkout Session intents, and marks the
+	 * order failed when the session resolves it.
+	 *
+	 * @dataProvider provide_process_payment_intent_checkout_session_fallback
+	 *
+	 * @param bool   $has_marker       Whether the failed intent carries the Adaptive Pricing checkout_type.
+	 * @param bool   $session_resolves Whether Stripe returns the order's Checkout Session for the intent.
+	 * @param bool   $expect_lookup    Whether the session lookup should be attempted.
+	 * @param string $expected_status  The order status after processing.
+	 */
+	public function test_process_payment_intent_checkout_session_fallback(
+		bool $has_marker,
+		bool $session_resolves,
+		bool $expect_lookup,
+		string $expected_status
+	): void {
+		$checkout_session_id = 'cs_test_pi_fallback';
+		$intent_id           = 'pi_test_pi_fallback';
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::PENDING );
+		$order->save();
+		WC_Stripe_Order_Helper::get_instance()->update_stripe_checkout_session_id( $order, $checkout_session_id );
+		$order->save_meta_data();
+
+		$lookup_called   = false;
+		$pre_http_filter = $this->stub_checkout_session_lookup( $intent_id, $session_resolves ? $checkout_session_id : null, $lookup_called );
+		add_filter( 'pre_http_request', $pre_http_filter, 10, 3 );
+
+		$intent = [
+			'id'                 => $intent_id,
+			'last_payment_error' => (object) [ 'message' => 'Your card was declined.' ],
+		];
+		if ( $has_marker ) {
+			$intent['metadata'] = (object) [ 'checkout_type' => WC_Stripe_Checkout_Sessions_Ajax_Handler::ADAPTIVE_PRICING_CHECKOUT_TYPE ];
+		}
+
+		$notification = (object) [
+			'type' => 'payment_intent.payment_failed',
+			'data' => (object) [
+				'object' => (object) $intent,
+			],
+		];
+
+		$this->mock_webhook_handler->process_payment_intent( $notification );
+		remove_filter( 'pre_http_request', $pre_http_filter );
+
+		$this->assertSame( $expect_lookup, $lookup_called );
+		$this->assertSame( $expected_status, wc_get_order( $order->get_id() )->get_status() );
+	}
+
+	/**
+	 * Data provider for `test_process_payment_intent_checkout_session_fallback`.
+	 *
+	 * @return array<string, array{0: bool, 1: bool, 2: bool, 3: string}>
+	 */
+	public function provide_process_payment_intent_checkout_session_fallback(): array {
+		return [
+			'flagged intent, session resolves -> order failed'       => [ true, true, true, OrderStatus::FAILED ],
+			'flagged intent, no matching session -> order untouched' => [ true, false, true, OrderStatus::PENDING ],
+			'unflagged intent -> lookup skipped, order untouched'    => [ false, true, false, OrderStatus::PENDING ],
+		];
+	}
+
+	/**
+	 * charge.failed is intentionally not used to resolve declined Adaptive Pricing orders — the
+	 * paired payment_intent.payment_failed event handles that — so it must not run the session lookup.
+	 */
+	public function test_process_webhook_charge_failed_does_not_resolve_declined_adaptive_pricing_order_via_checkout_session() {
+		$checkout_session_id = 'cs_test_charge_no_resolve';
+		$intent_id           = 'pi_test_charge_no_resolve';
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::PENDING );
+		$order->save();
+		WC_Stripe_Order_Helper::get_instance()->update_stripe_checkout_session_id( $order, $checkout_session_id );
+		$order->save_meta_data();
+
+		$lookup_called   = false;
+		$pre_http_filter = $this->stub_checkout_session_lookup( $intent_id, $checkout_session_id, $lookup_called );
+		add_filter( 'pre_http_request', $pre_http_filter, 10, 3 );
+
+		$notification = (object) [
+			'type' => 'charge.failed',
+			'data' => (object) [
+				'object' => (object) [
+					'id'             => 'ch_test_no_resolve',
+					'payment_intent' => $intent_id,
+				],
+			],
+		];
+
+		$this->mock_webhook_handler->process_webhook_charge_failed( $notification );
+		remove_filter( 'pre_http_request', $pre_http_filter );
+
+		$this->assertFalse( $lookup_called, 'charge.failed must not trigger the Checkout Session lookup.' );
+		$final_order = wc_get_order( $order->get_id() );
+		$this->assertSame( OrderStatus::PENDING, $final_order->get_status() );
+	}
+
+	/**
 	 * Test for `process_webhook_dispute`.
 	 *
 	 * @param bool $order_status_final Whether the order status is final.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->
Forum thread: https://wordpress.org/support/topic/order-status-not-changing-to-failed-after-payment-decline/


## Changes proposed in this Pull Request:

When Adaptive Pricing is enabled, checkout runs through Stripe Checkout Sessions, where the payment is confirmed on Stripe's side and the order status is updated by webhooks. If a customer's card was declined, the order couldn't be matched back from the failure webhook, so it was left stuck in "Pending Payment" until the session expired - up to 24 hours later.

This change lets the failed-payment webhook find the order through its checkout session and mark it failed right away. 
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. Enable Optimized Checkout and Adaptive Pricing, and make sure webhooks are working.
2. Add a product to the cart and go to checkout.
3. Pay with a card that is declined (Stripe test card 4000 0000 0000 0002).
4. Confirm the payment is declined at checkout.
5. Check the order in the WooCommerce admin: 
- In develop, order status will be Pending Payments
- In this branch, it should be "Failed" 
6. Regression check: complete a normal successful Adaptive Pricing payment and confirm the order is marked paid as usual.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
