### PR TITLE
Fix error when saving express checkout settings by introducing change-payment-method as a location option

### DIFF
--- a/client/entrypoints/link-settings/__tests__/link-settings-locations.test.js
+++ b/client/entrypoints/link-settings/__tests__/link-settings-locations.test.js
@@ -120,4 +120,42 @@ describe( 'LinkSettingsSection locations', () => {
 			'checkout',
 		] );
 	} );
+
+	it( 'should not render the change payment method location when Subscriptions is inactive', () => {
+		global.wc_stripe_link_settings_params.is_subscriptions_active = false;
+
+		render( <LinkSettingsSection /> );
+
+		expect(
+			screen.queryByRole( 'checkbox', {
+				name: /change payment method/i,
+			} )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should render and toggle the change payment method location when Subscriptions is active', async () => {
+		global.wc_stripe_link_settings_params.is_subscriptions_active = true;
+
+		const updateLinkLocationsHandler = jest.fn();
+		useLinkLocations.mockReturnValue( [
+			[ 'checkout' ],
+			updateLinkLocationsHandler,
+		] );
+
+		render( <LinkSettingsSection /> );
+
+		const changePaymentMethodCheckbox = screen.getByRole( 'checkbox', {
+			name: /change payment method/i,
+		} );
+
+		expect( changePaymentMethodCheckbox ).not.toBeDisabled();
+		expect( changePaymentMethodCheckbox ).not.toBeChecked();
+
+		await userEvent.click( changePaymentMethodCheckbox );
+
+		expect( updateLinkLocationsHandler ).toHaveBeenLastCalledWith( [
+			'checkout',
+			'change_payment_method',
+		] );
+	} );
 } );

--- a/client/entrypoints/link-settings/link-settings-section.js
+++ b/client/entrypoints/link-settings/link-settings-section.js
@@ -169,6 +169,29 @@ const LinkSettingsSection = () => {
 							label={ __( 'Cart', 'woocommerce-gateway-stripe' ) }
 						/>
 					</li>
+					{
+						// eslint-disable-next-line camelcase
+						wc_stripe_link_settings_params?.is_subscriptions_active && (
+							<li>
+								<CheckboxControl
+									disabled={ ! isLinkEnabled }
+									checked={
+										isLinkEnabled &&
+										linkLocations.includes(
+											'change_payment_method'
+										)
+									}
+									onChange={ makeLocationChangeHandler(
+										'change_payment_method'
+									) }
+									label={ __(
+										'Change payment method for WooCommerce Subscriptions',
+										'woocommerce-gateway-stripe'
+									) }
+								/>
+							</li>
+						)
+					}
 				</ul>
 				<h4>{ __( 'Appearance', 'woocommerce-gateway-stripe' ) }</h4>
 				<RadioControl

--- a/includes/admin/class-wc-stripe-link-controller.php
+++ b/includes/admin/class-wc-stripe-link-controller.php
@@ -44,6 +44,7 @@ class WC_Stripe_Link_Controller {
 			'key'                        => WC_Stripe_Mode::is_test() ? ( $stripe_settings['test_publishable_key'] ?? '' ) : ( $stripe_settings['publishable_key'] ?? '' ),
 			'locale'                     => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
 			'is_button_style_overridden' => WC_Stripe_Helper::is_express_checkout_button_style_overridden(),
+			'is_subscriptions_active'    => WC_Stripe_Subscriptions_Helper::is_subscriptions_enabled(),
 		];
 		wp_localize_script(
 			'wc-stripe-link-settings',

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -13,8 +13,6 @@ $wc_stripe_express_checkout_location_options = [
 
 $wc_stripe_default_express_checkout_locations = [ 'product', 'cart', 'checkout' ];
 
-$wc_stripe_default_button_locations = $wc_stripe_default_express_checkout_locations;
-
 if ( WC_Stripe_Subscriptions_Helper::is_subscriptions_enabled() ) {
 	$wc_stripe_express_checkout_location_options['change_payment_method'] = __( 'Change payment method (subscriptions)', 'woocommerce-gateway-stripe' );
 	$wc_stripe_default_express_checkout_locations[]                       = 'change_payment_method';
@@ -270,7 +268,7 @@ return apply_filters(
 				'cart'     => __( 'Cart', 'woocommerce-gateway-stripe' ),
 				'checkout' => __( 'Checkout', 'woocommerce-gateway-stripe' ),
 			],
-			'default'           => $wc_stripe_default_button_locations,
+			'default'           => [ 'product', 'cart', 'checkout' ],
 			'custom_attributes' => [
 				'data-placeholder' => __( 'Select pages', 'woocommerce-gateway-stripe' ),
 			],
@@ -293,12 +291,8 @@ return apply_filters(
 			'description'       => __( 'Select where you would like Link by Stripe button to be displayed', 'woocommerce-gateway-stripe' ),
 			'desc_tip'          => true,
 			'class'             => 'wc-enhanced-select',
-			'options'           => [
-				'product'  => __( 'Product', 'woocommerce-gateway-stripe' ),
-				'cart'     => __( 'Cart', 'woocommerce-gateway-stripe' ),
-				'checkout' => __( 'Checkout', 'woocommerce-gateway-stripe' ),
-			],
-			'default'           => $wc_stripe_default_button_locations,
+			'options'           => $wc_stripe_express_checkout_location_options,
+			'default'           => $wc_stripe_default_express_checkout_locations,
 			'custom_attributes' => [
 				'data-placeholder' => __( 'Select pages', 'woocommerce-gateway-stripe' ),
 			],

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -6,16 +6,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 $is_gte_wc6_6 = defined( WC_VERSION ) && version_compare( WC_VERSION, '6.6', '>=' );
 
 $wc_stripe_express_checkout_location_options = [
-	'product'  => __( 'Product', 'woocommerce-gateway-stripe' ),
-	'cart'     => __( 'Cart', 'woocommerce-gateway-stripe' ),
-	'checkout' => __( 'Checkout', 'woocommerce-gateway-stripe' ),
+	'product'               => __( 'Product', 'woocommerce-gateway-stripe' ),
+	'cart'                  => __( 'Cart', 'woocommerce-gateway-stripe' ),
+	'checkout'              => __( 'Checkout', 'woocommerce-gateway-stripe' ),
+	'change_payment_method' => __( 'Change payment method (subscriptions)', 'woocommerce-gateway-stripe' ),
 ];
 
 $wc_stripe_default_express_checkout_locations = [ 'product', 'cart', 'checkout' ];
 
 if ( WC_Stripe_Subscriptions_Helper::is_subscriptions_enabled() ) {
-	$wc_stripe_express_checkout_location_options['change_payment_method'] = __( 'Change payment method (subscriptions)', 'woocommerce-gateway-stripe' );
-	$wc_stripe_default_express_checkout_locations[]                       = 'change_payment_method';
+	$wc_stripe_default_express_checkout_locations[] = 'change_payment_method';
 }
 
 return apply_filters(

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -13,6 +13,8 @@ $wc_stripe_express_checkout_location_options = [
 
 $wc_stripe_default_express_checkout_locations = [ 'product', 'cart', 'checkout' ];
 
+$wc_stripe_default_button_locations = $wc_stripe_default_express_checkout_locations;
+
 if ( WC_Stripe_Subscriptions_Helper::is_subscriptions_enabled() ) {
 	$wc_stripe_express_checkout_location_options['change_payment_method'] = __( 'Change payment method (subscriptions)', 'woocommerce-gateway-stripe' );
 	$wc_stripe_default_express_checkout_locations[]                       = 'change_payment_method';
@@ -268,7 +270,7 @@ return apply_filters(
 				'cart'     => __( 'Cart', 'woocommerce-gateway-stripe' ),
 				'checkout' => __( 'Checkout', 'woocommerce-gateway-stripe' ),
 			],
-			'default'           => [ 'product', 'cart', 'checkout' ],
+			'default'           => $wc_stripe_default_button_locations,
 			'custom_attributes' => [
 				'data-placeholder' => __( 'Select pages', 'woocommerce-gateway-stripe' ),
 			],
@@ -296,7 +298,7 @@ return apply_filters(
 				'cart'     => __( 'Cart', 'woocommerce-gateway-stripe' ),
 				'checkout' => __( 'Checkout', 'woocommerce-gateway-stripe' ),
 			],
-			'default'           => $wc_stripe_default_express_checkout_locations,
+			'default'           => $wc_stripe_default_button_locations,
 			'custom_attributes' => [
 				'data-placeholder' => __( 'Select pages', 'woocommerce-gateway-stripe' ),
 			],

--- a/includes/migrations/class-wc-stripe-migrate-link-button-locations.php
+++ b/includes/migrations/class-wc-stripe-migrate-link-button-locations.php
@@ -34,18 +34,7 @@ class WC_Stripe_Migrate_Link_Button_Locations {
 			return;
 		}
 
-		$express_locations = $stripe_settings['express_checkout_button_locations'];
-
-		// Express checkout supports the express-only `change_payment_method` location
-		// (when Subscriptions is active), which Link does not. Drop anything outside
-		// Link's own allowed locations.
-		if ( is_array( $express_locations ) ) {
-			$form_fields       = WC_Stripe::get_instance()->get_main_stripe_gateway()->get_form_fields();
-			$allowed_locations = array_keys( $form_fields['link_button_locations']['options'] ?? [] );
-			$express_locations = array_values( array_intersect( $express_locations, $allowed_locations ) );
-		}
-
-		$stripe_settings['link_button_locations'] = $express_locations;
+		$stripe_settings['link_button_locations'] = $stripe_settings['express_checkout_button_locations'];
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 	}
 }

--- a/includes/migrations/class-wc-stripe-migrate-link-button-locations.php
+++ b/includes/migrations/class-wc-stripe-migrate-link-button-locations.php
@@ -34,7 +34,18 @@ class WC_Stripe_Migrate_Link_Button_Locations {
 			return;
 		}
 
-		$stripe_settings['link_button_locations'] = $stripe_settings['express_checkout_button_locations'];
+		$express_locations = $stripe_settings['express_checkout_button_locations'];
+
+		// Express checkout supports the express-only `change_payment_method` location
+		// (when Subscriptions is active), which Link does not. Drop anything outside
+		// Link's own allowed locations.
+		if ( is_array( $express_locations ) ) {
+			$form_fields       = WC_Stripe::get_instance()->get_main_stripe_gateway()->get_form_fields();
+			$allowed_locations = array_keys( $form_fields['link_button_locations']['options'] ?? [] );
+			$express_locations = array_values( array_intersect( $express_locations, $allowed_locations ) );
+		}
+
+		$stripe_settings['link_button_locations'] = $express_locations;
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->


## Changes proposed in this Pull Request:

This PR fixes a recent regression when saving express checkout settings. We recently introduced a `change_payment_method` option for express button locations. We also decoupled Link locations to its own set of locations. However,  Link was trying to save with the added `change_payment_method` and was rejected with the error
```
{
    "code": "rest_invalid_param",
    "message": "Invalid parameter(s): link_button_locations",
    "data": {
        "status": 400,
        "params": {
            "link_button_locations": "link_button_locations[3] is not one of product, cart, and checkout."
        },
        "details": {
            "link_button_locations": {
                "code": "rest_not_in_enum",
                "message": "link_button_locations[3] is not one of product, cart, and checkout.",
                "data": null
            }
        }
    }
}
```

This PR fixes it by introducing `change_payment_method` option for Link

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Make sure WooCommerce Subscriptions plugin is active
2. Go to Stripe -> Settings -> Express Checkouts
3. Go to Customize page of any express checkout 
4. Make a settings change and try to save.
5. In Develop, you'll get an error. In this branch, you should be able to save settings without any errors.
6.  Go to Stripe → Settings → Payments → Link by Stripe → Customize
7. Confirm a **Change payment method for WooCommerce Subscriptions** location checkbox is shown (alongside Product, Cart, Checkout).
8. Enable the Change payment method location for Link, then open a subscription's "Change payment method" page and confirm the Link button renders there.
9. Deactivate Subscriptions and confirm the extra checkbox is hidden and saving still works.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This is an unreleased regression. 

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
