### PR TITLE
Deprecate WC_Stripe_Feature_Flags::is_amazon_pay_available()

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ xxxx-xx-xx - version 10.9.0
 * Dev - Add a Code Comment Conventions section to AGENTS.md to standardize agent and contributor comment guidance
 * Fix - Run the woocommerce_gateway_description filter for Stripe payment methods so third parties can add or replace their checkout descriptions
 * Fix - Show an error notice when a Stripe OAuth connection attempt fails its security check
+* Dev - Deprecate the internal WC_Stripe_Feature_Flags::is_amazon_pay_available() helper now that Amazon Pay is permanently enabled
 
 2026-06-15 - version 10.8.2
 * Fix - Disable Adaptive Pricing when webhooks are disabled

--- a/client/blocks/upe/index.js
+++ b/client/blocks/upe/index.js
@@ -55,10 +55,7 @@ Object.entries( paymentMethodsConfig )
 	} );
 
 // Register Express Checkout Elements.
-if (
-	getBlocksConfiguration()?.isAmazonPayAvailable && // Hide behind feature flag so the editor does not show the button.
-	getBlocksConfiguration()?.isAmazonPayEnabled
-) {
+if ( getBlocksConfiguration()?.isAmazonPayEnabled ) {
 	registerExpressPaymentMethod( expressCheckoutElementAmazonPay( api ) );
 }
 if ( getBlocksConfiguration()?.isExpressCheckoutEnabled ) {

--- a/client/settings/payment-request-section/__tests__/index.test.js
+++ b/client/settings/payment-request-section/__tests__/index.test.js
@@ -49,7 +49,6 @@ describe( 'PaymentRequestSection', () => {
 		useIsAdaptivePricingEnabled.mockReturnValue( [ false, jest.fn() ] );
 		global.wc_stripe_settings_params = {
 			...globalValues,
-			is_amazon_pay_available: true,
 			taxes_based_on_billing: false,
 			is_card_method_enabled: true,
 		};
@@ -99,22 +98,17 @@ describe( 'PaymentRequestSection', () => {
 		expect( linkCheckbox ).not.toBeChecked();
 	} );
 
-	it( 'render Amazon Pay if feature flag is on', () => {
-		global.wc_stripe_settings_params = {
-			...globalValues,
-			is_amazon_pay_available: true,
-		};
-
+	it( 'render Amazon Pay if it is an available payment method', () => {
 		render( <PaymentRequestSection /> );
 
 		expect( screen.queryByText( 'Amazon Pay' ) ).toBeInTheDocument();
 	} );
 
-	it( 'hide Amazon Pay if feature flag is off', () => {
-		global.wc_stripe_settings_params = {
-			...globalValues,
-			is_amazon_pay_available: false,
-		};
+	it( 'hide Amazon Pay if it is not an available payment method', () => {
+		useGetAvailablePaymentMethodIds.mockReturnValue( [
+			PAYMENT_METHOD_CARD,
+			PAYMENT_METHOD_LINK,
+		] );
 
 		render( <PaymentRequestSection /> );
 
@@ -142,7 +136,6 @@ describe( 'PaymentRequestSection', () => {
 	it( 'Amazon Pay checkbox disabled', () => {
 		global.wc_stripe_settings_params = {
 			...globalValues,
-			is_amazon_pay_available: true,
 			taxes_based_on_billing: true,
 		};
 

--- a/client/settings/payment-request-section/index.js
+++ b/client/settings/payment-request-section/index.js
@@ -1,5 +1,3 @@
-/* global wc_stripe_settings_params */
-
 import React from 'react';
 import interpolateComponents from '@automattic/interpolate-components';
 import PaymentRequestIcon from '../../payment-method-icons/payment-request';
@@ -99,9 +97,9 @@ const PaymentRequestSection = () => {
 		area: 'link',
 	} );
 
-	const isAmazonPayAvailable =
-		wc_stripe_settings_params.is_amazon_pay_available && // eslint-disable-line camelcase
-		availablePaymentMethodIds.includes( PAYMENT_METHOD_AMAZON_PAY );
+	const isAmazonPayAvailable = availablePaymentMethodIds.includes(
+		PAYMENT_METHOD_AMAZON_PAY
+	);
 
 	const isAmazonPayDisabled =
 		amazonPayUnavailableReason !== null &&

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -254,7 +254,6 @@ class WC_Stripe_Settings_Controller {
 			'plugin_version'                        => WC_STRIPE_VERSION,
 			'account_country'                       => $this->account->get_account_country(),
 			'are_apms_deprecated'                   => false,
-			'is_amazon_pay_available'               => WC_Stripe_Feature_Flags::is_amazon_pay_available(),
 			'is_oc_available'                       => WC_Stripe_Feature_Flags::is_oc_available(),
 			'is_oc_enabled'                         => $is_oc_enabled,
 			'is_cs_available'                       => $is_checkout_sessions_available,

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -88,9 +88,10 @@ class WC_Stripe_Feature_Flags {
 	 * Feature flag to control Amazon Pay feature availability.
 	 *
 	 * @return bool
-	 * @deprecated This method will be removed in a future version. Amazon Pay is permanently enabled as of version 10.4.0.
+	 * @deprecated 10.9.0 Amazon Pay is permanently enabled as of version 10.4.0.
 	 */
 	public static function is_amazon_pay_available() {
+		wc_deprecated_function( __METHOD__, '10.9.0' );
 		return true;
 	}
 

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -232,7 +232,7 @@ class WC_Stripe {
 				if ( self::$instance === $this ) {
 					new WC_Stripe_Express_Checkout_Controller();
 				}
-			} elseif ( 'amazon_pay' === $area && WC_Stripe_Feature_Flags::is_amazon_pay_available() ) {
+			} elseif ( 'amazon_pay' === $area ) {
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-amazon-pay-controller.php';
 				if ( self::$instance === $this ) {
 					new WC_Stripe_Amazon_Pay_Controller();
@@ -1068,12 +1068,6 @@ class WC_Stripe {
 			$this->maybe_deactivate_bnpls( $gateways->payment_gateways, $enabled_payment_methods )
 		);
 
-		// Check if Amazon Pay should be deactivated.
-		$payment_method_ids_to_disable = array_merge(
-			$payment_method_ids_to_disable,
-			$this->maybe_deactivate_amazon_pay( $enabled_payment_methods )
-		);
-
 		if ( [] === $payment_method_ids_to_disable ) {
 			return;
 		}
@@ -1113,29 +1107,5 @@ class WC_Stripe {
 		}
 
 		return $payment_method_ids_to_disable;
-	}
-
-	/**
-	 * Deactivate Amazon Pay if it's not available, i.e. unreleased.
-	 *
-	 * TODO: Remove this method once Amazon Pay is released.
-	 *
-	 * @param array $enabled_payment_methods The enabled payment methods.
-	 * @return array Amazon Pay payment method ID, if it should be disabled.
-	 */
-	private function maybe_deactivate_amazon_pay( $enabled_payment_methods ) {
-		// Safety guard only. Ideally, we will remove this method once Amazon Pay is released.
-		if ( WC_Stripe_Feature_Flags::is_amazon_pay_available() ) {
-			// Nothing to do if Amazon Pay is already released.
-			return [];
-		}
-
-		if ( ! in_array( WC_Stripe_Payment_Methods::AMAZON_PAY, $enabled_payment_methods, true ) ) {
-			// Nothing to do if Amazon Pay is not enabled.
-			return [];
-		}
-
-		// Disable Amazon Pay.
-		return [ WC_Stripe_Payment_Methods::AMAZON_PAY ];
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -593,9 +593,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			}
 		}
 
-		// Amazon Pay feature flag.
-		$stripe_params['isAmazonPayAvailable'] = WC_Stripe_Feature_Flags::is_amazon_pay_available();
-
 		/**
 		 * Filters the list of permitted font domains for the Stripe Payment Element.
 		 * These host names will be used in the client Javascript to identify additional domains

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
@@ -161,11 +161,6 @@ class WC_Stripe_UPE_Payment_Method_Amazon_Pay extends WC_Stripe_UPE_Payment_Meth
 	 * @return bool
 	 */
 	public static function is_amazon_pay_enabled( WC_Stripe_Payment_Gateway $gateway ) {
-		// Amazon Pay is disabled if feature flag is disabled.
-		if ( ! WC_Stripe_Feature_Flags::is_amazon_pay_available() ) {
-			return false;
-		}
-
 		$upe_enabled_method_ids = $gateway->get_upe_enabled_payment_method_ids();
 
 		return is_array( $upe_enabled_method_ids ) && in_array( self::STRIPE_ID, $upe_enabled_method_ids, true );

--- a/readme.txt
+++ b/readme.txt
@@ -176,5 +176,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Add a Code Comment Conventions section to AGENTS.md to standardize agent and contributor comment guidance
 * Fix - Show an error notice when a Stripe OAuth connection attempt fails its security check
 * Fix - Run the woocommerce_gateway_description filter for Stripe payment methods so third parties can add or replace their checkout descriptions
+* Dev - Deprecate the internal WC_Stripe_Feature_Flags::is_amazon_pay_available() helper now that Amazon Pay is permanently enabled
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-feature-flags-test.php
+++ b/tests/phpunit/class-wc-stripe-feature-flags-test.php
@@ -20,6 +20,16 @@ class WC_Stripe_Feature_Flags_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
+	 * `is_amazon_pay_available()` is deprecated but must keep returning true so any
+	 * lingering third-party callers continue to treat Amazon Pay as permanently enabled.
+	 */
+	public function test_is_amazon_pay_available_is_deprecated(): void {
+		$this->setExpectedDeprecated( 'WC_Stripe_Feature_Flags::is_amazon_pay_available' );
+
+		$this->assertTrue( WC_Stripe_Feature_Flags::is_amazon_pay_available() );
+	}
+
+	/**
 	 * Test for `is_oc_available`.
 	 *
 	 * @param bool $pmc_enabled Whether the Payment Method Configuration API is enabled.


### PR DESCRIPTION
Fixes STRIPE-943
Fixes #4989

## Changes proposed in this Pull Request:

Amazon Pay has been permanently enabled since 10.4.0, so `WC_Stripe_Feature_Flags::is_amazon_pay_available()` always returns `true`. This PR completes the deprecation that was prepared in #4859 but backed out because the live `wc_deprecated_function()` call tripped unit-test deprecation assertions while internal callers still existed.

This removes all 5 internal callers first, then adds the deprecation:

- **`is_amazon_pay_available()`** — added `wc_deprecated_function( __METHOD__, '10.9.0' )`.
- **`class-wc-stripe.php`** — dropped the flag check from the `amazon_pay` admin-area branch and removed the dead `maybe_deactivate_amazon_pay()` method and its call site (it only ever returned `[]` once Amazon Pay shipped; its own TODOs said to delete it post-release).
- **`is_amazon_pay_enabled()`** (Amazon Pay method) — removed the always-false feature-flag guard.
- **Localized params** — removed `is_amazon_pay_available` (settings controller) and `isAmazonPayAvailable` (UPE gateway), plus the now-constant conditionals they gated in `client/settings/payment-request-section/index.js` and `client/blocks/upe/index.js`. Amazon Pay availability now derives from the enabled/available payment method IDs.

Because the flag was always `true`, this is behaviorally a no-op — Amazon Pay stays permanently enabled. The only externally observable change is that any lingering third-party caller of `is_amazon_pay_available()` now gets a deprecation notice.

## Testing instructions

This is an internal refactor with no intended user-facing change; the goal of testing is to confirm Amazon Pay behaves exactly as before.

1. Connect a Stripe account in a supported Amazon Pay country (e.g. US) and enable Amazon Pay.
2. **Settings:** go to the Stripe settings → Payment Methods / Express Checkout section and confirm the Amazon Pay row renders and its checkbox toggles as before.
3. **Blocks checkout:** add a product to the cart and confirm the Amazon Pay express button still renders on the Blocks cart/checkout.
4. **Classic / shortcode checkout:** confirm the Amazon Pay express button still renders.
5. Disable Amazon Pay and confirm it disappears from all surfaces.
6. Confirm no PHP `is_amazon_pay_available` deprecation notices appear during normal checkout (no internal code calls it anymore).

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

Added under 10.9.0 in both `changelog.txt` and `readme.txt`:

> Dev - Deprecate the internal WC_Stripe_Feature_Flags::is_amazon_pay_available() helper now that Amazon Pay is permanently enabled

**Post merge**

-   [ ] Added testing instructions to the Release Testing Instructions wiki page (or does not apply)
-   [ ] Added the needs docs label (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
