### PR TITLE
Fix silent card-decline failure on woocommerce/classic-shortcode checkout pages

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,7 @@ xxxx-xx-xx - version 10.9.0
 * Add - Show a "What's new" inbox note after the plugin updates, including via auto-update
 * Tweak - Don't show the Stripe API outage notice on local and development sites, where Stripe is often unreachable for benign reasons
 * Dev - Rename internal Blocks API references to Store API in the Express Checkout client for naming consistency
+* Fix - Show the card decline error message on classic-shortcode checkout pages instead of silently failing
 
 2026-06-15 - version 10.8.2
 * Fix - Disable Adaptive Pricing when webhooks are disabled

--- a/client/stripe-utils/__tests__/utils.test.js
+++ b/client/stripe-utils/__tests__/utils.test.js
@@ -5,9 +5,11 @@ import {
 	getBillingDetailsForDeferredFlow,
 	getHiddenBillingFields,
 	getStripeServerData,
+	showErrorCheckout,
 } from '../utils';
 import { initializeUPEAppearance } from '../upe-appearance';
 import { getAppearance } from '../../styles/upe';
+import { dispatch } from '@wordpress/data';
 
 jest.mock( '../../styles/upe', () => ( {
 	getAppearance: jest.fn(),
@@ -16,6 +18,11 @@ jest.mock( '../../styles/upe', () => ( {
 
 jest.mock( '@woocommerce/settings', () => ( {
 	getSetting: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	dispatch: jest.fn(),
 } ) );
 
 describe( 'utils', () => {
@@ -753,5 +760,88 @@ describe( 'utils', () => {
 			expect( () => getStripeServerData() ).not.toThrow();
 			expect( getStripeServerData() ).toBeNull();
 		} );
+	} );
+} );
+
+describe( 'showErrorCheckout', () => {
+	let container;
+	const originalJQuery = global.jQuery;
+	const originalWcSettings = global.wcSettings;
+	const originalWc = global.wc;
+
+	beforeEach( () => {
+		container = {
+			length: 1,
+			find: jest.fn().mockReturnThis(),
+			remove: jest.fn().mockReturnThis(),
+			prepend: jest.fn().mockReturnThis(),
+		};
+
+		const jQueryMock = jest.fn( ( selector ) => {
+			if ( selector === '.woocommerce-notices-wrapper' ) {
+				return { first: () => container };
+			}
+			if ( selector === '.woocommerce-MyAccount-content' ) {
+				return { length: 0 };
+			}
+			if ( selector === 'form.checkout' ) {
+				return { find: () => ( { length: 0 } ) };
+			}
+			return { trigger: jest.fn().mockReturnThis(), each: jest.fn() };
+		} );
+		jQueryMock.scroll_to_notices = jest.fn();
+		global.jQuery = jQueryMock;
+
+		// A classic-shortcode page never mounts the Blocks checkout StoreNotice helper.
+		delete global.wc;
+	} );
+
+	afterEach( () => {
+		global.jQuery = originalJQuery;
+		global.wcSettings = originalWcSettings;
+		global.wc = originalWc;
+		dispatch.mockReset();
+	} );
+
+	it( 'uses the WC Blocks notices store when it is registered', () => {
+		const createErrorNotice = jest.fn();
+		dispatch.mockReturnValue( { createErrorNotice } );
+		global.wcSettings = { wcBlocksConfig: { foo: true } };
+
+		showErrorCheckout( 'Your card was declined.' );
+
+		expect( createErrorNotice ).toHaveBeenCalledWith(
+			'Your card was declined.',
+			{ context: 'wc/checkout/payments' }
+		);
+		// The classic notice markup must not also be prepended.
+		expect( container.prepend ).not.toHaveBeenCalled();
+	} );
+
+	// Regression: on a woocommerce/classic-shortcode page wcBlocksConfig is truthy but the
+	// core/notices store isn't registered, so dispatch() returns null. The error must not be
+	// silently dropped via an uncaught TypeError.
+	it( 'falls back to the classic notice when core/notices is not registered', () => {
+		dispatch.mockReturnValue( null );
+		global.wcSettings = { wcBlocksConfig: { foo: true } };
+
+		expect( () =>
+			showErrorCheckout( 'Your card was declined.' )
+		).not.toThrow();
+
+		expect( container.prepend ).toHaveBeenCalledWith(
+			expect.stringContaining( 'woocommerce-error' )
+		);
+	} );
+
+	it( 'renders the classic notice when not in a block context', () => {
+		dispatch.mockReturnValue( null );
+		global.wcSettings = { wcBlocksConfig: false };
+
+		showErrorCheckout( 'Your card was declined.' );
+
+		expect( container.prepend ).toHaveBeenCalledWith(
+			expect.stringContaining( 'Your card was declined.' )
+		);
 	} );
 } );

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -817,24 +817,24 @@ export const showErrorCheckout = ( errorMessage ) => {
 		}
 	}
 
-	// Use the WC Blocks API to show the error notice if we're in a block context.
-	if (
-		typeof wcSettings !== 'undefined' &&
-		wcSettings.wcBlocksConfig &&
-		! isMyAccountPage
-	) {
-		dispatch( 'core/notices' ).createErrorNotice( errorMessage, {
+	// wcSettings.wcBlocksConfig is also truthy on woocommerce/classic-shortcode pages, but
+	// there the checkout notices store isn't mounted (dispatch() returns null) and
+	// StoreNotice may be absent — guard both so a failed payment falls through to the
+	// classic notice below instead of throwing and silently dropping the message.
+	const inBlockContext =
+		typeof wcSettings !== 'undefined' && wcSettings.wcBlocksConfig;
+	const noticesStore = inBlockContext ? dispatch( 'core/notices' ) : null;
+
+	if ( noticesStore?.createErrorNotice && ! isMyAccountPage ) {
+		noticesStore.createErrorNotice( errorMessage, {
 			context: 'wc/checkout/payments', // Display the notice in the payments context.
 		} );
 		return;
 	}
 
 	let messageWrapper = '';
-	if ( typeof wcSettings !== 'undefined' && wcSettings.wcBlocksConfig ) {
-		const StoreNotice = window.wc?.blocksCheckout?.StoreNotice;
-		if ( ! StoreNotice ) {
-			return;
-		}
+	const StoreNotice = window.wc?.blocksCheckout?.StoreNotice;
+	if ( inBlockContext && StoreNotice ) {
 		const NoticeComponent = () => (
 			<StoreNotice status="error" isDismissible={ true }>
 				{ errorMessage }

--- a/readme.txt
+++ b/readme.txt
@@ -182,5 +182,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Show a "What's new" inbox note after the plugin updates, including via auto-update
 * Tweak - Don't show the Stripe API outage notice on local and development sites, where Stripe is often unreachable for benign reasons
 * Dev - Rename internal Blocks API references to Store API in the Express Checkout client for naming consistency
+* Fix - Show the card decline error message on classic-shortcode checkout pages instead of silently failing
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-1234
Fixes #5613

## Changes proposed in this Pull Request:
`showErrorCheckout()` in `client/stripe-utils/utils.js` decided how to render the notice based solely on `wcSettings.wcBlocksConfig`. On a classic-shortcode page in a block theme that flag is truthy (the Blocks JS env loads), but the Blocks checkout notice system isn't actually mounted.
So `dispatch('core/notices')` returns `null` and `dispatch('core/notices').createErrorNotice()` threw `Cannot read properties of null (reading 'createErrorNotice')`, dropping the message.

This PR makes sure it goes through the fallback path in this case. 
The PR makes the notice rendering robust to that mismatch:

- Only use the Blocks notices store when it's genuinely registered (`noticesStore?.createErrorNotice`).
- Only use the `StoreNotice` portal path when `window.wc.blocksCheckout.StoreNotice` is actually present.
- Otherwise fall through to the classic jQuery `woocommerce-error` notice, which always works.


## Testing instructions
- Add a product, go to checkout, and pay with the decline test card `4000 0000 0000 0002`.
- Verify that an error notice is displayed on both classic and block checkout pages.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
