### PR TITLE
Dim the test mode checkbox when it can't be toggled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.9.0
+* Tweak - Dim the test mode checkbox when it can't be toggled so the disabled state is visible in the UI
 * Add - Add dedicated settings page for Link with button size and location customization
 * Fix - Ignore incoming webhook events whose Stripe account does not match the connected account to avoid acting on another account's data
 * Fix - When changing a subscription's payment method, reflect the new card and its Apple Pay/Google Pay branding on My Account and clarify the admin order note

--- a/client/settings/payment-settings/style.scss
+++ b/client/settings/payment-settings/style.scss
@@ -63,3 +63,9 @@
 	display: block;
 	padding-top: styles.$grid-unit-10;
 }
+
+.wcstripe-test-mode-checkbox--disabled {
+	.components-checkbox-control__input-container {
+		opacity: 0.5;
+	}
+}

--- a/client/settings/payment-settings/test-mode-checkbox.js
+++ b/client/settings/payment-settings/test-mode-checkbox.js
@@ -23,6 +23,8 @@ const TestModeCheckbox = () => {
 	// otherwise the gateway would run in test mode without test keys.
 	const isLockedToLiveMode = ! isTestModeEnabled && ! isTestAccountConnected;
 
+	const isLocked = isLockedToTestMode || isLockedToLiveMode;
+
 	const handleCheckboxChange = ( isChecked ) => {
 		setTestMode( isChecked );
 	};
@@ -48,8 +50,13 @@ const TestModeCheckbox = () => {
 		<>
 			<h4>{ __( 'Test mode', 'woocommerce-gateway-stripe' ) }</h4>
 			<CheckboxControl
+				className={
+					isLocked
+						? 'wcstripe-test-mode-checkbox--disabled'
+						: undefined
+				}
 				checked={ isTestModeEnabled }
-				disabled={ isLockedToTestMode || isLockedToLiveMode }
+				disabled={ isLocked }
 				onChange={ handleCheckboxChange }
 				label={ __( 'Enable test mode', 'woocommerce-gateway-stripe' ) }
 				help={

--- a/readme.txt
+++ b/readme.txt
@@ -156,6 +156,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.9.0 - xxxx-xx-xx =
+* Tweak - Dim the test mode checkbox when it can't be toggled so the disabled state is visible in the UI
 * Add - Add dedicated settings page for Link with button size and location customization
 * Fix - Ignore incoming webhook events whose Stripe account does not match the connected account to avoid acting on another account's data
 * Fix - When changing a subscription's payment method, reflect the new card and its Apple Pay/Google Pay branding on My Account and clarify the admin order note


### PR DESCRIPTION
Suggested in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5488#issuecomment-4716585167

## Changes proposed in this Pull Request:
Adds a `wcstripe-test-mode-checkbox--disabled` class when the checkbox is locked, and `style.scss` dims that control's checkbox.

## Testing instructions
1. Connect a test account but no live account; enable test mode.
2. Go to **WooCommerce → Settings → Payments → Stripe → Settings**.
3. The "Enable test mode" checkbox should appear dimmed and be un-toggleable, with the lock-reason help text fully legible below it.


<img width="754" height="117" alt="Screenshot 2026-06-18 at 1 30 09 AM" src="https://github.com/user-attachments/assets/a57c18d4-3d26-47d7-8b71-c863b02d2c88" />


### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
