### PR TITLE
Fix checkout Payment Element not rendering on newer Stripe.js builds (Adaptive Pricing)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.9.0
+* Fix - Keep the checkout Payment Element visible on newer Stripe.js builds where Adaptive Pricing can't initialize, falling back to the standard element instead of rendering no payment form
 * Fix - Send the admin New Order and customer Processing emails when an asynchronous payment method (iDEAL, Klarna, Bancontact) is confirmed via the deferred webhook path
 * Fix - Use the Amazon Pay custom button size setting on the product, cart, and checkout pages instead of falling back to the Apple Pay/Google Pay size
 * Tweak - Render the Express Checkout button on the cart and checkout from page-bootstrapped data, removing a cart-details request from the critical path to first button render

--- a/client/blocks/checkout-sessions/__tests__/adaptive-pricing-initcheckout-fallback.test.js
+++ b/client/blocks/checkout-sessions/__tests__/adaptive-pricing-initcheckout-fallback.test.js
@@ -1,0 +1,128 @@
+/**
+ * Regression coverage for the OCS "Payment Element rendered" drop after 10.8.3.
+ *
+ * 10.8.3 (#5618) removed the Stripe.js capability guard that used to route
+ * Adaptive Pricing loads to standard Elements when Stripe.js no longer supported
+ * initCheckout(). On "dahlia+" Stripe.js, initCheckout() is a throwing stub.
+ *
+ * These tests exercise the REAL @stripe/react-stripe-js CheckoutProvider (the
+ * component the Blocks Adaptive Pricing path mounts) to demonstrate the asymmetry
+ * that makes the render drop Blocks-only:
+ *
+ *   - Blocks falls back to standard Elements only when checkoutState.type === 'error'
+ *     (see checkout-form.js). react-stripe-js sets that state ONLY from the async
+ *     loadActions() path — a SYNCHRONOUS initCheckout() throw never produces it, so
+ *     the Blocks fallback cannot fire and the Payment Element fails to render.
+ *   - The classic path wraps initCheckout() in try/catch and renders anyway; see
+ *     ../../../classic/upe/__tests__/payment-processing.test.js.
+ */
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import {
+	CheckoutProvider,
+	useCheckout,
+} from '@stripe/react-stripe-js/checkout';
+
+// A minimal object that passes react-stripe-js's isStripe() validation
+// (elements/createToken/createPaymentMethod/confirmCardPayment must be functions).
+const baseStripe = () => ( {
+	elements: jest.fn(),
+	createToken: jest.fn(),
+	createPaymentMethod: jest.fn(),
+	confirmCardPayment: jest.fn(),
+} );
+
+// dahlia+: initCheckout() is a throwing stub; the replacement method exists.
+const dahliaStripe = () => ( {
+	...baseStripe(),
+	initCheckout: jest.fn( () => {
+		throw new Error( 'stripe.initCheckout() has been removed' );
+	} ),
+	initCheckoutElementsSdk: jest.fn(),
+} );
+
+// A working-but-async-failing build: initCheckout() returns an SDK whose
+// loadActions() rejects. This is the ONLY shape that reaches checkoutState 'error'.
+const asyncFailingStripe = () => ( {
+	...baseStripe(),
+	initCheckout: jest.fn( () => ( {
+		loadActions: jest.fn( () =>
+			Promise.reject( new Error( 'loadActions failed' ) )
+		),
+	} ) ),
+} );
+
+class ErrorBoundary extends React.Component {
+	constructor( props ) {
+		super( props );
+		this.state = { caught: false };
+	}
+	static getDerivedStateFromError() {
+		return { caught: true };
+	}
+	componentDidCatch( error ) {
+		this.props.onCatch?.( error );
+	}
+	render() {
+		return this.state.caught ? null : this.props.children;
+	}
+}
+
+// Records every checkoutState.type the provider exposes across the render lifecycle,
+// mirroring how checkout-form.js reads useCheckout() to decide whether to fall back.
+const StateProbe = ( { seen } ) => {
+	const checkoutState = useCheckout();
+	seen.add( checkoutState?.type );
+	return null;
+};
+
+const renderProvider = ( stripe, seen, onCatch ) =>
+	render(
+		<ErrorBoundary onCatch={ onCatch }>
+			<CheckoutProvider
+				stripe={ stripe }
+				options={ { clientSecret: 'cs_test_123' } }
+			>
+				<StateProbe seen={ seen } />
+			</CheckoutProvider>
+		</ErrorBoundary>
+	);
+
+describe( 'Blocks Adaptive Pricing initCheckout fallback', () => {
+	let consoleErrorSpy;
+
+	beforeEach( () => {
+		// React logs caught render/effect errors; silence the expected noise.
+		consoleErrorSpy = jest
+			.spyOn( console, 'error' )
+			.mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		consoleErrorSpy.mockRestore();
+	} );
+
+	it( 'never reaches checkoutState "error" when initCheckout throws synchronously (dahlia+), so the Blocks fallback cannot fire', async () => {
+		const seen = new Set();
+		const onCatch = jest.fn();
+
+		renderProvider( dahliaStripe(), seen, onCatch );
+
+		// The synchronous throw surfaces as an uncaught error (error boundary),
+		// NOT as checkoutState.type === 'error'. checkout-form.js keys its
+		// standard-Elements fallback on 'error', so it can never run here.
+		await waitFor( () => expect( onCatch ).toHaveBeenCalled() );
+		expect( seen.has( 'error' ) ).toBe( false );
+	} );
+
+	it( 'does reach checkoutState "error" when the async loadActions path fails, which is the only case the Blocks fallback handles', async () => {
+		const seen = new Set();
+		const onCatch = jest.fn();
+
+		renderProvider( asyncFailingStripe(), seen, onCatch );
+
+		await waitFor( () => expect( seen.has( 'error' ) ).toBe( true ) );
+		// No synchronous throw in this path.
+		expect( onCatch ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/blocks/upe/upe-deferred-intent-creation/__tests__/payment-elements.test.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/__tests__/payment-elements.test.js
@@ -67,7 +67,14 @@ const buildApi = ( stripe ) => ( {
 	initSetupIntent: jest.fn(),
 } );
 
+// clover: working initCheckout, no replacement method.
 const STRIPE = { elements: jest.fn(), initCheckout: jest.fn() };
+// dahlia+: initCheckout() is a throwing stub and the replacement method exists.
+const DAHLIA_STRIPE = {
+	elements: jest.fn(),
+	initCheckout: jest.fn(),
+	initCheckoutElementsSdk: jest.fn(),
+};
 
 describe( 'PaymentElements adaptive pricing selection', () => {
 	afterEach( () => {
@@ -88,6 +95,25 @@ describe( 'PaymentElements adaptive pricing selection', () => {
 
 		expect( CheckoutContainer ).toHaveBeenCalled();
 		expect( PaymentProcessor ).not.toHaveBeenCalled();
+	} );
+
+	// Regression guard for the OCS render drop (#5618): on dahlia+ Stripe.js the
+	// CheckoutProvider's synchronous initCheckout() throw would leave the Payment
+	// Element unrendered, so Adaptive Pricing must fall back to standard Elements.
+	it( 'falls back to standard elements on dahlia+ even when Adaptive Pricing is enabled', () => {
+		getBlocksConfiguration.mockReturnValue( {
+			isAdaptivePricingEnabled: true,
+			paymentMethodsConfig: { card: { isReusable: false } },
+			cartTotal: 1000,
+			currency: 'USD',
+			shouldShowOptimizedCheckout: false,
+			isAdmin: false,
+		} );
+
+		renderFields( buildApi( DAHLIA_STRIPE ) );
+
+		expect( CheckoutContainer ).not.toHaveBeenCalled();
+		expect( PaymentProcessor ).toHaveBeenCalled();
 	} );
 
 	it( 'uses the standard elements flow when Adaptive Pricing is disabled', () => {

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
@@ -15,6 +15,7 @@ import {
 	getExcludedPaymentMethodTypes,
 } from 'wcstripe/stripe-utils';
 import { initializeUPEAppearance } from 'wcstripe/stripe-utils/upe-appearance';
+import { recordStripeJsCapability } from 'wcstripe/stripe-utils/stripe-js-capability';
 import {
 	getBlocksConfiguration,
 	shouldSetupOffSessionPayment,
@@ -210,8 +211,32 @@ const PaymentElements = ( {
 	...props
 } ) => {
 	const stripeServerData = getBlocksConfiguration();
+
+	// react-stripe-js's CheckoutProvider calls initCheckout() synchronously on mount.
+	// On "dahlia+" Stripe.js that is a throwing stub (detectable because the replacement
+	// initCheckoutElementsSdk exists), and the synchronous throw bypasses the standard-
+	// Elements fallback in checkout-form.js — leaving the Payment Element unrendered.
+	// Gate Adaptive Pricing on a working initCheckout so those loads fall back to
+	// standard Elements instead. Migration to initCheckoutElementsSdk is tracked in #5614.
+	const stripe = api.getStripe();
+	const stripeSupportsInitCheckout =
+		typeof stripe?.initCheckout === 'function' &&
+		typeof stripe?.initCheckoutElementsSdk !== 'function';
 	const isAdaptivePricingSupported =
-		stripeServerData?.isAdaptivePricingEnabled;
+		stripeServerData?.isAdaptivePricingEnabled &&
+		stripeSupportsInitCheckout;
+
+	// Measure which Stripe.js build actually loaded, so the Clover:Dahlia ratio and
+	// the (now-mitigated) render-risk population stay observable in production.
+	useEffect( () => {
+		recordStripeJsCapability( {
+			stripe,
+			surface: 'blocks',
+			serverData: stripeServerData,
+		} );
+		// Fire once on mount; the helper also dedupes per surface per page load.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 
 	const [ errorMessage, setErrorMessage ] = useState( null );
 	const [

--- a/client/classic/upe/__tests__/payment-processing.test.js
+++ b/client/classic/upe/__tests__/payment-processing.test.js
@@ -587,6 +587,47 @@ describe( 'payment-processing', () => {
 				expect( api._stripe.initCheckout ).not.toHaveBeenCalled();
 			} );
 
+			// Regression guard for the OCS render drop after 10.8.3 (#5618 removed the
+			// Stripe.js capability guard). On "dahlia+" Stripe.js initCheckout() is a
+			// throwing stub, detectable because the replacement initCheckoutElementsSdk
+			// exists. Skip the Checkout Session path entirely so no orphan session is
+			// created; standard Elements render instead.
+			it( 'skips Adaptive Pricing and renders standard elements on dahlia+ (initCheckoutElementsSdk present)', async () => {
+				const checkoutElements = createMockElements();
+				const api = createMockApi( checkoutElements );
+				api._stripe.initCheckoutElementsSdk = jest.fn();
+				const dom = document.createElement( 'div' );
+				dom.dataset.paymentMethodType = 'card';
+
+				await paymentProcessing.mountStripePaymentElement( api, dom );
+
+				expect( api._stripe.initCheckout ).not.toHaveBeenCalled();
+				expect(
+					api.checkoutSessionsCreateSession
+				).not.toHaveBeenCalled();
+				expect( api._stripe.elements ).toHaveBeenCalled();
+			} );
+
+			// Defense in depth: even for a build that passes the capability guard, a
+			// synchronous initCheckout() throw is caught so the Payment Element still
+			// renders via standard Elements. The Blocks path has no equivalent
+			// synchronous catch — see adaptive-pricing-initcheckout-fallback.test.js.
+			it( 'falls back to standard elements when initCheckout throws synchronously', async () => {
+				const checkoutElements = createMockElements();
+				const api = createMockApi( checkoutElements );
+				api._stripe.initCheckout = jest.fn( () => {
+					throw new Error( 'stripe.initCheckout() has been removed' );
+				} );
+				const dom = document.createElement( 'div' );
+				dom.dataset.paymentMethodType = 'card';
+
+				await paymentProcessing.mountStripePaymentElement( api, dom );
+
+				expect( api._stripe.initCheckout ).toHaveBeenCalled();
+				// The Payment Element still renders through the standard Elements fallback.
+				expect( api._stripe.elements ).toHaveBeenCalled();
+			} );
+
 			it( 'falls back to standard elements when client_secret or session_id is absent', async () => {
 				const checkoutElements = createMockElements();
 				const api = createMockApi( checkoutElements );

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -38,6 +38,7 @@ import {
 } from 'wcstripe/stripe-utils/constants';
 import { handleDisplayOfPaymentInstructions } from 'wcstripe/optimized-checkout/handle-display-of-payment-instructions';
 import { handleDisplayOfSavingCheckbox } from 'wcstripe/optimized-checkout/handle-display-of-saving-checkbox';
+import { recordStripeJsCapability } from 'wcstripe/stripe-utils/stripe-js-capability';
 
 /**
  * @typedef {Object} UPEComponent
@@ -336,12 +337,29 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 	}
 
 	const stripe = api.getStripe();
+
+	// Measure which Stripe.js build actually loaded (Clover vs the rare dahlia edge
+	// case) so the render-risk population is observable in production.
+	recordStripeJsCapability( {
+		stripe,
+		surface: 'classic',
+		serverData: stripeServerData,
+	} );
+
 	let elements;
 	let shouldLoadStripeElements = true;
+	// On "dahlia+" Stripe.js initCheckout() is a throwing stub (detectable because the
+	// replacement initCheckoutElementsSdk exists). Skip the Checkout Session path on those
+	// builds so we don't create an orphan session and throw; standard Elements still render.
+	// Migration to initCheckoutElementsSdk is tracked in #5614.
+	const stripeSupportsInitCheckout =
+		typeof stripe?.initCheckout === 'function' &&
+		typeof stripe?.initCheckoutElementsSdk !== 'function';
 	// If Adaptive Pricing is enabled, use the Checkout Session API to load the elements.
 	if (
 		stripeServerData?.isAdaptivePricingEnabled &&
-		supportsDeferredIntent
+		supportsDeferredIntent &&
+		stripeSupportsInitCheckout
 	) {
 		try {
 			const response = await api.checkoutSessionsCreateSession();

--- a/client/stripe-utils/__tests__/stripe-js-capability.test.js
+++ b/client/stripe-utils/__tests__/stripe-js-capability.test.js
@@ -1,0 +1,131 @@
+import { recordEvent } from 'wcstripe/tracking';
+import {
+	detectStripeJsBuild,
+	recordStripeJsCapability,
+	resetStripeJsCapabilityGuard,
+} from 'wcstripe/stripe-utils/stripe-js-capability';
+
+jest.mock( 'wcstripe/tracking', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+// isStripe()-shaped base so the probe classifies from the checkout capabilities only.
+const cloverStripe = () => ( {
+	initCheckout: jest.fn(),
+} );
+const dahliaStripe = () => ( {
+	initCheckout: jest.fn( () => {
+		throw new Error( 'stripe.initCheckout() has been removed' );
+	} ),
+	initCheckoutElementsSdk: jest.fn(),
+} );
+const legacyStripe = () => ( {} );
+
+describe( 'detectStripeJsBuild', () => {
+	it.each( [
+		[ 'clover', cloverStripe(), false ],
+		[ 'dahlia', dahliaStripe(), true ],
+		[ 'legacy', legacyStripe(), false ],
+	] )( 'classifies %s builds', ( expectedBuild, stripe, expectsSdk ) => {
+		const result = detectStripeJsBuild( stripe );
+		expect( result.build ).toBe( expectedBuild );
+		expect( result.hasInitCheckoutElementsSdk ).toBe( expectsSdk );
+	} );
+
+	it( 'never invokes the (throwing) initCheckout stub while probing', () => {
+		const stripe = dahliaStripe();
+		detectStripeJsBuild( stripe );
+		expect( stripe.initCheckout ).not.toHaveBeenCalled();
+	} );
+
+	it( 'returns unknown when there is no Stripe instance', () => {
+		expect( detectStripeJsBuild( null ).build ).toBe( 'unknown' );
+	} );
+} );
+
+describe( 'recordStripeJsCapability', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		resetStripeJsCapabilityGuard();
+	} );
+
+	it( 'flags predicted_render_risk for a dahlia + Adaptive Pricing Blocks load', () => {
+		recordStripeJsCapability( {
+			stripe: dahliaStripe(),
+			surface: 'blocks',
+			serverData: {
+				isAdaptivePricingEnabled: true,
+				shouldShowOptimizedCheckout: true,
+			},
+		} );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'wcstripe_stripe_js_capability',
+			expect.objectContaining( {
+				checkout_surface: 'blocks',
+				stripe_js_build: 'dahlia',
+				adaptive_pricing_enabled: 'yes',
+				predicted_render_risk: 'yes',
+			} )
+		);
+	} );
+
+	it( 'does not flag render risk for classic, since classic falls back on the throw', () => {
+		recordStripeJsCapability( {
+			stripe: dahliaStripe(),
+			surface: 'classic',
+			serverData: { isAdaptivePricingEnabled: true },
+		} );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'wcstripe_stripe_js_capability',
+			expect.objectContaining( {
+				checkout_surface: 'classic',
+				stripe_js_build: 'dahlia',
+				predicted_render_risk: 'no',
+			} )
+		);
+	} );
+
+	it( 'does not flag render risk on the pinned clover build', () => {
+		recordStripeJsCapability( {
+			stripe: cloverStripe(),
+			surface: 'blocks',
+			serverData: { isAdaptivePricingEnabled: true },
+		} );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'wcstripe_stripe_js_capability',
+			expect.objectContaining( {
+				stripe_js_build: 'clover',
+				predicted_render_risk: 'no',
+			} )
+		);
+	} );
+
+	it( 'records at most one event per surface per page load', () => {
+		const args = {
+			stripe: cloverStripe(),
+			surface: 'blocks',
+			serverData: {},
+		};
+		recordStripeJsCapability( args );
+		recordStripeJsCapability( args );
+
+		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'never throws, even if recordEvent blows up', () => {
+		recordEvent.mockImplementationOnce( () => {
+			throw new Error( 'tracks unavailable' );
+		} );
+
+		expect( () =>
+			recordStripeJsCapability( {
+				stripe: cloverStripe(),
+				surface: 'classic',
+				serverData: {},
+			} )
+		).not.toThrow();
+	} );
+} );

--- a/client/stripe-utils/stripe-js-capability.js
+++ b/client/stripe-utils/stripe-js-capability.js
@@ -1,0 +1,97 @@
+import { recordEvent } from 'wcstripe/tracking';
+
+// Fire at most one capability event per surface per page load, so a checkout with
+// several element mounts doesn't inflate the counts.
+const recordedSurfaces = {};
+
+/**
+ * Classifies the loaded Stripe.js build from capability presence alone.
+ *
+ * We must NOT call initCheckout() to probe: on "dahlia+" builds it is a throwing
+ * stub. The presence of initCheckoutElementsSdk is the reliable dahlia marker.
+ *
+ * - dahlia: initCheckoutElementsSdk present (initCheckout is a throwing stub).
+ * - clover: initCheckout present, initCheckoutElementsSdk absent (works normally).
+ * - legacy: initCheckout absent (older build).
+ * - unknown: no Stripe instance.
+ *
+ * @param {Object} stripe Resolved Stripe.js instance (from api.getStripe()).
+ * @return {{build: string, hasInitCheckout: boolean, hasInitCheckoutElementsSdk: boolean}} Capability summary.
+ */
+export function detectStripeJsBuild( stripe ) {
+	const hasInitCheckout = typeof stripe?.initCheckout === 'function';
+	const hasInitCheckoutElementsSdk =
+		typeof stripe?.initCheckoutElementsSdk === 'function';
+
+	let build = 'unknown';
+	if ( hasInitCheckoutElementsSdk ) {
+		build = 'dahlia';
+	} else if ( hasInitCheckout ) {
+		build = 'clover';
+	} else if ( stripe ) {
+		build = 'legacy';
+	}
+
+	return { build, hasInitCheckout, hasInitCheckoutElementsSdk };
+}
+
+/**
+ * Records which Stripe.js build actually loaded at Payment Element mount, so the
+ * Clover:Dahlia ratio and the render-risk population can be measured in production.
+ *
+ * The pinned channel is Clover, where the 10.8.3 guard removal (#5618) is inert.
+ * On the rare dahlia load with Adaptive Pricing enabled, the Blocks Payment Element
+ * fails to render (a synchronous initCheckout() throw bypasses the fallback); classic
+ * still renders via its try/catch. predicted_render_risk flags that at-risk combination.
+ *
+ * Best-effort and non-throwing: telemetry must never affect checkout.
+ *
+ * @param {Object}  options
+ * @param {Object}  options.stripe     Resolved Stripe.js instance.
+ * @param {string}  options.surface    'classic' | 'blocks'.
+ * @param {Object=} options.serverData Frontend config (isAdaptivePricingEnabled, shouldShowOptimizedCheckout).
+ */
+export function recordStripeJsCapability( { stripe, surface, serverData } ) {
+	try {
+		if ( recordedSurfaces[ surface ] ) {
+			return;
+		}
+		recordedSurfaces[ surface ] = true;
+
+		const { build, hasInitCheckout, hasInitCheckoutElementsSdk } =
+			detectStripeJsBuild( stripe );
+
+		const adaptivePricingEnabled = Boolean(
+			serverData?.isAdaptivePricingEnabled
+		);
+		const renderRisk =
+			surface === 'blocks' &&
+			adaptivePricingEnabled &&
+			build === 'dahlia';
+
+		recordEvent( 'wcstripe_stripe_js_capability', {
+			checkout_surface: surface,
+			stripe_js_build: build,
+			has_init_checkout: hasInitCheckout ? 'yes' : 'no',
+			has_init_checkout_elements_sdk: hasInitCheckoutElementsSdk
+				? 'yes'
+				: 'no',
+			adaptive_pricing_enabled: adaptivePricingEnabled ? 'yes' : 'no',
+			optimized_checkout: serverData?.shouldShowOptimizedCheckout
+				? 'yes'
+				: 'no',
+			predicted_render_risk: renderRisk ? 'yes' : 'no',
+		} );
+	} catch ( e ) {
+		// Never let telemetry affect checkout.
+	}
+}
+
+/**
+ * Test-only: clears the per-surface guard so each test starts fresh.
+ */
+export function resetStripeJsCapabilityGuard() {
+	Object.keys( recordedSurfaces ).forEach(
+		( key ) => delete recordedSurfaces[ key ]
+	);
+}

--- a/readme.txt
+++ b/readme.txt
@@ -156,6 +156,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.9.0 - xxxx-xx-xx =
+* Fix - Keep the checkout Payment Element visible on newer Stripe.js builds where Adaptive Pricing can't initialize, falling back to the standard element instead of rendering no payment form
 * Fix - Send the admin New Order and customer Processing emails when an asynchronous payment method (iDEAL, Klarna, Bancontact) is confirmed via the deferred webhook path
 * Fix - Use the Amazon Pay custom button size setting on the product, cart, and checkout pages instead of falling back to the Apple Pay/Google Pay size
 * Tweak - Render the Express Checkout button on the cart and checkout from page-bootstrapped data, removing a cart-details request from the critical path to first button render


### PR DESCRIPTION
## Problem

On the Blocks checkout, the Stripe **Payment Element can fail to render entirely** on newer "dahlia+" Stripe.js builds when Adaptive Pricing is enabled — the shopper is left with no payment form. Classic/shortcode checkout is unaffected.

## Root cause

#5568 added a Stripe.js capability guard that skipped the Adaptive Pricing / Checkout Session path when Stripe.js no longer supports a working `initCheckout()`. #5618 removed that guard. On "dahlia+" builds `initCheckout()` is a **throwing stub**:

- **Classic** wraps `initCheckout()` in `try/catch`, so it falls back to standard Elements and still renders.
- **Blocks** mounts react-stripe-js's `CheckoutProvider`, which calls `initCheckout()` **synchronously** in an effect. That synchronous throw never sets `checkoutState.type === 'error'` — the only state `checkout-form.js` keys its standard-Elements fallback on — so the fallback never fires and the Payment Element does not render.

The plugin pins the **Clover** channel (`js.stripe.com/clover/stripe.js`), where `initCheckout()` works and the guard is inert; the failure only affects the edge-case loads Stripe serves as dahlia. It presents as a **Blocks-only** regression in Payment-Element render rate beginning with the guard removal.

## Fix

Restore the capability guard on **both** surfaces — gate Adaptive Pricing on a working `initCheckout()`, detected by `initCheckoutElementsSdk` being absent (its presence is the reliable dahlia marker, checked without calling the throwing stub):

```js
const stripeSupportsInitCheckout =
    typeof stripe?.initCheckout === 'function' &&
    typeof stripe?.initCheckoutElementsSdk !== 'function';
```

On dahlia builds, Adaptive Pricing now falls back to standard Elements (which render); on the pinned Clover channel the guard is `true`, so Adaptive Pricing is unchanged. Migrating to the replacement `initCheckoutElementsSdk()` API is the longer-term path and is tracked in #5614.

## Telemetry probe

Adds a `wcstripe_stripe_js_capability` Tracks event at Payment Element mount that classifies the loaded build (`clover` / `dahlia` / `legacy`) without calling the throwing stub, plus a `predicted_render_risk` flag for the dahlia + Adaptive Pricing + Blocks combination. This makes the real Clover:Dahlia ratio and the affected population measurable in production. It is best-effort and non-throwing, and no-ops where site tracking is disabled.

> **Note:** the event lands only where WooCommerce site tracking is enabled on the storefront. If build data is needed from all stores, a server-side beacon would be required instead.

## Testing

`npm run test:js` (targeted): 72 passing across 4 suites.

- **Repro** — `adaptive-pricing-initcheckout-fallback.test.js` drives the real `CheckoutProvider` to show the synchronous throw never reaches `checkoutState.type === 'error'` (fallback can't fire), contrasted with the async-failure path that does.
- **Classic** — skips Adaptive Pricing and renders standard Elements on dahlia+ (no orphan Checkout Session); retains a defense-in-depth `try/catch` fallback test.
- **Blocks** — falls back to standard Elements on dahlia+ even with Adaptive Pricing enabled; Clover still uses the Adaptive Pricing container.
- **Probe** — build classification, render-risk flag, once-per-surface dedupe, and never-throws.

Validated across classic and Blocks at the unit level. Not exercised via live E2E in this environment.

## Changelog

Added matching entries to `changelog.txt` and `readme.txt` under 10.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)