### PR TITLE
Exclude subscription products from the Agentic Commerce feed

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,7 @@ xxxx-xx-xx - version 10.9.0
 * Add - Show a "What's new" inbox note after the plugin updates, including via auto-update
 * Tweak - Don't show the Stripe API outage notice on local and development sites, where Stripe is often unreachable for benign reasons
 * Dev - Rename internal Blocks API references to Store API in the Express Checkout client for naming consistency
+* Fix - Exclude WooCommerce Subscriptions products from the Agentic Commerce product feed so they no longer make every sync report a partial success
 
 2026-06-15 - version 10.8.2
 * Fix - Disable Adaptive Pricing when webhooks are disabled

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper.php
@@ -987,6 +987,12 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 	 * @return bool
 	 */
 	public static function should_sync_product( \WC_Product $product ): bool {
+		// A variable-subscription's variations share the `product_variation`
+		// post type, so the feed's simple/variation query returns them; left in,
+		// they fail validation and downgrade every sync to a partial success.
+		// Excluded by default, still overridable via the filter below.
+		$default_should_sync = ! $product->is_type( [ 'subscription', 'variable-subscription', 'subscription_variation' ] );
+
 		/**
 		 * Filter whether a product should be included in any Agentic Commerce sync.
 		 *
@@ -1008,12 +1014,12 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 		 * enqueue an immediate full-catalog sync.
 		 *
 		 * @since 10.8.0
-		 * @param bool        $should_sync Whether to include the product. Default true.
+		 * @param bool        $should_sync Whether to include the product. Default true (false for subscriptions).
 		 * @param \WC_Product $product     Product being evaluated.
 		 */
 		// wp_validate_boolean() rather than a plain (bool) cast: an adapter that
 		// returns the string 'false' would be truthy under a cast and wrongly
 		// sync the product. This still normalises null / 0 / '' to false.
-		return wp_validate_boolean( apply_filters( 'wc_stripe_agentic_commerce_should_sync_product', true, $product ) );
+		return wp_validate_boolean( apply_filters( 'wc_stripe_agentic_commerce_should_sync_product', $default_should_sync, $product ) );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -182,5 +182,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Show a "What's new" inbox note after the plugin updates, including via auto-update
 * Tweak - Don't show the Stripe API outage notice on local and development sites, where Stripe is often unreachable for benign reasons
 * Dev - Rename internal Blocks API references to Store API in the Express Checkout client for naming consistency
+* Fix - Exclude WooCommerce Subscriptions products from the Agentic Commerce product feed so they no longer make every sync report a partial success
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper-test.php
@@ -946,6 +946,78 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * WooCommerce Subscriptions product types that must be excluded from the feed.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function provide_subscription_product_types(): array {
+		return [
+			'simple subscription'    => [ 'subscription' ],
+			'variable subscription'  => [ 'variable-subscription' ],
+			'subscription variation' => [ 'subscription_variation' ],
+		];
+	}
+
+	/**
+	 * Subscription products are excluded by default — otherwise a single one
+	 * fails validation and downgrades every sync to a partial success.
+	 *
+	 * @dataProvider provide_subscription_product_types
+	 * @param string $product_type WooCommerce subscription product type.
+	 * @return void
+	 */
+	public function test_should_sync_product_excludes_subscription_products( string $product_type ) {
+		$product = $this->getMockBuilder( WC_Product::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_type' ] )
+			->getMock();
+		$product->method( 'get_type' )->willReturn( $product_type );
+
+		$this->assertFalse( \WC_Stripe_Agentic_Commerce_Product_Mapper::should_sync_product( $product ) );
+	}
+
+	/**
+	 * The subscription exclusion is a default, not a hard block: the filter can
+	 * opt them back in.
+	 *
+	 * @return void
+	 */
+	public function test_should_sync_product_filter_can_re_include_subscriptions() {
+		$product = $this->getMockBuilder( WC_Product::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_type' ] )
+			->getMock();
+		$product->method( 'get_type' )->willReturn( 'subscription_variation' );
+
+		$callback = static fn() => true;
+		add_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback );
+
+		try {
+			$this->assertTrue( \WC_Stripe_Agentic_Commerce_Product_Mapper::should_sync_product( $product ) );
+		} finally {
+			remove_filter( 'wc_stripe_agentic_commerce_should_sync_product', $callback );
+		}
+	}
+
+	/**
+	 * map_product short-circuits subscription products to an empty row, the
+	 * signal the validator treats as a clean exclusion.
+	 *
+	 * @return void
+	 */
+	public function test_map_product_returns_empty_row_for_subscription_products() {
+		$product = $this->getMockBuilder( WC_Product::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_type' ] )
+			->getMock();
+		$product->method( 'get_type' )->willReturn( 'subscription_variation' );
+
+		$mapper = new \WC_Stripe_Agentic_Commerce_Product_Mapper();
+
+		$this->assertSame( [], $mapper->map_product( $product ) );
+	}
+
+	/**
 	 * Data provider for falsy adapter return values.
 	 *
 	 * @return array<string, array{0: mixed}>


### PR DESCRIPTION
Fixes STRIPE-1231

## Changes proposed in this Pull Request:

A `variable-subscription`'s variations are stored as `product_variation` posts, the same post type as ordinary variations. The Agentic Commerce feed query scopes to `simple` + `variation`, so WooCommerce returns those subscription variations too (their `get_type()` is `subscription_variation`, but the query can't tell). They then reach the mapper, which only special-cases the exact `variation` type, so they're mapped without a parent (`item_group_id`/`item_group_title` null), fail the validator's required-field checks, and get counted as **skipped** — which downgrades every sync to `succeeded_with_errors` ("Partial success"). The only workaround was deleting the variable subscription product.

This gates subscription products in `WC_Stripe_Agentic_Commerce_Product_Mapper::should_sync_product()`, the single per-product chokepoint shared by the full feed, the inventory tracker, and the archive tracker. When it returns `false`, the mapper emits an empty row, which the validator records as a **clean exclusion** (`excluded_count`, subtracted out of `skipped_count`) rather than a validation failure — so subscriptions are dropped without log noise and the sync reports a plain success.

Notes:
- Matches WooCommerce Subscriptions' registered type strings (`subscription`, `variable-subscription`, `subscription_variation`) via `is_type()` so it works whether or not the plugin's classes are loaded, consistent with existing usage in `class-wc-stripe-express-checkout-helper.php`. (WC Core's `ProductType` enum has no subscription types — those belong to the Subscriptions plugin.)
- Kept as the filter **default** rather than a hard block, so an adapter that genuinely supports subscriptions can still opt them back in via `wc_stripe_agentic_commerce_should_sync_product`.

## Testing instructions

**Setup — enable Agentic Commerce**

1. Connect Stripe in **test mode**.
2. Enable the developer feature flag: `wp option update _wcstripe_feature_agentic_commerce yes` (or return `true` from the `wc_stripe_is_agentic_commerce_enabled` filter).
3. Enable the merchant toggle in **WooCommerce → Settings → Payments → Stripe → Agentic Commerce**.
4. Make sure **WooCommerce Subscriptions** is active (needed to create the products under test).

**Reproduce the fix**

1. Create a **variable subscription** product with at least one variation.
2. Trigger a full sync: `wp stripe agentic-commerce sync` (add `--push` to upload to Stripe), or the **Sync** button on the Agentic Commerce settings screen.
3. **Before this change:** the sync finishes as "Partial success" (the subscription variations are skipped) and stays that way until the product is deleted.
4. **After this change:** the sync finishes as a clean success; the subscription product and its variations are excluded from the feed.
5. Confirm ordinary simple/variable products still appear in the feed unchanged.

**Automated**

`npm run test:php -- --filter WC_Stripe_Agentic_Commerce_Product_Mapper_Test`

### Changelog entry

* Fix - Exclude WooCommerce Subscriptions products from the Agentic Commerce product feed so they no longer make every sync report a partial success

---

*Drafted with AI (Claude Code); reviewed by me.*