### PR TITLE
Skip payment methods Stripe reports as unavailable at checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -33,6 +33,7 @@ xxxx-xx-xx - version 10.9.0
 * Dev - Rename internal Blocks API references to Store API in the Express Checkout client for naming consistency
 * Add - Verify that Stripe.js was served from the official Stripe origin before processing checkout payments
 * Fix - Exclude WooCommerce Subscriptions products from the Agentic Commerce product feed so they no longer make every sync report a partial success
+* Fix - Don't offer a payment method at checkout when Stripe reports it as unavailable in the payment method configuration, which caused an empty Payment Element and failed orders (e.g. iDEAL)
 
 2026-06-15 - version 10.8.2
 * Fix - Disable Adaptive Pricing when webhooks are disabled

--- a/changelog.txt
+++ b/changelog.txt
@@ -33,7 +33,7 @@ xxxx-xx-xx - version 10.9.0
 * Dev - Rename internal Blocks API references to Store API in the Express Checkout client for naming consistency
 * Add - Verify that Stripe.js was served from the official Stripe origin before processing checkout payments
 * Fix - Exclude WooCommerce Subscriptions products from the Agentic Commerce product feed so they no longer make every sync report a partial success
-* Fix - Don't offer a payment method at checkout when Stripe reports it as unavailable in the payment method configuration, which caused an empty Payment Element and failed orders (e.g. iDEAL)
+* Fix - Skip payment methods that Stripe reports as unavailable in the payment method configuration, fixing empty iDEAL checkout
 
 2026-06-15 - version 10.8.2
 * Fix - Disable Adaptive Pricing when webhooks are disabled

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -408,19 +408,14 @@ class WC_Stripe_Payment_Method_Configurations {
 	/**
 	 * Whether a payment method is renderable in the active Payment Method Configuration.
 	 *
-	 * Stripe can report a method as `available: false` even while its
-	 * `display_preference` is 'on' (e.g. the account capability or eligibility for
-	 * that method is not active for this configuration). Offering such a method at
-	 * checkout makes Stripe.js render an empty Payment Element and order placement
-	 * fails with "...make sure the Element you are attempting to use has a payment
-	 * method selection." Treat a method as available unless the PMC explicitly says
-	 * otherwise, so accounts whose PMC omits the flag are unaffected.
+	 * Stripe can report a method as `available: false` while its `display_preference`
+	 * is 'on'; offering it makes the Payment Element render empty and checkout fail.
+	 * Treats a method as available unless the PMC explicitly says otherwise.
 	 *
 	 * @param string $payment_method_id Stripe payment method ID (e.g. 'ideal').
 	 * @return bool
 	 */
 	public static function is_payment_method_available( string $payment_method_id ): bool {
-		// No PMC in use means there is nothing to gate on; defer to the other checks.
 		if ( ! self::is_enabled() ) {
 			return true;
 		}

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -406,6 +406,36 @@ class WC_Stripe_Payment_Method_Configurations {
 	}
 
 	/**
+	 * Whether a payment method is renderable in the active Payment Method Configuration.
+	 *
+	 * Stripe can report a method as `available: false` even while its
+	 * `display_preference` is 'on' (e.g. the account capability or eligibility for
+	 * that method is not active for this configuration). Offering such a method at
+	 * checkout makes Stripe.js render an empty Payment Element and order placement
+	 * fails with "...make sure the Element you are attempting to use has a payment
+	 * method selection." Treat a method as available unless the PMC explicitly says
+	 * otherwise, so accounts whose PMC omits the flag are unaffected.
+	 *
+	 * @param string $payment_method_id Stripe payment method ID (e.g. 'ideal').
+	 * @return bool
+	 */
+	public static function is_payment_method_available( string $payment_method_id ): bool {
+		// No PMC in use means there is nothing to gate on; defer to the other checks.
+		if ( ! self::is_enabled() ) {
+			return true;
+		}
+
+		$configuration = self::get_primary_configuration();
+		if ( ! $configuration || ! isset( $configuration->$payment_method_id ) ) {
+			return true;
+		}
+
+		$payment_method = $configuration->$payment_method_id;
+
+		return ! ( isset( $payment_method->available ) && false === $payment_method->available );
+	}
+
+	/**
 	 * Get the UPE enabled payment method IDs.
 	 *
 	 * @param bool $force_refresh Whether to force a refresh of the payment method configuration from Stripe.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -381,6 +381,14 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 			return false;
 		}
 
+		// A method can be toggled on in the Payment Method Configuration yet still be
+		// unavailable for rendering (Stripe reports `available: false`). Offering it
+		// would produce an empty Payment Element and a failed checkout, so gate on the
+		// PMC's availability for this method.
+		if ( ! WC_Stripe_Payment_Method_Configurations::is_payment_method_available( $this->stripe_id ) ) {
+			return false;
+		}
+
 		// Check currency compatibility. On the pay for order page, check the order currency.
 		// Otherwise, check the store currency.
 		$current_store_currency = $this->get_woocommerce_currency();

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -381,10 +381,8 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 			return false;
 		}
 
-		// A method can be toggled on in the Payment Method Configuration yet still be
-		// unavailable for rendering (Stripe reports `available: false`). Offering it
-		// would produce an empty Payment Element and a failed checkout, so gate on the
-		// PMC's availability for this method.
+		// Stripe can report a method as unavailable even when it's toggled on in the PMC;
+		// offering it would render an empty Payment Element and fail checkout.
 		if ( ! WC_Stripe_Payment_Method_Configurations::is_payment_method_available( $this->stripe_id ) ) {
 			return false;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -188,6 +188,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Rename internal Blocks API references to Store API in the Express Checkout client for naming consistency
 * Add - Verify that Stripe.js was served from the official Stripe origin before processing checkout payments
 * Fix - Exclude WooCommerce Subscriptions products from the Agentic Commerce product feed so they no longer make every sync report a partial success
-* Fix - Don't offer a payment method at checkout when Stripe reports it as unavailable in the payment method configuration, which caused an empty Payment Element and failed orders (e.g. iDEAL)
+* Fix - Skip payment methods that Stripe reports as unavailable in the payment method configuration, fixing empty iDEAL checkout
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -188,5 +188,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Rename internal Blocks API references to Store API in the Express Checkout client for naming consistency
 * Add - Verify that Stripe.js was served from the official Stripe origin before processing checkout payments
 * Fix - Exclude WooCommerce Subscriptions products from the Agentic Commerce product feed so they no longer make every sync report a partial success
+* Fix - Don't offer a payment method at checkout when Stripe reports it as unavailable in the payment method configuration, which caused an empty Payment Element and failed orders (e.g. iDEAL)
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-payment-method-configurations-test.php
+++ b/tests/phpunit/class-wc-stripe-payment-method-configurations-test.php
@@ -1014,9 +1014,7 @@ class WC_Stripe_Payment_Method_Configurations_Test extends WC_Mock_Stripe_API_Un
 	}
 
 	/**
-	 * A method toggled on but reported `available: false` by Stripe must not be
-	 * treated as available; one with the flag absent or true must be. Guards the
-	 * empty-Payment-Element checkout failure (STRIPE-1233).
+	 * Only `available: false` makes a method unavailable; flag absent or true is available.
 	 *
 	 * @param array  $settings          Stripe settings to apply.
 	 * @param object $mock_api_response Mock `get_payment_method_configurations` response.

--- a/tests/phpunit/class-wc-stripe-payment-method-configurations-test.php
+++ b/tests/phpunit/class-wc-stripe-payment-method-configurations-test.php
@@ -1012,4 +1012,127 @@ class WC_Stripe_Payment_Method_Configurations_Test extends WC_Mock_Stripe_API_Un
 			],
 		];
 	}
+
+	/**
+	 * A method toggled on but reported `available: false` by Stripe must not be
+	 * treated as available; one with the flag absent or true must be. Guards the
+	 * empty-Payment-Element checkout failure (STRIPE-1233).
+	 *
+	 * @param array  $settings          Stripe settings to apply.
+	 * @param object $mock_api_response Mock `get_payment_method_configurations` response.
+	 * @param string $payment_method_id Method ID under test.
+	 * @param bool   $expected          Expected availability.
+	 * @return void
+	 * @dataProvider provide_is_payment_method_available
+	 */
+	public function test_is_payment_method_available( array $settings, $mock_api_response, string $payment_method_id, bool $expected ) {
+		$initial_settings = WC_Stripe_Helper::get_stripe_settings();
+
+		$mock_api = $this->getMockBuilder( \WC_Stripe_API::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$mock_api->method( 'get_payment_method_configurations' )->willReturn( $mock_api_response );
+
+		$reflection = new ReflectionClass( \WC_Stripe_API::class );
+		$property   = $reflection->getProperty( 'instance' );
+		$property->setAccessible( true );
+		$property->setValue( null, $mock_api );
+
+		WC_Stripe_Helper::update_main_stripe_settings( $settings );
+		delete_option( WC_Stripe_Payment_Method_Configurations::FETCH_COOLDOWN_OPTION_KEY );
+		WC_Stripe_Payment_Method_Configurations::clear_payment_method_configuration_cache();
+
+		$result = WC_Stripe_Payment_Method_Configurations::is_payment_method_available( $payment_method_id );
+
+		WC_Stripe_Helper::update_main_stripe_settings( $initial_settings );
+		$property->setValue( null, null );
+		delete_option( WC_Stripe_Payment_Method_Configurations::FETCH_COOLDOWN_OPTION_KEY );
+		WC_Stripe_Payment_Method_Configurations::clear_payment_method_configuration_cache();
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Data provider for `test_is_payment_method_available`.
+	 *
+	 * @return array
+	 */
+	public function provide_is_payment_method_available(): array {
+		$settings_base = WC_Stripe_Helper::get_stripe_settings();
+		$connected     = array_merge(
+			$settings_base,
+			[
+				'pmc_enabled'          => 'yes',
+				'testmode'             => 'yes',
+				'test_publishable_key' => 'pk_test_1234567890',
+				'test_secret_key'      => 'sk_test_1234567890',
+				'test_connection_type' => 'connect',
+			]
+		);
+		$pmc           = function ( array $ideal ) {
+			return (object) [
+				'data' => [
+					(object) array_merge(
+						[
+							'id'       => 'pmc_test',
+							'parent'   => WC_Stripe_Payment_Method_Configurations::TEST_MODE_CONFIGURATION_PARENT_ID,
+							'active'   => true,
+							'livemode' => false,
+							'card'     => (object) [ 'display_preference' => (object) [ 'value' => 'on' ] ],
+						],
+						$ideal
+					),
+				],
+			];
+		};
+
+		return [
+			'available false -> unavailable'      => [
+				'settings'          => $connected,
+				'mock_api_response' => $pmc(
+					[
+						'ideal' => (object) [
+							'available'          => false,
+							'display_preference' => (object) [ 'value' => 'on' ],
+						],
+					]
+				),
+				'payment_method_id' => 'ideal',
+				'expected'          => false,
+			],
+			'available true -> available'         => [
+				'settings'          => $connected,
+				'mock_api_response' => $pmc(
+					[
+						'ideal' => (object) [
+							'available'          => true,
+							'display_preference' => (object) [ 'value' => 'on' ],
+						],
+					]
+				),
+				'payment_method_id' => 'ideal',
+				'expected'          => true,
+			],
+			'flag absent -> available'            => [
+				'settings'          => $connected,
+				'mock_api_response' => $pmc(
+					[ 'ideal' => (object) [ 'display_preference' => (object) [ 'value' => 'on' ] ] ]
+				),
+				'payment_method_id' => 'ideal',
+				'expected'          => true,
+			],
+			'method absent from PMC -> available' => [
+				'settings'          => $connected,
+				'mock_api_response' => $pmc( [] ),
+				'payment_method_id' => 'ideal',
+				'expected'          => true,
+			],
+			'PMC disabled -> available'           => [
+				'settings'          => array_merge( $settings_base, [ 'pmc_enabled' => 'no' ] ),
+				'mock_api_response' => (object) [ 'data' => [] ],
+				'payment_method_id' => 'ideal',
+				'expected'          => true,
+			],
+		];
+	}
 }


### PR DESCRIPTION
Related to STRIPE-1233 (defensive hardening found while investigating; not a confirmed fix for that ticket — see note).

## Changes proposed in this Pull Request:

The plugin decides a payment method is enabled from the PMC's `display_preference.value` only, and never reads Stripe's per-method `available` flag. Stripe can report a method `display_preference.value: 'on'` **and** `available: false`; in that state the plugin still offers the method and adds it to the intent, but Stripe renders an empty Payment Element and checkout fails with *"We could not retrieve data from the specified Element…"*.

**Change:** add `WC_Stripe_Payment_Method_Configurations::is_payment_method_available()` and gate `is_enabled_at_checkout()` on it. A method counts as available unless the PMC explicitly reports `available: false`, so accounts without the flag are unaffected. Admin toggles are untouched; only checkout offering is gated. This is a defensive guard against offering a method Stripe won't render.

> **Status:** Investigation of the STRIPE-1233 merchant's account (NL, EUR, iDEAL capability Active, iDEAL ON in both configs) did **not** confirm `available: false` for that account, so this is **not** verified as the fix for that ticket — it's a general guard. Keeping as draft until either the raw API confirms an `available: false` case or we decide to land it as standalone hardening.

## Testing instructions

Needs an account whose PMC has a method with `display_preference.value: 'on'` but `available: false`.

1. Before: the method is offered at checkout → empty Payment Element, order placement errors.
2. After: the method is not offered (classic radio / OC / intent `payment_method_types`); other available methods unaffected.
3. A method with `available: true` (or no flag) still shows and completes.

Automated: `WC_Stripe_Payment_Method_Configurations_Test` (+5 cases) and `WC_Stripe_UPE_Payment_Method_Test` — 66 + 117 green; PHPCS clean.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

Fix - Skip payment methods that Stripe reports as unavailable in the payment method configuration, fixing empty iDEAL checkout

**Post merge**

-   [ ] Added testing instructions to the Release Testing Instructions wiki page (or does not apply)
-   [ ] Added the needs docs label (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)