### PR TITLE
Suppress Stripe API outage notice on local/development environments

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Run the woocommerce_gateway_description filter for Stripe payment methods so third parties can add or replace their checkout descriptions
 * Fix - Show an error notice when a Stripe OAuth connection attempt fails its security check
 * Dev - Deprecate the internal WC_Stripe_Feature_Flags::is_amazon_pay_available() helper now that Amazon Pay is permanently enabled
+* Tweak - Don't show the Stripe API outage notice on local and development sites, where Stripe is often unreachable for benign reasons
 
 2026-06-15 - version 10.8.2
 * Fix - Disable Adaptive Pricing when webhooks are disabled

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -424,6 +424,13 @@ class WC_Stripe_Admin_Notices {
 			return;
 		}
 
+		// Suppress on local/development clones, where Stripe is often unreachable
+		// for benign reasons and this non-dismissible notice would stick forever.
+		// Staging is kept: those sites usually have internet, so an outage is real.
+		if ( in_array( $this->get_environment_type(), [ 'local', 'development' ], true ) ) {
+			return;
+		}
+
 		$message = sprintf(
 			/* translators: 1) HTML strong open tag 2) HTML strong closing tag */
 			__( '%1$sStripe is temporarily unreachable.%2$s Payments and account updates may not go through until the connection is restored. This notice will clear automatically once requests start succeeding again.', 'woocommerce-gateway-stripe' ),
@@ -432,6 +439,18 @@ class WC_Stripe_Admin_Notices {
 		);
 
 		$this->add_admin_notice( 'api_outage', 'notice notice-warning', $message );
+	}
+
+	/**
+	 * Wrapper around wp_get_environment_type().
+	 *
+	 * A test seam: wp_get_environment_type() memoizes in a static and can't be
+	 * varied between test cases.
+	 *
+	 * @return string One of 'local', 'development', 'staging', 'production'.
+	 */
+	protected function get_environment_type(): string {
+		return wp_get_environment_type();
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -177,5 +177,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Show an error notice when a Stripe OAuth connection attempt fails its security check
 * Fix - Run the woocommerce_gateway_description filter for Stripe payment methods so third parties can add or replace their checkout descriptions
 * Dev - Deprecate the internal WC_Stripe_Feature_Flags::is_amazon_pay_available() helper now that Amazon Pay is permanently enabled
+* Tweak - Don't show the Stripe API outage notice on local and development sites, where Stripe is often unreachable for benign reasons
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/admin/class-wc-stripe-admin-notices-test.php
+++ b/tests/phpunit/admin/class-wc-stripe-admin-notices-test.php
@@ -1308,6 +1308,42 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
+	 * The outage notice is suppressed on local/development but kept on staging
+	 * and production.
+	 *
+	 * @dataProvider provide_outage_notice_environment_gating
+	 *
+	 * @param string $environment_type Value returned by wp_get_environment_type().
+	 * @param bool   $expect_notice    Whether the outage notice should be added.
+	 */
+	public function test_api_outage_notice_is_gated_by_environment( string $environment_type, bool $expect_notice ) {
+		WC_Stripe_API_Outage_Status::record_outage();
+
+		$notices = $this->getMockBuilder( WC_Stripe_Admin_Notices::class )
+			->setMethods( [ 'get_environment_type' ] )
+			->getMock();
+		$notices->method( 'get_environment_type' )->willReturn( $environment_type );
+
+		$notices->check_api_outage();
+
+		$this->assertSame( $expect_notice, isset( $notices->notices['api_outage'] ) );
+
+		WC_Stripe_API_Outage_Status::record_success();
+	}
+
+	/**
+	 * @return array[] environment type => whether the notice should display.
+	 */
+	public function provide_outage_notice_environment_gating(): array {
+		return [
+			'local environment suppresses notice'       => [ 'local', false ],
+			'development environment suppresses notice' => [ 'development', false ],
+			'staging environment shows notice'          => [ 'staging', true ],
+			'production environment shows notice'       => [ 'production', true ],
+		];
+	}
+
+	/**
 	 * Injects a (possibly mocked) main Stripe gateway into the singleton so
 	 * check_ocs_ap_update_notices() reads our controlled OC/AP state.
 	 *


### PR DESCRIPTION
Fixes STRIPE-1192

## Changes proposed in this Pull Request:

Follow-up to #5407, which added Stripe API outage detection and a **non-dismissible** yellow admin notice ("Stripe is temporarily unreachable…") shown while the outage flag is active (shipped in 10.8.0).

Because that notice can't be dismissed, a production site cloned into a local/development context (Studio, local copies, generic dev clones) — where Stripe is routinely unreachable for benign reasons — would show the warning permanently with nothing the merchant can do about it.

This PR gates the notice on `wp_get_environment_type()`:

- `check_api_outage()` bails when the environment is `local` or `development`.
- `staging` and `production` keep the notice: staging sites usually have outbound internet, so a real outage there is still actionable, and `wp_get_environment_type()` defaults to `production` when unset, preserving existing behavior.
- Only the **rendering** is gated. Outage *detection* still records the transient flag in `WC_Stripe_API`, so the data stays available for debugging in any environment (the smaller, lower-risk change).

A small `get_environment_type()` wrapper was added purely as a test seam: `wp_get_environment_type()` memoizes its result in a static and can't be varied between test cases (the repo already notes this in `class-wc-stripe-api-test.php`).

**How can this break?** Only the outage notice's visibility changes; no payment or detection path is altered. The environment list is explicit (`local`, `development`) so staging/production are unaffected.

## Testing instructions

Two things are needed to see the notice: (a) the outage flag must be set, and (b) the environment must be one where the notice is *not* suppressed.

> **Environment gotcha:** `wp_get_environment_type()` reads the `WP_ENVIRONMENT_TYPE` **constant** ahead of the env var, and the constant can only be defined once (typically in `wp-config.php`). It's also memoized per request, so it can't be changed at runtime from a snippet. Set/change it in `wp-config.php` and reload.

### Main flow

1. In `wp-config.php`, set `define( 'WP_ENVIRONMENT_TYPE', 'local' );` (or `'development'`).
2. Set the outage flag (see "Ways to simulate the outage" below).
3. Visit **WP Admin** → the yellow "Stripe is temporarily unreachable…" notice does **not** appear. ✅ (suppressed)
4. Change the constant to `'staging'` or `'production'` (or remove it — defaults to `production`), keep the flag set, reload WP Admin → the notice **does** appear. ✅

### Ways to simulate the outage

Pick whichever fits your setup — all set the same transient (`wc_stripe_api_outage`):

**A. WP-CLI** (must run *inside* the WordPress container, not the host repo dir):
```bash
# set
wp eval 'WC_Stripe_API_Outage_Status::record_outage();'
# clear
wp eval 'WC_Stripe_API_Outage_Status::record_success();'
```
In the Docker dev env, prefix with: `docker compose exec -u www-data wordpress wp eval '…'`.

**B. mu-plugin / Code Snippets — faithful detection path (no CLI).** Forces real Stripe HTTP requests to fail, so the plugin's own detection sets the flag, and because requests keep failing it never auto-clears. Drop into `wp-content/mu-plugins/stripe-outage-sim.php`:
```php
<?php
/** Plugin Name: Stripe Outage Simulator (dev only) — delete to stop. */

// Make Stripe API requests return a 503, which is_outage_response() treats as an outage.
add_filter( 'pre_http_request', function ( $pre, $args, $url ) {
	if ( false !== strpos( $url, 'api.stripe.com' ) ) {
		return [ 'response' => [ 'code' => 503, 'message' => 'Service Unavailable' ], 'body' => '', 'headers' => [] ];
	}
	return $pre;
}, 10, 3 );

// Re-arm each admin load in case no Stripe request fires on the page you're viewing.
add_action( 'admin_init', function () {
	set_transient( 'wc_stripe_api_outage', [ 'detected_at' => time() ], 10 * MINUTE_IN_SECONDS );
} );
```
Remove the file when done (the flag also self-expires after its 10-minute TTL).

**Diagnostic** (optional) — surfaces the flag/env regardless of suppression, so you can tell "flag not set" from "notice correctly suppressed":
```php
add_action( 'admin_notices', function () {
	printf( '<div class="notice notice-info"><p>outage flag: <strong>%s</strong> · env: <strong>%s</strong></p></div>',
		get_transient( 'wc_stripe_api_outage' ) ? 'SET' : 'clear', esc_html( wp_get_environment_type() ) );
} );
```

Automated coverage: `test_api_outage_notice_is_gated_by_environment` (data provider over all four environment types).

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

* Tweak - Don't show the Stripe API outage notice on local and development sites, where Stripe is often unreachable for benign reasons

**Post merge**

-   [ ] Added testing instructions to the Release Testing Instructions wiki page (or does not apply)
-   [ ] Added the needs docs label (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
