### PR TITLE
Add backward-compatibility guardrails to AGENTS.md and CodeRabbit config

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -78,6 +78,15 @@ reviews:
         For webhooks, require signature verification and idempotent processing before mutating state.
         Never expose secrets or sensitive payment/customer data in logs, notes, metadata, or errors.
         Preserve backward compatibility for existing hooks/options and supported WordPress/WooCommerce versions.
+        Treat any change to a public or externally exposed class, interface, function, or method signature as high-risk
+        and ask the author to state the backwards-compatibility impact in the PR description. Flag adding a method to an
+        interface that external code can implement: this is backwards-incompatible because existing implementers fatal on
+        load. Suggest a non-breaking alternative (add the method to a concrete class, introduce a new interface, or
+        provide a default via an abstract base class). For renames or removals of existing public symbols, follow
+        deprecate-don't-rename: keep the original with an `@deprecated` notice pointing to the replacement. This plugin
+        also implements upstream WooCommerce interfaces (e.g. `Internal\ProductFeed\Feed\FeedInterface` in
+        `includes/agentic-commerce/`); flag changes to those implementations that could break compatibility with the
+        supported WooCommerce range.
         Request PHPUnit coverage when behavior changes.
     - path: "client/**/*.{js,jsx,ts,tsx}"
       instructions: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,16 @@ This repository supports:
 - WooCommerce: current and the previous two major versions (L, L-1, L-2).
 - WordPress: current and the previous major version (L, L-1) — transitively constrained by WC's [support policy](https://woocommerce.com/support-policy/).
 
+## Backward Compatibility
+
+This plugin has backward-compatibility obligations in **both directions**. State the BC impact of any risky change in the PR description.
+
+**As a producer of public API.** This plugin exposes a large public surface that extensions, themes, and other plugins consume: `do_action`/`apply_filters` hooks, public gateway and `WC_Stripe_UPE_Payment_Method` classes, REST routes, and `woocommerce_stripe_*` option keys. Any change to a public or externally exposed class, interface, function, or method signature is **high-risk**. Adding a required method to an interface external code can implement is backward-incompatible — existing implementers fatal on load. Prefer a non-breaking alternative: add the method to a concrete class, introduce a separate new interface, or provide a default via an abstract base class.
+
+**Deprecate, don't rename.** Never rename or remove an existing public symbol (class, interface, method, constant, hook, option key) in place. Mark the old one `@deprecated`, add the replacement alongside it, and keep both working through a deprecation window so consumers can migrate.
+
+**As a consumer of upstream WooCommerce contracts.** This plugin implements upstream WooCommerce interfaces — notably `Automattic\WooCommerce\Internal\ProductFeed\Feed\FeedInterface` (see `includes/agentic-commerce/`). The `Internal` namespace is **not** a stability guarantee: WooCommerce can change these contracts, and doing so is exactly what broke this plugin when WC 10.9.0 added a required `get_entry_count()` to `FeedInterface` and older Stripe versions fataled on load. When implementing an upstream interface, keep the implementation compatible with the supported WC range (L, L-1, L-2) and guard against upstream contract changes rather than assuming the interface is frozen. See `includes/agentic-commerce/AGENTS.md`.
+
 ## Documentation and Context Sources
 
 - Root project docs: `README.md`


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Adds backward-compatibility guardrails to this repo's agent/reviewer instructions, adapting the guardrails introduced upstream in `woocommerce/woocommerce` [#65985](https://github.com/woocommerce/woocommerce/pull/65985) and [#65986](https://github.com/woocommerce/woocommerce/pull/65986).

**Why:** WooCommerce 10.9.0 was reverted on WP Cloud after a required `get_entry_count(): int` method was added to `Internal\ProductFeed\Feed\FeedInterface`. This plugin implements that interface (`includes/agentic-commerce/`), so older versions fataled on load. The upstream PRs add producer-side guardrails to WooCommerce; this PR brings the equivalent guidance here, reframed for our surface.

- **`AGENTS.md`** — new `## Backward Compatibility` section covering both directions of our BC exposure:
  - *As a producer:* changes to public/exposed class/interface/function/method signatures are high-risk; adding a required method to an implementable interface is breaking; prefer non-breaking alternatives; deprecate-don't-rename.
  - *As a consumer:* we implement upstream WC `Internal` interfaces (`FeedInterface`) — the incident that actually bit us — so `Internal` is not a stability guarantee; keep implementations compatible with the supported WC range and guard against upstream contract changes.
- **`.coderabbit.yml`** — extends the existing catch-all `includes/**/*.php` path instructions with the same signature-change / interface-implementation checks.

The third upstream PR ([#65987](https://github.com/woocommerce/woocommerce/pull/65987)) edits WooCommerce's own `backwards-compatibility-review.yml` workflow. We don't have that workflow — our AI review uses the shared reusable `woocommerce/.github` workflow — so there's no in-repo equivalent to adopt.

Docs/CI-config only; no shipping code changed.

## Testing instructions

- Confirm `.coderabbit.yml` parses as valid YAML: `ruby -ryaml -e "YAML.load_file('.coderabbit.yml')"`.
- Read the new `## Backward Compatibility` section in `AGENTS.md` and confirm it renders correctly.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️) — documentation/CI-config only, no runtime behavior.
-   [x] Tested on mobile (or does not apply) — does not apply.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Agent/reviewer instruction files only (`AGENTS.md`, `.coderabbit.yml`); no shipping plugin code changed, so no changelog entry is required.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
