### PR TITLE
Rename internal Blocks API references to Store API in Express Checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Show an error notice when a Stripe OAuth connection attempt fails its security check
 * Dev - Deprecate the internal WC_Stripe_Feature_Flags::is_amazon_pay_available() helper now that Amazon Pay is permanently enabled
 * Tweak - Don't show the Stripe API outage notice on local and development sites, where Stripe is often unreachable for benign reasons
+* Dev - Rename internal Blocks API references to Store API in the Express Checkout client for naming consistency
 
 2026-06-15 - version 10.8.2
 * Fix - Disable Adaptive Pricing when webhooks are disabled

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -533,16 +533,16 @@ export default class WCStripeAPI {
 		// Rename qty to quantity to match StoreAPI expected parameter.
 		const { qty, ...rest } = productData;
 		const quantity = qty ?? 1;
-		const blocksApiProductData = {
+		const storeApiProductData = {
 			...rest,
 			quantity,
 		};
 
 		const data = applyFilters(
 			'wcstripe.express-checkout.cart-add-item',
-			blocksApiProductData
+			storeApiProductData
 		);
-		return this.postToBlocksAPI( '/wc/store/v1/cart/add-item', data );
+		return this.postToStoreApi( '/wc/store/v1/cart/add-item', data );
 	}
 
 	/**
@@ -576,7 +576,7 @@ export default class WCStripeAPI {
 				},
 			} );
 			const removeItemsPromises = cartData.items.map( ( item ) => {
-				return this.postToBlocksAPI( '/wc/store/v1/cart/remove-item', {
+				return this.postToStoreApi( '/wc/store/v1/cart/remove-item', {
 					key: item.key,
 					booking_id: bookingId,
 				} );
@@ -609,7 +609,7 @@ export default class WCStripeAPI {
 	 * @return {Promise} Promise for the request to the server.
 	 */
 	expressCheckoutECECreateOrder( orderData ) {
-		return this.postToBlocksAPI(
+		return this.postToStoreApi(
 			'/wc/store/v1/checkout',
 			{
 				...orderData,
@@ -638,18 +638,18 @@ export default class WCStripeAPI {
 		const billingEmail = orderDetails.billingEmail ?? '';
 		const key = orderDetails.orderKey ?? '';
 		const url = `/wc/store/v1/checkout/${ order }?key=${ key }&billing_email=${ billingEmail }`;
-		return this.postToBlocksAPI( url, paymentData );
+		return this.postToStoreApi( url, paymentData );
 	}
 
 	/**
-	 * Posts data to the Blocks API.
+	 * Posts data to the Store API.
 	 *
 	 * @param {string} path    The path to post to.
 	 * @param {Object} data    The data to post.
 	 * @param {Object} headers The headers for the request.
 	 * @return {Promise} The promise for the request to the server.
 	 */
-	postToBlocksAPI( path, data, headers = {} ) {
+	postToStoreApi( path, data, headers = {} ) {
 		return apiFetch( {
 			method: 'POST',
 			path,

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -555,7 +555,7 @@ jQuery( function ( $ ) {
 				} = wcStripeExpressCheckoutPayForOrderParams;
 
 				// When paying as guest, the order key and billing email are required by the
-				// Blocks API Pay for Order endpoint, which ECE uses.
+				// Store API Pay for Order endpoint, which ECE uses.
 				// These fields are both present when the user is logged in.
 				if (
 					! orderDetails?.orderKey ||

--- a/client/express-checkout/compatibility/wc-product-page.js
+++ b/client/express-checkout/compatibility/wc-product-page.js
@@ -2,7 +2,7 @@ import jQuery from 'jquery';
 import { addFilter } from '@wordpress/hooks';
 
 /**
- * Sets the product ID when using the BlocksAPI and single variation form is present.
+ * Sets the product ID when using the Store API and single variation form is present.
  */
 addFilter(
 	'wcstripe.express-checkout.cart-add-item',

--- a/client/express-checkout/utils/normalize.js
+++ b/client/express-checkout/utils/normalize.js
@@ -25,7 +25,7 @@ export const normalizeLineItems = ( displayItems ) => {
 };
 
 /**
- * Builds the payment data for the Blocks API.
+ * Builds the payment data for the Store API.
  *
  * @param {Object} params
  * @param {string} params.expressPaymentType  The express payment type.
@@ -34,7 +34,7 @@ export const normalizeLineItems = ( displayItems ) => {
  *
  * @return {Array} The payment data.
  */
-const buildBlocksAPIPaymentData = ( {
+const buildStoreApiPaymentData = ( {
 	expressPaymentType,
 	paymentMethodId = '',
 	confirmationTokenId = '',
@@ -404,7 +404,7 @@ const getShippingAddressData = ( event ) => {
 };
 
 /**
- * Normalize order data from Stripe's object to the expected format for WC (when using the Blocks API).
+ * Normalize order data from Stripe's object to the expected format for WC (when using the Store API).
  *
  * @param {Object} params
  * @param {Object} params.event               Stripe's event object.
@@ -422,7 +422,7 @@ export const normalizeOrderData = ( {
 		billing_address: getBillingAddressData( event ),
 		shipping_address: getShippingAddressData( event ),
 		payment_method: 'stripe',
-		payment_data: buildBlocksAPIPaymentData( {
+		payment_data: buildStoreApiPaymentData( {
 			expressPaymentType: event?.expressPaymentType,
 			paymentMethodId,
 			confirmationTokenId,

--- a/readme.txt
+++ b/readme.txt
@@ -180,5 +180,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Run the woocommerce_gateway_description filter for Stripe payment methods so third parties can add or replace their checkout descriptions
 * Dev - Deprecate the internal WC_Stripe_Feature_Flags::is_amazon_pay_available() helper now that Amazon Pay is permanently enabled
 * Tweak - Don't show the Stripe API outage notice on local and development sites, where Stripe is often unreachable for benign reasons
+* Dev - Rename internal Blocks API references to Store API in the Express Checkout client for naming consistency
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Related to STRIPE-694

## Changes proposed in this Pull Request:

Several Express Checkout client helpers and comments referred to the WooCommerce **Store API** (`/wc/store/v1/*`) as the "Blocks API" — a misnomer that reads like the WC Blocks UI, which is a different thing. The rest of the codebase already standardizes on "Store API" (`cart-api.js`, `ExpressCheckoutCartApi`, PHP `is_request_to_store_api`), so this aligns the stragglers.

Renamed:

- `WCStripeAPI.postToBlocksAPI` → `postToStoreApi` (private method)
- `buildBlocksAPIPaymentData` → `buildStoreApiPaymentData` (module-local helper)
- `blocksApiProductData` → `storeApiProductData` (local variable)
- Related comments in `client/api/index.js`, `client/express-checkout/utils/normalize.js`, `client/express-checkout/compatibility/wc-product-page.js`, and the Pay-for-Order comment in the entrypoint.

All targets are **internal** — no exported, hooked, or otherwise public surface changes (the public `wcstripe.express-checkout.*` filter names are untouched), so there's no behavior change and nothing for extension authors to migrate.

**Deliberately left as-is:**
- `client/stripe-utils/utils.js` — "WC Blocks API to show the error notice… in a block context" genuinely refers to the WC Blocks notices system (`core/notices` + `wcBlocksConfig`), not the Store API.
- The `// BlocksAPI partial support` comment in the entrypoint's `addToCart()` is removed by #5602, so it's left out here to avoid a conflict.

## Testing instructions

This is a no-op rename; behavior is unchanged.

1. `npm run test:js -- client/express-checkout/utils/__tests__/normalize.test.js` passes (exercises `normalizeOrderData`, which builds Store API payment data via the renamed helper).
2. Smoke-test an Express Checkout purchase (Apple Pay / Google Pay / Link) on cart/checkout to confirm order creation still works — it routes through the renamed `postToStoreApi`.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

> Dev - Rename internal Blocks API references to Store API in the Express Checkout client for naming consistency

**Post merge**

-   [ ] Added testing instructions to the Release Testing Instructions wiki page (or does not apply)
-   [ ] Added the needs docs label (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
