### PR TITLE
Add client-side Stripe.js origin assertion as defense-in-depth against checkout skimmers

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Run the woocommerce_gateway_description filter for Stripe payment methods so third parties can add or replace their checkout descriptions
 * Fix - Show an error notice when a Stripe OAuth connection attempt fails its security check
 * Dev - Deprecate the internal WC_Stripe_Feature_Flags::is_amazon_pay_available() helper now that Amazon Pay is permanently enabled
+* Add - Verify that Stripe.js was served from the official Stripe origin before processing checkout payments
 
 2026-06-15 - version 10.8.2
 * Fix - Disable Adaptive Pricing when webhooks are disabled

--- a/client/api/__tests__/index.test.js
+++ b/client/api/__tests__/index.test.js
@@ -24,6 +24,7 @@ describe( 'WCStripeAPI', () => {
 		} );
 
 		afterEach( () => {
+			warnSpy.mockRestore();
 			delete global.Stripe;
 			document.getElementById( 'stripe-js' )?.remove();
 		} );

--- a/client/api/__tests__/index.test.js
+++ b/client/api/__tests__/index.test.js
@@ -1,0 +1,65 @@
+import WCStripeAPI from '..';
+
+jest.mock( 'wcstripe/stripe-utils', () => ( {
+	getStripeServerData: jest.fn(),
+	getStripeDevWidgetOptions: jest.fn( () => ( {} ) ),
+} ) );
+
+describe( 'WCStripeAPI', () => {
+	describe( 'getStripe', () => {
+		let warnSpy;
+
+		const addStripeScriptTag = ( src ) => {
+			const script = document.createElement( 'script' );
+			script.id = 'stripe-js';
+			script.setAttribute( 'src', src );
+			document.body.appendChild( script );
+		};
+
+		beforeEach( () => {
+			global.Stripe = jest.fn( () => ( {} ) );
+			warnSpy = jest
+				.spyOn( console, 'warn' )
+				.mockImplementation( () => {} );
+		} );
+
+		afterEach( () => {
+			delete global.Stripe;
+			document.getElementById( 'stripe-js' )?.remove();
+		} );
+
+		it( 'instantiates Stripe when Stripe.js was loaded from the official origin', () => {
+			addStripeScriptTag( 'https://js.stripe.com/clover/stripe.js' );
+			const api = new WCStripeAPI( { key: 'pk_test_123', locale: 'en' } );
+
+			expect( api.getStripe() ).toBeTruthy();
+			expect( global.Stripe ).toHaveBeenCalledWith( 'pk_test_123', {
+				locale: 'en',
+			} );
+			expect( warnSpy ).not.toHaveBeenCalled();
+		} );
+
+		it( 'warns and blocks when Stripe.js was loaded from an unexpected origin', () => {
+			addStripeScriptTag(
+				'https://js.stripe.com.evil.example/clover/stripe.js'
+			);
+			const api = new WCStripeAPI( { key: 'pk_test_123', locale: 'en' } );
+
+			expect( () => api.getStripe() ).toThrow(
+				/provenance check failed/
+			);
+			expect( global.Stripe ).not.toHaveBeenCalled();
+			expect( warnSpy ).toHaveBeenCalled();
+		} );
+
+		it( 'warns and blocks when no Stripe.js tag is present', () => {
+			const api = new WCStripeAPI( { key: 'pk_test_123', locale: 'en' } );
+
+			expect( () => api.getStripe() ).toThrow(
+				/provenance check failed/
+			);
+			expect( global.Stripe ).not.toHaveBeenCalled();
+			expect( warnSpy ).toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -11,6 +11,7 @@ import {
 	getStripeServerData,
 	getStripeDevWidgetOptions,
 } from 'wcstripe/stripe-utils';
+import { assertStripeJsOrigin } from 'wcstripe/stripe-utils/verify-stripe-js-origin';
 import {
 	PAYMENT_INTENT_STATUS_REQUIRES_ACTION,
 	PAYMENT_METHOD_CASHAPP,
@@ -95,6 +96,8 @@ export default class WCStripeAPI {
 	 * @return {Object} The Stripe instance.
 	 */
 	createStripe( key, locale, betas = [] ) {
+		assertStripeJsOrigin();
+
 		const options = {
 			locale,
 			...getStripeDevWidgetOptions(),

--- a/client/blocks/__tests__/load-stripe.test.js
+++ b/client/blocks/__tests__/load-stripe.test.js
@@ -1,28 +1,67 @@
-const mockLoadStripe = jest.fn( () => Promise.resolve( {} ) );
-
-jest.mock( '@stripe/stripe-js', () => ( {
-	loadStripe: ( ...args ) => mockLoadStripe( ...args ),
-} ) );
-
-jest.mock( 'wcstripe/blocks/utils', () => ( {
-	getApiKey: jest.fn( () => 'pk_test_xxx' ),
-	getBlocksConfiguration: jest.fn( () => ( { stripe_locale: 'en' } ) ),
-} ) );
-
-import { loadStripe } from 'wcstripe/blocks/load-stripe';
+import { loadStripe as loadStripeFromNpm } from '@stripe/stripe-js';
+import { loadStripe } from '../load-stripe';
 import { getStripeDevWidgetOptions } from 'wcstripe/stripe-utils';
 
+jest.mock( '@stripe/stripe-js', () => ( {
+	loadStripe: jest.fn( () => Promise.resolve( {} ) ),
+} ) );
+jest.mock( '../utils', () => ( {
+	getApiKey: jest.fn( () => 'pk_test_123' ),
+	getBlocksConfiguration: jest.fn( () => ( { stripe_locale: 'en' } ) ),
+} ) );
 jest.mock( 'wcstripe/stripe-utils', () => ( {
-	getStripeDevWidgetOptions: jest.fn(),
+	getStripeDevWidgetOptions: jest.fn( () => ( {} ) ),
 } ) );
 
-describe( 'load-stripe', () => {
+describe( 'loadStripe', () => {
+	let warnSpy;
+
+	const addStripeScriptTag = ( src ) => {
+		const script = document.createElement( 'script' );
+		script.id = 'stripe-js';
+		script.setAttribute( 'src', src );
+		document.body.appendChild( script );
+	};
+
 	beforeEach( () => {
-		mockLoadStripe.mockClear();
+		loadStripeFromNpm.mockClear();
 		getStripeDevWidgetOptions.mockReset();
+		getStripeDevWidgetOptions.mockReturnValue( {} );
+		warnSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		document.getElementById( 'stripe-js' )?.remove();
+		warnSpy.mockRestore();
+	} );
+
+	it( 'loads Stripe when Stripe.js was loaded from the official origin', async () => {
+		addStripeScriptTag( 'https://js.stripe.com/clover/stripe.js' );
+
+		const result = await loadStripe();
+
+		expect( result.error ).toBeUndefined();
+		expect( loadStripeFromNpm ).toHaveBeenCalledWith( 'pk_test_123', {
+			locale: 'en',
+		} );
+		expect( warnSpy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'warns and blocks when Stripe.js was loaded from an unexpected origin', async () => {
+		addStripeScriptTag(
+			'https://js.stripe.com.evil.example/clover/stripe.js'
+		);
+
+		const result = await loadStripe();
+
+		expect( result.error ).toBeInstanceOf( Error );
+		expect( result.error.message ).toMatch( /provenance check failed/ );
+		expect( loadStripeFromNpm ).not.toHaveBeenCalled();
+		expect( warnSpy ).toHaveBeenCalled();
 	} );
 
 	it( 'passes developerTools.assistant.enabled false to Stripe loadStripe when disabled', async () => {
+		addStripeScriptTag( 'https://js.stripe.com/clover/stripe.js' );
 		getStripeDevWidgetOptions.mockReturnValue( {
 			developerTools: {
 				assistant: {
@@ -30,9 +69,11 @@ describe( 'load-stripe', () => {
 				},
 			},
 		} );
+
 		await loadStripe();
-		expect( mockLoadStripe ).toHaveBeenCalledWith(
-			'pk_test_xxx',
+
+		expect( loadStripeFromNpm ).toHaveBeenCalledWith(
+			'pk_test_123',
 			expect.objectContaining( {
 				locale: 'en',
 				developerTools: {
@@ -45,6 +86,7 @@ describe( 'load-stripe', () => {
 	} );
 
 	it( 'passes developerTools.assistant.enabled true to Stripe loadStripe when enabled', async () => {
+		addStripeScriptTag( 'https://js.stripe.com/clover/stripe.js' );
 		getStripeDevWidgetOptions.mockReturnValue( {
 			developerTools: {
 				assistant: {
@@ -52,9 +94,11 @@ describe( 'load-stripe', () => {
 				},
 			},
 		} );
+
 		await loadStripe();
-		expect( mockLoadStripe ).toHaveBeenCalledWith(
-			'pk_test_xxx',
+
+		expect( loadStripeFromNpm ).toHaveBeenCalledWith(
+			'pk_test_123',
 			expect.objectContaining( {
 				locale: 'en',
 				developerTools: {

--- a/client/blocks/load-stripe.js
+++ b/client/blocks/load-stripe.js
@@ -1,10 +1,15 @@
 import { loadStripe } from '@stripe/stripe-js';
 import { getApiKey, getBlocksConfiguration } from './utils';
 import { getStripeDevWidgetOptions } from 'wcstripe/stripe-utils';
+import { assertStripeJsOrigin } from 'wcstripe/stripe-utils/verify-stripe-js-origin';
 
 const stripePromise = () =>
 	new Promise( ( resolve ) => {
 		try {
+			// The Stripe.js loader reuses an ambient window.Stripe when the
+			// script tag is already on the page, so verify where it came from.
+			assertStripeJsOrigin();
+
 			// Default to the 'auto' locale so Stripe chooses the browser's locale
 			// if the store's locale is not available.
 			const locale = getBlocksConfiguration()?.stripe_locale ?? 'auto';

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -363,7 +363,16 @@ jQuery( function ( $ ) {
 				elementsMode = 'payment';
 			}
 
-			const elements = api.getStripe().elements( {
+			let stripe;
+			try {
+				stripe = api.getStripe();
+			} catch ( error ) {
+				// Stripe.js failed the origin assertion (fail closed): skip
+				// rendering the express checkout button instead of throwing.
+				return;
+			}
+
+			const elements = stripe.elements( {
 				mode: elementsMode,
 				...( elementsMode !== 'setup' && {
 					amount: options.total,

--- a/client/stripe-utils/__tests__/verify-stripe-js-origin.test.js
+++ b/client/stripe-utils/__tests__/verify-stripe-js-origin.test.js
@@ -104,6 +104,21 @@ describe( 'verifyStripeJsOrigin', () => {
 		} );
 	} );
 
+	it( 'ignores a non-script element sharing the stripe-js id and falls back to a legitimate script', () => {
+		const doc = document.implementation.createHTMLDocument( 'test' );
+		const collision = doc.createElement( 'div' );
+		collision.id = 'stripe-js';
+		doc.body.appendChild( collision );
+		const script = doc.createElement( 'script' );
+		script.setAttribute( 'src', 'https://js.stripe.com/v3/' );
+		doc.body.appendChild( script );
+
+		expect( verifyStripeJsOrigin( doc ) ).toMatchObject( {
+			ok: true,
+			detectedOrigin: STRIPE_JS_ORIGIN,
+		} );
+	} );
+
 	it( 'fails closed when no Stripe.js tag is present', () => {
 		const doc = createDocumentWithScript();
 

--- a/client/stripe-utils/__tests__/verify-stripe-js-origin.test.js
+++ b/client/stripe-utils/__tests__/verify-stripe-js-origin.test.js
@@ -139,6 +139,22 @@ describe( 'verifyStripeJsOrigin', () => {
 		} );
 	} );
 
+	it( 'does not fall back when a srcless script#stripe-js shadows a legitimate script', () => {
+		// An attacker-injected srcless handle must not let an unrelated
+		// official-origin script satisfy the check while window.Stripe is loaded
+		// from elsewhere. The handle is authoritative whenever it is a <script>.
+		const doc = createDocumentWithScript(
+			{ id: 'stripe-js' },
+			{ src: 'https://js.stripe.com/v3/' }
+		);
+
+		expect( verifyStripeJsOrigin( doc ) ).toEqual( {
+			ok: false,
+			detectedSrc: null,
+			detectedOrigin: null,
+		} );
+	} );
+
 	it( 'fails closed when the src cannot be parsed as a URL', () => {
 		const doc = {
 			querySelector: () => ( { src: 'https://' } ),

--- a/client/stripe-utils/__tests__/verify-stripe-js-origin.test.js
+++ b/client/stripe-utils/__tests__/verify-stripe-js-origin.test.js
@@ -104,6 +104,28 @@ describe( 'verifyStripeJsOrigin', () => {
 		} );
 	} );
 
+	it( 'keeps the script handle authoritative when a non-script #stripe-js precedes it', () => {
+		// A non-script id collision injected before the real handle must not
+		// divert to the fallback (where a benign official-origin script could
+		// mask a repointed handle); the real script#stripe-js stays authoritative.
+		const doc = document.implementation.createHTMLDocument( 'test' );
+		const collision = doc.createElement( 'div' );
+		collision.id = 'stripe-js';
+		doc.body.appendChild( collision );
+		const benign = doc.createElement( 'script' );
+		benign.setAttribute( 'src', 'https://js.stripe.com/v3/' );
+		doc.body.appendChild( benign );
+		const handle = doc.createElement( 'script' );
+		handle.id = 'stripe-js';
+		handle.setAttribute( 'src', 'https://js.stripe.com.evil.example/v3/' );
+		doc.body.appendChild( handle );
+
+		expect( verifyStripeJsOrigin( doc ) ).toMatchObject( {
+			ok: false,
+			detectedOrigin: 'https://js.stripe.com.evil.example',
+		} );
+	} );
+
 	it( 'ignores a non-script element sharing the stripe-js id and falls back to a legitimate script', () => {
 		const doc = document.implementation.createHTMLDocument( 'test' );
 		const collision = doc.createElement( 'div' );

--- a/client/stripe-utils/__tests__/verify-stripe-js-origin.test.js
+++ b/client/stripe-utils/__tests__/verify-stripe-js-origin.test.js
@@ -1,0 +1,192 @@
+import {
+	STRIPE_JS_ORIGIN,
+	verifyStripeJsOrigin,
+	assertStripeJsOrigin,
+} from '../verify-stripe-js-origin';
+
+/**
+ * Creates a detached document containing the given script tags, in order.
+ *
+ * @param {...Object} tags       The script tags to add. Pass none to create an empty document.
+ * @param {string}    [tags.id]  The id attribute for a tag.
+ * @param {string}    [tags.src] The src attribute for a tag.
+ * @return {Document} The created document.
+ */
+const createDocumentWithScript = ( ...tags ) => {
+	const doc = document.implementation.createHTMLDocument( 'test' );
+	tags.forEach( ( tag ) => {
+		const script = doc.createElement( 'script' );
+		if ( tag.id ) {
+			script.id = tag.id;
+		}
+		if ( tag.src ) {
+			script.setAttribute( 'src', tag.src );
+		}
+		doc.body.appendChild( script );
+	} );
+	return doc;
+};
+
+describe( 'verifyStripeJsOrigin', () => {
+	it( 'accepts the official origin with the /v3/ path', () => {
+		const doc = createDocumentWithScript( {
+			id: 'stripe-js',
+			src: 'https://js.stripe.com/v3/',
+		} );
+
+		expect( verifyStripeJsOrigin( doc ) ).toEqual( {
+			ok: true,
+			detectedSrc: 'https://js.stripe.com/v3/',
+			detectedOrigin: STRIPE_JS_ORIGIN,
+		} );
+	} );
+
+	it( 'accepts the official origin with a release train path', () => {
+		const doc = createDocumentWithScript( {
+			id: 'stripe-js',
+			src: 'https://js.stripe.com/clover/stripe.js',
+		} );
+
+		expect( verifyStripeJsOrigin( doc ) ).toMatchObject( {
+			ok: true,
+			detectedOrigin: STRIPE_JS_ORIGIN,
+		} );
+	} );
+
+	it( 'accepts a tag found via the src fallback when the id is missing', () => {
+		const doc = createDocumentWithScript( {
+			src: 'https://js.stripe.com/v3/stripe.js',
+		} );
+
+		expect( verifyStripeJsOrigin( doc ) ).toMatchObject( {
+			ok: true,
+			detectedOrigin: STRIPE_JS_ORIGIN,
+		} );
+	} );
+
+	it( 'rejects a look-alike origin', () => {
+		const doc = createDocumentWithScript( {
+			id: 'stripe-js',
+			src: 'https://js-stripe.example/v3/',
+		} );
+
+		expect( verifyStripeJsOrigin( doc ) ).toEqual( {
+			ok: false,
+			detectedSrc: 'https://js-stripe.example/v3/',
+			detectedOrigin: 'https://js-stripe.example',
+		} );
+	} );
+
+	it( 'rejects a subdomain-suffix look-alike origin', () => {
+		const doc = createDocumentWithScript( {
+			id: 'stripe-js',
+			src: 'https://js.stripe.com.evil.example/v3/',
+		} );
+
+		expect( verifyStripeJsOrigin( doc ) ).toMatchObject( {
+			ok: false,
+			detectedOrigin: 'https://js.stripe.com.evil.example',
+		} );
+	} );
+
+	it( 'rejects a tampered #stripe-js tag even when a legitimate Stripe script appears earlier in the DOM', () => {
+		const doc = createDocumentWithScript(
+			{ src: 'https://js.stripe.com/v3/extras.js' },
+			{
+				id: 'stripe-js',
+				src: 'https://js.stripe.com.evil.example/clover/stripe.js',
+			}
+		);
+
+		expect( verifyStripeJsOrigin( doc ) ).toMatchObject( {
+			ok: false,
+			detectedOrigin: 'https://js.stripe.com.evil.example',
+		} );
+	} );
+
+	it( 'fails closed when no Stripe.js tag is present', () => {
+		const doc = createDocumentWithScript();
+
+		expect( verifyStripeJsOrigin( doc ) ).toEqual( {
+			ok: false,
+			detectedSrc: null,
+			detectedOrigin: null,
+		} );
+	} );
+
+	it( 'fails closed when the tag has no src', () => {
+		const doc = createDocumentWithScript( { id: 'stripe-js' } );
+
+		expect( verifyStripeJsOrigin( doc ) ).toEqual( {
+			ok: false,
+			detectedSrc: null,
+			detectedOrigin: null,
+		} );
+	} );
+
+	it( 'fails closed when the src cannot be parsed as a URL', () => {
+		const doc = {
+			querySelector: () => ( { src: 'https://' } ),
+		};
+
+		expect( verifyStripeJsOrigin( doc ) ).toEqual( {
+			ok: false,
+			detectedSrc: 'https://',
+			detectedOrigin: null,
+		} );
+	} );
+} );
+
+describe( 'assertStripeJsOrigin', () => {
+	it( 'passes silently for the official origin', () => {
+		const warnSpy = jest
+			.spyOn( console, 'warn' )
+			.mockImplementation( () => {} );
+		const doc = createDocumentWithScript( {
+			id: 'stripe-js',
+			src: 'https://js.stripe.com/clover/stripe.js',
+		} );
+
+		expect( () => assertStripeJsOrigin( doc ) ).not.toThrow();
+		expect( warnSpy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'warns with the detected src and throws a generic error for an unexpected origin', () => {
+		const warnSpy = jest
+			.spyOn( console, 'warn' )
+			.mockImplementation( () => {} );
+		const doc = createDocumentWithScript( {
+			id: 'stripe-js',
+			src: 'https://js.stripe.com.evil.example/clover/stripe.js',
+		} );
+
+		// The thrown message can be rendered to shoppers by checkout error
+		// handling, so it must stay generic; diagnostics go to the console.
+		expect( () => assertStripeJsOrigin( doc ) ).toThrow(
+			/provenance check failed/
+		);
+		expect( () => assertStripeJsOrigin( doc ) ).not.toThrow( /evil/ );
+		expect( warnSpy ).toHaveBeenCalledWith(
+			expect.stringContaining(
+				'https://js.stripe.com.evil.example/clover/stripe.js'
+			)
+		);
+	} );
+
+	it( 'warns and throws when no Stripe.js tag is found', () => {
+		const warnSpy = jest
+			.spyOn( console, 'warn' )
+			.mockImplementation( () => {} );
+		const doc = createDocumentWithScript();
+
+		expect( () => assertStripeJsOrigin( doc ) ).toThrow(
+			/provenance check failed/
+		);
+		expect( warnSpy ).toHaveBeenCalledWith(
+			expect.stringContaining( 'no Stripe.js script tag was found' )
+		);
+		expect( warnSpy ).not.toHaveBeenCalledWith(
+			expect.stringContaining( 'null' )
+		);
+	} );
+} );

--- a/client/stripe-utils/verify-stripe-js-origin.js
+++ b/client/stripe-utils/verify-stripe-js-origin.js
@@ -1,0 +1,79 @@
+/**
+ * The only origin Stripe.js is allowed to be served from.
+ *
+ * @type {string}
+ */
+export const STRIPE_JS_ORIGIN = 'https://js.stripe.com';
+
+/**
+ * Inspects the Stripe.js script tag on the page and verifies that it was
+ * loaded from the official Stripe origin.
+ *
+ * Only the origin is compared (not the full URL), so Stripe.js path changes
+ * (`/v3/`, `/clover/stripe.js`, named release trains) do not cause mismatches.
+ *
+ * The `#stripe-js` id is the fingerprint WordPress renders for the `stripe`
+ * script handle, so a repointed handle is read by id regardless of its
+ * current src. It is looked up explicitly (not via a selector list) so it
+ * always takes precedence: `querySelector` on a comma-separated selector
+ * returns the first match in document order, so a legitimate js.stripe.com
+ * tag inserted earlier in the DOM could otherwise mask a repointed handle.
+ * Only when no handle tag exists do we fall back to any script served from
+ * the official origin.
+ *
+ * @param {Document} [doc] The document to inspect. Defaults to the global document.
+ * @return {Object} Result object with `ok` (boolean), `detectedSrc` (string|null), and `detectedOrigin` (string|null).
+ */
+export const verifyStripeJsOrigin = ( doc = document ) => {
+	const tag =
+		doc.querySelector( '#stripe-js' ) ??
+		doc.querySelector( 'script[src^="https://js.stripe.com/"]' );
+
+	if ( ! tag || ! tag.src ) {
+		return { ok: false, detectedSrc: null, detectedOrigin: null };
+	}
+
+	try {
+		const origin = new URL( tag.src ).origin;
+		return {
+			ok: origin === STRIPE_JS_ORIGIN,
+			detectedSrc: tag.src,
+			detectedOrigin: origin,
+		};
+	} catch ( error ) {
+		return { ok: false, detectedSrc: tag.src, detectedOrigin: null };
+	}
+};
+
+/**
+ * Asserts that Stripe.js was loaded from the official Stripe origin,
+ * blocking payment processing otherwise (fail closed).
+ *
+ * This is a defense-in-depth measure against checkout skimmers that swap the
+ * Stripe.js script for a look-alike hosted on an attacker-controlled origin.
+ *
+ * The full diagnostics (including the detected src) go to the console only;
+ * the thrown message may be rendered to shoppers by existing checkout error
+ * handling, so it stays generic.
+ *
+ * @param {Document} [doc] The document to inspect. Defaults to the global document.
+ * @throws {Error} If Stripe.js was not loaded from the official origin.
+ */
+export const assertStripeJsOrigin = ( doc = document ) => {
+	const result = verifyStripeJsOrigin( doc );
+
+	if ( result.ok ) {
+		return;
+	}
+
+	const reason =
+		result.detectedSrc === null
+			? 'no Stripe.js script tag was found'
+			: `Stripe.js was loaded from an unexpected origin (${ result.detectedSrc })`;
+
+	// eslint-disable-next-line no-console
+	console.warn(
+		`WooCommerce Stripe Gateway: blocking checkout — ${ reason }. Expected Stripe.js from ${ STRIPE_JS_ORIGIN }.`
+	);
+	throw new Error( 'Stripe.js provenance check failed.' );
+};

--- a/client/stripe-utils/verify-stripe-js-origin.js
+++ b/client/stripe-utils/verify-stripe-js-origin.js
@@ -1,3 +1,5 @@
+import { __ } from '@wordpress/i18n';
+
 /**
  * The only origin Stripe.js is allowed to be served from.
  *
@@ -6,33 +8,24 @@
 export const STRIPE_JS_ORIGIN = 'https://js.stripe.com';
 
 /**
- * Inspects the Stripe.js script tag on the page and verifies that it was
- * loaded from the official Stripe origin.
+ * Verifies that the page's Stripe.js was served from the official Stripe origin.
  *
- * Only the origin is compared (not the full URL), so Stripe.js path changes
- * (`/v3/`, `/clover/stripe.js`, named release trains) do not cause mismatches.
- *
- * The `#stripe-js` id is the fingerprint WordPress renders for the `stripe`
- * script handle, so a repointed handle is read by id regardless of its
- * current src. It is looked up explicitly (not via a selector list) so it
- * always takes precedence: `querySelector` on a comma-separated selector
- * returns the first match in document order, so a legitimate js.stripe.com
- * tag inserted earlier in the DOM could otherwise mask a repointed handle.
- * The handle match is only honored when it is actually a `<script>` with a
- * src — an unrelated element that happens to share the `stripe-js` id must not
- * fail the check closed while a legitimate script is present. Only when no
- * usable handle tag exists do we fall back to any script served from the
- * official origin.
+ * Only the origin is compared, so Stripe.js path/release-train changes do not
+ * false-positive. The `#stripe-js` handle (WordPress's id for the `stripe`
+ * script) is authoritative whenever it is a `<script>`: a repointed or
+ * src-stripped handle must fail closed rather than fall back to another tag,
+ * since an earlier official-origin script could otherwise mask it. Only when no
+ * handle script exists do we fall back to any script from the official origin.
  *
  * @param {Document} [doc] The document to inspect. Defaults to the global document.
- * @return {Object} Result object with `ok` (boolean), `detectedSrc` (string|null), and `detectedOrigin` (string|null).
+ * @return {Object} Result with `ok` (boolean), `detectedSrc` (string|null), and `detectedOrigin` (string|null).
  */
 export const verifyStripeJsOrigin = ( doc = document ) => {
 	const handleTag = doc.querySelector( '#stripe-js' );
 	const tag =
-		handleTag?.tagName === 'SCRIPT' && handleTag.src
+		handleTag?.tagName === 'SCRIPT'
 			? handleTag
-			: doc.querySelector( 'script[src^="https://js.stripe.com/"]' );
+			: doc.querySelector( `script[src^="${ STRIPE_JS_ORIGIN }/"]` );
 
 	if ( ! tag || ! tag.src ) {
 		return { ok: false, detectedSrc: null, detectedOrigin: null };
@@ -51,15 +44,10 @@ export const verifyStripeJsOrigin = ( doc = document ) => {
 };
 
 /**
- * Asserts that Stripe.js was loaded from the official Stripe origin,
- * blocking payment processing otherwise (fail closed).
- *
- * This is a defense-in-depth measure against checkout skimmers that swap the
- * Stripe.js script for a look-alike hosted on an attacker-controlled origin.
- *
- * The full diagnostics (including the detected src) go to the console only;
- * the thrown message may be rendered to shoppers by existing checkout error
- * handling, so it stays generic.
+ * Asserts Stripe.js came from the official origin, throwing to block payment
+ * otherwise (fail closed) — defense-in-depth against skimmers that swap the
+ * script for a look-alike. The thrown message stays generic because checkout
+ * error handling may render it to shoppers; full diagnostics go to the console.
  *
  * @param {Document} [doc] The document to inspect. Defaults to the global document.
  * @throws {Error} If Stripe.js was not loaded from the official origin.
@@ -74,11 +62,13 @@ export const assertStripeJsOrigin = ( doc = document ) => {
 	const reason =
 		result.detectedSrc === null
 			? 'no Stripe.js script tag was found'
-			: `Stripe.js was loaded from an unexpected origin (${ result.detectedSrc })`;
+			: `Stripe.js was loaded from an unexpected source (${ result.detectedSrc })`;
 
 	// eslint-disable-next-line no-console
 	console.warn(
 		`WooCommerce Stripe Gateway: blocking checkout — ${ reason }. Expected Stripe.js from ${ STRIPE_JS_ORIGIN }.`
 	);
-	throw new Error( 'Stripe.js provenance check failed.' );
+	throw new Error(
+		__( 'Stripe.js provenance check failed.', 'woocommerce-gateway-stripe' )
+	);
 };

--- a/client/stripe-utils/verify-stripe-js-origin.js
+++ b/client/stripe-utils/verify-stripe-js-origin.js
@@ -11,21 +11,22 @@ export const STRIPE_JS_ORIGIN = 'https://js.stripe.com';
  * Verifies that the page's Stripe.js was served from the official Stripe origin.
  *
  * Only the origin is compared, so Stripe.js path/release-train changes do not
- * false-positive. The `#stripe-js` handle (WordPress's id for the `stripe`
- * script) is authoritative whenever it is a `<script>`: a repointed or
- * src-stripped handle must fail closed rather than fall back to another tag,
- * since an earlier official-origin script could otherwise mask it. Only when no
- * handle script exists do we fall back to any script from the official origin.
+ * false-positive. The `script#stripe-js` handle (WordPress's id for the
+ * `stripe` script) is authoritative: a repointed or src-stripped handle must
+ * fail closed rather than fall back to another tag. Selecting `script#stripe-js`
+ * (not `#stripe-js`) keeps the real handle authoritative even when a non-script
+ * element shares the id, which would otherwise divert to the fallback and let an
+ * earlier official-origin script mask the handle. Only when no script handle
+ * exists do we fall back to any script from the official origin.
  *
  * @param {Document} [doc] The document to inspect. Defaults to the global document.
  * @return {Object} Result with `ok` (boolean), `detectedSrc` (string|null), and `detectedOrigin` (string|null).
  */
 export const verifyStripeJsOrigin = ( doc = document ) => {
-	const handleTag = doc.querySelector( '#stripe-js' );
+	const handleTag = doc.querySelector( 'script#stripe-js' );
 	const tag =
-		handleTag?.tagName === 'SCRIPT'
-			? handleTag
-			: doc.querySelector( `script[src^="${ STRIPE_JS_ORIGIN }/"]` );
+		handleTag ??
+		doc.querySelector( `script[src^="${ STRIPE_JS_ORIGIN }/"]` );
 
 	if ( ! tag || ! tag.src ) {
 		return { ok: false, detectedSrc: null, detectedOrigin: null };

--- a/client/stripe-utils/verify-stripe-js-origin.js
+++ b/client/stripe-utils/verify-stripe-js-origin.js
@@ -18,16 +18,21 @@ export const STRIPE_JS_ORIGIN = 'https://js.stripe.com';
  * always takes precedence: `querySelector` on a comma-separated selector
  * returns the first match in document order, so a legitimate js.stripe.com
  * tag inserted earlier in the DOM could otherwise mask a repointed handle.
- * Only when no handle tag exists do we fall back to any script served from
- * the official origin.
+ * The handle match is only honored when it is actually a `<script>` with a
+ * src — an unrelated element that happens to share the `stripe-js` id must not
+ * fail the check closed while a legitimate script is present. Only when no
+ * usable handle tag exists do we fall back to any script served from the
+ * official origin.
  *
  * @param {Document} [doc] The document to inspect. Defaults to the global document.
  * @return {Object} Result object with `ok` (boolean), `detectedSrc` (string|null), and `detectedOrigin` (string|null).
  */
 export const verifyStripeJsOrigin = ( doc = document ) => {
+	const handleTag = doc.querySelector( '#stripe-js' );
 	const tag =
-		doc.querySelector( '#stripe-js' ) ??
-		doc.querySelector( 'script[src^="https://js.stripe.com/"]' );
+		handleTag?.tagName === 'SCRIPT' && handleTag.src
+			? handleTag
+			: doc.querySelector( 'script[src^="https://js.stripe.com/"]' );
 
 	if ( ! tag || ! tag.src ) {
 		return { ok: false, detectedSrc: null, detectedOrigin: null };

--- a/readme.txt
+++ b/readme.txt
@@ -177,5 +177,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Show an error notice when a Stripe OAuth connection attempt fails its security check
 * Fix - Run the woocommerce_gateway_description filter for Stripe payment methods so third parties can add or replace their checkout descriptions
 * Dev - Deprecate the internal WC_Stripe_Feature_Flags::is_amazon_pay_available() helper now that Amazon Pay is permanently enabled
+* Add - Verify that Stripe.js was served from the official Stripe origin before processing checkout payments
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Partially fixes WOOPMNT-6210

Minimal, client-only defense-in-depth against checkout skimmers that swap Stripe.js. Ports the equivalent client-side origin assertion from WooPayments (woocommerce/woocommerce-payments#11853).

## Changes proposed in this Pull Request:

The gateway loads Stripe.js via a rewritable WordPress script handle and instantiates it from the ambient `window.Stripe` with no provenance check — on Blocks too, since the `@stripe/stripe-js` loader reuses the already-loaded global. On a compromised store, repointing that handle to a look-alike origin makes the card iframe render from an attacker while charges still succeed.

This adds an origin assertion at the two Stripe-instantiation choke points (`WCStripeAPI.createStripe()` and `client/blocks/load-stripe.js`): a new helper (`client/stripe-utils/verify-stripe-js-origin.js`) checks the loaded Stripe.js tag's origin is `https://js.stripe.com`; on a mismatch it warns (console only) and throws a generic error, blocking the payment. The `#stripe-js` handle is looked up explicitly so a legitimate `js.stripe.com` tag elsewhere in the DOM cannot mask a repointed handle.

**Scope / limitations:** defense-in-depth, not a gateway vulnerability fix. The gateway isn't the entry vector, and a fully-compromised box can bypass this. It defends the Stripe.js *substitution* vector specifically (the variant seen in the wild), not an attacker-injected custom form.

## Testing instructions

Simulate the attack on a test site, then open checkout (console warns, payment blocked on classic, Blocks, and express checkout):

    add_filter( 'script_loader_src', fn( $src, $h ) => 'stripe' === $h ? 'https://js.evil.example/v3/' : $src, PHP_INT_MAX, 2 );

---

-   [x] Covered with tests (or have a good reason not to test in description)
-   [x] Tested on mobile (or does not apply)

*Drafted with AI (Claude Code); reviewed by me.*
