### PR TITLE
Improve Express Checkout settings button preview visibility

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -47,6 +47,7 @@ xxxx-xx-xx - version 10.9.0
 * Dev - Update subscription E2E fixtures to use WooCommerce Subscriptions product plans
 * Tweak - Cap the Agentic Commerce feed preview scan so it stays responsive on large catalogs instead of timing out
 * Dev - Make the Express Checkout entrypoint bootstrap test deterministic to remove a CI flake
+* Fix - Render the Express Checkout settings button preview background based on the button color
 
 2026-06-22 - version 10.8.3
 * Fix - Ensure Adaptive Pricing appears on the checkout page when enabled

--- a/client/settings/express-checkout-preview/__tests__/index.test.js
+++ b/client/settings/express-checkout-preview/__tests__/index.test.js
@@ -300,4 +300,24 @@ describe( 'ExpressCheckoutPreview', () => {
 		const wrapper = screen.getByTestId( 'stripe-elements' ).parentElement;
 		expect( wrapper ).toHaveStyle( { minHeight: '40px', width: '100%' } );
 	} );
+
+	it.each( [ [ 'dark' ], [ 'light' ], [ 'light-outline' ] ] )(
+		'tags the wrapper with the "%s" theme so the SCSS can pick a contrasting background',
+		( theme ) => {
+			render(
+				<ExpressCheckoutPreview { ...eceProps } theme={ theme } />
+			);
+
+			const wrapper =
+				screen.getByTestId( 'stripe-elements' ).parentElement;
+			expect( wrapper ).toHaveAttribute( 'data-theme', theme );
+		}
+	);
+
+	it( 'leaves the wrapper untagged when no theme is supplied (Amazon Pay / Link previews)', () => {
+		render( <ExpressCheckoutPreview { ...amazonProps } /> );
+
+		const wrapper = screen.getByTestId( 'stripe-elements' ).parentElement;
+		expect( wrapper ).not.toHaveAttribute( 'data-theme' );
+	} );
 } );

--- a/client/settings/express-checkout-preview/index.js
+++ b/client/settings/express-checkout-preview/index.js
@@ -8,6 +8,7 @@ import {
 	EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY,
 	EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY,
 } from 'wcstripe/stripe-utils/constants';
+import './style.scss';
 
 const buttonSizeToPxMap = {
 	small: 40,
@@ -125,6 +126,8 @@ const ExpressCheckoutPreview = ( {
 	if ( canRenderButtons ) {
 		return (
 			<div
+				className="wcstripe-express-checkout-preview"
+				data-theme={ theme || undefined }
 				key={
 					buttonType && theme
 						? `${ buttonType }-${ theme }`

--- a/client/settings/express-checkout-preview/style.scss
+++ b/client/settings/express-checkout-preview/style.scss
@@ -1,0 +1,18 @@
+@use '../../styles/abstracts/styles';
+
+.wcstripe-express-checkout-preview {
+	box-sizing: border-box;
+	border: none;
+	border-radius: 4px;
+	padding: 24px;
+
+	// The "light" theme renders white buttons, so the preview needs a dark
+	// surface for them to be visible against the white settings card.
+	&[data-theme='light'] {
+		background: styles.$gray-800;
+	}
+
+	&[data-theme='light-outline'] {
+		background: styles.$gray-100;
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -202,5 +202,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Update subscription E2E fixtures to use WooCommerce Subscriptions product plans
 * Tweak - Cap the Agentic Commerce feed preview scan so it stays responsive on large catalogs instead of timing out
 * Dev - Make the Express Checkout entrypoint bootstrap test deterministic to remove a CI flake
+* Fix - Render the Express Checkout settings button preview background based on the button color
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-1046

## Changes proposed in this Pull Request:


Express button preview was drawn on a plain white area. With the Light theme, the Apple Pay / Google Pay buttons are white, so they were hard to see against that white background.
This change gives the preview a background that adapts to the selected theme, so the buttons always stand out, and removes the surrounding border so the preview better matches how the buttons actually look at checkout.

This mirrors how the same preview already behaves in WooPayments. Only the admin preview is affected - there are no changes to the real checkout, and the Amazon Pay and Link previews are left as they were.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. Go to WooCommerce → Settings → Payments → Stripe → Express Checkout
2. Under Appearance → Theme, switch between **Dark**, **Light**, and **Outline**.
3. Confirm the preview has no border and the buttons stay clearly visible on every theme
   (Light buttons on a dark background, Outline on a light grey background, Dark on the plain card).
4. Open the Amazon Pay and Link settings pages and confirm their previews are unchanged.

<img width="760" height="474" alt="CleanShot 2026-06-29 at 12 15 36" src="https://github.com/user-attachments/assets/2561b155-c4a1-4a14-a4f7-d730e351491a" />

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Express Checkout settings preview so its background now reflects the selected button color/theme more accurately.
  * Fixed preview styling for light and light-outline variants, including cases where no theme is shown.
  
* **Tests**
  * Added coverage for theme-related preview behavior to ensure the correct theme attributes are applied consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->