### PR TITLE
Add woocommerce_agentic_commerce_should_sync_product filter and deprecate the Stripe-prefixed one

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,7 +23,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Show an error notice when a Stripe OAuth connection attempt fails its security check
 * Dev - Deprecate the internal WC_Stripe_Feature_Flags::is_amazon_pay_available() helper now that Amazon Pay is permanently enabled
 * Tweak - Don't show the Stripe API outage notice on local and development sites, where Stripe is often unreachable for benign reasons
-* Update - Add the woocommerce_agentic_commerce_should_sync_product filter for excluding products from Agentic Commerce sync and deprecate the Stripe-prefixed wc_stripe_agentic_commerce_should_sync_product so other plugins can share the hook
+* Update - Deprecate the wc_stripe_agentic_commerce_should_sync_product filter in favor of the shareable woocommerce_agentic_commerce_should_sync_product
 
 2026-06-15 - version 10.8.2
 * Fix - Disable Adaptive Pricing when webhooks are disabled

--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Show an error notice when a Stripe OAuth connection attempt fails its security check
 * Dev - Deprecate the internal WC_Stripe_Feature_Flags::is_amazon_pay_available() helper now that Amazon Pay is permanently enabled
 * Tweak - Don't show the Stripe API outage notice on local and development sites, where Stripe is often unreachable for benign reasons
+* Update - Add the woocommerce_agentic_commerce_should_sync_product filter for excluding products from Agentic Commerce sync and deprecate the Stripe-prefixed wc_stripe_agentic_commerce_should_sync_product so other plugins can share the hook
 
 2026-06-15 - version 10.8.2
 * Fix - Disable Adaptive Pricing when webhooks are disabled

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-integration.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-integration.php
@@ -185,7 +185,7 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 		add_action( self::SCHEDULED_ACTION, [ $this, 'sync_feed' ] ); // @phpstan-ignore return.void (sync_feed returns bool for manual callers; WP ignores the return value when invoked via action hook)
 
 		// Adapter-fired hook for converging Stripe's catalog when the
-		// `wc_stripe_agentic_commerce_should_sync_product` filter outcome changes.
+		// `woocommerce_agentic_commerce_should_sync_product` filter outcome changes.
 		// See the filter docblock for the contract — without this, a previously
 		// exported product that becomes excluded would only drop out of Stripe's
 		// catalog on the next scheduled full sync.

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper.php
@@ -987,8 +987,23 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 	 * @return bool
 	 */
 	public static function should_sync_product( \WC_Product $product ): bool {
+		// The Stripe-prefixed filter is retained for backward compatibility. Its
+		// result seeds the default for the canonical filter below, so existing
+		// adapters keep working while a hook on the new name still takes precedence.
+		$should_sync = apply_filters_deprecated(
+			'wc_stripe_agentic_commerce_should_sync_product',
+			[ true, $product ],
+			'10.9.0',
+			'woocommerce_agentic_commerce_should_sync_product',
+			'The wc_stripe_agentic_commerce_should_sync_product filter is deprecated since WooCommerce Stripe Gateway 10.9.0. Use woocommerce_agentic_commerce_should_sync_product instead.'
+		);
+
 		/**
 		 * Filter whether a product should be included in any Agentic Commerce sync.
+		 *
+		 * Uses the WooCommerce core `woocommerce_` prefix rather than `wc_stripe_`
+		 * so the same hook can be shared by other Agentic Commerce integrations
+		 * that are not Stripe-specific.
 		 *
 		 * Applied per product at three entry points: the full-feed mapper, the
 		 * inventory-change tracker, and the archive tracker. Returning false from
@@ -1007,13 +1022,13 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 		 * `do_action( 'wc_stripe_agentic_commerce_schedule_full_resync' )` to
 		 * enqueue an immediate full-catalog sync.
 		 *
-		 * @since 10.8.0
+		 * @since 10.9.0
 		 * @param bool        $should_sync Whether to include the product. Default true.
 		 * @param \WC_Product $product     Product being evaluated.
 		 */
 		// wp_validate_boolean() rather than a plain (bool) cast: an adapter that
 		// returns the string 'false' would be truthy under a cast and wrongly
 		// sync the product. This still normalises null / 0 / '' to false.
-		return wp_validate_boolean( apply_filters( 'wc_stripe_agentic_commerce_should_sync_product', true, $product ) );
+		return wp_validate_boolean( apply_filters( 'woocommerce_agentic_commerce_should_sync_product', $should_sync, $product ) );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -178,5 +178,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Run the woocommerce_gateway_description filter for Stripe payment methods so third parties can add or replace their checkout descriptions
 * Dev - Deprecate the internal WC_Stripe_Feature_Flags::is_amazon_pay_available() helper now that Amazon Pay is permanently enabled
 * Tweak - Don't show the Stripe API outage notice on local and development sites, where Stripe is often unreachable for benign reasons
+* Update - Add the woocommerce_agentic_commerce_should_sync_product filter for excluding products from Agentic Commerce sync and deprecate the Stripe-prefixed wc_stripe_agentic_commerce_should_sync_product so other plugins can share the hook
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -178,6 +178,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Run the woocommerce_gateway_description filter for Stripe payment methods so third parties can add or replace their checkout descriptions
 * Dev - Deprecate the internal WC_Stripe_Feature_Flags::is_amazon_pay_available() helper now that Amazon Pay is permanently enabled
 * Tweak - Don't show the Stripe API outage notice on local and development sites, where Stripe is often unreachable for benign reasons
-* Update - Add the woocommerce_agentic_commerce_should_sync_product filter for excluding products from Agentic Commerce sync and deprecate the Stripe-prefixed wc_stripe_agentic_commerce_should_sync_product so other plugins can share the hook
+* Update - Deprecate the wc_stripe_agentic_commerce_should_sync_product filter in favor of the shareable woocommerce_agentic_commerce_should_sync_product
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-feed-validator-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-feed-validator-test.php
@@ -726,7 +726,7 @@ class WC_Stripe_Agentic_Commerce_Feed_Validator_Test extends WP_UnitTestCase {
 		$product = WC_Helper_Product::create_simple_product();
 
 		$callback = static fn( $sync, $candidate ) => $candidate->get_id() !== $product->get_id();
-		add_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10, 2 );
+		add_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10, 2 );
 
 		try {
 			$validator = new \WC_Stripe_Agentic_Commerce_Feed_Validator();
@@ -736,7 +736,7 @@ class WC_Stripe_Agentic_Commerce_Feed_Validator_Test extends WP_UnitTestCase {
 			$this->assertSame( 1, $validator->get_excluded_count(), 'The exclusion must be counted.' );
 			$this->assertSame( [], $validator->get_collected_errors()['products'], 'An exclusion must not be recorded as a validation failure.' );
 		} finally {
-			remove_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10 );
+			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10 );
 			$product->delete( true );
 		}
 	}

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-integration-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-integration-test.php
@@ -265,7 +265,7 @@ class WC_Stripe_Agentic_Commerce_Integration_Test extends WP_UnitTestCase {
 
 		$excluded_id = $excluded->get_id();
 		$filter      = static fn( $sync, $candidate ) => $candidate->get_id() !== $excluded_id;
-		add_filter( 'wc_stripe_agentic_commerce_should_sync_product', $filter, 10, 2 );
+		add_filter( 'woocommerce_agentic_commerce_should_sync_product', $filter, 10, 2 );
 
 		// Scope the walk to these two products so other tests' leftovers don't
 		// skew the counts.
@@ -306,7 +306,7 @@ class WC_Stripe_Agentic_Commerce_Integration_Test extends WP_UnitTestCase {
 			$this->assertSame( 1, (int) $last_sync['products'], 'Only the kept product belongs in the feed; the excluded one is dropped.' );
 			$this->assertNotSame( 'succeeded_with_errors', $last_sync['status'], 'A pure exclusion must not flip the sync to Partial success.' );
 		} finally {
-			remove_filter( 'wc_stripe_agentic_commerce_should_sync_product', $filter, 10 );
+			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $filter, 10 );
 			remove_filter( 'wc_stripe_agentic_commerce_product_query_args', $scope );
 			remove_filter( 'wc_stripe_agentic_commerce_files_api_pre_request', $files_stub, 10 );
 			remove_filter( 'pre_http_request', $http_stub, 10 );

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-inventory-tracker-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-inventory-tracker-test.php
@@ -346,7 +346,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 
 	/**
 	 * Test that `track_stock_change` skips products an adapter excluded via
-	 * `wc_stripe_agentic_commerce_should_sync_product`. Guards the contract that
+	 * `woocommerce_agentic_commerce_should_sync_product`. Guards the contract that
 	 * a product excluded from the catalog must not generate inventory deltas
 	 * either — otherwise Stripe would receive stock updates for SKUs it doesn't
 	 * know about.
@@ -356,14 +356,14 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 	public function test_track_stock_change_skips_excluded_product() {
 		$product  = $this->create_simple_product_with_stock( 10 );
 		$callback = static fn( $sync, $candidate ) => $candidate->get_id() !== $product->get_id();
-		add_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10, 2 );
+		add_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10, 2 );
 
 		try {
 			$this->sut->track_stock_change( $product );
 
 			$this->assertSame( [], get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_UPDATES_OPTION, [] ) );
 		} finally {
-			remove_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10 );
+			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10 );
 		}
 	}
 
@@ -385,14 +385,14 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 
 		// Flip the filter to exclude this product, then trigger another stock change.
 		$callback = static fn( $sync, $candidate ) => $candidate->get_id() !== $product->get_id();
-		add_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10, 2 );
+		add_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10, 2 );
 
 		try {
 			$this->sut->track_stock_change( $product );
 
 			$this->assertSame( [], get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_UPDATES_OPTION, [] ) );
 		} finally {
-			remove_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10 );
+			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10 );
 		}
 	}
 
@@ -652,7 +652,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 		// and no further event fires for it before the flush.
 		$flipped_id = $flipped_product->get_id();
 		$callback   = static fn( $sync, $candidate ) => $candidate->get_id() !== $flipped_id;
-		add_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10, 2 );
+		add_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10, 2 );
 
 		// Capture the file path passed to the Files API request so we can read
 		// the uploaded CSV content and prove what was actually sent. Asserting
@@ -679,7 +679,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 		try {
 			$this->sut->sync_inventory();
 		} finally {
-			remove_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10 );
+			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10 );
 		}
 
 		$this->assertNotNull( $uploaded_skus, 'A feed should have been uploaded for the kept product.' );
@@ -840,7 +840,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 
 	/**
 	 * Test that `track_product_archive` skips products an adapter excluded via
-	 * `wc_stripe_agentic_commerce_should_sync_product`. An excluded product was
+	 * `woocommerce_agentic_commerce_should_sync_product`. An excluded product was
 	 * never on Stripe in the first place, so emitting an out_of_stock entry for
 	 * it on deletion would surface a SKU Stripe doesn't recognise.
 	 *
@@ -849,14 +849,14 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 	public function test_track_product_archive_skips_excluded_product() {
 		$product  = $this->create_simple_product_with_stock( 3 );
 		$callback = static fn( $sync, $candidate ) => $candidate->get_id() !== $product->get_id();
-		add_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10, 2 );
+		add_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10, 2 );
 
 		try {
 			$this->sut->track_product_archive( $product );
 
 			$this->assertSame( [], get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] ) );
 		} finally {
-			remove_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10 );
+			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10 );
 		}
 	}
 
@@ -879,7 +879,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 
 		// Flip the filter, then trigger another archive event.
 		$callback = static fn( $sync, $candidate ) => $candidate->get_id() !== $product->get_id();
-		add_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10, 2 );
+		add_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10, 2 );
 
 		try {
 			$this->sut->track_product_archive( $product );
@@ -887,7 +887,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 			$this->assertSame( [], get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_UPDATES_OPTION, [] ) );
 			$this->assertSame( [], get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] ) );
 		} finally {
-			remove_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10 );
+			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10 );
 		}
 	}
 
@@ -1189,7 +1189,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 
 		$flipped_id = $flipped_product->get_id();
 		$callback   = static fn( $sync, $candidate ) => $candidate->get_id() !== $flipped_id;
-		add_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10, 2 );
+		add_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10, 2 );
 
 		$uploaded_ids = null;
 		add_filter(
@@ -1212,7 +1212,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 		try {
 			$this->sut->sync_archives();
 		} finally {
-			remove_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10 );
+			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10 );
 		}
 
 		$this->assertNotNull( $uploaded_ids, 'A feed should have been uploaded for the kept product.' );
@@ -1303,7 +1303,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 		// event while still resolvable (mirrors before_delete_post) and is
 		// permanently deleted.
 		$callback = static fn( $sync, $candidate ) => $candidate->get_id() !== $id;
-		add_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10, 2 );
+		add_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10, 2 );
 
 		$uploaded = false;
 		add_filter(
@@ -1320,7 +1320,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 
 			$this->sut->sync_archives();
 		} finally {
-			remove_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10 );
+			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10 );
 		}
 
 		$this->assertFalse( $uploaded, 'Excluded product evicted at delete time must not ship despite prune keeping rows for deleted products.' );

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper-test.php
@@ -977,12 +977,12 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper_Test extends WP_UnitTestCase {
 		$product->save();
 
 		$callback = static fn() => $filtered_value;
-		add_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback );
+		add_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback );
 
 		try {
 			$this->assertFalse( \WC_Stripe_Agentic_Commerce_Product_Mapper::should_sync_product( $product ) );
 		} finally {
-			remove_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback );
+			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback );
 			$product->delete( true );
 		}
 	}
@@ -1002,7 +1002,7 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper_Test extends WP_UnitTestCase {
 		$product->save();
 
 		$callback = static fn( $sync, $candidate ) => $candidate->get_id() !== $product->get_id();
-		add_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10, 2 );
+		add_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10, 2 );
 
 		try {
 			$mapper = new \WC_Stripe_Agentic_Commerce_Product_Mapper();
@@ -1010,7 +1010,7 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper_Test extends WP_UnitTestCase {
 
 			$this->assertSame( [], $result );
 		} finally {
-			remove_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10 );
+			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10 );
 			$product->delete( true );
 		}
 	}
@@ -1032,16 +1032,68 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper_Test extends WP_UnitTestCase {
 		$excluded->save();
 
 		$callback = static fn( $sync, $candidate ) => $candidate->get_id() !== $excluded->get_id();
-		add_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10, 2 );
+		add_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10, 2 );
 
 		try {
 			$mapper = new \WC_Stripe_Agentic_Commerce_Product_Mapper();
 			$this->assertNotEmpty( $mapper->map_product( $included ) );
 			$this->assertSame( [], $mapper->map_product( $excluded ) );
 		} finally {
-			remove_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback, 10 );
+			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10 );
 			$included->delete( true );
 			$excluded->delete( true );
+		}
+	}
+
+	/**
+	 * Test that the deprecated `wc_stripe_agentic_commerce_should_sync_product`
+	 * filter is still honoured for backward compatibility, and that hooking it
+	 * surfaces a deprecation notice pointing adapters at the WooCommerce-core
+	 * prefixed replacement.
+	 *
+	 * @return void
+	 */
+	public function test_should_sync_product_honours_deprecated_filter() {
+		$this->setExpectedDeprecated( 'wc_stripe_agentic_commerce_should_sync_product' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		$callback = static fn() => false;
+		add_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback );
+
+		try {
+			$this->assertFalse( \WC_Stripe_Agentic_Commerce_Product_Mapper::should_sync_product( $product ) );
+		} finally {
+			remove_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback );
+			$product->delete( true );
+		}
+	}
+
+	/**
+	 * Test that the canonical filter takes precedence over the deprecated one:
+	 * a value from the new `woocommerce_`-prefixed hook overrides the result the
+	 * deprecated hook seeded as its default.
+	 *
+	 * @return void
+	 */
+	public function test_should_sync_product_new_filter_overrides_deprecated() {
+		$this->setExpectedDeprecated( 'wc_stripe_agentic_commerce_should_sync_product' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		$deprecated = static fn() => false;
+		$canonical  = static fn() => true;
+		add_filter( 'wc_stripe_agentic_commerce_should_sync_product', $deprecated );
+		add_filter( 'woocommerce_agentic_commerce_should_sync_product', $canonical );
+
+		try {
+			$this->assertTrue( \WC_Stripe_Agentic_Commerce_Product_Mapper::should_sync_product( $product ) );
+		} finally {
+			remove_filter( 'wc_stripe_agentic_commerce_should_sync_product', $deprecated );
+			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $canonical );
+			$product->delete( true );
 		}
 	}
 }


### PR DESCRIPTION
Towards STRIPE-1168

## Changes proposed in this Pull Request:

Merchants/integrations can exclude products from the Agentic Commerce sync (full feed, inventory updates, archive events) via a `should_sync_product` filter. Until now that hook used the Stripe-specific `wc_stripe_` prefix, which prevents other (non-Stripe) plugins from registering against a shared, generic hook name.

This PR:

- Adds a new canonical filter **`woocommerce_agentic_commerce_should_sync_product`** using the WooCommerce-core `woocommerce_` prefix, so the hook can be integrated by other plugins.
- Deprecates **`wc_stripe_agentic_commerce_should_sync_product`** via `apply_filters_deprecated()` (since 10.9.0). The deprecated filter's result seeds the default for the new filter, so:
  - Adapters still hooking the old name keep working (with a standard deprecation notice).
  - A hook on the new name takes precedence over the deprecated one.
- The existing `wp_validate_boolean()` normalization and the full lifecycle/convergence contract in the docblock are preserved.

**How can this break?** An adapter relying on the old filter would only be affected if the old hook stopped firing — it still does, and is covered by a dedicated backward-compat test. The new filter overriding the old one is also covered by a test.

## Testing instructions

This is a developer-facing hook change with no merchant UI. To verify:

1. Add a snippet hooking the **new** filter to exclude a product:
   ```php
   add_filter( 'woocommerce_agentic_commerce_should_sync_product', function ( $sync, $product ) {
       return 'My Excluded Product' !== $product->get_name();
   }, 10, 2 );
   ```
   Trigger an Agentic Commerce feed sync and confirm the product is omitted from the feed, inventory, and archive surfaces.
2. Repeat with the **deprecated** filter `wc_stripe_agentic_commerce_should_sync_product` and confirm it still excludes the product (and emits a `_deprecated_hook` notice with `WP_DEBUG` on, pointing to the new name).
3. Run the suites: `npm run test:php -- --filter WC_Stripe_Agentic_Commerce_Product_Mapper_Test` (and the inventory-tracker / feed-validator / integration agentic-commerce suites).

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

Added to the 10.9.0 block in both `changelog.txt` and `readme.txt`:

> Update - Add the woocommerce_agentic_commerce_should_sync_product filter for excluding products from Agentic Commerce sync and deprecate the Stripe-prefixed wc_stripe_agentic_commerce_should_sync_product so other plugins can share the hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)