### PR TITLE
Ensure Adaptive Pricing renders on the checkout page when enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@ xxxx-xx-xx - version 10.9.0
 * Tweak - Don't show the Stripe API outage notice on local and development sites, where Stripe is often unreachable for benign reasons
 * Dev - Rename internal Blocks API references to Store API in the Express Checkout client for naming consistency
 * Add - Verify that Stripe.js was served from the official Stripe origin before processing checkout payments
+* Fix - Ensure Adaptive Pricing appears on the checkout page when enabled
 
 2026-06-15 - version 10.8.2
 * Fix - Disable Adaptive Pricing when webhooks are disabled

--- a/client/blocks/upe/upe-deferred-intent-creation/__tests__/payment-elements.test.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/__tests__/payment-elements.test.js
@@ -67,17 +67,14 @@ const buildApi = ( stripe ) => ( {
 	initSetupIntent: jest.fn(),
 } );
 
-// clover: working initCheckout, no replacement method.
-const CLOVER_STRIPE = { elements: jest.fn(), initCheckout: jest.fn() };
-// dahlia+: initCheckout() remains as a throwing stub and the renamed method exists.
-const DAHLIA_STRIPE = {
-	elements: jest.fn(),
-	initCheckout: jest.fn(),
-	initCheckoutElementsSdk: jest.fn(),
-};
+const STRIPE = { elements: jest.fn(), initCheckout: jest.fn() };
 
 describe( 'PaymentElements adaptive pricing selection', () => {
-	beforeEach( () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'uses the Adaptive Pricing container when Adaptive Pricing is enabled', () => {
 		getBlocksConfiguration.mockReturnValue( {
 			isAdaptivePricingEnabled: true,
 			paymentMethodsConfig: { card: { isReusable: false } },
@@ -86,28 +83,24 @@ describe( 'PaymentElements adaptive pricing selection', () => {
 			shouldShowOptimizedCheckout: false,
 			isAdmin: false,
 		} );
-	} );
 
-	afterEach( () => {
-		jest.clearAllMocks();
-	} );
-
-	it( 'uses the Adaptive Pricing container when Stripe.js supports initCheckout', () => {
-		renderFields( buildApi( CLOVER_STRIPE ) );
+		renderFields( buildApi( STRIPE ) );
 
 		expect( CheckoutContainer ).toHaveBeenCalled();
 		expect( PaymentProcessor ).not.toHaveBeenCalled();
 	} );
 
-	it( 'falls back to the standard elements flow when Stripe.js exposes initCheckoutElementsSdk (dahlia+)', () => {
-		renderFields( buildApi( DAHLIA_STRIPE ) );
+	it( 'uses the standard elements flow when Adaptive Pricing is disabled', () => {
+		getBlocksConfiguration.mockReturnValue( {
+			isAdaptivePricingEnabled: false,
+			paymentMethodsConfig: { card: { isReusable: false } },
+			cartTotal: 1000,
+			currency: 'USD',
+			shouldShowOptimizedCheckout: false,
+			isAdmin: false,
+		} );
 
-		expect( CheckoutContainer ).not.toHaveBeenCalled();
-		expect( PaymentProcessor ).toHaveBeenCalled();
-	} );
-
-	it( 'falls back to the standard elements flow when initCheckout is absent (older Stripe.js)', () => {
-		renderFields( buildApi( { elements: jest.fn() } ) );
+		renderFields( buildApi( STRIPE ) );
 
 		expect( CheckoutContainer ).not.toHaveBeenCalled();
 		expect( PaymentProcessor ).toHaveBeenCalled();

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
@@ -210,16 +210,8 @@ const PaymentElements = ( {
 	...props
 } ) => {
 	const stripeServerData = getBlocksConfiguration();
-	// Adaptive Pricing renders <CheckoutProvider>, which calls initCheckout() on mount. Newer
-	// Stripe.js (dahlia+) turns that into a stub that throws, so detect it via the
-	// replacement method and fall back before the provider mounts.
-	const stripe = api.getStripe();
-	const stripeSupportsInitCheckout =
-		typeof stripe?.initCheckout === 'function' &&
-		typeof stripe?.initCheckoutElementsSdk !== 'function';
 	const isAdaptivePricingSupported =
-		stripeServerData?.isAdaptivePricingEnabled &&
-		stripeSupportsInitCheckout;
+		stripeServerData?.isAdaptivePricingEnabled;
 
 	const [ errorMessage, setErrorMessage ] = useState( null );
 	const [

--- a/client/classic/upe/__tests__/payment-processing.test.js
+++ b/client/classic/upe/__tests__/payment-processing.test.js
@@ -432,44 +432,6 @@ describe( 'payment-processing', () => {
 				expect( api._stripe.elements ).not.toHaveBeenCalled();
 			} );
 
-			it( 'skips Adaptive Pricing and loads standard elements when Stripe.js exposes initCheckoutElementsSdk (dahlia+)', async () => {
-				const checkoutElements = createMockElements();
-				const api = createMockApi( checkoutElements );
-				// dahlia+ keeps initCheckout() as a throwing stub plus the replacement
-				// method, so AP must be skipped before the stub is ever called.
-				api._stripe.initCheckout = jest.fn( () => {
-					throw new Error( 'stripe.initCheckout() has been removed' );
-				} );
-				api._stripe.initCheckoutElementsSdk = jest.fn();
-				const dom = document.createElement( 'div' );
-				dom.dataset.paymentMethodType = 'card';
-
-				await paymentProcessing.mountStripePaymentElement( api, dom );
-
-				expect(
-					api.checkoutSessionsCreateSession
-				).not.toHaveBeenCalled();
-				expect( api._stripe.initCheckout ).not.toHaveBeenCalled();
-				expect( api._stripe.elements ).toHaveBeenCalled();
-			} );
-
-			it( 'skips Adaptive Pricing and loads standard elements when initCheckout is absent (older Stripe.js)', async () => {
-				const checkoutElements = createMockElements();
-				const api = createMockApi( checkoutElements );
-				// Older builds predate initCheckout() entirely; the gateway must
-				// degrade to the standard elements flow instead of crashing checkout.
-				delete api._stripe.initCheckout;
-				const dom = document.createElement( 'div' );
-				dom.dataset.paymentMethodType = 'card';
-
-				await paymentProcessing.mountStripePaymentElement( api, dom );
-
-				expect(
-					api.checkoutSessionsCreateSession
-				).not.toHaveBeenCalled();
-				expect( api._stripe.elements ).toHaveBeenCalled();
-			} );
-
 			it( 'uses createPaymentElement (not create) when using initCheckout', async () => {
 				const checkoutElements = createMockElements();
 				checkoutElements.loadActions.mockResolvedValue( {

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -311,13 +311,9 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 	let elements;
 	let shouldLoadStripeElements = true;
 	// If Adaptive Pricing is enabled, use the Checkout Session API to load the elements.
-	// dahlia+ keeps initCheckout() as a throwing stub, so detect the replacement method and
-	// skip AP before creating a Checkout Session instead of falling back after it throws.
 	if (
 		stripeServerData?.isAdaptivePricingEnabled &&
-		supportsDeferredIntent &&
-		typeof stripe?.initCheckout === 'function' &&
-		typeof stripe?.initCheckoutElementsSdk !== 'function'
+		supportsDeferredIntent
 	) {
 		try {
 			const response = await api.checkoutSessionsCreateSession();

--- a/readme.txt
+++ b/readme.txt
@@ -183,5 +183,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Don't show the Stripe API outage notice on local and development sites, where Stripe is often unreachable for benign reasons
 * Dev - Rename internal Blocks API references to Store API in the Express Checkout client for naming consistency
 * Add - Verify that Stripe.js was served from the official Stripe origin before processing checkout payments
+* Fix - Ensure Adaptive Pricing appears on the checkout page when enabled
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-1235

## Changes proposed in this Pull Request:
PR https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5568 guarded Adaptive Pricing on initCheckout being present and initCheckoutElementsSdk being absent. That check doesn't hold on current Stripe.js: initCheckoutElementsSdk is actually present, so the condition evaluated false and Adaptive Pricing was wrongly hidden.

This PR removes the capability check from both checkout pages so Adaptive Pricing renders whenever it's enabled:
  
- `client/classic/upe/payment-processing.js` — the Adaptive Pricing branch now keys solely on `isAdaptivePricingEnabled && supportsDeferredIntent`.
- `client/blocks/upe/upe-deferred-intent-creation/payment-elements.js` — `isAdaptivePricingSupported` now keys solely on `isAdaptivePricingEnabled`.

## Testing instructions

- Enable Adaptive Pricing
- Adaptive pricing should work in classic checkout
- Adaptive pricing should work in block checkout

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
