### PR TITLE
Use a live Store API nonce for Express Checkout order requests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Decommission the previously configured webhook before connecting via OAuth so reconnecting to a different Stripe account no longer leaves an orphaned webhook on the old account
 * Fix - Send the billing address to Stripe on the Pay for Order page so payments aren't incorrectly blocked by Stripe Radar rules
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element
+* Fix - Reuse the Store API nonce rotated during the Express Checkout cart requests when completing the order, so guest Apple Pay/Google Pay payments no longer fail with a nonce error on cached classic checkout pages
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
 * Fix - Prevent an uncaught "Stripe initialization data is not available" error on product pages when express checkout loads without the Stripe payment configuration
 * Add - Stripe admin pages to the WordPress Command Palette

--- a/changelog.txt
+++ b/changelog.txt
@@ -12,7 +12,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Decommission the previously configured webhook before connecting via OAuth so reconnecting to a different Stripe account no longer leaves an orphaned webhook on the old account
 * Fix - Send the billing address to Stripe on the Pay for Order page so payments aren't incorrectly blocked by Stripe Radar rules
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element
-* Fix - Reuse the Store API nonce rotated during the Express Checkout cart requests when completing the order, so guest Apple Pay/Google Pay payments no longer fail with a nonce error on cached classic checkout pages
+* Fix - Reuse the Store API nonce from Express Checkout cart requests when completing orders, preventing guest Apple Pay/Google Pay failures on cached classic checkout pages
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
 * Fix - Prevent an uncaught "Stripe initialization data is not available" error on product pages when express checkout loads without the Stripe payment configuration
 * Add - Stripe admin pages to the WordPress Command Palette

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -606,9 +606,10 @@ export default class WCStripeAPI {
 	 * Creates order based on Express Checkout ECE payment method.
 	 *
 	 * @param {Object} orderData Order data.
+	 * @param {Object} headers   Optional header overrides (e.g. a refreshed `Nonce`).
 	 * @return {Promise} Promise for the request to the server.
 	 */
-	expressCheckoutECECreateOrder( orderData ) {
+	expressCheckoutECECreateOrder( orderData, headers = {} ) {
 		return this.postToBlocksAPI(
 			'/wc/store/v1/checkout',
 			{
@@ -620,6 +621,7 @@ export default class WCStripeAPI {
 				'X-WCSTRIPE-EXPRESS-CHECKOUT-NONCE':
 					getExpressCheckoutData( 'nonce' )
 						?.wc_store_api_express_checkout,
+				...headers,
 			}
 		);
 	}
@@ -630,15 +632,21 @@ export default class WCStripeAPI {
 	 * @param {number} order        The order ID.
 	 * @param {Object} orderDetails Order details, including order key and billing email.
 	 * @param {Object} paymentData  Order data.
+	 * @param {Object} headers      Optional header overrides (e.g. a refreshed `Nonce`).
 	 * @return {Promise} Promise for the request to the server.
 	 */
-	expressCheckoutECEPayForOrder( order, orderDetails, paymentData ) {
+	expressCheckoutECEPayForOrder(
+		order,
+		orderDetails,
+		paymentData,
+		headers = {}
+	) {
 		paymentData.shipping_address = orderDetails.shippingAddress;
 
 		const billingEmail = orderDetails.billingEmail ?? '';
 		const key = orderDetails.orderKey ?? '';
 		const url = `/wc/store/v1/checkout/${ order }?key=${ key }&billing_email=${ billingEmail }`;
-		return this.postToBlocksAPI( url, paymentData );
+		return this.postToBlocksAPI( url, paymentData, headers );
 	}
 
 	/**

--- a/client/express-checkout/__tests__/cart-api.test.js
+++ b/client/express-checkout/__tests__/cart-api.test.js
@@ -142,4 +142,29 @@ describe( 'ExpressCheckoutCartApi', () => {
 			);
 		} );
 	} );
+
+	describe( 'getStoreApiNonce', () => {
+		// Guests on full-page-cached shortcode checkout get a stale/absent page
+		// nonce, so the checkout POST reuses the nonce the cart calls already
+		// rotated instead.
+		it( 'reuses the nonce rotated by an earlier cart request without making a request', async () => {
+			apiFetch.mockResolvedValue(
+				mockResponse( { totals: {} }, { Nonce: 'refreshed_nonce' } )
+			);
+			await cartApi.updateCustomer( { shipping_address: {} } );
+			apiFetch.mockClear();
+
+			const nonce = cartApi.getStoreApiNonce();
+
+			expect( nonce ).toBe( 'refreshed_nonce' );
+			expect( apiFetch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'falls back to the page nonce when no cart request has rotated one', () => {
+			const nonce = cartApi.getStoreApiNonce();
+
+			expect( nonce ).toBe( 'test_store_api_nonce' );
+			expect( apiFetch ).not.toHaveBeenCalled();
+		} );
+	} );
 } );

--- a/client/express-checkout/__tests__/cart-api.test.js
+++ b/client/express-checkout/__tests__/cart-api.test.js
@@ -154,17 +154,44 @@ describe( 'ExpressCheckoutCartApi', () => {
 			await cartApi.updateCustomer( { shipping_address: {} } );
 			apiFetch.mockClear();
 
-			const nonce = cartApi.getStoreApiNonce();
+			const nonce = await cartApi.getStoreApiNonce();
 
 			expect( nonce ).toBe( 'refreshed_nonce' );
 			expect( apiFetch ).not.toHaveBeenCalled();
 		} );
 
-		it( 'falls back to the page nonce when no cart request has rotated one', () => {
-			const nonce = cartApi.getStoreApiNonce();
+		// Virtual/downloadable carts skip the shipping step, so no cart call has
+		// rotated a nonce — fetch the cart (no nonce required on GET) to harvest one.
+		it( 'fetches the cart to harvest a fresh nonce when none has been rotated', async () => {
+			apiFetch.mockResolvedValue(
+				mockResponse( {}, { Nonce: 'fetched_nonce' } )
+			);
+
+			const nonce = await cartApi.getStoreApiNonce();
+
+			expect( apiFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					method: 'GET',
+					path: '/wc/store/v1/cart',
+				} )
+			);
+			expect( nonce ).toBe( 'fetched_nonce' );
+		} );
+
+		it( 'falls back to the page nonce when the cart fetch yields no nonce', async () => {
+			apiFetch.mockResolvedValue( mockResponse( {} ) );
+
+			const nonce = await cartApi.getStoreApiNonce();
 
 			expect( nonce ).toBe( 'test_store_api_nonce' );
-			expect( apiFetch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'falls back to the page nonce when the cart fetch fails', async () => {
+			apiFetch.mockRejectedValue( new Error( 'network' ) );
+
+			const nonce = await cartApi.getStoreApiNonce();
+
+			expect( nonce ).toBe( 'test_store_api_nonce' );
 		} );
 	} );
 } );

--- a/client/express-checkout/__tests__/event-handler.test.js
+++ b/client/express-checkout/__tests__/event-handler.test.js
@@ -22,6 +22,7 @@ jest.mock( 'wcstripe/express-checkout/cart-api', () => {
 		updateCustomer: jest.fn(),
 		selectShippingRate: jest.fn(),
 		getCart: jest.fn(),
+		getStoreApiNonce: jest.fn().mockReturnValue( 'fresh_nonce' ),
 	} ) );
 } );
 
@@ -242,6 +243,11 @@ describe( 'Express checkout event handlers', () => {
 				blockUI: jest.fn(),
 				unblockUI: jest.fn(),
 			};
+			// Earlier describe blocks swap the module-scoped cart API; restore
+			// one that resolves the Store API nonce the order request needs.
+			setCartApiHandler( {
+				getStoreApiNonce: jest.fn().mockReturnValue( 'fresh_nonce' ),
+			} );
 			api = {
 				expressCheckoutNormalizeAddress: jest.fn(),
 				expressCheckoutECECreateOrder: jest.fn(),
@@ -391,7 +397,8 @@ describe( 'Express checkout event handlers', () => {
 				paymentMethodId: 'pm_123',
 			} );
 			expect( api.expressCheckoutECECreateOrder ).toHaveBeenCalledWith(
-				expectedOrderData
+				expectedOrderData,
+				{ Nonce: 'fresh_nonce' }
 			);
 			expect( abortPayment ).toHaveBeenCalledWith(
 				event,
@@ -538,7 +545,8 @@ describe( 'Express checkout event handlers', () => {
 			expect( api.expressCheckoutECEPayForOrder ).toHaveBeenCalledWith(
 				123,
 				{},
-				expectedOrderData
+				expectedOrderData,
+				{ Nonce: 'fresh_nonce' }
 			);
 			expect( abortPayment ).toHaveBeenCalledWith(
 				event,

--- a/client/express-checkout/cart-api.js
+++ b/client/express-checkout/cart-api.js
@@ -43,6 +43,27 @@ export default class ExpressCheckoutCartApi {
 	}
 
 	/**
+	 * Returns the freshest Store API nonce we already hold, without a request.
+	 *
+	 * The nonce localized into the page can be stale or absent for guests when
+	 * the checkout page is served from full-page cache (logged-in users bypass
+	 * the cache, which is why only guests hit `woocommerce_rest_missing_nonce`).
+	 * Every Store API cart response rotates the `Nonce` header, which the cart
+	 * calls made while the wallet sheet is open (`updateCustomer` /
+	 * `selectShippingRate`) store here — prefer that over the page nonce. This
+	 * deliberately makes no request of its own so it adds no latency to the
+	 * express checkout submit path; it only reuses a value already fetched.
+	 *
+	 * @return {string|undefined} The freshest Store API nonce available.
+	 */
+	getStoreApiNonce() {
+		return (
+			this.cartRequestHeaders.Nonce ||
+			getExpressCheckoutData( 'nonce' )?.wc_store_api
+		);
+	}
+
+	/**
 	 * Returns the cart object.
 	 *
 	 * @return {Promise} Cart response object.

--- a/client/express-checkout/cart-api.js
+++ b/client/express-checkout/cart-api.js
@@ -43,16 +43,21 @@ export default class ExpressCheckoutCartApi {
 	}
 
 	/**
-	 * Returns the freshest Store API nonce we already hold, without a request.
+	 * Resolves a live Store API nonce for the checkout request.
 	 *
-	 * The page-localized nonce can be stale or absent for guests on full-page-cached
-	 * checkout (logged-in users bypass the cache, so only guests hit the nonce error).
-	 * Every cart response rotates the `Nonce` header, which `updateCustomer` /
-	 * `selectShippingRate` store here; prefer that over the page nonce.
+	 * The page nonce is stale for guests on full-page-cached checkout, so prefer the
+	 * one a cart call rotated. With no shipping step nothing rotated it, so fetch the
+	 * cart (a GET needs no nonce yet returns a fresh one); fall back to the page nonce.
 	 *
-	 * @return {string|undefined} The freshest Store API nonce available.
+	 * @return {Promise<string|undefined>} The freshest Store API nonce available.
 	 */
-	getStoreApiNonce() {
+	async getStoreApiNonce() {
+		if ( ! this.cartRequestHeaders.Nonce ) {
+			try {
+				await this.getCart();
+			} catch ( e ) {}
+		}
+
 		return (
 			this.cartRequestHeaders.Nonce ||
 			getExpressCheckoutData( 'nonce' )?.wc_store_api

--- a/client/express-checkout/cart-api.js
+++ b/client/express-checkout/cart-api.js
@@ -45,14 +45,10 @@ export default class ExpressCheckoutCartApi {
 	/**
 	 * Returns the freshest Store API nonce we already hold, without a request.
 	 *
-	 * The nonce localized into the page can be stale or absent for guests when
-	 * the checkout page is served from full-page cache (logged-in users bypass
-	 * the cache, which is why only guests hit `woocommerce_rest_missing_nonce`).
-	 * Every Store API cart response rotates the `Nonce` header, which the cart
-	 * calls made while the wallet sheet is open (`updateCustomer` /
-	 * `selectShippingRate`) store here — prefer that over the page nonce. This
-	 * deliberately makes no request of its own so it adds no latency to the
-	 * express checkout submit path; it only reuses a value already fetched.
+	 * The page-localized nonce can be stale or absent for guests on full-page-cached
+	 * checkout (logged-in users bypass the cache, so only guests hit the nonce error).
+	 * Every cart response rotates the `Nonce` header, which `updateCustomer` /
+	 * `selectShippingRate` store here; prefer that over the page nonce.
 	 *
 	 * @return {string|undefined} The freshest Store API nonce available.
 	 */

--- a/client/express-checkout/event-handler.js
+++ b/client/express-checkout/event-handler.js
@@ -125,7 +125,7 @@ export const onConfirmHandler = async ( params ) => {
 
 	// Reuse the live nonce the cart calls rotated; the page nonce is stale for
 	// guests on cached checkout. See ExpressCheckoutCartApi#getStoreApiNonce.
-	const storeApiNonce = cartApi.getStoreApiNonce();
+	const storeApiNonce = await cartApi.getStoreApiNonce();
 	const orderParams = { ...params, storeApiNonce };
 
 	if (

--- a/client/express-checkout/event-handler.js
+++ b/client/express-checkout/event-handler.js
@@ -123,16 +123,23 @@ export const onConfirmHandler = async ( params ) => {
 		return handleChangePaymentMethodFlow( params );
 	}
 
+	// Prefer the nonce the cart calls already rotated while the wallet sheet was
+	// open. The page-localized nonce can be stale or absent for guests on
+	// full-page-cached checkout pages, which is what breaks them; reusing the
+	// rotated value avoids that without adding a request to the submit path.
+	const storeApiNonce = cartApi.getStoreApiNonce();
+	const orderParams = { ...params, storeApiNonce };
+
 	if (
 		! isManualPaymentMethodCreation(
 			event.expressPaymentType,
 			hasFreeTrial
 		)
 	) {
-		return handleConfirmationTokenFlow( params );
+		return handleConfirmationTokenFlow( orderParams );
 	}
 
-	return handleManualPaymentMethodFlow( params );
+	return handleManualPaymentMethodFlow( orderParams );
 };
 
 /**

--- a/client/express-checkout/event-handler.js
+++ b/client/express-checkout/event-handler.js
@@ -123,10 +123,8 @@ export const onConfirmHandler = async ( params ) => {
 		return handleChangePaymentMethodFlow( params );
 	}
 
-	// Prefer the nonce the cart calls already rotated while the wallet sheet was
-	// open. The page-localized nonce can be stale or absent for guests on
-	// full-page-cached checkout pages, which is what breaks them; reusing the
-	// rotated value avoids that without adding a request to the submit path.
+	// Reuse the live nonce the cart calls rotated; the page nonce is stale for
+	// guests on cached checkout. See ExpressCheckoutCartApi#getStoreApiNonce.
 	const storeApiNonce = cartApi.getStoreApiNonce();
 	const orderParams = { ...params, storeApiNonce };
 

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -68,8 +68,7 @@ const processOrder = async ( {
 } ) => {
 	let orderResponse;
 
-	// The page-localized nonce can be stale/absent on cached guest checkout
-	// pages, so override it with the live one resolved from the cart.
+	// Override the stale page nonce with the live one resolved from the cart.
 	const headers = storeApiNonce ? { Nonce: storeApiNonce } : {};
 
 	const normalizedOrderData = normalizeOrderData( {

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -54,6 +54,7 @@ const handlePaymentFlowException = ( event, exception, abortPayment ) => {
  * @param {string} params.confirmationTokenId The Stripe confirmation token ID (token flow).
  * @param {number} params.order               The WooCommerce order ID when paying for an existing order.
  * @param {Object} params.orderDetails        Additional order details (e.g. order key, billing email).
+ * @param {string} params.storeApiNonce       A freshly resolved Store API nonce for the checkout request.
  * @return {Promise<{result: string, errorMessage: string|undefined, redirect: string}>} The order result.
  */
 const processOrder = async ( {
@@ -63,8 +64,13 @@ const processOrder = async ( {
 	confirmationTokenId,
 	order = 0,
 	orderDetails = {},
+	storeApiNonce,
 } ) => {
 	let orderResponse;
+
+	// The page-localized nonce can be stale/absent on cached guest checkout
+	// pages, so override it with the live one resolved from the cart.
+	const headers = storeApiNonce ? { Nonce: storeApiNonce } : {};
 
 	const normalizedOrderData = normalizeOrderData( {
 		event,
@@ -87,11 +93,14 @@ const processOrder = async ( {
 		orderResponse = await api.expressCheckoutECEPayForOrder(
 			order,
 			orderDetails,
-			normalizedOrderData
+			normalizedOrderData,
+			headers
 		);
 	} else {
-		orderResponse =
-			await api.expressCheckoutECECreateOrder( normalizedOrderData );
+		orderResponse = await api.expressCheckoutECECreateOrder(
+			normalizedOrderData,
+			headers
+		);
 	}
 
 	// Extract redirect URL from payment_details if redirect_url is empty
@@ -127,6 +136,7 @@ const processOrder = async ( {
  * @param {Object}   params.event           The Stripe express checkout event.
  * @param {number}   params.order           The WooCommerce order ID when paying for an existing order.
  * @param {Object}   params.orderDetails    Additional order details.
+ * @param {string}   params.storeApiNonce   A freshly resolved Store API nonce for the checkout request.
  * @return {Promise<void>} Resolves when the payment flow has completed or been aborted.
  */
 export const handleManualPaymentMethodFlow = async ( {
@@ -138,6 +148,7 @@ export const handleManualPaymentMethodFlow = async ( {
 	event,
 	order = 0,
 	orderDetails = {},
+	storeApiNonce,
 } ) => {
 	try {
 		const { paymentMethod, error } = await stripe.createPaymentMethod( {
@@ -155,6 +166,7 @@ export const handleManualPaymentMethodFlow = async ( {
 			paymentMethodId: paymentMethod.id,
 			order,
 			orderDetails,
+			storeApiNonce,
 		} );
 
 		if ( result !== 'success' ) {
@@ -195,6 +207,7 @@ export const handleManualPaymentMethodFlow = async ( {
  * @param {Object}   params.event           The Stripe express checkout event.
  * @param {number}   params.order           The WooCommerce order ID when paying for an existing order.
  * @param {Object}   params.orderDetails    Additional order details.
+ * @param {string}   params.storeApiNonce   A freshly resolved Store API nonce for the checkout request.
  * @return {Promise<void>} Resolves when the payment flow has completed or been aborted.
  */
 export const handleConfirmationTokenFlow = async ( {
@@ -206,6 +219,7 @@ export const handleConfirmationTokenFlow = async ( {
 	event,
 	order = 0,
 	orderDetails = {},
+	storeApiNonce,
 } ) => {
 	try {
 		// Create a ConfirmationToken that we can use later to create and confirm the payment intent.
@@ -228,6 +242,7 @@ export const handleConfirmationTokenFlow = async ( {
 			confirmationTokenId: confirmationToken.id,
 			order,
 			orderDetails,
+			storeApiNonce,
 		} );
 
 		if ( result !== 'success' ) {

--- a/readme.txt
+++ b/readme.txt
@@ -165,6 +165,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Decommission the previously configured webhook before connecting via OAuth so reconnecting to a different Stripe account no longer leaves an orphaned webhook on the old account
 * Fix - Send the billing address to Stripe on the Pay for Order page so payments aren't incorrectly blocked by Stripe Radar rules
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element
+* Fix - Reuse the Store API nonce rotated during the Express Checkout cart requests when completing the order, so guest Apple Pay/Google Pay payments no longer fail with a nonce error on cached classic checkout pages
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
 * Fix - Prevent an uncaught "Stripe initialization data is not available" error on product pages when express checkout loads without the Stripe payment configuration
 * Add - Stripe admin pages to the WordPress Command Palette

--- a/readme.txt
+++ b/readme.txt
@@ -167,7 +167,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Decommission the previously configured webhook before connecting via OAuth so reconnecting to a different Stripe account no longer leaves an orphaned webhook on the old account
 * Fix - Send the billing address to Stripe on the Pay for Order page so payments aren't incorrectly blocked by Stripe Radar rules
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element
-* Fix - Reuse the Store API nonce rotated during the Express Checkout cart requests when completing the order, so guest Apple Pay/Google Pay payments no longer fail with a nonce error on cached classic checkout pages
+* Fix - Reuse the Store API nonce from Express Checkout cart requests when completing orders, preventing guest Apple Pay/Google Pay failures on cached classic checkout pages
 * Tweak - Consolidate the default payment intent metadata fields into a shared method so they stay consistent across payment flows
 * Fix - Prevent an uncaught "Stripe initialization data is not available" error on product pages when express checkout loads without the Stripe payment configuration
 * Add - Stripe admin pages to the WordPress Command Palette


### PR DESCRIPTION
Related to STRIPE-1214

## Changes proposed in this Pull Request:
The final `/wc/store/v1/checkout` request sends the `wc_store_api` nonce that's rendered into the checkout page HTML. When that page is served from full-page cache, the embedded nonce can be stale or missing for guests — and logged-in users bypass full-page cache (Excluding `/wp-json/wc/store/` from cache doesn't help: the nonce lives in the checkout *page*, not the REST endpoint.)

Every Store API cart response rotates the `Nonce` header, and the cart calls the wallet sheet already makes (`updateCustomer` / `selectShippingRate`) store that rotated value. This change reuses it for the create-order / pay-for-order requests instead of the page-rendered nonce, falling back to the page nonce when no cart call has run. It is a synchronous lookup of a value we already hold.

## Testing instructions
**No-regression smoke check**
1. Enable Express Checkout (Apple Pay / Google Pay) under WooCommerce → Settings → Payments → Stripe → Express Checkout.
2. Use a classic shortcode `[woocommerce_checkout]` page.
3. As a **guest**, add a product to the cart, go to checkout, and pay with Apple Pay / Google Pay.
4. Expected: order completes successfully.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
