### PR TITLE
Fix STRIPE-882: validate customer before saved cards

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ xxxx-xx-xx - version 10.9.0
 * Dev - Use a shared hook manager to prevent duplicate subscription hook registrations
 * Dev - Initial infrastructure for more complex Agentic feed filtering
 * Fix - Prevent unnecessary Stripe payment method creation when shortcode checkout has empty required fields
+* Fix - Hide saved cards at checkout when the stored Stripe customer ID is missing or no longer exists
 * Fix - Decommission the previously configured webhook before connecting via OAuth so reconnecting to a different Stripe account no longer leaves an orphaned webhook on the old account
 * Fix - Send the billing address to Stripe on the Pay for Order page so payments aren't incorrectly blocked by Stripe Radar rules
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -382,10 +382,35 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 * @return array               Filtered list of customers payment methods.
 	 */
 	public function filter_saved_payment_methods_list( $list, $customer_id ) {
-		if ( ! $this->saved_cards ) {
+		if ( ! $this->saved_cards || empty( $list ) ) {
 			return [];
 		}
+
+		if ( ! $this->has_valid_stripe_customer_for_saved_payment_methods( $customer_id ) ) {
+			return [];
+		}
+
 		return $list;
+	}
+
+	/**
+	 * Validates that the saved methods list can be backed by Stripe customer payment methods.
+	 *
+	 * @param int $customer_id The WooCommerce customer ID.
+	 * @return bool Whether saved payment methods can be displayed.
+	 */
+	private function has_valid_stripe_customer_for_saved_payment_methods( $customer_id ): bool {
+		$customer_id = absint( $customer_id );
+		if ( ! $customer_id ) {
+			return false;
+		}
+
+		$customer = new WC_Stripe_Customer( $customer_id );
+		if ( ! $customer->get_id() ) {
+			return false;
+		}
+
+		return ! empty( $customer->get_all_payment_methods( [], 1 ) );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -386,7 +386,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			return [];
 		}
 
-		if ( ! $this->has_valid_stripe_customer_for_saved_payment_methods( $customer_id ) ) {
+		if ( $this->should_hide_saved_payment_methods_list( $customer_id ) ) {
 			return [];
 		}
 
@@ -394,23 +394,55 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Validates that the saved methods list can be backed by Stripe customer payment methods.
+	 * Determines whether the saved payment methods list should be hidden.
 	 *
 	 * @param int $customer_id The WooCommerce customer ID.
-	 * @return bool Whether saved payment methods can be displayed.
+	 * @return bool Whether saved payment methods should be hidden.
 	 */
-	private function has_valid_stripe_customer_for_saved_payment_methods( $customer_id ): bool {
+	private function should_hide_saved_payment_methods_list( $customer_id ): bool {
 		$customer_id = absint( $customer_id );
 		if ( ! $customer_id ) {
-			return false;
+			return true;
 		}
 
 		$customer = new WC_Stripe_Customer( $customer_id );
 		if ( ! $customer->get_id() ) {
+			return true;
+		}
+
+		try {
+			$response = $this->stripe_request(
+				'payment_methods',
+				[
+					'customer' => $customer->get_id(),
+					'limit'    => 1,
+				],
+				null,
+				'GET'
+			);
+		} catch ( WC_Stripe_Exception $e ) {
 			return false;
 		}
 
-		return ! empty( $customer->get_all_payment_methods( [], 1 ) );
+		if ( ! empty( $response->error ) ) {
+			return $this->is_missing_stripe_customer_response( $response );
+		}
+
+		return empty( $response->data );
+	}
+
+	/**
+	 * Checks if Stripe reported that the stored customer no longer exists.
+	 *
+	 * @param object $response The Stripe API response.
+	 * @return bool Whether the response is a missing-customer error.
+	 */
+	private function is_missing_stripe_customer_response( $response ): bool {
+		return (
+			isset( $response->error->param, $response->error->code )
+			&& 'customer' === $response->error->param
+			&& 'resource_missing' === $response->error->code
+		);
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -162,6 +162,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Use a shared hook manager to prevent duplicate subscription hook registrations
 * Dev - Initial infrastructure for more complex Agentic feed filtering
 * Fix - Prevent unnecessary Stripe payment method creation when shortcode checkout has empty required fields
+* Fix - Hide saved cards at checkout when the stored Stripe customer ID is missing or no longer exists
 * Fix - Decommission the previously configured webhook before connecting via OAuth so reconnecting to a different Stripe account no longer leaves an orphaned webhook on the old account
 * Fix - Send the billing address to Stripe on the Pay for Order page so payments aren't incorrectly blocked by Stripe Radar rules
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -4459,12 +4459,69 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	 * @dataProvider provide_test_filter_saved_payment_methods_list
 	 */
 	public function test_filter_saved_payment_methods_list( $saved_cards, $item, $expected ) {
-		$payment_token                   = $this->getMockBuilder( 'WC_Payment_Token_CC' )
-			->disableOriginalConstructor()
-			->getMock();
+		$user_id = $this->factory->user->create();
+		update_user_option( $user_id, '_stripe_customer_id', 'cus_saved_cards_filter', false );
+
+		$mock_http_request = $this->mock_stripe_payment_methods_response(
+			[
+				[
+					'id'   => 'pm_saved_cards_filter',
+					'type' => WC_Stripe_Payment_Methods::CARD,
+					'card' => [
+						'brand'     => 'visa',
+						'exp_month' => '7',
+						'exp_year'  => '2099',
+						'last4'     => '4242',
+					],
+				],
+			]
+		);
+		add_filter( 'pre_http_request', $mock_http_request, 10, 3 );
+
 		$this->mock_gateway->saved_cards = $saved_cards;
-		$list                            = $this->mock_gateway->filter_saved_payment_methods_list( $item, $payment_token );
+
+		try {
+			$list = $this->mock_gateway->filter_saved_payment_methods_list( $item, $user_id );
+		} finally {
+			remove_filter( 'pre_http_request', $mock_http_request, 10 );
+		}
+
 		$this->assertSame( $expected, $list );
+	}
+
+	/**
+	 * Saved cards should not be shown when the WooCommerce user has no Stripe customer ID.
+	 */
+	public function test_filter_saved_payment_methods_list_hides_methods_without_customer_id(): void {
+		$user_id = $this->factory->user->create();
+
+		$this->mock_gateway->saved_cards = true;
+
+		$this->assertSame(
+			[],
+			$this->mock_gateway->filter_saved_payment_methods_list( $this->get_saved_card_list_item(), $user_id )
+		);
+	}
+
+	/**
+	 * Saved cards should not be shown when Stripe cannot find the stored customer ID.
+	 */
+	public function test_filter_saved_payment_methods_list_hides_methods_when_customer_is_missing_in_stripe(): void {
+		$user_id = $this->factory->user->create();
+		update_user_option( $user_id, '_stripe_customer_id', 'cus_missing_in_stripe', false );
+
+		$mock_http_request = $this->mock_stripe_missing_customer_response();
+		add_filter( 'pre_http_request', $mock_http_request, 10, 3 );
+
+		$this->mock_gateway->saved_cards = true;
+
+		try {
+			$list = $this->mock_gateway->filter_saved_payment_methods_list( $this->get_saved_card_list_item(), $user_id );
+		} finally {
+			remove_filter( 'pre_http_request', $mock_http_request, 10 );
+		}
+
+		$this->assertSame( [], $list );
 	}
 
 	/**
@@ -4473,12 +4530,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	 * @return array
 	 */
 	public function provide_test_filter_saved_payment_methods_list() {
-		$item = [
-			'brand'     => 'visa',
-			'exp_month' => '7',
-			'exp_year'  => '2099',
-			'last4'     => '4242',
-		];
+		$item = $this->get_saved_card_list_item();
 		return [
 			'Saved cards enabled'  => [
 				'saved cards' => true,
@@ -4491,6 +4543,86 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 				'expected'    => [],
 			],
 		];
+	}
+
+	/**
+	 * Returns a minimal saved card list item shaped like WooCommerce's saved methods list.
+	 *
+	 * @return array
+	 */
+	private function get_saved_card_list_item(): array {
+		return [
+			'cc' => [
+				[
+					'method' => [
+						'gateway'   => WC_Stripe_UPE_Payment_Gateway::ID,
+						'brand'     => 'visa',
+						'exp_month' => '7',
+						'exp_year'  => '2099',
+						'last4'     => '4242',
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Returns a mock HTTP callback for a successful Stripe payment methods response.
+	 *
+	 * @param array $payment_methods Stripe payment method response data.
+	 * @return callable
+	 */
+	private function mock_stripe_payment_methods_response( array $payment_methods ): callable {
+		return function ( $preempt, $request_args, $url ) use ( $payment_methods ) {
+			if ( false === strpos( $url, 'payment_methods' ) ) {
+				return $preempt;
+			}
+
+			return [
+				'headers'  => [],
+				'body'     => wp_json_encode(
+					[
+						'data'     => $payment_methods,
+						'has_more' => false,
+					]
+				),
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+			];
+		};
+	}
+
+	/**
+	 * Returns a mock HTTP callback for Stripe's missing-customer error response.
+	 *
+	 * @return callable
+	 */
+	private function mock_stripe_missing_customer_response(): callable {
+		return function ( $preempt, $request_args, $url ) {
+			if ( false === strpos( $url, 'payment_methods' ) ) {
+				return $preempt;
+			}
+
+			return [
+				'headers'  => [],
+				'body'     => wp_json_encode(
+					[
+						'error' => [
+							'code'    => 'resource_missing',
+							'message' => 'No such customer: cus_missing_in_stripe',
+							'param'   => 'customer',
+							'type'    => 'invalid_request_error',
+						],
+					]
+				),
+				'response' => [
+					'code'    => 404,
+					'message' => 'Not Found',
+				],
+			];
+		};
 	}
 
 	/**

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -4462,29 +4462,42 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		$user_id = $this->factory->user->create();
 		update_user_option( $user_id, '_stripe_customer_id', 'cus_saved_cards_filter', false );
 
-		$mock_http_request = $this->mock_stripe_payment_methods_response(
-			[
-				[
-					'id'   => 'pm_saved_cards_filter',
-					'type' => WC_Stripe_Payment_Methods::CARD,
-					'card' => [
-						'brand'     => 'visa',
-						'exp_month' => '7',
-						'exp_year'  => '2099',
-						'last4'     => '4242',
+		if ( $saved_cards ) {
+			$this->mock_gateway->expects( $this->once() )
+				->method( 'stripe_request' )
+				->with(
+					'payment_methods',
+					[
+						'customer' => 'cus_saved_cards_filter',
+						'limit'    => 1,
 					],
-				],
-			]
-		);
-		add_filter( 'pre_http_request', $mock_http_request, 10, 3 );
+					null,
+					'GET'
+				)
+				->willReturn(
+					$this->mock_stripe_payment_methods_response(
+						[
+							[
+								'id'   => 'pm_saved_cards_filter',
+								'type' => WC_Stripe_Payment_Methods::CARD,
+								'card' => [
+									'brand'     => 'visa',
+									'exp_month' => '7',
+									'exp_year'  => '2099',
+									'last4'     => '4242',
+								],
+							],
+						]
+					)
+				);
+		} else {
+			$this->mock_gateway->expects( $this->never() )
+				->method( 'stripe_request' );
+		}
 
 		$this->mock_gateway->saved_cards = $saved_cards;
 
-		try {
-			$list = $this->mock_gateway->filter_saved_payment_methods_list( $item, $user_id );
-		} finally {
-			remove_filter( 'pre_http_request', $mock_http_request, 10 );
-		}
+		$list = $this->mock_gateway->filter_saved_payment_methods_list( $item, $user_id );
 
 		$this->assertSame( $expected, $list );
 	}
@@ -4495,6 +4508,8 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	public function test_filter_saved_payment_methods_list_hides_methods_without_customer_id(): void {
 		$user_id = $this->factory->user->create();
 
+		$this->mock_gateway->expects( $this->never() )
+			->method( 'stripe_request' );
 		$this->mock_gateway->saved_cards = true;
 
 		$this->assertSame(
@@ -4510,18 +4525,83 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		$user_id = $this->factory->user->create();
 		update_user_option( $user_id, '_stripe_customer_id', 'cus_missing_in_stripe', false );
 
-		$mock_http_request = $this->mock_stripe_missing_customer_response();
-		add_filter( 'pre_http_request', $mock_http_request, 10, 3 );
+		$this->mock_gateway->expects( $this->once() )
+			->method( 'stripe_request' )
+			->with(
+				'payment_methods',
+				[
+					'customer' => 'cus_missing_in_stripe',
+					'limit'    => 1,
+				],
+				null,
+				'GET'
+			)
+			->willReturn( $this->mock_stripe_missing_customer_response() );
 
 		$this->mock_gateway->saved_cards = true;
 
-		try {
-			$list = $this->mock_gateway->filter_saved_payment_methods_list( $this->get_saved_card_list_item(), $user_id );
-		} finally {
-			remove_filter( 'pre_http_request', $mock_http_request, 10 );
-		}
+		$this->assertSame(
+			[],
+			$this->mock_gateway->filter_saved_payment_methods_list( $this->get_saved_card_list_item(), $user_id )
+		);
+	}
 
-		$this->assertSame( [], $list );
+	/**
+	 * Saved cards should remain visible when Stripe fails without proving the customer is missing.
+	 */
+	public function test_filter_saved_payment_methods_list_keeps_methods_when_stripe_errors_without_missing_customer(): void {
+		$user_id = $this->factory->user->create();
+		update_user_option( $user_id, '_stripe_customer_id', 'cus_stripe_api_error', false );
+
+		$this->mock_gateway->expects( $this->once() )
+			->method( 'stripe_request' )
+			->with(
+				'payment_methods',
+				[
+					'customer' => 'cus_stripe_api_error',
+					'limit'    => 1,
+				],
+				null,
+				'GET'
+			)
+			->willReturn( $this->mock_stripe_error_response() );
+
+		$this->mock_gateway->saved_cards = true;
+		$saved_card_list                 = $this->get_saved_card_list_item();
+
+		$this->assertSame(
+			$saved_card_list,
+			$this->mock_gateway->filter_saved_payment_methods_list( $saved_card_list, $user_id )
+		);
+	}
+
+	/**
+	 * Saved cards should remain visible when Stripe customer validation fails before a response is returned.
+	 */
+	public function test_filter_saved_payment_methods_list_keeps_methods_when_stripe_request_throws(): void {
+		$user_id = $this->factory->user->create();
+		update_user_option( $user_id, '_stripe_customer_id', 'cus_stripe_exception', false );
+
+		$this->mock_gateway->expects( $this->once() )
+			->method( 'stripe_request' )
+			->with(
+				'payment_methods',
+				[
+					'customer' => 'cus_stripe_exception',
+					'limit'    => 1,
+				],
+				null,
+				'GET'
+			)
+			->willThrowException( new WC_Stripe_Exception( 'api_error', 'Stripe API did not answer.' ) );
+
+		$this->mock_gateway->saved_cards = true;
+		$saved_card_list                 = $this->get_saved_card_list_item();
+
+		$this->assertSame(
+			$saved_card_list,
+			$this->mock_gateway->filter_saved_payment_methods_list( $saved_card_list, $user_id )
+		);
 	}
 
 	/**
@@ -4567,62 +4647,59 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
-	 * Returns a mock HTTP callback for a successful Stripe payment methods response.
+	 * Returns a mock successful Stripe payment methods response.
 	 *
 	 * @param array $payment_methods Stripe payment method response data.
-	 * @return callable
+	 * @return stdClass
 	 */
-	private function mock_stripe_payment_methods_response( array $payment_methods ): callable {
-		return function ( $preempt, $request_args, $url ) use ( $payment_methods ) {
-			if ( false === strpos( $url, 'payment_methods' ) ) {
-				return $preempt;
-			}
-
-			return [
-				'headers'  => [],
-				'body'     => wp_json_encode(
-					[
-						'data'     => $payment_methods,
-						'has_more' => false,
-					]
-				),
-				'response' => [
-					'code'    => 200,
-					'message' => 'OK',
-				],
-			];
-		};
+	private function mock_stripe_payment_methods_response( array $payment_methods ): stdClass {
+		return json_decode(
+			wp_json_encode(
+				[
+					'data'     => $payment_methods,
+					'has_more' => false,
+				]
+			)
+		);
 	}
 
 	/**
-	 * Returns a mock HTTP callback for Stripe's missing-customer error response.
+	 * Returns a mock Stripe missing-customer error response.
 	 *
-	 * @return callable
+	 * @return stdClass
 	 */
-	private function mock_stripe_missing_customer_response(): callable {
-		return function ( $preempt, $request_args, $url ) {
-			if ( false === strpos( $url, 'payment_methods' ) ) {
-				return $preempt;
-			}
+	private function mock_stripe_missing_customer_response(): stdClass {
+		return json_decode(
+			wp_json_encode(
+				[
+					'error' => [
+						'code'    => 'resource_missing',
+						'message' => 'No such customer: cus_missing_in_stripe',
+						'param'   => 'customer',
+						'type'    => 'invalid_request_error',
+					],
+				]
+			)
+		);
+	}
 
-			return [
-				'headers'  => [],
-				'body'     => wp_json_encode(
-					[
-						'error' => [
-							'code'    => 'resource_missing',
-							'message' => 'No such customer: cus_missing_in_stripe',
-							'param'   => 'customer',
-							'type'    => 'invalid_request_error',
-						],
-					]
-				),
-				'response' => [
-					'code'    => 404,
-					'message' => 'Not Found',
-				],
-			];
-		};
+	/**
+	 * Returns a mock generic Stripe API error response.
+	 *
+	 * @return stdClass
+	 */
+	private function mock_stripe_error_response(): stdClass {
+		return json_decode(
+			wp_json_encode(
+				[
+					'error' => [
+						'code'    => 'api_error',
+						'message' => 'Stripe API did not answer.',
+						'type'    => 'api_error',
+					],
+				]
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes STRIPE-882

## Changes proposed in this Pull Request:

This PR prevents stale or missing Stripe customer IDs from leaving unusable saved cards visible at checkout.

- Hide the saved payment methods list when the WooCommerce customer does not have a stored Stripe customer ID.
- Validate the stored Stripe customer before showing saved cards, and hide the list when Stripe reports the customer no longer exists.
- Keep saved cards visible when Stripe returns a generic API error or throws before returning a response, so transient Stripe failures do not remove existing local payment methods from checkout.
- Add regression coverage for the saved-card list filtering behavior.

## Testing instructions

1. Run `php -l includes/payment-methods/class-wc-stripe-upe-payment-gateway.php`.
2. Run `php -l tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php`.
3. Run `npm run test:php -- --filter=test_filter_saved_payment_methods_list`.
4. As a logged-in customer with saved cards, clear the local `_stripe_customer_id` user option and confirm the saved payment methods list is hidden at checkout.
5. Set `_stripe_customer_id` to a deleted/missing Stripe customer and confirm the saved payment methods list is hidden at checkout.
6. Use a valid Stripe customer with saved cards and confirm saved payment methods still display at checkout.
7. Simulate a generic Stripe API failure while validating the customer and confirm existing saved payment methods remain visible.

---

-   [x] Covered with tests (or have a good reason not to test in description)
-   [x] Tested on mobile (or does not apply): Does not apply; this is server-side saved payment method list filtering.

### Changelog entry

-   [x] Added changelog entries to `changelog.txt` and `readme.txt`.

> *Drafted with AI; reviewed by me.*

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
