### PR TITLE
Add "What's new" inbox note for plugin upgraders

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Run the woocommerce_gateway_description filter for Stripe payment methods so third parties can add or replace their checkout descriptions
 * Fix - Show an error notice when a Stripe OAuth connection attempt fails its security check
 * Dev - Deprecate the internal WC_Stripe_Feature_Flags::is_amazon_pay_available() helper now that Amazon Pay is permanently enabled
+* Add - Show a "What's new" inbox note after the plugin updates so merchants who auto-update are still pointed to the release notes
 
 2026-06-15 - version 10.8.2
 * Fix - Disable Adaptive Pricing when webhooks are disabled

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,7 +22,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Run the woocommerce_gateway_description filter for Stripe payment methods so third parties can add or replace their checkout descriptions
 * Fix - Show an error notice when a Stripe OAuth connection attempt fails its security check
 * Dev - Deprecate the internal WC_Stripe_Feature_Flags::is_amazon_pay_available() helper now that Amazon Pay is permanently enabled
-* Add - Show a "What's new" inbox note after the plugin updates so merchants who auto-update are still pointed to the release notes
+* Add - Show a "What's new" inbox note after the plugin updates, including via auto-update
 
 2026-06-15 - version 10.8.2
 * Fix - Disable Adaptive Pricing when webhooks are disabled

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
         "includes/migrations/class-wc-stripe-express-checkout-add-change-payment-method-location-update.php",
         "includes/migrations/class-wc-stripe-migrate-link-button-locations.php",
         "includes/migrations/class-wc-stripe-ocs-ap-default-on-update.php",
+        "includes/notes/class-wc-stripe-whats-new-note.php",
         "includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php",
         "includes/payment-tokens/class-wc-stripe-ach-payment-token.php",
         "includes/payment-tokens/class-wc-stripe-acss-payment-token.php",

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -71,6 +71,9 @@ class WC_Stripe_Inbox_Notes {
 
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/notes/class-wc-stripe-oc-promotion-note.php';
 		WC_Stripe_OC_Promotion_Note::init( $gateway );
+
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/notes/class-wc-stripe-whats-new-note.php';
+		WC_Stripe_Whats_New_Note::init();
 	}
 
 	/**

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -72,7 +72,6 @@ class WC_Stripe_Inbox_Notes {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/notes/class-wc-stripe-oc-promotion-note.php';
 		WC_Stripe_OC_Promotion_Note::init( $gateway );
 
-		require_once WC_STRIPE_PLUGIN_PATH . '/includes/notes/class-wc-stripe-whats-new-note.php';
 		WC_Stripe_Whats_New_Note::init();
 	}
 

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -390,9 +390,8 @@ class WC_Stripe {
 			update_option( 'wc_stripe_optimized_checkout_default_on', 'yes' );
 		}
 
-		// Seed the version baseline so the "What's new" inbox note fires for
-		// upgraders only — auto-updaters never revisit the Plugins screen, so
-		// this upgrade routine is the reliable place to detect the bump.
+		// Seed the "What's new" note baseline here: this upgrade routine is the
+		// reliable place to detect the bump for auto-updaters.
 		WC_Stripe_Whats_New_Note::record_install_version( $previous_version );
 
 		add_woocommerce_inbox_variant();

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -393,7 +393,6 @@ class WC_Stripe {
 		// Seed the version baseline so the "What's new" inbox note fires for
 		// upgraders only — auto-updaters never revisit the Plugins screen, so
 		// this upgrade routine is the reliable place to detect the bump.
-		require_once WC_STRIPE_PLUGIN_PATH . '/includes/notes/class-wc-stripe-whats-new-note.php';
 		WC_Stripe_Whats_New_Note::record_install_version( $previous_version );
 
 		add_woocommerce_inbox_variant();

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -390,6 +390,12 @@ class WC_Stripe {
 			update_option( 'wc_stripe_optimized_checkout_default_on', 'yes' );
 		}
 
+		// Seed the version baseline so the "What's new" inbox note fires for
+		// upgraders only — auto-updaters never revisit the Plugins screen, so
+		// this upgrade routine is the reliable place to detect the bump.
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/notes/class-wc-stripe-whats-new-note.php';
+		WC_Stripe_Whats_New_Note::record_install_version( $previous_version );
+
 		add_woocommerce_inbox_variant();
 		$this->update_plugin_version();
 

--- a/includes/notes/class-wc-stripe-whats-new-note.php
+++ b/includes/notes/class-wc-stripe-whats-new-note.php
@@ -40,9 +40,9 @@ final class WC_Stripe_Whats_New_Note {
 
 		$note->set_title(
 			sprintf(
-				/* translators: %s: plugin version, e.g. "10.9". */
+				/* translators: %s: plugin version, e.g. "10.8.2". */
 				__( 'WooCommerce Stripe %s: see what\'s new', 'woocommerce-gateway-stripe' ),
-				self::get_marketing_version()
+				WC_STRIPE_VERSION
 			)
 		);
 		$note->set_content( __( 'You\'re now on the latest version of WooCommerce Stripe. Check the release notes to see the new features and improvements in this update.', 'woocommerce-gateway-stripe' ) );
@@ -134,16 +134,5 @@ final class WC_Stripe_Whats_New_Note {
 		return self_admin_url(
 			'plugin-install.php?tab=plugin-information&plugin=woocommerce-gateway-stripe&section=changelog'
 		);
-	}
-
-	/**
-	 * Major.minor of the running version for the headline (e.g. "10.9.2" -> "10.9").
-	 *
-	 * @return string
-	 */
-	private static function get_marketing_version(): string {
-		$parts = explode( '.', WC_STRIPE_VERSION );
-
-		return isset( $parts[1] ) ? $parts[0] . '.' . $parts[1] : WC_STRIPE_VERSION;
 	}
 }

--- a/includes/notes/class-wc-stripe-whats-new-note.php
+++ b/includes/notes/class-wc-stripe-whats-new-note.php
@@ -46,10 +46,8 @@ final class WC_Stripe_Whats_New_Note {
 			)
 		);
 		$note->set_content( __( 'You\'re now on the latest version of WooCommerce Stripe. Check the release notes to see the new features and improvements in this update.', 'woocommerce-gateway-stripe' ) );
-		// Must be a type the Inbox renders: its query is limited to
-		// info/marketing/survey/warning, so the semantically-apt "update" type
-		// would be created but never displayed. "info" also avoids the
-		// marketplace-suggestions opt-out that hides "marketing" notes.
+		// The Inbox only renders info/marketing/survey/warning; "update" would
+		// save but never display. "info" also dodges the marketing opt-out.
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-gateway-stripe' );

--- a/includes/notes/class-wc-stripe-whats-new-note.php
+++ b/includes/notes/class-wc-stripe-whats-new-note.php
@@ -125,14 +125,15 @@ final class WC_Stripe_Whats_New_Note {
 	/**
 	 * In-admin changelog deep link for the note action.
 	 *
-	 * Omits the thickbox iframe params the Plugins-screen link uses: a note
+	 * Returns a relative admin path, not an absolute URL: the Inbox REST layer
+	 * runs it through admin_url() per request, so the base resolves to the
+	 * store's current address rather than baking one in at creation time.
+	 * Omits the thickbox iframe params the Plugins-screen link uses — a note
 	 * action is a plain navigation, so it must resolve to a full admin page.
 	 *
 	 * @return string
 	 */
 	private static function get_changelog_url(): string {
-		return self_admin_url(
-			'plugin-install.php?tab=plugin-information&plugin=woocommerce-gateway-stripe&section=changelog'
-		);
+		return 'plugin-install.php?tab=plugin-information&plugin=woocommerce-gateway-stripe&section=changelog';
 	}
 }

--- a/includes/notes/class-wc-stripe-whats-new-note.php
+++ b/includes/notes/class-wc-stripe-whats-new-note.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Surfaces a "What's new" inbox note after a plugin upgrade.
+ *
+ * The Plugins-screen "what's new" surfaces only fire on `plugins.php`, which
+ * stores on auto-update never revisit. This note reaches those merchants on
+ * their next wp-admin visit regardless of how the plugin was updated.
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+use Automattic\WooCommerce\Admin\Notes\Note;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WC_Stripe_Whats_New_Note
+ */
+final class WC_Stripe_Whats_New_Note {
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	public const NOTE_NAME = 'wc-stripe-whats-new-note';
+
+	/**
+	 * Option recording the plugin version a merchant was last shown the note
+	 * for. It is compared against WC_STRIPE_VERSION so the note fires for
+	 * upgraders only.
+	 */
+	public const LAST_SEEN_VERSION_OPTION = 'wc_stripe_whats_new_note_version';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		$note = new Note();
+
+		$note->set_title(
+			sprintf(
+				/* translators: %s: plugin version, e.g. "10.9". */
+				__( 'WooCommerce Stripe %s: see what\'s new', 'woocommerce-gateway-stripe' ),
+				self::get_marketing_version()
+			)
+		);
+		$note->set_content( __( 'You\'re now on the latest version of WooCommerce Stripe. Check the release notes to see the new features and improvements in this update.', 'woocommerce-gateway-stripe' ) );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_UPDATE );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-gateway-stripe' );
+		$note->add_action(
+			'view-whats-new',
+			__( 'See what\'s new', 'woocommerce-gateway-stripe' ),
+			self::get_changelog_url(),
+			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			true
+		);
+
+		return $note;
+	}
+
+	/**
+	 * Show the note to merchants who just upgraded.
+	 *
+	 * @return void
+	 * @throws \Automattic\WooCommerce\Admin\Notes\NotesUnavailableException
+	 */
+	public static function init() {
+		if ( ! defined( 'WC_STRIPE_VERSION' ) || ! self::is_upgrade_pending() ) {
+			return;
+		}
+
+		// Drop any note left over from an earlier release so a single, current
+		// note surfaces per upgrade; the fixed note name would otherwise block
+		// re-adding it.
+		self::possibly_delete_note();
+		self::possibly_add_note();
+
+		// Bank the running version so the note shows once per upgrade. This is
+		// the only writer that advances the baseline to the current version;
+		// record_install_version() never rolls it back below this value.
+		update_option( self::LAST_SEEN_VERSION_OPTION, WC_STRIPE_VERSION );
+	}
+
+	/**
+	 * Whether the merchant has upgraded past the version they last saw the note for.
+	 *
+	 * @return bool
+	 */
+	public static function is_upgrade_pending(): bool {
+		$last_seen = get_option( self::LAST_SEEN_VERSION_OPTION );
+
+		// No baseline yet: we cannot tell an upgrade from a fresh install, so
+		// stay silent. record_install_version() seeds the baseline on the
+		// upgrade/activation pass and a later visit will surface the note.
+		if ( false === $last_seen || '' === $last_seen ) {
+			return false;
+		}
+
+		return version_compare( $last_seen, WC_STRIPE_VERSION, '<' );
+	}
+
+	/**
+	 * Seed the version baseline from the plugin's upgrade routine.
+	 *
+	 * Fresh installs (no previous version) bank the current version so the note
+	 * never fires for them. Upgraders bank the version they came from, but only
+	 * when no baseline exists yet, so we never roll back a value init() has
+	 * already advanced to the current version (the two run on the same
+	 * `admin_init` pass in an undefined order).
+	 *
+	 * @param string|false $previous_version Version stored before this upgrade, or false on a fresh install.
+	 * @return void
+	 */
+	public static function record_install_version( $previous_version ): void {
+		if ( false === $previous_version ) {
+			update_option( self::LAST_SEEN_VERSION_OPTION, WC_STRIPE_VERSION );
+			return;
+		}
+
+		if ( false === get_option( self::LAST_SEEN_VERSION_OPTION ) ) {
+			update_option( self::LAST_SEEN_VERSION_OPTION, $previous_version );
+		}
+	}
+
+	/**
+	 * In-admin changelog deep link for the note action.
+	 *
+	 * Unlike the Plugins-screen "Release notes" link, this omits the thickbox
+	 * iframe params: an inbox-note action is a plain navigation, so it must
+	 * resolve to a full admin page rather than a modal that needs thickbox JS.
+	 *
+	 * @return string
+	 */
+	private static function get_changelog_url(): string {
+		return self_admin_url(
+			'plugin-install.php?tab=plugin-information&plugin=woocommerce-gateway-stripe&section=changelog'
+		);
+	}
+
+	/**
+	 * Major.minor of the running version for the headline (e.g. "10.9.2" -> "10.9").
+	 *
+	 * @return string
+	 */
+	private static function get_marketing_version(): string {
+		$parts = explode( '.', WC_STRIPE_VERSION );
+
+		return isset( $parts[1] ) ? $parts[0] . '.' . $parts[1] : WC_STRIPE_VERSION;
+	}
+}

--- a/includes/notes/class-wc-stripe-whats-new-note.php
+++ b/includes/notes/class-wc-stripe-whats-new-note.php
@@ -123,17 +123,15 @@ final class WC_Stripe_Whats_New_Note {
 	}
 
 	/**
-	 * In-admin changelog deep link for the note action.
+	 * Public changelog URL for the note action.
 	 *
-	 * Returns a relative admin path, not an absolute URL: the Inbox REST layer
-	 * runs it through admin_url() per request, so the base resolves to the
-	 * store's current address rather than baking one in at creation time.
-	 * Omits the thickbox iframe params the Plugins-screen link uses — a note
-	 * action is a plain navigation, so it must resolve to a full admin page.
+	 * An external (non-admin) URL is required for the Inbox to open the action
+	 * in a new tab: it routes any link under the admin URL to the same tab and
+	 * only `window.open()`s URLs outside it.
 	 *
 	 * @return string
 	 */
 	private static function get_changelog_url(): string {
-		return 'plugin-install.php?tab=plugin-information&plugin=woocommerce-gateway-stripe&section=changelog';
+		return 'https://wordpress.org/plugins/woocommerce-gateway-stripe/#developers';
 	}
 }

--- a/includes/notes/class-wc-stripe-whats-new-note.php
+++ b/includes/notes/class-wc-stripe-whats-new-note.php
@@ -46,7 +46,11 @@ final class WC_Stripe_Whats_New_Note {
 			)
 		);
 		$note->set_content( __( 'You\'re now on the latest version of WooCommerce Stripe. Check the release notes to see the new features and improvements in this update.', 'woocommerce-gateway-stripe' ) );
-		$note->set_type( Note::E_WC_ADMIN_NOTE_UPDATE );
+		// Must be a type the Inbox renders: its query is limited to
+		// info/marketing/survey/warning, so the semantically-apt "update" type
+		// would be created but never displayed. "info" also avoids the
+		// marketplace-suggestions opt-out that hides "marketing" notes.
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-gateway-stripe' );
 		$note->add_action(

--- a/includes/notes/class-wc-stripe-whats-new-note.php
+++ b/includes/notes/class-wc-stripe-whats-new-note.php
@@ -92,8 +92,9 @@ final class WC_Stripe_Whats_New_Note {
 		$last_seen = get_option( self::LAST_SEEN_VERSION_OPTION );
 
 		// No baseline yet: can't tell an upgrade from a fresh install, so stay
-		// silent until record_install_version() seeds it.
-		if ( false === $last_seen || '' === $last_seen ) {
+		// silent until record_install_version() seeds it. Reject non-strings
+		// too — the option is untrusted and version_compare() fatals on arrays.
+		if ( ! is_string( $last_seen ) || '' === $last_seen ) {
 			return false;
 		}
 
@@ -114,6 +115,12 @@ final class WC_Stripe_Whats_New_Note {
 	public static function record_install_version( $previous_version ): void {
 		if ( false === $previous_version ) {
 			update_option( self::LAST_SEEN_VERSION_OPTION, WC_STRIPE_VERSION );
+			return;
+		}
+
+		// `wc_stripe_version` is untrusted; never bank a non-string/empty value
+		// as the baseline (is_upgrade_pending() would reject it anyway).
+		if ( ! is_string( $previous_version ) || '' === $previous_version ) {
 			return;
 		}
 

--- a/includes/notes/class-wc-stripe-whats-new-note.php
+++ b/includes/notes/class-wc-stripe-whats-new-note.php
@@ -1,10 +1,9 @@
 <?php
 /**
- * Surfaces a "What's new" inbox note after a plugin upgrade.
+ * "What's new" inbox note shown after a plugin upgrade.
  *
- * The Plugins-screen "what's new" surfaces only fire on `plugins.php`, which
- * stores on auto-update never revisit. This note reaches those merchants on
- * their next wp-admin visit regardless of how the plugin was updated.
+ * Reaches auto-updaters, who never revisit `plugins.php` where the other
+ * "what's new" surfaces fire.
  *
  * @package WooCommerce\Payments\Admin
  */
@@ -26,9 +25,8 @@ final class WC_Stripe_Whats_New_Note {
 	public const NOTE_NAME = 'wc-stripe-whats-new-note';
 
 	/**
-	 * Option recording the plugin version a merchant was last shown the note
-	 * for. It is compared against WC_STRIPE_VERSION so the note fires for
-	 * upgraders only.
+	 * Version a merchant was last shown the note for; compared against
+	 * WC_STRIPE_VERSION so the note fires for upgraders only.
 	 */
 	public const LAST_SEEN_VERSION_OPTION = 'wc_stripe_whats_new_note_version';
 
@@ -73,15 +71,13 @@ final class WC_Stripe_Whats_New_Note {
 			return;
 		}
 
-		// Drop any note left over from an earlier release so a single, current
-		// note surfaces per upgrade; the fixed note name would otherwise block
-		// re-adding it.
+		// Drop any earlier-release note first; the fixed note name would
+		// otherwise block re-adding it.
 		self::possibly_delete_note();
 		self::possibly_add_note();
 
-		// Bank the running version so the note shows once per upgrade. This is
-		// the only writer that advances the baseline to the current version;
-		// record_install_version() never rolls it back below this value.
+		// Only writer that advances the baseline to the current version, so the
+		// note shows once per upgrade; record_install_version() never lowers it.
 		update_option( self::LAST_SEEN_VERSION_OPTION, WC_STRIPE_VERSION );
 	}
 
@@ -93,9 +89,8 @@ final class WC_Stripe_Whats_New_Note {
 	public static function is_upgrade_pending(): bool {
 		$last_seen = get_option( self::LAST_SEEN_VERSION_OPTION );
 
-		// No baseline yet: we cannot tell an upgrade from a fresh install, so
-		// stay silent. record_install_version() seeds the baseline on the
-		// upgrade/activation pass and a later visit will surface the note.
+		// No baseline yet: can't tell an upgrade from a fresh install, so stay
+		// silent until record_install_version() seeds it.
 		if ( false === $last_seen || '' === $last_seen ) {
 			return false;
 		}
@@ -106,13 +101,12 @@ final class WC_Stripe_Whats_New_Note {
 	/**
 	 * Seed the version baseline from the plugin's upgrade routine.
 	 *
-	 * Fresh installs (no previous version) bank the current version so the note
-	 * never fires for them. Upgraders bank the version they came from, but only
-	 * when no baseline exists yet, so we never roll back a value init() has
-	 * already advanced to the current version (the two run on the same
+	 * Fresh installs bank the current version so the note never fires. Upgraders
+	 * bank the version they came from, but only when no baseline exists yet, so
+	 * we never lower a value init() already advanced (both run on the same
 	 * `admin_init` pass in an undefined order).
 	 *
-	 * @param string|false $previous_version Version stored before this upgrade, or false on a fresh install.
+	 * @param string|false $previous_version Version before this upgrade, or false on a fresh install.
 	 * @return void
 	 */
 	public static function record_install_version( $previous_version ): void {
@@ -129,9 +123,8 @@ final class WC_Stripe_Whats_New_Note {
 	/**
 	 * In-admin changelog deep link for the note action.
 	 *
-	 * Unlike the Plugins-screen "Release notes" link, this omits the thickbox
-	 * iframe params: an inbox-note action is a plain navigation, so it must
-	 * resolve to a full admin page rather than a modal that needs thickbox JS.
+	 * Omits the thickbox iframe params the Plugins-screen link uses: a note
+	 * action is a plain navigation, so it must resolve to a full admin page.
 	 *
 	 * @return string
 	 */

--- a/readme.txt
+++ b/readme.txt
@@ -177,6 +177,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Show an error notice when a Stripe OAuth connection attempt fails its security check
 * Fix - Run the woocommerce_gateway_description filter for Stripe payment methods so third parties can add or replace their checkout descriptions
 * Dev - Deprecate the internal WC_Stripe_Feature_Flags::is_amazon_pay_available() helper now that Amazon Pay is permanently enabled
-* Add - Show a "What's new" inbox note after the plugin updates so merchants who auto-update are still pointed to the release notes
+* Add - Show a "What's new" inbox note after the plugin updates, including via auto-update
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -177,5 +177,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Show an error notice when a Stripe OAuth connection attempt fails its security check
 * Fix - Run the woocommerce_gateway_description filter for Stripe payment methods so third parties can add or replace their checkout descriptions
 * Dev - Deprecate the internal WC_Stripe_Feature_Flags::is_amazon_pay_available() helper now that Amazon Pay is permanently enabled
+* Add - Show a "What's new" inbox note after the plugin updates so merchants who auto-update are still pointed to the release notes
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/notes/class-wc-stripe-whats-new-note-test.php
+++ b/tests/phpunit/notes/class-wc-stripe-whats-new-note-test.php
@@ -41,11 +41,9 @@ class WC_Stripe_Whats_New_Note_Test extends WP_UnitTestCase {
 		list( $action ) = $note->get_actions();
 		$this->assertSame( 'view-whats-new', $action->name );
 		$this->assertSame( 'See what\'s new', $action->label );
-		// Stored as a relative path so the Inbox REST layer resolves the base
-		// via admin_url() per request; an absolute URL would bake in the origin.
-		$this->assertStringContainsString( 'section=changelog', $action->query );
-		$this->assertStringStartsWith( 'plugin-install.php?', $action->query );
-		$this->assertStringNotContainsString( '://', $action->query );
+		// Must stay an external URL: the Inbox only opens links outside the
+		// admin URL in a new tab; an in-admin link would open in the same tab.
+		$this->assertSame( 'https://wordpress.org/plugins/woocommerce-gateway-stripe/#developers', $action->query );
 	}
 
 	/**

--- a/tests/phpunit/notes/class-wc-stripe-whats-new-note-test.php
+++ b/tests/phpunit/notes/class-wc-stripe-whats-new-note-test.php
@@ -41,7 +41,11 @@ class WC_Stripe_Whats_New_Note_Test extends WP_UnitTestCase {
 		list( $action ) = $note->get_actions();
 		$this->assertSame( 'view-whats-new', $action->name );
 		$this->assertSame( 'See what\'s new', $action->label );
+		// Stored as a relative path so the Inbox REST layer resolves the base
+		// via admin_url() per request; an absolute URL would bake in the origin.
 		$this->assertStringContainsString( 'section=changelog', $action->query );
+		$this->assertStringStartsWith( 'plugin-install.php?', $action->query );
+		$this->assertStringNotContainsString( '://', $action->query );
 	}
 
 	/**

--- a/tests/phpunit/notes/class-wc-stripe-whats-new-note-test.php
+++ b/tests/phpunit/notes/class-wc-stripe-whats-new-note-test.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * Class WC_Stripe_Whats_New_Note_Test
+ *
+ * @package WooCommerce/Stripe/WC_Stripe_Whats_New_Note
+ *
+ * Class WC_Stripe_Whats_New_Note tests.
+ */
+class WC_Stripe_Whats_New_Note_Test extends WP_UnitTestCase {
+
+	/**
+	 * Pre-test setup.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/notes/class-wc-stripe-whats-new-note.php';
+
+		// Each test runs inside a DB transaction that WP_UnitTestCase rolls back,
+		// so notes/options created here don't leak between tests; we only reset
+		// the baseline option up front for an explicit starting state.
+		delete_option( WC_Stripe_Whats_New_Note::LAST_SEEN_VERSION_OPTION );
+	}
+
+	/**
+	 * Guards the note's title, content, type, source and action wiring.
+	 *
+	 * @return void
+	 */
+	public function test_get_note() {
+		$note = WC_Stripe_Whats_New_Note::get_note();
+
+		$parts            = explode( '.', WC_STRIPE_VERSION );
+		$marketing        = isset( $parts[1] ) ? $parts[0] . '.' . $parts[1] : WC_STRIPE_VERSION;
+		$expected_heading = sprintf( 'WooCommerce Stripe %s: see what\'s new', $marketing );
+
+		$this->assertSame( $expected_heading, $note->get_title() );
+		$this->assertSame( 'update', $note->get_type() );
+		$this->assertSame( 'wc-stripe-whats-new-note', $note->get_name() );
+		$this->assertSame( 'woocommerce-gateway-stripe', $note->get_source() );
+
+		list( $action ) = $note->get_actions();
+		$this->assertSame( 'view-whats-new', $action->name );
+		$this->assertSame( 'See what\'s new', $action->label );
+		$this->assertStringContainsString( 'section=changelog', $action->query );
+	}
+
+	/**
+	 * The version gate only opens when the stored baseline is older than the running version.
+	 *
+	 * @dataProvider provider_is_upgrade_pending
+	 *
+	 * @param string|false $stored   Value to seed the last-seen option with, or false to leave it unset.
+	 * @param bool         $expected Whether the gate should report a pending upgrade.
+	 * @return void
+	 */
+	public function test_is_upgrade_pending( $stored, bool $expected ) {
+		if ( false === $stored ) {
+			delete_option( WC_Stripe_Whats_New_Note::LAST_SEEN_VERSION_OPTION );
+		} else {
+			update_option( WC_Stripe_Whats_New_Note::LAST_SEEN_VERSION_OPTION, $stored );
+		}
+
+		$this->assertSame( $expected, WC_Stripe_Whats_New_Note::is_upgrade_pending() );
+	}
+
+	/**
+	 * Data provider for test_is_upgrade_pending.
+	 *
+	 * @return array<string, array{0: string|false, 1: bool}>
+	 */
+	public function provider_is_upgrade_pending(): array {
+		return [
+			'no baseline yet (fresh install / pre-feature)' => [ false, false ],
+			'empty baseline'                                => [ '', false ],
+			'older baseline -> upgraded'                    => [ '0.0.1', true ],
+			'same as running version'                       => [ WC_STRIPE_VERSION, false ],
+			'newer than running version'                    => [ '999.0.0', false ],
+		];
+	}
+
+	/**
+	 * record_install_version() banks the running version on a fresh install so the note never fires.
+	 *
+	 * @return void
+	 */
+	public function test_record_install_version_fresh_install_banks_current_version() {
+		WC_Stripe_Whats_New_Note::record_install_version( false );
+
+		$this->assertSame( WC_STRIPE_VERSION, get_option( WC_Stripe_Whats_New_Note::LAST_SEEN_VERSION_OPTION ) );
+		$this->assertFalse( WC_Stripe_Whats_New_Note::is_upgrade_pending() );
+	}
+
+	/**
+	 * record_install_version() banks the prior version on upgrade so the gate opens.
+	 *
+	 * @return void
+	 */
+	public function test_record_install_version_upgrade_banks_previous_version() {
+		WC_Stripe_Whats_New_Note::record_install_version( '0.0.1' );
+
+		$this->assertSame( '0.0.1', get_option( WC_Stripe_Whats_New_Note::LAST_SEEN_VERSION_OPTION ) );
+		$this->assertTrue( WC_Stripe_Whats_New_Note::is_upgrade_pending() );
+	}
+
+	/**
+	 * record_install_version() never rolls the baseline back below a value init() already advanced.
+	 *
+	 * Both run on the same admin_init pass in an undefined order; an existing baseline must win.
+	 *
+	 * @return void
+	 */
+	public function test_record_install_version_does_not_overwrite_existing_baseline() {
+		update_option( WC_Stripe_Whats_New_Note::LAST_SEEN_VERSION_OPTION, '10.0.0' );
+
+		WC_Stripe_Whats_New_Note::record_install_version( '9.0.0' );
+
+		$this->assertSame( '10.0.0', get_option( WC_Stripe_Whats_New_Note::LAST_SEEN_VERSION_OPTION ) );
+	}
+
+	/**
+	 * init() creates the note for an upgrader and advances the baseline to the running version.
+	 *
+	 * @return void
+	 */
+	public function test_init_creates_note_for_upgrader_and_advances_baseline() {
+		update_option( WC_Stripe_Whats_New_Note::LAST_SEEN_VERSION_OPTION, '0.0.1' );
+
+		WC_Stripe_Whats_New_Note::init();
+
+		$this->assertSame( 1, $this->count_notes() );
+		$this->assertSame( WC_STRIPE_VERSION, get_option( WC_Stripe_Whats_New_Note::LAST_SEEN_VERSION_OPTION ) );
+	}
+
+	/**
+	 * init() shows the note once per upgrade: a second pass on the same version is a no-op.
+	 *
+	 * @return void
+	 */
+	public function test_init_shows_note_once_per_upgrade() {
+		update_option( WC_Stripe_Whats_New_Note::LAST_SEEN_VERSION_OPTION, '0.0.1' );
+
+		WC_Stripe_Whats_New_Note::init();
+		WC_Stripe_Whats_New_Note::init();
+
+		$this->assertSame( 1, $this->count_notes() );
+	}
+
+	/**
+	 * init() does not create the note for a fresh install (baseline already at the running version).
+	 *
+	 * @return void
+	 */
+	public function test_init_does_not_create_note_for_fresh_install() {
+		update_option( WC_Stripe_Whats_New_Note::LAST_SEEN_VERSION_OPTION, WC_STRIPE_VERSION );
+
+		WC_Stripe_Whats_New_Note::init();
+
+		$this->assertSame( 0, $this->count_notes() );
+	}
+
+	/**
+	 * init() stays silent until a baseline is recorded, so fresh installs are never shown the note.
+	 *
+	 * @return void
+	 */
+	public function test_init_does_nothing_without_a_baseline() {
+		delete_option( WC_Stripe_Whats_New_Note::LAST_SEEN_VERSION_OPTION );
+
+		WC_Stripe_Whats_New_Note::init();
+
+		$this->assertSame( 0, $this->count_notes() );
+		$this->assertFalse( get_option( WC_Stripe_Whats_New_Note::LAST_SEEN_VERSION_OPTION ) );
+	}
+
+	/**
+	 * Count the notes stored under this note's name.
+	 *
+	 * @return int
+	 */
+	private function count_notes(): int {
+		$data_store = WC_Data_Store::load( 'admin-note' );
+
+		return count( $data_store->get_notes_with_name( WC_Stripe_Whats_New_Note::NOTE_NAME ) );
+	}
+}

--- a/tests/phpunit/notes/class-wc-stripe-whats-new-note-test.php
+++ b/tests/phpunit/notes/class-wc-stripe-whats-new-note-test.php
@@ -17,9 +17,8 @@ class WC_Stripe_Whats_New_Note_Test extends WP_UnitTestCase {
 	public function set_up(): void {
 		parent::set_up();
 
-		// Each test runs inside a DB transaction that WP_UnitTestCase rolls back,
-		// so notes/options created here don't leak between tests; we only reset
-		// the baseline option up front for an explicit starting state.
+		// Notes/options created per test are rolled back by WP_UnitTestCase's
+		// transaction; just reset the baseline for an explicit starting state.
 		delete_option( WC_Stripe_Whats_New_Note::LAST_SEEN_VERSION_OPTION );
 	}
 

--- a/tests/phpunit/notes/class-wc-stripe-whats-new-note-test.php
+++ b/tests/phpunit/notes/class-wc-stripe-whats-new-note-test.php
@@ -17,8 +17,6 @@ class WC_Stripe_Whats_New_Note_Test extends WP_UnitTestCase {
 	public function set_up(): void {
 		parent::set_up();
 
-		require_once WC_STRIPE_PLUGIN_PATH . '/includes/notes/class-wc-stripe-whats-new-note.php';
-
 		// Each test runs inside a DB transaction that WP_UnitTestCase rolls back,
 		// so notes/options created here don't leak between tests; we only reset
 		// the baseline option up front for an explicit starting state.

--- a/tests/phpunit/notes/class-wc-stripe-whats-new-note-test.php
+++ b/tests/phpunit/notes/class-wc-stripe-whats-new-note-test.php
@@ -30,9 +30,7 @@ class WC_Stripe_Whats_New_Note_Test extends WP_UnitTestCase {
 	public function test_get_note() {
 		$note = WC_Stripe_Whats_New_Note::get_note();
 
-		$parts            = explode( '.', WC_STRIPE_VERSION );
-		$marketing        = isset( $parts[1] ) ? $parts[0] . '.' . $parts[1] : WC_STRIPE_VERSION;
-		$expected_heading = sprintf( 'WooCommerce Stripe %s: see what\'s new', $marketing );
+		$expected_heading = sprintf( 'WooCommerce Stripe %s: see what\'s new', WC_STRIPE_VERSION );
 
 		$this->assertSame( $expected_heading, $note->get_title() );
 		// Inbox only renders info/marketing/survey/warning — not "update".

--- a/tests/phpunit/notes/class-wc-stripe-whats-new-note-test.php
+++ b/tests/phpunit/notes/class-wc-stripe-whats-new-note-test.php
@@ -35,7 +35,8 @@ class WC_Stripe_Whats_New_Note_Test extends WP_UnitTestCase {
 		$expected_heading = sprintf( 'WooCommerce Stripe %s: see what\'s new', $marketing );
 
 		$this->assertSame( $expected_heading, $note->get_title() );
-		$this->assertSame( 'update', $note->get_type() );
+		// Inbox only renders info/marketing/survey/warning — not "update".
+		$this->assertSame( 'info', $note->get_type() );
 		$this->assertSame( 'wc-stripe-whats-new-note', $note->get_name() );
 		$this->assertSame( 'woocommerce-gateway-stripe', $note->get_source() );
 

--- a/tests/phpunit/notes/class-wc-stripe-whats-new-note-test.php
+++ b/tests/phpunit/notes/class-wc-stripe-whats-new-note-test.php
@@ -51,8 +51,8 @@ class WC_Stripe_Whats_New_Note_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider provider_is_upgrade_pending
 	 *
-	 * @param string|false $stored   Value to seed the last-seen option with, or false to leave it unset.
-	 * @param bool         $expected Whether the gate should report a pending upgrade.
+	 * @param mixed $stored   Value to seed the last-seen option with, or false to leave it unset.
+	 * @param bool  $expected Whether the gate should report a pending upgrade.
 	 * @return void
 	 */
 	public function test_is_upgrade_pending( $stored, bool $expected ) {
@@ -68,7 +68,7 @@ class WC_Stripe_Whats_New_Note_Test extends WP_UnitTestCase {
 	/**
 	 * Data provider for test_is_upgrade_pending.
 	 *
-	 * @return array<string, array{0: string|false, 1: bool}>
+	 * @return array<string, array{0: mixed, 1: bool}>
 	 */
 	public function provider_is_upgrade_pending(): array {
 		return [
@@ -77,6 +77,7 @@ class WC_Stripe_Whats_New_Note_Test extends WP_UnitTestCase {
 			'older baseline -> upgraded'                    => [ '0.0.1', true ],
 			'same as running version'                       => [ WC_STRIPE_VERSION, false ],
 			'newer than running version'                    => [ '999.0.0', false ],
+			'malformed array payload'                       => [ [ '0.0.1' ], false ],
 		];
 	}
 
@@ -117,6 +118,19 @@ class WC_Stripe_Whats_New_Note_Test extends WP_UnitTestCase {
 		WC_Stripe_Whats_New_Note::record_install_version( '9.0.0' );
 
 		$this->assertSame( '10.0.0', get_option( WC_Stripe_Whats_New_Note::LAST_SEEN_VERSION_OPTION ) );
+	}
+
+	/**
+	 * record_install_version() ignores a malformed previous version and banks nothing.
+	 *
+	 * The stored wc_stripe_version is untrusted, so a non-string must not become the baseline.
+	 *
+	 * @return void
+	 */
+	public function test_record_install_version_ignores_non_string_previous_version() {
+		WC_Stripe_Whats_New_Note::record_install_version( [ '9.0.0' ] );
+
+		$this->assertFalse( get_option( WC_Stripe_Whats_New_Note::LAST_SEEN_VERSION_OPTION ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes STRIPE-1188

## Changes proposed in this Pull Request:

The two post-update "what's new" surfaces added in #5386 (the plugin-row "Release notes" link and the "See what's new" link on the *Updated!* notice) are both gated on `'plugins.php' === $hook_suffix`. Stores on auto-update never return to `plugins.php`, so neither surface ever fires for them.

This PR adds a WC Inbox note that reaches upgraders on their next `wp-admin` visit anywhere, regardless of how the plugin was updated.

- **`WC_Stripe_Whats_New_Note`** (`includes/notes/class-wc-stripe-whats-new-note.php`) — follows the `WC_Stripe_OC_Promotion_Note` pattern (`NoteTraits` + `get_note()` + `init()`), registered in `WC_Stripe_Inbox_Notes::create_upe_notes()` and Composer-classmap autoloaded. The title carries the full version (e.g. "WooCommerce Stripe X.Y.Z: see what's new"). Note type is `info`: the Inbox only renders `info`/`marketing`/`survey`/`warning`, and `info` (unlike `marketing`) isn't suppressed by the marketplace-suggestions opt-out. The **See what's new** action points to the public WordPress.org changelog (`…/woocommerce-gateway-stripe/#developers`) and **opens in a new tab** — the Inbox only `window.open()`s action URLs that fall outside the admin URL, so an external target is required. No image is set (`set_image()` is deprecated as of WC Admin 10.8.0).
- **Version gate** — a new `wc_stripe_whats_new_note_version` option records the version a merchant was last shown the note for. `WC_Stripe::install()` calls `record_install_version()`: a fresh install banks the *current* version (so the note never fires); an upgrader banks the version it came *from*, but only when no baseline exists yet, so an existing baseline is never rolled back. `init()` fires only when the baseline is older than `WC_STRIPE_VERSION`, then advances it — so the note shows **once per upgrade** and stays dismissible.

`install()` and `create_upe_notes()` both run on `admin_init` in an undefined order; the gate is written to be order-independent (worst case is a one-page-load delay, never a note shown to the wrong audience).

Preview:
<img width="721" height="216" alt="Screenshot 2026-06-17 at 11 05 54" src="https://github.com/user-attachments/assets/e3dfec85-a402-4885-a0bb-2bac84919498" />

### Out of scope: Remote Inbox Notification (RIN)

The RIN feed-filter approach raised in the Linear discussion is intentionally **not** included. Registering a `data_source_poller_data_sources` feed URL from the plugin would point WC's daily poller at a `notes.json` that this repo doesn't host (a recurring 404), and a Stripe release-notes RIN can already be delivered through woocommerce.com's existing core feed using `plugin_version`/`plugins_activated` rules with zero plugin code. RIN remains an optional, complementary campaign owned by the Remote Inbox team.

#### How can this code break?
- If the baseline option were written in a way that rolled back below the running version, the note could re-show every page load. The `record_install_version()` no-rollback guard and the dedicated init-only baseline advance prevent this.
- A fresh install could wrongly see the note if the baseline were absent. `init()` stays silent when the baseline is unset.

#### What keeps it from breaking?
Targeted PHPUnit coverage for the version-gate logic (below).

## Testing instructions

1. **Upgrader path:** On a store already running an older version, set the baseline to an older value and visit any `wp-admin` page:
   - `wp option update wc_stripe_whats_new_note_version 10.8.0`
   - Load `wp-admin` → confirm a note titled "WooCommerce Stripe X.Y.Z: see what's new" appears under **WooCommerce → Home → Inbox**.
   - Click **See what's new** → confirm it opens the WordPress.org changelog in a **new tab**.
2. **Once per upgrade:** Reload several `wp-admin` pages → confirm only one note exists and `wc_stripe_whats_new_note_version` now equals the current plugin version. Dismiss the note → confirm it does not reappear.
3. **Fresh install:** `wp option update wc_stripe_whats_new_note_version <current plugin version>` (simulates a fresh install's baseline) → load `wp-admin` → confirm **no** note appears.
4. Automated: `npm run test:php -- --filter WC_Stripe_Whats_New_Note_Test` (13 tests) and `--filter WC_Stripe_Inbox_Notes_Test`.

### Alternative ways to test (faster, no real upgrade)

`WC_Stripe_Whats_New_Note` is autoloaded, so these work from `wp shell`/`wp eval` without any `require`.

**A) Force-render the actual note immediately (bypasses the version gate):**

```bash
wp eval 'WC_Stripe_Whats_New_Note::get_note()->save();'
```

Then open **WooCommerce → Home → Inbox**. Uses the real `get_note()`, so it's the quickest way to eyeball the title/copy/CTA. Re-running duplicates it — reset first (see C).

**B) Exercise the real gate end-to-end (`install()` → `init()`):**

```bash
wp option update wc_stripe_whats_new_note_version 0.0.1
wp eval 'WC_Stripe_Inbox_Notes::create_upe_notes();'   # what admin_init runs
wp option get wc_stripe_whats_new_note_version          # should now equal WC_STRIPE_VERSION
```

The option advancing back to the current version proves the note fired exactly once.

**C) Reset between runs:**

```bash
wp eval 'Automattic\WooCommerce\Admin\Notes\Notes::delete_notes_with_name( WC_Stripe_Whats_New_Note::NOTE_NAME );'
```

**D) Confirm the note reaches the browser (DevTools console on any wc-admin page):**

```js
wp.apiFetch( { path: '/wc-analytics/admin/notes?status=unactioned&per_page=5&type=info,marketing,survey,warning' } )
  .then( n => console.log( n.map( x => x.name ) ) )
// expect 'wc-stripe-whats-new-note' in the list
```

> Note: the Inbox only renders notes of type `info`/`marketing`/`survey`/`warning` and only opens action URLs **outside** the admin URL in a new tab — both are exercised by the steps above.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

> Add - Show a "What's new" inbox note after the plugin updates so merchants who auto-update are still pointed to the release notes

**Post merge**

-   [ ] Added testing instructions to the Release Testing Instructions wiki page (or does not apply)
-   [ ] Added the needs docs label (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @pierorocca 
