### PR TITLE
Fix Adaptive Pricing PaymentIntent fallback

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ xxxx-xx-xx - version 10.9.0
 * Dev - Initial infrastructure for more complex Agentic feed filtering
 * Fix - Prevent unnecessary Stripe payment method creation when shortcode checkout has empty required fields
 * Fix - Prevent classic and Blocks checkout submissions from failing while the Stripe Payment Element is re-mounting after a checkout update
+* Fix - Recover Adaptive Pricing orders when the successful PaymentIntent webhook arrives without the matching Checkout Session webhook
 * Fix - Decommission the previously configured webhook before connecting via OAuth so reconnecting to a different Stripe account no longer leaves an orphaned webhook on the old account
 * Fix - Send the billing address to Stripe on the Pay for Order page so payments aren't incorrectly blocked by Stripe Radar rules
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1278,7 +1278,9 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			&& $is_adaptive_pricing_checkout_intent
 			&& in_array( $notification->type, $checkout_session_intent_event_types, true );
 		$checkout_session_order_reference    = $intent->payment_details->order_reference ?? '';
-		$checkout_session_order_reference    = is_string( $checkout_session_order_reference ) ? $checkout_session_order_reference : '';
+		$checkout_session_order_reference    = is_string( $checkout_session_order_reference ) && 0 === strpos( $checkout_session_order_reference, 'cs_' )
+			? $checkout_session_order_reference
+			: '';
 
 		// Checkout Session PaymentIntents can arrive without order metadata; the session remains the durable order link.
 		if ( $should_resolve_via_checkout_session ) {
@@ -1528,22 +1530,22 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * object-shaped payload.
 	 *
 	 * @param array|object $notification Raw notification from the scheduled job.
-	 * @return object      The normalized notification object.
+	 * @return stdClass    The normalized notification object.
 	 * @throws Exception When the payload cannot be normalized.
 	 */
 	private function normalize_deferred_webhook_notification_to_object( $notification ) {
-		if ( is_object( $notification ) ) {
+		if ( $notification instanceof stdClass ) {
 			return $notification;
 		}
 
-		if ( is_array( $notification ) ) {
+		if ( is_array( $notification ) || is_object( $notification ) ) {
 			$json = wp_json_encode( $notification );
 			if ( false === $json ) {
 				throw new Exception( 'Failed to encode deferred webhook notification for object restoration.' );
 			}
 
 			$object = json_decode( $json );
-			if ( ! is_object( $object ) ) {
+			if ( ! $object instanceof stdClass ) {
 				throw new Exception( 'Failed to restore deferred webhook notification to an object.' );
 			}
 
@@ -1574,10 +1576,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				case 'payment_intent.succeeded':
 				case 'payment_intent.amount_capturable_updated':
 					if ( ! empty( $additional_data['retry_process_payment_intent'] ) ) {
-						if ( $notification instanceof stdClass ) {
-							$this->process_payment_intent( $notification );
-						}
-
+						$this->process_payment_intent( $notification );
 						return;
 					}
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1266,13 +1266,24 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$intent = $notification->data->object;
 		$order  = $this->get_order_from_intent( $intent );
 
-		$checkout_type = $intent->metadata->checkout_type ?? '';
+		$checkout_type                       = $intent->metadata->checkout_type ?? '';
+		$resolved_order_via_checkout_session = false;
+		$checkout_session_intent_event_types = [
+			'payment_intent.payment_failed',
+			'payment_intent.succeeded',
+			'payment_intent.amount_capturable_updated',
+		];
+		$is_adaptive_pricing_checkout_intent = WC_Stripe_Checkout_Sessions_Ajax_Handler::ADAPTIVE_PRICING_CHECKOUT_TYPE === $checkout_type;
+		$should_resolve_via_checkout_session = ! $order
+			&& $is_adaptive_pricing_checkout_intent
+			&& in_array( $notification->type, $checkout_session_intent_event_types, true );
+		$checkout_session_order_reference    = $intent->payment_details->order_reference ?? '';
+		$checkout_session_order_reference    = is_string( $checkout_session_order_reference ) ? $checkout_session_order_reference : '';
 
-		// For AP, attempt to find the order via the checkout session.
-		if ( ! $order
-			&& 'payment_intent.payment_failed' === $notification->type
-			&& WC_Stripe_Checkout_Sessions_Ajax_Handler::ADAPTIVE_PRICING_CHECKOUT_TYPE === $checkout_type ) {
-			$order = $this->get_order_by_intent_checkout_session( isset( $intent->id ) ? (string) $intent->id : '' );
+		// Checkout Session PaymentIntents can arrive without order metadata; the session remains the durable order link.
+		if ( $should_resolve_via_checkout_session ) {
+			$order                               = $this->get_order_by_intent_checkout_session( isset( $intent->id ) ? (string) $intent->id : '', $checkout_session_order_reference );
+			$resolved_order_via_checkout_session = $order instanceof WC_Order;
 		}
 
 		if ( ! $order ) {
@@ -1297,6 +1308,14 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		if ( $order_helper->lock_order_payment( $order ) ) {
 			return;
+		}
+
+		if (
+			$resolved_order_via_checkout_session
+			&& isset( $intent->id )
+			&& in_array( $notification->type, [ 'payment_intent.succeeded', 'payment_intent.amount_capturable_updated' ], true )
+		) {
+			$order_helper->add_payment_intent_to_order( (string) $intent->id, $order );
 		}
 
 		$order_id           = $order->get_id();
@@ -2327,10 +2346,18 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Resolves the order behind a PaymentIntent via its Checkout Session.
 	 *
-	 * @param string $intent_id PaymentIntent ID from the failed event.
+	 * @param string $intent_id           PaymentIntent ID from the event.
+	 * @param string $checkout_session_id Checkout Session ID from the event, when available.
 	 * @return WC_Order|null
 	 */
-	private function get_order_by_intent_checkout_session( string $intent_id ): ?WC_Order {
+	private function get_order_by_intent_checkout_session( string $intent_id, string $checkout_session_id = '' ): ?WC_Order {
+		if ( '' !== $checkout_session_id ) {
+			$order = WC_Stripe_Helper::get_order_by_checkout_session_id( $checkout_session_id );
+			if ( $order instanceof WC_Order ) {
+				return $order;
+			}
+		}
+
 		if ( '' === $intent_id ) {
 			return null;
 		}

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1304,14 +1304,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		// Set the order being processed for the `wc_stripe_webhook_received` action later.
 		$this->resolved_order = $order;
 
-		$order_helper = WC_Stripe_Order_Helper::get_instance();
+		$order_helper                 = WC_Stripe_Order_Helper::get_instance();
+		$is_recoverable_success_event = $resolved_order_via_checkout_session
+			&& isset( $intent->id )
+			&& in_array( $notification->type, [ 'payment_intent.succeeded', 'payment_intent.amount_capturable_updated' ], true );
 
 		if ( $order_helper->lock_order_payment( $order ) ) {
-			if (
-				$resolved_order_via_checkout_session
-				&& isset( $intent->id )
-				&& in_array( $notification->type, [ 'payment_intent.succeeded', 'payment_intent.amount_capturable_updated' ], true )
-			) {
+			if ( $is_recoverable_success_event ) {
 				$this->defer_webhook_processing(
 					$notification,
 					[
@@ -1326,11 +1325,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		if (
-			$resolved_order_via_checkout_session
-			&& isset( $intent->id )
-			&& in_array( $notification->type, [ 'payment_intent.succeeded', 'payment_intent.amount_capturable_updated' ], true )
-		) {
+		if ( $is_recoverable_success_event ) {
 			$order_helper->add_payment_intent_to_order( (string) $intent->id, $order );
 		}
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1307,6 +1307,22 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$order_helper = WC_Stripe_Order_Helper::get_instance();
 
 		if ( $order_helper->lock_order_payment( $order ) ) {
+			if (
+				$resolved_order_via_checkout_session
+				&& isset( $intent->id )
+				&& in_array( $notification->type, [ 'payment_intent.succeeded', 'payment_intent.amount_capturable_updated' ], true )
+			) {
+				$this->defer_webhook_processing(
+					$notification,
+					[
+						'order_id'                     => $order->get_id(),
+						'intent_id'                    => (string) $intent->id,
+						'retry_process_payment_intent' => true,
+					],
+					$this->locked_order_retry_delay
+				);
+			}
+
 			return;
 		}
 
@@ -1562,6 +1578,14 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			switch ( $webhook_type ) {
 				case 'payment_intent.succeeded':
 				case 'payment_intent.amount_capturable_updated':
+					if ( ! empty( $additional_data['retry_process_payment_intent'] ) ) {
+						if ( $notification instanceof stdClass ) {
+							$this->process_payment_intent( $notification );
+						}
+
+						return;
+					}
+
 					$order     = isset( $additional_data['order_id'] ) ? wc_get_order( $additional_data['order_id'] ) : null;
 					$intent_id = $additional_data['intent_id'] ?? '';
 

--- a/readme.txt
+++ b/readme.txt
@@ -169,6 +169,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Initial infrastructure for more complex Agentic feed filtering
 * Fix - Prevent unnecessary Stripe payment method creation when shortcode checkout has empty required fields
 * Fix - Prevent classic and Blocks checkout submissions from failing while the Stripe Payment Element is re-mounting after a checkout update
+* Fix - Recover Adaptive Pricing orders when the successful PaymentIntent webhook arrives without the matching Checkout Session webhook
 * Fix - Decommission the previously configured webhook before connecting via OAuth so reconnecting to a different Stripe account no longer leaves an orphaned webhook on the old account
 * Fix - Send the billing address to Stripe on the Pay for Order page so payments aren't incorrectly blocked by Stripe Radar rules
 * Update - Replace shipping AJAX endpoints with Store API calls for Express Checkout Element

--- a/tests/e2e/bin/setup.sh
+++ b/tests/e2e/bin/setup.sh
@@ -165,6 +165,9 @@ redirect_output cli wp plugin install /var/www/html/wp-content/plugins/woocommer
 rm -rf $E2E_ROOT/woocommerce-subscriptions.zip
 
 redirect_output cli wp plugin activate woocommerce-subscriptions
+echo " - Enabling legacy subscription product types"
+redirect_output cli wp option update woocommerce_subscriptions_enable_simple_subscription 'yes'
+redirect_output cli wp option update woocommerce_subscriptions_enable_variable_subscription 'yes'
 
 step "Installing Woo Pre-Orders"
 echo " - Fetching latest version"

--- a/tests/e2e/config/global-setup.js
+++ b/tests/e2e/config/global-setup.js
@@ -6,6 +6,7 @@ import {
 	loginAdminAndSaveState,
 	createApiTokens,
 	installPluginFromRepository,
+	enableLegacySubscriptionProductTypes,
 	setupWoo,
 	setupStripe,
 } from '../utils/playwright-setup';
@@ -55,6 +56,8 @@ async function installPlugins( page ) {
 			`woocommerce/${ pluginSlug }`,
 			pluginSlug
 		);
+		await enableLegacySubscriptionProductTypes();
+
 		// Install WooCommerce Pre-Orders.
 		pluginSlug = 'woocommerce-pre-orders';
 		await installPluginFromRepository(

--- a/tests/e2e/utils/playwright-setup.js
+++ b/tests/e2e/utils/playwright-setup.js
@@ -177,6 +177,13 @@ export const installPluginFromRepository = async (
 	console.log( `\u2714 ${ pluginSlug } plugin installed successfully.` );
 };
 
+export const enableLegacySubscriptionProductTypes = async () => {
+	await sshExecCommands( [
+		'wp option update woocommerce_subscriptions_enable_simple_subscription yes',
+		'wp option update woocommerce_subscriptions_enable_variable_subscription yes',
+	] );
+};
+
 /**
  * Helper function to run an array of commands in a SSH server.
  * @param {Array.<string>} commands The array of commands.

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -1190,6 +1190,140 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Adaptive Pricing Checkout Session PaymentIntents can arrive without order metadata. When
+	 * Stripe includes the Checkout Session reference on the event, the handler should use that
+	 * direct link instead of depending on a second API lookup.
+	 *
+	 * @dataProvider provide_process_adaptive_pricing_payment_intent_order_reference_fallback
+	 *
+	 * @param string      $event_type           The PaymentIntent event type.
+	 * @param string|null $checkout_type        Checkout type metadata to include on the intent.
+	 * @param string      $expected_status      The order status after processing.
+	 * @param bool        $expect_deferred      Whether the event should schedule deferred settlement.
+	 * @param bool        $expect_intent_stored Whether the PaymentIntent ID should be stored on the order.
+	 */
+	public function test_process_adaptive_pricing_payment_intent_order_reference_fallback(
+		string $event_type,
+		?string $checkout_type,
+		string $expected_status,
+		bool $expect_deferred,
+		bool $expect_intent_stored
+	): void {
+		$event_slug          = str_replace( [ 'payment_intent.', '_' ], '', $event_type );
+		$checkout_session_id = 'cs_test_pi_reference_' . $event_slug;
+		$intent_id           = 'pi_test_pi_reference_' . $event_slug;
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::PENDING );
+		$order->save();
+		WC_Stripe_Order_Helper::get_instance()->update_stripe_checkout_session_id( $order, $checkout_session_id );
+		$order->save_meta_data();
+
+		$lookup_called   = false;
+		$pre_http_filter = $this->stub_checkout_session_lookup( $intent_id, $checkout_session_id, $lookup_called );
+		add_filter( 'pre_http_request', $pre_http_filter, 10, 3 );
+
+		$mock_scheduler = $this->createMock( WC_Stripe_Action_Scheduler_Service::class );
+		if ( $expect_deferred ) {
+			$mock_scheduler->expects( $this->once() )
+				->method( 'schedule_job' )
+				->with(
+					$this->isType( 'int' ),
+					'wc_stripe_deferred_webhook',
+					$this->callback(
+						function ( $args ) use ( $event_type, $intent_id, $order ) {
+							return ( $args['type'] ?? '' ) === $event_type
+								&& ( $args['data']['intent_id'] ?? '' ) === $intent_id
+								&& $order->get_id() === ( $args['data']['order_id'] ?? 0 )
+								&& isset( $args['notification'] );
+						}
+					)
+				);
+		} else {
+			$mock_scheduler->expects( $this->never() )->method( 'schedule_job' );
+		}
+
+		$prop = new ReflectionProperty( WC_Stripe_Webhook_Handler::class, 'action_scheduler_service' );
+		$prop->setAccessible( true );
+		$prop->setValue( $this->mock_webhook_handler, $mock_scheduler );
+
+		$metadata = (object) [];
+		if ( null !== $checkout_type ) {
+			$metadata->checkout_type = $checkout_type;
+		}
+
+		$notification = (object) [
+			'type' => $event_type,
+			'data' => (object) [
+				'object' => (object) [
+					'id'                 => $intent_id,
+					'metadata'           => $metadata,
+					'payment_details'    => (object) [
+						'order_reference' => $checkout_session_id,
+					],
+					'last_payment_error' => (object) [ 'message' => 'Your card was declined.' ],
+				],
+			],
+		];
+
+		$this->mock_webhook_handler->process_payment_intent( $notification );
+		remove_filter( 'pre_http_request', $pre_http_filter );
+
+		$final_order        = wc_get_order( $order->get_id() );
+		$stored_intent_id   = WC_Stripe_Order_Helper::get_instance()->get_intent_id_from_order( $final_order );
+		$expected_intent_id = $expect_intent_stored ? $intent_id : '';
+
+		$this->assertFalse( $lookup_called, 'The direct Checkout Session reference should avoid the PaymentIntent session lookup.' );
+		$this->assertSame( $expected_status, $final_order->get_status() );
+		$this->assertSame( $expected_intent_id, $stored_intent_id );
+	}
+
+	/**
+	 * Data provider for `test_process_adaptive_pricing_payment_intent_order_reference_fallback`.
+	 *
+	 * @return array<string, array{0: string, 1: string|null, 2: string, 3: bool, 4: bool}>
+	 */
+	public function provide_process_adaptive_pricing_payment_intent_order_reference_fallback(): array {
+		return [
+			'AP succeeded intent -> order linked and deferred'    => [
+				'payment_intent.succeeded',
+				WC_Stripe_Checkout_Sessions_Ajax_Handler::ADAPTIVE_PRICING_CHECKOUT_TYPE,
+				OrderStatus::PENDING,
+				true,
+				true,
+			],
+			'AP capturable intent -> order linked and deferred'   => [
+				'payment_intent.amount_capturable_updated',
+				WC_Stripe_Checkout_Sessions_Ajax_Handler::ADAPTIVE_PRICING_CHECKOUT_TYPE,
+				OrderStatus::PENDING,
+				true,
+				true,
+			],
+			'AP failed intent -> order failed'                    => [
+				'payment_intent.payment_failed',
+				WC_Stripe_Checkout_Sessions_Ajax_Handler::ADAPTIVE_PRICING_CHECKOUT_TYPE,
+				OrderStatus::FAILED,
+				false,
+				false,
+			],
+			'standard checkout succeeded intent -> order ignored' => [
+				'payment_intent.succeeded',
+				'standard_checkout',
+				OrderStatus::PENDING,
+				false,
+				false,
+			],
+			'unmarked succeeded intent -> order ignored'          => [
+				'payment_intent.succeeded',
+				null,
+				OrderStatus::PENDING,
+				false,
+				false,
+			],
+		];
+	}
+
+	/**
 	 * charge.failed is intentionally not used to resolve declined Adaptive Pricing orders — the
 	 * paired payment_intent.payment_failed event handles that — so it must not run the session lookup.
 	 */

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -1347,6 +1347,73 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		];
 	}
 
+	public function test_process_adaptive_pricing_payment_intent_ignores_non_checkout_session_order_reference(): void {
+		$suffix              = str_replace( '-', '', wp_generate_uuid4() );
+		$checkout_session_id = 'cs_test_pi_reference_' . $suffix;
+		$intent_id           = 'pi_test_pi_reference_' . $suffix;
+		$invalid_reference   = 'order_reference_' . $suffix;
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::PENDING );
+		$order->save();
+		WC_Stripe_Order_Helper::get_instance()->update_stripe_checkout_session_id( $order, $checkout_session_id );
+		$order->save_meta_data();
+
+		$conflicting_order = WC_Helper_Order::create_order();
+		$conflicting_order->set_status( OrderStatus::PENDING );
+		$conflicting_order->save();
+		WC_Stripe_Order_Helper::get_instance()->update_stripe_checkout_session_id( $conflicting_order, $invalid_reference );
+		$conflicting_order->save_meta_data();
+
+		$lookup_called   = false;
+		$pre_http_filter = $this->stub_checkout_session_lookup( $intent_id, $checkout_session_id, $lookup_called );
+		add_filter( 'pre_http_request', $pre_http_filter, 10, 3 );
+
+		$mock_scheduler = $this->createMock( WC_Stripe_Action_Scheduler_Service::class );
+		$mock_scheduler->expects( $this->once() )
+			->method( 'schedule_job' )
+			->with(
+				$this->isType( 'int' ),
+				'wc_stripe_deferred_webhook',
+				$this->callback(
+					function ( $args ) use ( $intent_id, $order ) {
+						return 'payment_intent.succeeded' === ( $args['type'] ?? '' )
+							&& ( $args['data']['intent_id'] ?? '' ) === $intent_id
+							&& $order->get_id() === ( $args['data']['order_id'] ?? 0 );
+					}
+				)
+			);
+
+		$prop = new ReflectionProperty( WC_Stripe_Webhook_Handler::class, 'action_scheduler_service' );
+		$prop->setAccessible( true );
+		$prop->setValue( $this->mock_webhook_handler, $mock_scheduler );
+
+		$notification = (object) [
+			'type' => 'payment_intent.succeeded',
+			'data' => (object) [
+				'object' => (object) [
+					'id'              => $intent_id,
+					'metadata'        => (object) [
+						'checkout_type' => WC_Stripe_Checkout_Sessions_Ajax_Handler::ADAPTIVE_PRICING_CHECKOUT_TYPE,
+					],
+					'payment_details' => (object) [
+						'order_reference' => $invalid_reference,
+					],
+				],
+			],
+		];
+
+		$this->mock_webhook_handler->process_payment_intent( $notification );
+		remove_filter( 'pre_http_request', $pre_http_filter );
+
+		$final_order             = wc_get_order( $order->get_id() );
+		$final_conflicting_order = wc_get_order( $conflicting_order->get_id() );
+
+		$this->assertTrue( $lookup_called );
+		$this->assertSame( $intent_id, WC_Stripe_Order_Helper::get_instance()->get_intent_id_from_order( $final_order ) );
+		$this->assertSame( '', WC_Stripe_Order_Helper::get_instance()->get_intent_id_from_order( $final_conflicting_order ) );
+	}
+
 	/**
 	 * Checkout Session-recovered successful PaymentIntents must be retried through
 	 * process_payment_intent() when the order lock is held, because the intent has not been stored yet.

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -1201,17 +1201,22 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	 * @param string      $expected_status      The order status after processing.
 	 * @param bool        $expect_deferred      Whether the event should schedule deferred settlement.
 	 * @param bool        $expect_intent_stored Whether the PaymentIntent ID should be stored on the order.
+	 * @param bool        $order_ref_resolves   Whether order_reference should resolve the order directly.
+	 * @param bool        $expect_lookup        Whether the PaymentIntent session lookup should be attempted.
 	 */
 	public function test_process_adaptive_pricing_payment_intent_order_reference_fallback(
 		string $event_type,
 		?string $checkout_type,
 		string $expected_status,
 		bool $expect_deferred,
-		bool $expect_intent_stored
+		bool $expect_intent_stored,
+		bool $order_ref_resolves,
+		bool $expect_lookup
 	): void {
 		$event_slug          = str_replace( [ 'payment_intent.', '_' ], '', $event_type );
 		$checkout_session_id = 'cs_test_pi_reference_' . $event_slug;
 		$intent_id           = 'pi_test_pi_reference_' . $event_slug;
+		$order_reference     = $order_ref_resolves ? $checkout_session_id : 'cs_test_stale_' . $event_slug;
 
 		$order = WC_Helper_Order::create_order();
 		$order->set_status( OrderStatus::PENDING );
@@ -1259,7 +1264,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 					'id'                 => $intent_id,
 					'metadata'           => $metadata,
 					'payment_details'    => (object) [
-						'order_reference' => $checkout_session_id,
+						'order_reference' => $order_reference,
 					],
 					'last_payment_error' => (object) [ 'message' => 'Your card was declined.' ],
 				],
@@ -1273,7 +1278,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$stored_intent_id   = WC_Stripe_Order_Helper::get_instance()->get_intent_id_from_order( $final_order );
 		$expected_intent_id = $expect_intent_stored ? $intent_id : '';
 
-		$this->assertFalse( $lookup_called, 'The direct Checkout Session reference should avoid the PaymentIntent session lookup.' );
+		$this->assertSame( $expect_lookup, $lookup_called );
 		$this->assertSame( $expected_status, $final_order->get_status() );
 		$this->assertSame( $expected_intent_id, $stored_intent_id );
 	}
@@ -1281,46 +1286,176 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	/**
 	 * Data provider for `test_process_adaptive_pricing_payment_intent_order_reference_fallback`.
 	 *
-	 * @return array<string, array{0: string, 1: string|null, 2: string, 3: bool, 4: bool}>
+	 * @return array<string, array{0: string, 1: string|null, 2: string, 3: bool, 4: bool, 5: bool, 6: bool}>
 	 */
 	public function provide_process_adaptive_pricing_payment_intent_order_reference_fallback(): array {
 		return [
-			'AP succeeded intent -> order linked and deferred'    => [
+			'AP succeeded intent -> order linked and deferred'              => [
 				'payment_intent.succeeded',
 				WC_Stripe_Checkout_Sessions_Ajax_Handler::ADAPTIVE_PRICING_CHECKOUT_TYPE,
 				OrderStatus::PENDING,
 				true,
 				true,
+				true,
+				false,
 			],
-			'AP capturable intent -> order linked and deferred'   => [
+			'AP succeeded intent, stale reference -> lookup resolves order' => [
+				'payment_intent.succeeded',
+				WC_Stripe_Checkout_Sessions_Ajax_Handler::ADAPTIVE_PRICING_CHECKOUT_TYPE,
+				OrderStatus::PENDING,
+				true,
+				true,
+				false,
+				true,
+			],
+			'AP capturable intent -> order linked and deferred'             => [
 				'payment_intent.amount_capturable_updated',
 				WC_Stripe_Checkout_Sessions_Ajax_Handler::ADAPTIVE_PRICING_CHECKOUT_TYPE,
 				OrderStatus::PENDING,
 				true,
 				true,
+				true,
+				false,
 			],
-			'AP failed intent -> order failed'                    => [
+			'AP failed intent -> order failed'                              => [
 				'payment_intent.payment_failed',
 				WC_Stripe_Checkout_Sessions_Ajax_Handler::ADAPTIVE_PRICING_CHECKOUT_TYPE,
 				OrderStatus::FAILED,
 				false,
 				false,
+				true,
+				false,
 			],
-			'standard checkout succeeded intent -> order ignored' => [
+			'standard checkout succeeded intent -> order ignored'           => [
 				'payment_intent.succeeded',
 				'standard_checkout',
 				OrderStatus::PENDING,
 				false,
 				false,
+				true,
+				false,
 			],
-			'unmarked succeeded intent -> order ignored'          => [
+			'unmarked succeeded intent -> order ignored'                    => [
 				'payment_intent.succeeded',
 				null,
 				OrderStatus::PENDING,
 				false,
 				false,
+				true,
+				false,
 			],
 		];
+	}
+
+	/**
+	 * Checkout Session-recovered successful PaymentIntents must be retried through
+	 * process_payment_intent() when the order lock is held, because the intent has not been stored yet.
+	 */
+	public function test_process_adaptive_pricing_payment_intent_order_reference_requeues_when_order_locked(): void {
+		$suffix              = str_replace( '-', '', wp_generate_uuid4() );
+		$checkout_session_id = 'cs_test_pi_reference_locked_' . substr( $suffix, 0, 12 );
+		$intent_id           = 'pi_test_pi_reference_locked_' . substr( $suffix, 0, 12 );
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::PENDING );
+		$order->save();
+		WC_Stripe_Order_Helper::get_instance()->update_stripe_checkout_session_id( $order, $checkout_session_id );
+		$order->save_meta_data();
+
+		$this->assertSame( $order->get_id(), WC_Stripe_Helper::get_order_by_checkout_session_id( $checkout_session_id )->get_id() );
+		$this->assertTrue( $order->has_status( OrderStatus::PENDING ) );
+
+		$order_helper = $this->createPartialMock(
+			WC_Stripe_Order_Helper::class,
+			[ 'lock_order_payment', 'unlock_order_payment' ]
+		);
+		$order_helper->method( 'lock_order_payment' )->willReturn( true );
+		$order_helper->method( 'unlock_order_payment' );
+		WC_Stripe_Order_Helper::set_instance( $order_helper );
+
+		$notification = (object) [
+			'type' => 'payment_intent.succeeded',
+			'data' => (object) [
+				'object' => (object) [
+					'id'              => $intent_id,
+					'metadata'        => (object) [
+						'checkout_type' => WC_Stripe_Checkout_Sessions_Ajax_Handler::ADAPTIVE_PRICING_CHECKOUT_TYPE,
+					],
+					'payment_details' => (object) [
+						'order_reference' => $checkout_session_id,
+					],
+				],
+			],
+		];
+
+		$start               = time();
+		$scheduled_timestamp = null;
+		$scheduled_hook      = null;
+		$scheduled_args      = null;
+		$mock_scheduler      = $this->createMock( WC_Stripe_Action_Scheduler_Service::class );
+		$mock_scheduler->expects( $this->once() )
+			->method( 'schedule_job' )
+			->willReturnCallback(
+				function ( $timestamp, $hook, $args ) use ( &$scheduled_timestamp, &$scheduled_hook, &$scheduled_args ) {
+					$scheduled_timestamp = $timestamp;
+					$scheduled_hook      = $hook;
+					$scheduled_args      = $args;
+				}
+			);
+
+		$prop = new ReflectionProperty( WC_Stripe_Webhook_Handler::class, 'action_scheduler_service' );
+		$prop->setAccessible( true );
+		$prop->setValue( $this->mock_webhook_handler, $mock_scheduler );
+
+		$this->mock_webhook_handler->process_payment_intent( $notification );
+
+		$final_order      = wc_get_order( $order->get_id() );
+		$stored_intent_id = WC_Stripe_Order_Helper::get_instance()->get_intent_id_from_order( $final_order );
+
+		$this->assertIsInt( $scheduled_timestamp );
+		$this->assertGreaterThanOrEqual( $start + 10, $scheduled_timestamp );
+		$this->assertLessThan( $start + MINUTE_IN_SECONDS, $scheduled_timestamp );
+		$this->assertSame( 'wc_stripe_deferred_webhook', $scheduled_hook );
+		$this->assertSame( 'payment_intent.succeeded', $scheduled_args['type'] ?? '' );
+		$this->assertSame( $intent_id, $scheduled_args['data']['intent_id'] ?? '' );
+		$this->assertSame( $order->get_id(), $scheduled_args['data']['order_id'] ?? 0 );
+		$this->assertTrue( $scheduled_args['data']['retry_process_payment_intent'] ?? false );
+		$this->assertSame( $notification, $scheduled_args['notification'] ?? null );
+		$this->assertSame( OrderStatus::PENDING, $final_order->get_status() );
+		$this->assertEmpty( $stored_intent_id );
+	}
+
+	/**
+	 * Lock retry jobs need to recover and store the intent before the normal deferred settlement path can run.
+	 */
+	public function test_process_deferred_webhook_retries_payment_intent_processing_when_requested(): void {
+		$notification = (object) [
+			'type' => 'payment_intent.succeeded',
+			'data' => (object) [
+				'object' => (object) [
+					'id' => 'pi_test_retry_process_payment_intent',
+				],
+			],
+		];
+
+		$handler = $this->getMockBuilder( WC_Stripe_Webhook_Handler::class )
+			->setMethods( [ 'process_payment_intent', 'handle_deferred_payment_intent_succeeded' ] )
+			->getMock();
+
+		$handler->expects( $this->once() )
+			->method( 'process_payment_intent' )
+			->with( $notification );
+
+		$handler->expects( $this->never() )
+			->method( 'handle_deferred_payment_intent_succeeded' );
+
+		$handler->process_deferred_webhook(
+			'payment_intent.succeeded',
+			[
+				'retry_process_payment_intent' => true,
+			],
+			$notification
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Recover Adaptive Pricing orders when a successful or capturable PaymentIntent webhook can only be linked through its Checkout Session.
- Store the recovered PaymentIntent ID on the order before deferring the existing settlement workflow.
- Keep the fallback scoped to Adaptive Pricing Checkout Session intents so non-AP lookalike events remain untouched.

## Changes
- Generalizes the Adaptive Pricing Checkout Session order fallback from failed intents to failed, succeeded, and capturable PaymentIntent events.
- Uses `payment_details.order_reference` as the direct Checkout Session link when Stripe includes it, falling back to the existing PaymentIntent session lookup.
- Requeues the recovered PaymentIntent webhook if the target order is currently locked, so the intent ID is not lost before deferred settlement can run.
- Adds webhook-handler PHPUnit coverage for AP success, AP capturable, AP failure, standard checkout, unmarked intents, stale session references, and locked-order retry handling.
- Enables legacy Woo Subscriptions product types during E2E setup so the existing subscription fixtures remain compatible with Woo Subscriptions 9.0.0.
- Adds a changelog/readme entry for the recovery fix.

Screenshots:
<img width="2820" height="1482" alt="image" src="https://github.com/user-attachments/assets/a6c84771-58fc-48d7-b834-5fb944547683" />
<img width="3484" height="1366" alt="image" src="https://github.com/user-attachments/assets/365caa34-38b2-411e-928d-8db67be21859" />


## Definition of Done
- Adaptive Pricing checkout orders can recover when `payment_intent.succeeded` or `payment_intent.amount_capturable_updated` arrives but the matching Checkout Session success webhook is missing or delayed.
- The recovered WooCommerce order records the Stripe PaymentIntent ID and continues through the existing deferred settlement workflow.
- Failed Adaptive Pricing intents continue to use the Checkout Session fallback behavior.
- Non-Adaptive-Pricing PaymentIntent events, including Checkout Session-looking references, do not recover or alter unrelated pending orders.
- Locked orders retry instead of dropping the PaymentIntent recovery path.
- Stripe E2E subscription tests can create their subscription fixtures with the latest Woo Subscriptions setup.

## Backwards Compatibility
No public API changes. No hooks, filters, classes, or files were renamed or removed. The changed helper is private and keeps a default value for the new optional parameter.

## Validation
- `php -l includes/class-wc-stripe-webhook-handler.php`
- `php -l tests/phpunit/class-wc-stripe-webhook-handler-test.php`
- `/Users/rakshitwesley/Desktop/claude/may12/woocommerce-gateway-stripe/vendor/bin/phpcs --standard=phpcs.xml.dist -n includes/class-wc-stripe-webhook-handler.php tests/phpunit/class-wc-stripe-webhook-handler-test.php`
- `npm run phpstan` / `composer phpstan` equivalent through the repo container — OK
- `npm run test:php -- --filter='WC_Stripe_Webhook_Handler_Test::test_process_adaptive_pricing_payment_intent_order_reference_fallback|WC_Stripe_Webhook_Handler_Test::test_process_payment_intent_checkout_session_fallback|WC_Stripe_Webhook_Handler_Test::test_process_payment_intent_checkout_session_fallback_retries_when_order_is_locked|WC_Stripe_Webhook_Handler_Test::test_process_deferred_webhook_retries_payment_intent_processing'` — OK, 11 tests / 46 assertions
- `docker compose exec -u www-data -e XDEBUG_MODE=coverage wordpress /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/vendor/bin/phpunit --configuration /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/phpunit.xml.dist --filter=WC_Stripe_Webhook_Handler_Test` — OK, 91 tests / 260 assertions
- `bash -n tests/e2e/bin/setup.sh`
- `node --check tests/e2e/config/global-setup.js`
- `node --check tests/e2e/utils/playwright-setup.js`
- `git diff --check`
- Targeted JS ESLint was not available locally because this checkout does not have a local `node_modules/.bin/eslint`; CI will run the project linter.
- Veloria: skipped — no hooks or public API modified.
- QIT: not configured locally; CI/QIT can run on the PR.

## Test Plan
- Enable Optimized Checkout Suite and Adaptive Pricing.
- Complete an Adaptive Pricing checkout where `payment_intent.succeeded` arrives but the matching Checkout Session success webhook is missing or delayed.
- Confirm the WooCommerce order records the PaymentIntent and proceeds through the existing deferred settlement workflow.
- Confirm non-Adaptive-Pricing PaymentIntent events with a Checkout Session-looking reference do not recover or alter unrelated pending orders.

STRIPE-1242
