### PR TITLE
Paginate listFiles in validate-changelog so large PRs are checked correctly

### DIFF
--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -33,12 +33,16 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { data: files } = await github.rest.pulls.listFiles({
+            // Paginate: a PR can change more files than a single listFiles page
+            // (default 30) returns, so without this changelog.txt/readme.txt can
+            // be missed on large PRs and the check fails despite valid entries.
+            const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number
+              pull_number: context.issue.number,
+              per_page: 100
             });
-            
+
             const changelogUpdated = files.some(file => file.filename === 'changelog.txt');
             const readmeUpdated = files.some(file => file.filename === 'readme.txt');
             


### PR DESCRIPTION
## Changes proposed in this Pull Request:

The `Validate Changelog` workflow calls `github.rest.pulls.listFiles()` without pagination, so it only inspects the first page of changed files (GitHub's default, 30). On PRs that touch more than 30 files, `changelog.txt`/`readme.txt` can fall onto a later page and go undetected — the check then fails with "This PR requires changelog entries" even though both files were updated correctly.

This switches the call to `github.paginate(github.rest.pulls.listFiles, { …, per_page: 100 })` so the full changed-file list is inspected.

Real-world trigger: PR #5402 changes 73 files; `readme.txt` is the 37th alphabetically (after `changelog.txt` + all `includes/*` + `package*.json` + `phpstan-baseline.neon`), so it never appeared on page 1.

## Testing instructions

- Open/observe a PR that targets `develop` or `trunk` and changes >30 files including both `changelog.txt` and `readme.txt` (e.g. #5402). The `Check for changelog updates` job should now pass.
- A PR that updates only one of the two files should still fail.
- A PR with the exemption box ticked should still skip the check.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️) — CI workflow change; no unit-testable surface
-   [x] Tested on mobile (or does not apply) — does not apply

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

CI-only change to a GitHub Actions workflow; no merchant- or extension-author-facing behavior changes.

</details>

> *Drafted with AI; reviewed by me.*
