### PR TITLE
Make Blocks checkout resilient to deferred render-blocking JS (SiteGround Speed Optimizer)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 xxxx-xx-xx - version 10.9.0
 * Fix - Render classic-checkout card fields when a host optimizer defers render-blocking JavaScript (e.g. SiteGround Speed Optimizer) by waiting for required WordPress/WooCommerce globals before initializing the Stripe bundle
+* Fix - Render the Blocks checkout when a host optimizer defers render-blocking JavaScript (e.g. SiteGround Speed Optimizer) by waiting for required WordPress/WooCommerce globals before initializing the Stripe Blocks bundle
 * Fix - Use the Amazon Pay custom button size setting on the product, cart, and checkout pages instead of falling back to the Apple Pay/Google Pay size
 * Tweak - Render the Express Checkout button on the cart and checkout from page-bootstrapped data, removing a cart-details request from the critical path to first button render
 * Fix - Scope admin gateway filter to block cart and checkout editors only

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@
 
 xxxx-xx-xx - version 10.9.0
 * Fix - Render classic-checkout card fields when a host optimizer defers render-blocking JavaScript (e.g. SiteGround Speed Optimizer) by waiting for required WordPress/WooCommerce globals before initializing the Stripe bundle
-* Fix - Render the Blocks checkout when a host optimizer defers render-blocking JavaScript (e.g. SiteGround Speed Optimizer) by waiting for required WordPress/WooCommerce globals before initializing the Stripe Blocks bundle
+* Fix - Render the Blocks checkout when a host optimizer defers render-blocking JavaScript (e.g. SiteGround Speed Optimizer)
 * Fix - Use the Amazon Pay custom button size setting on the product, cart, and checkout pages instead of falling back to the Apple Pay/Google Pay size
 * Tweak - Render the Express Checkout button on the cart and checkout from page-bootstrapped data, removing a cart-details request from the critical path to first button render
 * Fix - Scope admin gateway filter to block cart and checkout editors only

--- a/client/blocks/upe/__tests__/index.test.js
+++ b/client/blocks/upe/__tests__/index.test.js
@@ -1,0 +1,117 @@
+/**
+ * Tests for the Blocks-checkout UPE bootstrap.
+ *
+ * The bootstrap exists so a host "defer render-blocking JS" optimizer can't make
+ * our bundle evaluate (and register payment methods) before
+ * window.wp.data / window.wp.i18n / window.wc.wcSettings / window.wc.wcBlocksRegistry
+ * exist — which throws and breaks the whole Checkout Block. It must wait for those
+ * globals before loading the real init chunk. See STRIPE-1236.
+ */
+
+// Mock the real init module so importing the bootstrap doesn't pull the whole
+// Blocks graph; count how many times it's loaded.
+jest.mock(
+	'../init',
+	() => {
+		global.__upeBlocksInitLoadCount =
+			( global.__upeBlocksInitLoadCount || 0 ) + 1;
+		return {};
+	},
+	{ virtual: true }
+);
+
+const setDependenciesReady = () => {
+	window.wp = { data: {}, i18n: {} };
+	window.wc = { wcSettings: {}, wcBlocksRegistry: {} };
+};
+
+const clearDependencies = () => {
+	delete window.wp;
+	delete window.wc;
+};
+
+const flushPromises = () => new Promise( ( resolve ) => resolve() );
+
+describe( 'Blocks UPE bootstrap', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		global.__upeBlocksInitLoadCount = 0;
+		clearDependencies();
+	} );
+
+	afterEach( () => {
+		clearDependencies();
+		jest.useRealTimers();
+		jest.resetModules();
+	} );
+
+	it( 'loads init immediately when dependencies are already present', async () => {
+		setDependenciesReady();
+
+		await jest.isolateModulesAsync( async () => {
+			require( '../index' );
+			await flushPromises();
+		} );
+
+		expect( global.__upeBlocksInitLoadCount ).toBe( 1 );
+	} );
+
+	it( 'does not load init until the dependencies appear', async () => {
+		await jest.isolateModulesAsync( async () => {
+			require( '../index' );
+			await flushPromises();
+			expect( global.__upeBlocksInitLoadCount ).toBe( 0 );
+
+			setDependenciesReady();
+			jest.advanceTimersByTime( 50 );
+			await flushPromises();
+
+			expect( global.__upeBlocksInitLoadCount ).toBe( 1 );
+		} );
+	} );
+
+	it( 'stays gated until the Blocks registry is also present', async () => {
+		await jest.isolateModulesAsync( async () => {
+			require( '../index' );
+			await flushPromises();
+
+			// Everything but wcBlocksRegistry — registration would throw, so stay gated.
+			window.wp = { data: {}, i18n: {} };
+			window.wc = { wcSettings: {} };
+			jest.advanceTimersByTime( 50 );
+			await flushPromises();
+			expect( global.__upeBlocksInitLoadCount ).toBe( 0 );
+
+			window.wc.wcBlocksRegistry = {};
+			jest.advanceTimersByTime( 50 );
+			await flushPromises();
+			expect( global.__upeBlocksInitLoadCount ).toBe( 1 );
+		} );
+	} );
+
+	it( 'gives up waiting and loads init after the timeout', async () => {
+		await jest.isolateModulesAsync( async () => {
+			require( '../index' );
+			await flushPromises();
+			expect( global.__upeBlocksInitLoadCount ).toBe( 0 );
+
+			jest.advanceTimersByTime( 10000 );
+			await flushPromises();
+
+			expect( global.__upeBlocksInitLoadCount ).toBe( 1 );
+		} );
+	} );
+
+	it( 'loads init only once after readiness', async () => {
+		setDependenciesReady();
+
+		await jest.isolateModulesAsync( async () => {
+			require( '../index' );
+			await flushPromises();
+			jest.advanceTimersByTime( 500 );
+			await flushPromises();
+		} );
+
+		expect( global.__upeBlocksInitLoadCount ).toBe( 1 );
+	} );
+} );

--- a/client/blocks/upe/__tests__/index.test.js
+++ b/client/blocks/upe/__tests__/index.test.js
@@ -1,15 +1,7 @@
-/**
- * Tests for the Blocks-checkout UPE bootstrap.
- *
- * The bootstrap exists so a host "defer render-blocking JS" optimizer can't make
- * our bundle evaluate (and register payment methods) before
- * window.wp.data / window.wp.i18n / window.wc.wcSettings / window.wc.wcBlocksRegistry
- * exist — which throws and breaks the whole Checkout Block. It must wait for those
- * globals before loading the real init chunk. See STRIPE-1236.
- */
+// The bootstrap must wait for the WP/WC globals before loading the real init
+// chunk, so a defer-all optimizer can't make it throw. See STRIPE-1236.
 
-// Mock the real init module so importing the bootstrap doesn't pull the whole
-// Blocks graph; count how many times it's loaded.
+// Mock init so importing the bootstrap doesn't pull the Blocks graph; count loads.
 jest.mock(
 	'../init',
 	() => {

--- a/client/blocks/upe/index.js
+++ b/client/blocks/upe/index.js
@@ -1,37 +1,18 @@
 /* global wc_stripe_upe_blocks_params */
 /*
- * Bootstrap for the Blocks-checkout Stripe (UPE) bundle.
- *
- * The real entry (./init and its dependency graph) statically imports the
- * WooCommerce Blocks registry, WooCommerce settings, WordPress data, and i18n
- * packages, which webpack externalizes to window.wc.wcBlocksRegistry /
- * window.wc.wcSettings / window.wp.data / window.wp.i18n. It also reads the
- * localized config and calls registerPaymentMethod/registerExpressPaymentMethod
- * at module evaluation time. Those globals are populated by the scripts
- * WordPress runs first via our declared dependencies.
- *
- * Some host "defer all render-blocking JS" optimizers (e.g. SiteGround Speed
- * Optimizer) relocate and defer our bundle without preserving that dependency
- * order. The module graph then evaluates before those globals exist, the first
- * externalized read throws, and the throw aborts the integration script — which
- * breaks the whole Checkout Block, not just our payment method. Gate the real
- * init behind a readiness check and load it as a separate async chunk, so the
- * externals are only resolved (and the methods only registered) once those
- * globals are present.
- *
- * This file intentionally imports nothing that resolves a WordPress/WooCommerce
- * external, so it can never throw at load. The SCSS imports only produce the
- * entry stylesheet and carry no JS dependency.
+ * Bootstrap for the Blocks-checkout Stripe bundle. The real entry (./init)
+ * statically imports WP/WC externals and registers payment methods at load. A
+ * host "defer all render-blocking JS" optimizer (e.g. SiteGround Speed Optimizer)
+ * can run our bundle before those globals exist, throwing and breaking the whole
+ * Checkout Block. So wait for the globals, then load init as an async chunk.
+ * This file imports nothing resolving a WP/WC external, so it can't throw at load.
  */
 import './styles.scss';
 import '../express-checkout/styles.scss';
 
-// Pin the async-chunk base URL to the plugin's build directory. Under a JS
-// optimizer our entry script can be served from a rewritten path (e.g.
-// .../siteground-optimizer-assets/), and webpack's default "auto" publicPath
-// would resolve the init chunk against that path, where it does not exist. The
-// value is localized inline on its own tiny global (not via wcSettings, which
-// is itself deferred), so it is available before the bundle executes.
+// Pin the async chunk's base URL to the plugin build dir: under an optimizer our
+// entry can be served from a rewritten path where the chunk doesn't exist. The
+// value rides a tiny dedicated global (not wcSettings, which is itself deferred).
 // eslint-disable-next-line camelcase
 const bootstrapParams =
 	// eslint-disable-next-line camelcase
@@ -39,8 +20,7 @@ const bootstrapParams =
 		? wc_stripe_upe_blocks_params // eslint-disable-line camelcase
 		: null;
 
-// `typeof` guards the webpack-only magic identifier so this is a no-op outside
-// a webpack bundle (e.g. unit tests), where assigning it would throw.
+// `typeof` guards the webpack-only magic identifier so this is a no-op in tests.
 // eslint-disable-next-line no-undef, camelcase
 const hasWebpackPublicPath = typeof __webpack_public_path__ !== 'undefined';
 if (
@@ -52,9 +32,8 @@ if (
 	__webpack_public_path__ = bootstrapParams.pluginBuildUrl;
 }
 
-// Give up waiting after this long and load anyway, so a genuinely missing
-// dependency fails the same way it would without this gate rather than
-// silently never initializing.
+// Load anyway after the timeout so a genuinely missing dependency fails as it
+// would without this gate rather than silently never initializing.
 const READY_TIMEOUT_MS = 10000;
 const READY_POLL_MS = 50;
 

--- a/client/blocks/upe/index.js
+++ b/client/blocks/upe/index.js
@@ -1,76 +1,84 @@
-import {
-	registerPaymentMethod,
-	registerExpressPaymentMethod,
-} from '@woocommerce/blocks-registry';
-import {
-	PAYMENT_METHOD_AFFIRM,
-	PAYMENT_METHOD_AMAZON_PAY,
-	PAYMENT_METHOD_KLARNA,
-	PAYMENT_METHOD_LINK,
-} from '../../stripe-utils/constants';
-import { updateTokenLabelsWhenLoaded } from './token-label-updater.js';
-import {
-	expressCheckoutElementAmazonPay,
-	expressCheckoutElementApplePay,
-	expressCheckoutElementGooglePay,
-	expressCheckoutElementStripeLink,
-} from 'wcstripe/blocks/express-checkout';
-import WCStripeAPI from 'wcstripe/api';
-import {
-	addOrderAttributionInputsIfNotExists,
-	getBlocksConfiguration,
-	populateOrderAttributionInputs,
-} from 'wcstripe/blocks/utils';
+/* global wc_stripe_upe_blocks_params */
+/*
+ * Bootstrap for the Blocks-checkout Stripe (UPE) bundle.
+ *
+ * The real entry (./init and its dependency graph) statically imports the
+ * WooCommerce Blocks registry, WooCommerce settings, WordPress data, and i18n
+ * packages, which webpack externalizes to window.wc.wcBlocksRegistry /
+ * window.wc.wcSettings / window.wp.data / window.wp.i18n. It also reads the
+ * localized config and calls registerPaymentMethod/registerExpressPaymentMethod
+ * at module evaluation time. Those globals are populated by the scripts
+ * WordPress runs first via our declared dependencies.
+ *
+ * Some host "defer all render-blocking JS" optimizers (e.g. SiteGround Speed
+ * Optimizer) relocate and defer our bundle without preserving that dependency
+ * order. The module graph then evaluates before those globals exist, the first
+ * externalized read throws, and the throw aborts the integration script — which
+ * breaks the whole Checkout Block, not just our payment method. Gate the real
+ * init behind a readiness check and load it as a separate async chunk, so the
+ * externals are only resolved (and the methods only registered) once those
+ * globals are present.
+ *
+ * This file intentionally imports nothing that resolves a WordPress/WooCommerce
+ * external, so it can never throw at load. The SCSS imports only produce the
+ * entry stylesheet and carry no JS dependency.
+ */
 import './styles.scss';
-import 'wcstripe/blocks/express-checkout/styles.scss';
-import { upeElement } from 'wcstripe/blocks/upe/upe-element';
+import '../express-checkout/styles.scss';
 
-const api = new WCStripeAPI(
-	getBlocksConfiguration(),
-	// A promise-based interface to jQuery.post.
-	( url, args ) => {
-		return new Promise( ( resolve, reject ) => {
-			jQuery.post( url, args ).then( resolve ).fail( reject );
-		} );
-	}
-);
+// Pin the async-chunk base URL to the plugin's build directory. Under a JS
+// optimizer our entry script can be served from a rewritten path (e.g.
+// .../siteground-optimizer-assets/), and webpack's default "auto" publicPath
+// would resolve the init chunk against that path, where it does not exist. The
+// value is localized inline on its own tiny global (not via wcSettings, which
+// is itself deferred), so it is available before the bundle executes.
+// eslint-disable-next-line camelcase
+const bootstrapParams =
+	// eslint-disable-next-line camelcase
+	typeof wc_stripe_upe_blocks_params !== 'undefined'
+		? wc_stripe_upe_blocks_params // eslint-disable-line camelcase
+		: null;
 
-const paymentMethodsConfig =
-	getBlocksConfiguration()?.paymentMethodsConfig ?? {};
-
-const methodsToFilter = [ PAYMENT_METHOD_AMAZON_PAY, PAYMENT_METHOD_LINK ];
-
-// Filter out some BNPLs when other official extensions are present.
-if ( getBlocksConfiguration()?.hasAffirmGatewayPlugin ) {
-	methodsToFilter.push( PAYMENT_METHOD_AFFIRM );
-}
-if ( getBlocksConfiguration()?.hasKlarnaGatewayPlugin ) {
-	methodsToFilter.push( PAYMENT_METHOD_KLARNA );
-}
-
-Object.entries( paymentMethodsConfig )
-	.filter( ( [ method ] ) => ! methodsToFilter.includes( method ) )
-	.forEach( ( [ method, config ] ) => {
-		registerPaymentMethod( upeElement( method, api, config ) );
-	} );
-
-// Register Express Checkout Elements.
-if ( getBlocksConfiguration()?.isAmazonPayEnabled ) {
-	registerExpressPaymentMethod( expressCheckoutElementAmazonPay( api ) );
-}
-if ( getBlocksConfiguration()?.isExpressCheckoutEnabled ) {
-	registerExpressPaymentMethod( expressCheckoutElementApplePay( api ) );
-	registerExpressPaymentMethod( expressCheckoutElementGooglePay( api ) );
-}
-if ( getBlocksConfiguration()?.isLinkEnabled ) {
-	registerExpressPaymentMethod( expressCheckoutElementStripeLink( api ) );
+// `typeof` guards the webpack-only magic identifier so this is a no-op outside
+// a webpack bundle (e.g. unit tests), where assigning it would throw.
+// eslint-disable-next-line no-undef, camelcase
+const hasWebpackPublicPath = typeof __webpack_public_path__ !== 'undefined';
+if (
+	hasWebpackPublicPath &&
+	bootstrapParams &&
+	bootstrapParams.pluginBuildUrl
+) {
+	// eslint-disable-next-line no-undef, camelcase
+	__webpack_public_path__ = bootstrapParams.pluginBuildUrl;
 }
 
-// Update token labels when the checkout form is loaded.
-updateTokenLabelsWhenLoaded();
+// Give up waiting after this long and load anyway, so a genuinely missing
+// dependency fails the same way it would without this gate rather than
+// silently never initializing.
+const READY_TIMEOUT_MS = 10000;
+const READY_POLL_MS = 50;
 
-// Add order attribution inputs to the page.
-addOrderAttributionInputsIfNotExists();
+const dependenciesReady = () =>
+	typeof window !== 'undefined' &&
+	!! ( window.wp && window.wp.data ) &&
+	!! ( window.wp && window.wp.i18n ) &&
+	!! ( window.wc && window.wc.wcSettings ) &&
+	!! ( window.wc && window.wc.wcBlocksRegistry );
 
-// Populate order attribution inputs with order tracking data.
-populateOrderAttributionInputs();
+const loadInit = () =>
+	import( /* webpackChunkName: "upe-blocks-init" */ './init' );
+
+if ( dependenciesReady() ) {
+	loadInit();
+} else {
+	const startedAt = Date.now();
+	const timer = setInterval( () => {
+		if (
+			dependenciesReady() ||
+			Date.now() - startedAt >= READY_TIMEOUT_MS
+		) {
+			clearInterval( timer );
+			loadInit();
+		}
+	}, READY_POLL_MS );
+}

--- a/client/blocks/upe/init.js
+++ b/client/blocks/upe/init.js
@@ -1,0 +1,76 @@
+import {
+	registerPaymentMethod,
+	registerExpressPaymentMethod,
+} from '@woocommerce/blocks-registry';
+import {
+	PAYMENT_METHOD_AFFIRM,
+	PAYMENT_METHOD_AMAZON_PAY,
+	PAYMENT_METHOD_KLARNA,
+	PAYMENT_METHOD_LINK,
+} from '../../stripe-utils/constants';
+import { updateTokenLabelsWhenLoaded } from './token-label-updater.js';
+import {
+	expressCheckoutElementAmazonPay,
+	expressCheckoutElementApplePay,
+	expressCheckoutElementGooglePay,
+	expressCheckoutElementStripeLink,
+} from 'wcstripe/blocks/express-checkout';
+import WCStripeAPI from 'wcstripe/api';
+import {
+	addOrderAttributionInputsIfNotExists,
+	getBlocksConfiguration,
+	populateOrderAttributionInputs,
+} from 'wcstripe/blocks/utils';
+// The entry stylesheets are imported by the bootstrap (./index.js) so they ship
+// in upe-blocks.css rather than in this async init chunk.
+import { upeElement } from 'wcstripe/blocks/upe/upe-element';
+
+const api = new WCStripeAPI(
+	getBlocksConfiguration(),
+	// A promise-based interface to jQuery.post.
+	( url, args ) => {
+		return new Promise( ( resolve, reject ) => {
+			jQuery.post( url, args ).then( resolve ).fail( reject );
+		} );
+	}
+);
+
+const paymentMethodsConfig =
+	getBlocksConfiguration()?.paymentMethodsConfig ?? {};
+
+const methodsToFilter = [ PAYMENT_METHOD_AMAZON_PAY, PAYMENT_METHOD_LINK ];
+
+// Filter out some BNPLs when other official extensions are present.
+if ( getBlocksConfiguration()?.hasAffirmGatewayPlugin ) {
+	methodsToFilter.push( PAYMENT_METHOD_AFFIRM );
+}
+if ( getBlocksConfiguration()?.hasKlarnaGatewayPlugin ) {
+	methodsToFilter.push( PAYMENT_METHOD_KLARNA );
+}
+
+Object.entries( paymentMethodsConfig )
+	.filter( ( [ method ] ) => ! methodsToFilter.includes( method ) )
+	.forEach( ( [ method, config ] ) => {
+		registerPaymentMethod( upeElement( method, api, config ) );
+	} );
+
+// Register Express Checkout Elements.
+if ( getBlocksConfiguration()?.isAmazonPayEnabled ) {
+	registerExpressPaymentMethod( expressCheckoutElementAmazonPay( api ) );
+}
+if ( getBlocksConfiguration()?.isExpressCheckoutEnabled ) {
+	registerExpressPaymentMethod( expressCheckoutElementApplePay( api ) );
+	registerExpressPaymentMethod( expressCheckoutElementGooglePay( api ) );
+}
+if ( getBlocksConfiguration()?.isLinkEnabled ) {
+	registerExpressPaymentMethod( expressCheckoutElementStripeLink( api ) );
+}
+
+// Update token labels when the checkout form is loaded.
+updateTokenLabelsWhenLoaded();
+
+// Add order attribution inputs to the page.
+addOrderAttributionInputsIfNotExists();
+
+// Populate order attribution inputs with order tracking data.
+populateOrderAttributionInputs();

--- a/client/blocks/upe/init.js
+++ b/client/blocks/upe/init.js
@@ -21,8 +21,7 @@ import {
 	getBlocksConfiguration,
 	populateOrderAttributionInputs,
 } from 'wcstripe/blocks/utils';
-// The entry stylesheets are imported by the bootstrap (./index.js) so they ship
-// in upe-blocks.css rather than in this async init chunk.
+// Stylesheets are imported by the bootstrap (./index.js), not this async chunk.
 import { upeElement } from 'wcstripe/blocks/upe/upe-element';
 
 const api = new WCStripeAPI(

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -145,11 +145,8 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 			'wc-stripe-blocks-integration',
 			'woocommerce-gateway-stripe'
 		);
-		// Base URL for the Blocks UPE bundle's async init chunk. The JS bootstrap
-		// pins webpack's publicPath to this so the chunk loads from the plugin even
-		// when a host optimizer serves the entry script from a rewritten path. Kept
-		// on a tiny dedicated global (not wcSettings, which is itself deferred) so it
-		// is available before the deferred bundle executes.
+		// Base URL the JS bootstrap pins webpack's publicPath to, so the async init
+		// chunk loads from the plugin even when an optimizer rewrites the entry path.
 		wp_localize_script(
 			'wc-stripe-blocks-integration',
 			'wc_stripe_upe_blocks_params',

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -145,6 +145,18 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 			'wc-stripe-blocks-integration',
 			'woocommerce-gateway-stripe'
 		);
+		// Base URL for the Blocks UPE bundle's async init chunk. The JS bootstrap
+		// pins webpack's publicPath to this so the chunk loads from the plugin even
+		// when a host optimizer serves the entry script from a rewritten path. Kept
+		// on a tiny dedicated global (not wcSettings, which is itself deferred) so it
+		// is available before the deferred bundle executes.
+		wp_localize_script(
+			'wc-stripe-blocks-integration',
+			'wc_stripe_upe_blocks_params',
+			[
+				'pluginBuildUrl' => trailingslashit( WC_STRIPE_PLUGIN_URL ) . 'build/',
+			]
+		);
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -157,7 +157,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 10.9.0 - xxxx-xx-xx =
 * Fix - Render classic-checkout card fields when a host optimizer defers render-blocking JavaScript (e.g. SiteGround Speed Optimizer) by waiting for required WordPress/WooCommerce globals before initializing the Stripe bundle
-* Fix - Render the Blocks checkout when a host optimizer defers render-blocking JavaScript (e.g. SiteGround Speed Optimizer) by waiting for required WordPress/WooCommerce globals before initializing the Stripe Blocks bundle
+* Fix - Render the Blocks checkout when a host optimizer defers render-blocking JavaScript (e.g. SiteGround Speed Optimizer)
 * Fix - Use the Amazon Pay custom button size setting on the product, cart, and checkout pages instead of falling back to the Apple Pay/Google Pay size
 * Tweak - Render the Express Checkout button on the cart and checkout from page-bootstrapped data, removing a cart-details request from the critical path to first button render
 * Fix - Scope admin gateway filter to block cart and checkout editors only

--- a/readme.txt
+++ b/readme.txt
@@ -157,6 +157,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 10.9.0 - xxxx-xx-xx =
 * Fix - Render classic-checkout card fields when a host optimizer defers render-blocking JavaScript (e.g. SiteGround Speed Optimizer) by waiting for required WordPress/WooCommerce globals before initializing the Stripe bundle
+* Fix - Render the Blocks checkout when a host optimizer defers render-blocking JavaScript (e.g. SiteGround Speed Optimizer) by waiting for required WordPress/WooCommerce globals before initializing the Stripe Blocks bundle
 * Fix - Use the Amazon Pay custom button size setting on the product, cart, and checkout pages instead of falling back to the Apple Pay/Google Pay size
 * Tweak - Render the Express Checkout button on the cart and checkout from page-bootstrapped data, removing a cart-details request from the critical path to first button render
 * Fix - Scope admin gateway filter to block cart and checkout editors only


### PR DESCRIPTION
Refs STRIPE-1236
Refs #5615

**Stacked on #5631** (the classic-checkout fix). Review/merge that first; this PR's diff shows only the Blocks-checkout changes.

## Changes proposed in this Pull Request:

#5631 made the **classic** checkout resilient to host "defer all render-blocking JS" optimizers (SiteGround Speed Optimizer). The reporting merchant verified that fix works for classic, but found the **Checkout Block** still fails to render under the same conditions (Defer Render-Blocking JS ON + Apple Pay/Google Pay ON).

Same root cause: the Blocks UPE bundle reads the localized config and calls `registerPaymentMethod` / `registerExpressPaymentMethod` at module-evaluation time, statically importing `@woocommerce/blocks-registry`, `@woocommerce/settings`, and `@wordpress/data`/`i18n` (externalized to `window.wc.wcBlocksRegistry` / `window.wc.wcSettings` / `window.wp.data` / `window.wp.i18n`). When the optimizer reorders our bundle ahead of those globals, the first externalized read throws — and because the throw aborts the integration script, the **entire Checkout Block** fails to render, not just our payment method.

**Fix** (mirrors #5631): split the entry into a dependency-free **bootstrap** (`client/blocks/upe/index.js`) that waits for `window.wp.data` / `window.wp.i18n` / `window.wc.wcSettings` / `window.wc.wcBlocksRegistry`, then loads the former entry (now `client/blocks/upe/init.js`) as an async chunk so the externals resolve and the methods register only once those globals exist. The bootstrap imports nothing that resolves a WP/WC external, so it can't throw at load. `publicPath` is pinned to the plugin build dir via a tiny dedicated localized global (`wc_stripe_upe_blocks_params.pluginBuildUrl`) — not `wcSettings`, which is itself deferred — so the async chunk loads from the plugin even when the optimizer serves the entry from a rewritten path.

**How this can break / guards:** the bootstrap's external module *definitions* are lazy (only executed when the async chunk requires them, after the readiness check), confirmed against the build output — identical to the proven classic bootstrap. A 10s fallback loads init anyway so a genuine misconfiguration fails as it would today. Covered by Jest for the gating; the entry/async split is verified in the build (`upe-blocks.js` ~16 KB bootstrap, heavy graph in `upe-blocks-init.js`, `upe-blocks.css` preserved).

## Why draft

The triggering condition is a third-party host optimizer that can't be reproduced in CI, and Blocks payment-method **registration timing** under defer-all can only be confirmed in a real environment. A combined test build (classic + Blocks) is being shared with the merchant for verification. One known limitation: the merchant's console also showed the optimizer breaking WordPress's own `wp-data` script — that part isn't fixable from our plugin, so we can only shield our bundle.

## Testing instructions

Regression (no optimizer) — must be unchanged:
1. Blocks checkout: card fields render and a card payment completes, with Apple Pay/Google Pay enabled and disabled.
2. Classic checkout unaffected (covered by #5631).

The actual fix (needs a SiteGround Speed Optimizer env, or equivalent "defer all JS"):
3. Enable "Defer Render-Blocking JS" + Apple Pay/Google Pay, Blocks checkout, guest/incognito → the Checkout Block renders and card fields appear (previously the whole block was blank). Confirm no `window.wc`/`wcBlocksRegistry`/`wp.data` undefined errors abort our bundle.
4. Repeat with Pixel Manager for WooCommerce deactivated → still renders.

---

-   [x] Covered with tests (Jest for the bootstrap gating; manual verification noted above for the optimizer path)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

Fix - Render the Blocks checkout when a host optimizer defers render-blocking JavaScript (e.g. SiteGround Speed Optimizer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)