### PR TITLE
Fix express checkout tax preview for taxable product add-ons

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Show an error notice when a Stripe OAuth connection attempt fails its security check
 * Dev - Deprecate the internal WC_Stripe_Feature_Flags::is_amazon_pay_available() helper now that Amazon Pay is permanently enabled
 * Fix - Calculate the Apple Pay / Google Pay product tax preview on the selected quantity instead of a single unit
+* Fix - Include selected add-on costs in the Apple Pay / Google Pay tax preview so the wallet total is not understated when a taxable product add-on is selected
 
 2026-06-15 - version 10.8.2
 * Fix - Disable Adaptive Pricing when webhooks are disabled

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -414,8 +414,11 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 				'amount' => WC_Stripe_Helper::get_stripe_amount( $total ),
 			];
 
+			// Tax the full line amount shown to the shopper (product subtotal + add-ons), matching how
+			// WooCommerce folds the add-on cost into the taxable cart-item price. Taxing only the product
+			// subtotal understates the wallet total whenever a taxable add-on is selected.
 			$total_tax = 0;
-			foreach ( $this->express_checkout_helper->get_taxes_like_cart( $product, $line_subtotal ) as $tax ) {
+			foreach ( $this->express_checkout_helper->get_taxes_like_cart( $product, $total ) as $tax ) {
 				$total_tax += $tax;
 
 				$items[] = [

--- a/readme.txt
+++ b/readme.txt
@@ -173,6 +173,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Append the 3-letter currency code to the Stripe Fee and Stripe Payout amounts in WP Admin order totals when the Stripe account currency differs from the order currency
 * Dev - Add more robust purchase checks in e2e tests
 * Fix - Calculate the Apple Pay / Google Pay product tax preview on the selected quantity instead of a single unit
+* Fix - Include selected add-on costs in the Apple Pay / Google Pay tax preview so the wallet total is not understated when a taxable product add-on is selected
 * Fix - Only create an agentic commerce order on the site that produced the checkout, preventing duplicate or wrong-site orders when multiple stores share one Stripe account
 * Dev - Add a Code Comment Conventions section to AGENTS.md to standardize agent and contributor comment guidance
 * Fix - Show an error notice when a Stripe OAuth connection attempt fails its security check

--- a/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-ajax-handler-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-ajax-handler-test.php
@@ -243,6 +243,57 @@ class WC_Stripe_Express_Checkout_Ajax_Handler_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test ajax_get_selected_product_data includes the add-on cost in the tax base.
+	 *
+	 * Product Add-Ons folds the selected add-on cost into the taxable cart-item price, so the
+	 * express-checkout preview must tax the product subtotal plus add-ons. Taxing only the product
+	 * subtotal understates the Apple Pay / Google Pay total whenever a taxable add-on is selected.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_ajax_get_selected_product_data_includes_addons_in_tax_base() {
+		Ajax_Test_Helper::init_hooks();
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->express_checkout_helper->method( 'is_invalid_subscription_product' )->willReturn( false );
+		$this->express_checkout_helper->method( 'get_product_price' )->willReturn( 10.0 );
+		$this->express_checkout_helper->method( 'get_total_label' )->willReturn( 'Total' );
+		$this->express_checkout_helper->expects( $this->once() )
+			->method( 'get_taxes_like_cart' )
+			->with( $this->anything(), 15.0 )
+			->willReturn( [ 1.5 ] );
+
+		try {
+			$security_nonce       = wp_create_nonce( 'wc-stripe-get-selected-product-data' );
+			$_REQUEST['security'] = $security_nonce;
+			$_POST['security']    = $security_nonce;
+			$_POST['product_id']  = $product->get_id();
+			$_POST['qty']         = 1;
+			$_POST['addon_value'] = 5;
+
+			WC()->session->init();
+
+			ob_start();
+			$this->ajax_handler->ajax_get_selected_product_data();
+			$output = ob_get_clean();
+
+			$response = json_decode( $output, true );
+		} finally {
+			Ajax_Test_Helper::remove_hooks();
+			unset( $_POST['product_id'], $_POST['qty'], $_POST['addon_value'], $_POST['security'], $_REQUEST['security'] );
+		}
+
+		// $10 product + $5 add-on = $15 tax base; with the stubbed $1.50 tax the total is $16.50.
+		$this->assertIsArray( $response );
+		$this->assertArrayHasKey( 'displayItems', $response, 'response: ' . wp_json_encode( $response ) );
+		$this->assertSame( 1500, $response['displayItems'][0]['amount'] );
+		$this->assertSame( 150, $response['displayItems'][1]['amount'] );
+		$this->assertSame( 1650, $response['total']['amount'] );
+	}
+
+	/**
 	 * Builds an ajax handler backed by a helper that only stubs
 	 * is_express_checkout_context(), so the real state/postcode normalization runs.
 	 *


### PR DESCRIPTION
Fixes STRIPE-XXXX

## Changes proposed in this Pull Request

The express checkout (Apple Pay / Google Pay) product-data preview shows the selected add-on cost in the line-item total (`$line_subtotal + $addon_value`) but calculated tax from the product subtotal only. WooCommerce folds the add-on cost into the taxable cart-item price, so the wallet sheet understated tax — and therefore the total — whenever a taxable Product Add-On was selected. The shopper then authorizes less than the order is actually charged.

This taxes the full displayed line amount (`$total` = product subtotal + add-ons) via `get_taxes_like_cart()`, matching how the real cart taxes the add-on cost.

This is the same preview-tax-base family as #5585 (which scaled the base by quantity). It is **stacked on #5585** because it edits the same statement — this PR targets the #5585 branch so the diff is just the add-on change. Please merge #5585 first; this can then be retargeted to `develop`. Together they make the preview tax base both quantity- and add-on-correct.

### How this was found / verified

Reproduced on WordPress 7.0 / WooCommerce 10.8.1 with Product Add-Ons active and a single 10% tax rate, using a $10 taxable product and a $5 taxable add-on:

- Real cart (what is charged): item priced $15, tax **$1.50**.
- Preview before this change: tax **$1.00** (computed on $10) → wallet total $16.00 vs charged $16.50.
- A/B control: without an add-on the preview already matched the cart ($1.00 = $1.00); the $0.50 gap appeared only with the add-on, isolating the cause to the preview tax base (Product Add-Ons taxes the add-on correctly in the real cart).

## Testing instructions

1. Enable taxes with a standard rate (e.g. 10%); set price display to **excluding tax**.
2. Install Product Add-Ons; add a taxable add-on (e.g. a $5 flat-fee checkbox) to a $10 taxable product.
3. Enable Apple Pay / Google Pay express checkout and open the product page.
4. Select the add-on and open the wallet sheet.
5. **Before:** tax is calculated on $10 ($1.00); the wallet total is $16.00 — less than the $16.50 the order is actually charged.
6. **After:** tax reflects $15 ($1.50); the wallet total is $16.50 and matches the cart/order.

---

-   [x] Covered with tests (PHPUnit regression test for a taxable add-on in the preview tax base)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   Fix - Include selected add-on costs in the Apple Pay / Google Pay tax preview so the wallet total is not understated when a taxable product add-on is selected

*Drafted with AI; reviewed by me.*
