### PR TITLE
Make Express Checkout bootstrap test deterministic (remove CI flake)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -44,6 +44,7 @@ xxxx-xx-xx - version 10.9.0
 * Tweak - When enabling manual capture, clarify to agentic commerce merchants that Agentic Commerce purchases follow the capture setting in the Stripe agentic commerce dashboard
 * Dev - Centralize agentic commerce feed scheduling in integration class
 * Dev - Update subscription E2E fixtures to use WooCommerce Subscriptions product plans
+* Dev - Make the Express Checkout entrypoint bootstrap test deterministic to remove a CI flake
 
 2026-06-22 - version 10.8.3
 * Fix - Ensure Adaptive Pricing appears on the checkout page when enabled

--- a/client/entrypoints/express-checkout/__tests__/index.test.js
+++ b/client/entrypoints/express-checkout/__tests__/index.test.js
@@ -9,6 +9,18 @@
 
 const mockGetCartDetails = jest.fn();
 
+// Run jQuery's ready callback synchronously instead of on a `setTimeout` macrotask,
+// which raced the test's flush under CI load and bled into the next test. Other
+// jQuery calls delegate to the real library so `.on()`/`.trigger()` still work.
+jest.mock( 'jquery', () => {
+	const actualJQuery = jest.requireActual( 'jquery' );
+	const syncReadyJQuery = ( arg ) =>
+		typeof arg === 'function'
+			? arg( syncReadyJQuery )
+			: actualJQuery( arg );
+	return Object.assign( syncReadyJQuery, actualJQuery );
+} );
+
 // Stub the API so we can spy on the cart-details fetch without hitting the network.
 jest.mock( '../../../api', () =>
 	jest.fn().mockImplementation( () => ( {
@@ -42,11 +54,6 @@ jest.mock(
 	() => ( {} )
 );
 
-// jQuery resolves its ready Deferred on a macrotask when the document is already
-// loaded; give that chain a couple of timer turns to bind the entrypoint handlers.
-const flushReady = () =>
-	new Promise( ( resolve ) => setTimeout( resolve, 10 ) );
-
 const baseParams = () => ( {
 	has_block: false,
 	is_pay_for_order: false,
@@ -61,6 +68,7 @@ const baseParams = () => ( {
 // Load the entrypoint into the current module registry so the test and the
 // entrypoint share one jQuery instance (jQuery stores event handlers per copy,
 // so triggers must come from the same instance the entrypoint bound them on).
+// With the synchronous-ready mock above, requiring it runs the bootstrap inline.
 const loadEntrypoint = () => {
 	require( '../index.js' );
 };
@@ -86,7 +94,7 @@ describe( 'Express Checkout cart/checkout bootstrap', () => {
 		delete global.wc_stripe_express_checkout_params;
 	} );
 
-	it( 'renders from the localized snapshot and skips the cart-details fetch on first paint', async () => {
+	it( 'renders from the localized snapshot and skips the cart-details fetch on first paint', () => {
 		global.wc_stripe_express_checkout_params = {
 			...baseParams(),
 			cart: {
@@ -99,12 +107,11 @@ describe( 'Express Checkout cart/checkout bootstrap', () => {
 		};
 
 		loadEntrypoint();
-		await flushReady();
 
 		expect( mockGetCartDetails ).not.toHaveBeenCalled();
 	} );
 
-	it( 'falls back to the cart-details fetch on re-init once the snapshot is consumed', async () => {
+	it( 'falls back to the cart-details fetch on re-init once the snapshot is consumed', () => {
 		global.wc_stripe_express_checkout_params = {
 			...baseParams(),
 			cart: {
@@ -117,7 +124,6 @@ describe( 'Express Checkout cart/checkout bootstrap', () => {
 		};
 
 		loadEntrypoint();
-		await flushReady();
 		expect( mockGetCartDetails ).not.toHaveBeenCalled();
 
 		// A live cart mutation re-runs init(); the consume-once flag now routes it
@@ -128,14 +134,13 @@ describe( 'Express Checkout cart/checkout bootstrap', () => {
 		expect( mockGetCartDetails ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'fetches cart details on first paint when no snapshot is localized (develop parity)', async () => {
+	it( 'fetches cart details on first paint when no snapshot is localized (develop parity)', () => {
 		global.wc_stripe_express_checkout_params = {
 			...baseParams(),
 			cart: null,
 		};
 
 		loadEntrypoint();
-		await flushReady();
 
 		expect( mockGetCartDetails ).toHaveBeenCalledTimes( 1 );
 	} );

--- a/readme.txt
+++ b/readme.txt
@@ -199,5 +199,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - When enabling manual capture, clarify to agentic commerce merchants that Agentic Commerce purchases follow the capture setting in the Stripe agentic commerce dashboard
 * Dev - Centralize agentic commerce feed scheduling in integration class
 * Dev - Update subscription E2E fixtures to use WooCommerce Subscriptions product plans
+* Dev - Make the Express Checkout entrypoint bootstrap test deterministic to remove a CI flake
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:

The `client/entrypoints/express-checkout/__tests__/index.test.js` bootstrap tests are flaky on CI. The Express Checkout entrypoint runs its whole body inside a `jQuery( ( $ ) => { … } )` ready callback, which — when the document is already complete (as in jsdom) — resolves on a `window.setTimeout` **macrotask**. The test raced that with a fixed `setTimeout(resolve, 10)` (`flushReady`).

Under CI load that 10ms window slips, so a late ready callback from one test binds/runs during the **next** test and skews its `expressCheckoutGetCartDetails()` call count, e.g.:

```
● Express Checkout cart/checkout bootstrap › fetches cart details on first paint when no snapshot is localized
  Expected number of calls: 1
  Received number of calls: 2
```

It surfaces intermittently — typically when an unrelated PR shifts jest's file-to-worker scheduling — and does not reproduce locally under any worker count.

**Fix (test-only, no production change):** mock `jquery` so calling it with a function invokes the callback **synchronously** instead of deferring to a macrotask, while delegating every other `jQuery(...)` call to the real library (so `.on()`/`.trigger()` still operate on the instance the entrypoint bound on). The bootstrap now runs inline on `require`, the timer-based `flushReady` is removed, and the three cases are deterministic with no cross-test macrotask bleed.

### Related CI failures

Real CI runs that hit this flake, both on **unrelated PRs** (no Express Checkout changes), confirming the scheduling-induced cross-test bleed:

- [`add/express-checkout-placement-simulator` — 2026-06-25 15:41 UTC](https://github.com/woocommerce/woocommerce-gateway-stripe/actions/runs/28182160830/job/83475774721)
- [`fix/fix-failing-e2e-tests-with-subcriptions-9-0` — 2026-06-25 14:40 UTC](https://github.com/woocommerce/woocommerce-gateway-stripe/actions/runs/28178190365/job/83462447079)

Both show one bootstrap case inflated to `Received number of calls: 2` while the adjacent case drops to `0` — the late ready callback leaking across the test boundary.

## Testing instructions

This is a test-infrastructure change; verify the suite is green and stable:

1. `npm run test:js -- client/entrypoints/express-checkout/__tests__/index.test.js` — all 3 cases pass.
2. `npm run test:js` — full suite passes.
3. Optionally run the full suite a few times / with varied `--maxWorkers` to confirm the Express Checkout bootstrap cases no longer flake.

No runtime behavior changes; `client/entrypoints/express-checkout/index.js` is untouched.

---

- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

### Changelog entry

Dev - Make the Express Checkout entrypoint bootstrap test deterministic to remove a CI flake

🤖 Generated with [Claude Code](https://claude.com/claude-code)
