### PR TITLE
Add action hook when Stripe Radar blocks a subscription renewal payment

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -55,6 +55,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Prevent an error when creating the Adaptive Pricing checkout session for logged-in customers without a saved billing address
 * Tweak - Break down the Agentic Commerce feed preview's excluded product count by reason so subscriptions are no longer mistaken for a merchant-configured filter
 * Fix - Render the Express Checkout settings button preview background based on the button color
+* Add - Add a wc_stripe_subscription_renewal_blocked_by_radar action hook that fires when Stripe Radar blocks a subscription renewal payment
 
 2026-06-22 - version 10.8.3
 * Fix - Ensure Adaptive Pricing appears on the checkout page when enabled

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -671,9 +671,13 @@ trait WC_Stripe_Subscriptions_Trait {
 					 */
 					do_action( 'wc_stripe_subscription_renewal_blocked_by_radar', $renewal_order, $response, $radar_reason );
 				}
+			} catch ( Exception $exception ) {
+				WC_Stripe_Logger::error(
+					'Error while handling a Stripe Radar-blocked subscription renewal: ' . $exception->getMessage(),
+					[ 'order_id' => $renewal_order->get_id() ]
+				);
 			} finally {
-				// Runs even if a blocked-by-Radar hook listener throws; otherwise the order stays
-				// locked until the lock's TTL expires, blocking any further payment on it.
+				// Always release the lock, or the order stays locked until the lock's TTL expires.
 				if ( $order_locked && isset( $order_helper ) ) {
 					$order_helper->unlock_order_payment( $renewal_order );
 					$order_locked = false;

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -658,6 +658,15 @@ trait WC_Stripe_Subscriptions_Trait {
 						[ 'order_id' => $renewal_order->get_id() ]
 					);
 				}
+
+				/**
+				 * Fires when a subscription renewal payment is blocked by Stripe Radar.
+				 *
+				 * @param WC_Order $renewal_order The renewal order blocked by Radar.
+				 * @param object   $response      The Stripe API error response.
+				 * @param string   $radar_reason  The Radar block reason (e.g. 'rule', 'highest_risk_level').
+				 */
+				do_action( 'wc_stripe_subscription_renewal_blocked_by_radar', $renewal_order, $response, $radar_reason );
 			}
 
 			if ( $order_locked && isset( $order_helper ) ) {

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -598,81 +598,86 @@ trait WC_Stripe_Subscriptions_Trait {
 
 			$renewal_order->update_status( OrderStatus::FAILED );
 
-			// If the payment was blocked by Stripe Radar, cancel any scheduled
-			// retry attempt. Without this, WC Subscriptions schedules a retry
-			// that would create another charge for Radar to block, inflating
-			// the block rate.
-			if ( false !== $radar_reason ) {
-				$radar_cause = '';
-				switch ( $radar_reason ) {
-					case 'rule':
-						$radar_cause = __( 'Stripe Radar blocked payment for the saved payment method due to a custom Radar rule.', 'woocommerce-gateway-stripe' );
-						break;
-					case 'low_probability_of_authorization':
-						$radar_cause = __( 'Stripe blocked payment for the saved payment method due to low probability of authorization.', 'woocommerce-gateway-stripe' );
-						break;
-					case 'highest_risk_level':
-						$radar_cause = __( 'Stripe Radar blocked payment for the saved payment method as high risk.', 'woocommerce-gateway-stripe' );
-						break;
-					default:
-						$radar_cause = sprintf(
-							/* translators: %s is the Stripe Radar reason code returned by the API. */
-							__( 'Stripe Radar blocked payment for the saved payment method (reason: %s).', 'woocommerce-gateway-stripe' ),
-							$radar_reason
-						);
-						break;
-				}
-				$retry_cancelled_suffix = __( 'The automatic retry has been cancelled to prevent further blocked payment attempts.', 'woocommerce-gateway-stripe' );
+			// Guard the Radar side effects, which include a hook that runs listener code.
+			try {
+				// If the payment was blocked by Stripe Radar, cancel any scheduled
+				// retry attempt. Without this, WC Subscriptions schedules a retry
+				// that would create another charge for Radar to block, inflating
+				// the block rate.
+				if ( false !== $radar_reason ) {
+					$radar_cause = '';
+					switch ( $radar_reason ) {
+						case 'rule':
+							$radar_cause = __( 'Stripe Radar blocked payment for the saved payment method due to a custom Radar rule.', 'woocommerce-gateway-stripe' );
+							break;
+						case 'low_probability_of_authorization':
+							$radar_cause = __( 'Stripe blocked payment for the saved payment method due to low probability of authorization.', 'woocommerce-gateway-stripe' );
+							break;
+						case 'highest_risk_level':
+							$radar_cause = __( 'Stripe Radar blocked payment for the saved payment method as high risk.', 'woocommerce-gateway-stripe' );
+							break;
+						default:
+							$radar_cause = sprintf(
+								/* translators: %s is the Stripe Radar reason code returned by the API. */
+								__( 'Stripe Radar blocked payment for the saved payment method (reason: %s).', 'woocommerce-gateway-stripe' ),
+								$radar_reason
+							);
+							break;
+					}
+					$retry_cancelled_suffix = __( 'The automatic retry has been cancelled to prevent further blocked payment attempts.', 'woocommerce-gateway-stripe' );
 
-				try {
-					$subscriptions = function_exists( 'wcs_get_subscriptions_for_renewal_order' )
-						? wcs_get_subscriptions_for_renewal_order( $renewal_order )
-						: [];
+					try {
+						$subscriptions = function_exists( 'wcs_get_subscriptions_for_renewal_order' )
+							? wcs_get_subscriptions_for_renewal_order( $renewal_order )
+							: [];
 
-					$retry_cancelled = false;
-					if ( class_exists( 'WCS_Retry_Manager' ) && method_exists( 'WCS_Retry_Manager', 'is_retry_enabled' ) && WCS_Retry_Manager::is_retry_enabled() && method_exists( 'WCS_Retry_Manager', 'store' ) ) {
-						$retry_store = WCS_Retry_Manager::store();
-						$last_retry  = method_exists( $retry_store, 'get_last_retry_for_order' ) ? $retry_store->get_last_retry_for_order( $renewal_order->get_id() ) : null;
-						if ( $last_retry && 'pending' === $last_retry->get_status() ) {
-							$last_retry->update_status( 'cancelled' );
-							$retry_cancelled = true;
-						}
-						foreach ( $subscriptions as $subscription ) {
-							if ( $subscription->get_date( 'payment_retry' ) > 0 ) {
-								$subscription->delete_date( 'payment_retry' );
+						$retry_cancelled = false;
+						if ( class_exists( 'WCS_Retry_Manager' ) && method_exists( 'WCS_Retry_Manager', 'is_retry_enabled' ) && WCS_Retry_Manager::is_retry_enabled() && method_exists( 'WCS_Retry_Manager', 'store' ) ) {
+							$retry_store = WCS_Retry_Manager::store();
+							$last_retry  = method_exists( $retry_store, 'get_last_retry_for_order' ) ? $retry_store->get_last_retry_for_order( $renewal_order->get_id() ) : null;
+							if ( $last_retry && 'pending' === $last_retry->get_status() ) {
+								$last_retry->update_status( 'cancelled' );
 								$retry_cancelled = true;
 							}
+							foreach ( $subscriptions as $subscription ) {
+								if ( $subscription->get_date( 'payment_retry' ) > 0 ) {
+									$subscription->delete_date( 'payment_retry' );
+									$retry_cancelled = true;
+								}
+							}
 						}
+
+						$radar_note = $retry_cancelled
+							? $radar_cause . ' ' . $retry_cancelled_suffix
+							: $radar_cause;
+
+						foreach ( $subscriptions as $subscription ) {
+							$subscription->add_order_note( $radar_note );
+						}
+						$renewal_order->add_order_note( $radar_note );
+					} catch ( Exception $radar_e ) {
+						WC_Stripe_Logger::error(
+							'Failed to cancel scheduled retry after Stripe Radar blocked subscription renewal: ' . $radar_e->getMessage(),
+							[ 'order_id' => $renewal_order->get_id() ]
+						);
 					}
 
-					$radar_note = $retry_cancelled
-						? $radar_cause . ' ' . $retry_cancelled_suffix
-						: $radar_cause;
-
-					foreach ( $subscriptions as $subscription ) {
-						$subscription->add_order_note( $radar_note );
-					}
-					$renewal_order->add_order_note( $radar_note );
-				} catch ( Exception $radar_e ) {
-					WC_Stripe_Logger::error(
-						'Failed to cancel scheduled retry after Stripe Radar blocked subscription renewal: ' . $radar_e->getMessage(),
-						[ 'order_id' => $renewal_order->get_id() ]
-					);
+					/**
+					 * Fires when a subscription renewal payment is blocked by Stripe Radar.
+					 *
+					 * @param WC_Order    $renewal_order The renewal order blocked by Radar.
+					 * @param object|null $response      The Stripe API error response.
+					 * @param string      $radar_reason  The Radar block reason (e.g. 'rule', 'highest_risk_level').
+					 */
+					do_action( 'wc_stripe_subscription_renewal_blocked_by_radar', $renewal_order, $response, $radar_reason );
 				}
-
-				/**
-				 * Fires when a subscription renewal payment is blocked by Stripe Radar.
-				 *
-				 * @param WC_Order    $renewal_order The renewal order blocked by Radar.
-				 * @param object|null $response      The Stripe API error response.
-				 * @param string      $radar_reason  The Radar block reason (e.g. 'rule', 'highest_risk_level').
-				 */
-				do_action( 'wc_stripe_subscription_renewal_blocked_by_radar', $renewal_order, $response, $radar_reason );
-			}
-
-			if ( $order_locked && isset( $order_helper ) ) {
-				$order_helper->unlock_order_payment( $renewal_order );
-				$order_locked = false;
+			} finally {
+				// Runs even if a blocked-by-Radar hook listener throws; otherwise the order stays
+				// locked until the lock's TTL expires, blocking any further payment on it.
+				if ( $order_locked && isset( $order_helper ) ) {
+					$order_helper->unlock_order_payment( $renewal_order );
+					$order_locked = false;
+				}
 			}
 
 			return;

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -472,6 +472,7 @@ trait WC_Stripe_Subscriptions_Trait {
 	public function process_subscription_payment( $amount, $renewal_order, $retry = true, $previous_error = false ) {
 		$order_locked = false;
 		$radar_reason = false;
+		$response     = null;
 
 		try {
 			$order_id = $renewal_order->get_id();
@@ -662,9 +663,9 @@ trait WC_Stripe_Subscriptions_Trait {
 				/**
 				 * Fires when a subscription renewal payment is blocked by Stripe Radar.
 				 *
-				 * @param WC_Order $renewal_order The renewal order blocked by Radar.
-				 * @param object   $response      The Stripe API error response.
-				 * @param string   $radar_reason  The Radar block reason (e.g. 'rule', 'highest_risk_level').
+				 * @param WC_Order    $renewal_order The renewal order blocked by Radar.
+				 * @param object|null $response      The Stripe API error response.
+				 * @param string      $radar_reason  The Radar block reason (e.g. 'rule', 'highest_risk_level').
 				 */
 				do_action( 'wc_stripe_subscription_renewal_blocked_by_radar', $renewal_order, $response, $radar_reason );
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -210,5 +210,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Show the selected variation's line items in the Apple Pay/Google Pay payment sheet on variable product pages, instead of the previously selected variation's breakdown
 * Tweak - Break down the Agentic Commerce feed preview's excluded product count by reason so subscriptions are no longer mistaken for a merchant-configured filter
 * Fix - Render the Express Checkout settings button preview background based on the button color
+* Add - Add a wc_stripe_subscription_renewal_blocked_by_radar action hook that fires when Stripe Radar blocks a subscription renewal payment
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/compat/class-wc-stripe-subscription-renewal-test.php
+++ b/tests/phpunit/compat/class-wc-stripe-subscription-renewal-test.php
@@ -656,15 +656,10 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 		add_action( 'wc_stripe_subscription_renewal_blocked_by_radar', $listener, 10, 3 );
 
 		try {
-			// Act: the throwing listener bubbles up, but by then the order must already be unlocked.
-			try {
-				$this->wc_gateway_stripe->process_subscription_payment( 20, $renewal_order, false, false );
-				$this->fail( 'Expected the throwing listener to propagate an exception.' );
-			} catch ( Exception $e ) {
-				$this->assertSame( 'Listener failure.', $e->getMessage() );
-			}
+			// Act: the throwing listener is caught internally, so the call returns without error.
+			$this->wc_gateway_stripe->process_subscription_payment( 20, $renewal_order, false, false );
 
-			// Assert: the payment lock was released before the hook fired.
+			// Assert: the payment lock was released despite the listener throwing.
 			$order_helper = WC_Stripe_Order_Helper::get_instance();
 			$this->assertEmpty( $order_helper->get_order_existing_payment_lock( $renewal_order ) );
 		} finally {

--- a/tests/phpunit/compat/class-wc-stripe-subscription-renewal-test.php
+++ b/tests/phpunit/compat/class-wc-stripe-subscription-renewal-test.php
@@ -580,6 +580,102 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * A listener that throws must not leave the renewal order perpetually locked: the payment
+	 * lock is released before the hook fires, so a misbehaving listener cannot strand the order.
+	 */
+	public function test_renewal_radar_blocked_unlocks_order_when_listener_throws() {
+		// Arrange.
+		$renewal_order                 = WC_Helper_Order::create_order();
+		$customer                      = 'cus_123abc';
+		$source                        = 'src_123abc';
+		$payments_intents_api_endpoint = 'https://api.stripe.com/v1/payment_intents';
+		$charges_api_base              = 'https://api.stripe.com/v1/charges/';
+
+		$this->wc_gateway_stripe
+			->expects( $this->any() )
+			->method( 'prepare_order_source' )
+			->willReturn(
+				(object) [
+					'token_id'       => false,
+					'customer'       => $customer,
+					'source'         => $source,
+					'source_object'  => (object) [
+						'type' => WC_Stripe_Payment_Methods::CARD,
+					],
+					'payment_method' => null,
+				]
+			);
+
+		$mock_subscription = new WC_Subscription();
+		$mock_subscription->update_status( OrderStatus::ON_HOLD );
+		WC_Subscriptions_Helpers::$wcs_get_subscriptions_for_renewal_order = [ $mock_subscription ];
+
+		$pre_http_request_callback = function (
+			$preempt,
+			$request_args,
+			$url
+		) use (
+			$payments_intents_api_endpoint,
+			$charges_api_base
+		) {
+			if ( $payments_intents_api_endpoint === $url ) {
+				return [
+					'headers'  => [],
+					'body'     => file_get_contents( __DIR__ . '/dummy-data/subscription_renewal_response_radar_blocked.json' ),
+					'response' => [
+						'code'    => 402,
+						'message' => 'Payment Required',
+					],
+					'cookies'  => [],
+					'filename' => null,
+				];
+			}
+
+			if ( strpos( $url, $charges_api_base ) === 0 ) {
+				return [
+					'headers'  => [],
+					'body'     => file_get_contents( __DIR__ . '/dummy-data/subscription_renewal_charge_radar_blocked.json' ),
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'cookies'  => [],
+					'filename' => null,
+				];
+			}
+
+			return false;
+		};
+
+		add_filter( 'pre_http_request', $pre_http_request_callback, 10, 3 );
+
+		$listener = function () {
+			throw new Exception( 'Listener failure.' );
+		};
+		add_action( 'wc_stripe_subscription_renewal_blocked_by_radar', $listener, 10, 3 );
+
+		try {
+			// Act: the throwing listener bubbles up, but by then the order must already be unlocked.
+			try {
+				$this->wc_gateway_stripe->process_subscription_payment( 20, $renewal_order, false, false );
+				$this->fail( 'Expected the throwing listener to propagate an exception.' );
+			} catch ( Exception $e ) {
+				$this->assertSame( 'Listener failure.', $e->getMessage() );
+			}
+
+			// Assert: the payment lock was released before the hook fired.
+			$order_helper = WC_Stripe_Order_Helper::get_instance();
+			$this->assertEmpty( $order_helper->get_order_existing_payment_lock( $renewal_order ) );
+		} finally {
+			// Clean up.
+			remove_action( 'wc_stripe_subscription_renewal_blocked_by_radar', $listener, 10 );
+			remove_filter( 'pre_http_request', $pre_http_request_callback );
+			WC_Subscriptions_Helpers::$wcs_get_subscriptions_for_renewal_order = null;
+			WCS_Retry_Manager::mock_reset();
+		}
+	}
+
 	public function test_missing_customer() {
 		$renewal_order = WC_Helper_Order::create_order();
 		$source        = 'src_123abc';

--- a/tests/phpunit/compat/class-wc-stripe-subscription-renewal-test.php
+++ b/tests/phpunit/compat/class-wc-stripe-subscription-renewal-test.php
@@ -485,6 +485,97 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 		WCS_Retry_Manager::mock_reset();
 	}
 
+	/**
+	 * A Radar-blocked renewal fires the hook with the order, error response, and reason.
+	 */
+	public function test_renewal_radar_blocked_fires_action_hook() {
+		// Arrange.
+		$renewal_order                 = WC_Helper_Order::create_order();
+		$customer                      = 'cus_123abc';
+		$source                        = 'src_123abc';
+		$payments_intents_api_endpoint = 'https://api.stripe.com/v1/payment_intents';
+		$charges_api_base              = 'https://api.stripe.com/v1/charges/';
+
+		$this->wc_gateway_stripe
+			->expects( $this->any() )
+			->method( 'prepare_order_source' )
+			->willReturn(
+				(object) [
+					'token_id'       => false,
+					'customer'       => $customer,
+					'source'         => $source,
+					'source_object'  => (object) [
+						'type' => WC_Stripe_Payment_Methods::CARD,
+					],
+					'payment_method' => null,
+				]
+			);
+
+		$mock_subscription = new WC_Subscription();
+		$mock_subscription->update_status( OrderStatus::ON_HOLD );
+		WC_Subscriptions_Helpers::$wcs_get_subscriptions_for_renewal_order = [ $mock_subscription ];
+
+		$pre_http_request_callback = function (
+			$preempt,
+			$request_args,
+			$url
+		) use (
+			$payments_intents_api_endpoint,
+			$charges_api_base
+		) {
+			if ( $payments_intents_api_endpoint === $url ) {
+				return [
+					'headers'  => [],
+					'body'     => file_get_contents( __DIR__ . '/dummy-data/subscription_renewal_response_radar_blocked.json' ),
+					'response' => [
+						'code'    => 402,
+						'message' => 'Payment Required',
+					],
+					'cookies'  => [],
+					'filename' => null,
+				];
+			}
+
+			if ( strpos( $url, $charges_api_base ) === 0 ) {
+				return [
+					'headers'  => [],
+					'body'     => file_get_contents( __DIR__ . '/dummy-data/subscription_renewal_charge_radar_blocked.json' ),
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'cookies'  => [],
+					'filename' => null,
+				];
+			}
+
+			return false;
+		};
+
+		add_filter( 'pre_http_request', $pre_http_request_callback, 10, 3 );
+
+		$hook_args = [];
+		$listener  = function ( $order, $response, $radar_reason ) use ( &$hook_args ) {
+			$hook_args[] = [ $order, $response, $radar_reason ];
+		};
+		add_action( 'wc_stripe_subscription_renewal_blocked_by_radar', $listener, 10, 3 );
+
+		// Act.
+		$this->wc_gateway_stripe->process_subscription_payment( 20, $renewal_order, false, false );
+
+		// Assert: the hook fired exactly once with the expected arguments.
+		$this->assertCount( 1, $hook_args );
+		$this->assertSame( $renewal_order->get_id(), $hook_args[0][0]->get_id() );
+		$this->assertNotEmpty( $hook_args[0][1]->error );
+		$this->assertSame( 'highest_risk_level', $hook_args[0][2] );
+
+		// Clean up.
+		remove_action( 'wc_stripe_subscription_renewal_blocked_by_radar', $listener, 10 );
+		remove_filter( 'pre_http_request', $pre_http_request_callback );
+		WC_Subscriptions_Helpers::$wcs_get_subscriptions_for_renewal_order = null;
+		WCS_Retry_Manager::mock_reset();
+	}
+
 	public function test_missing_customer() {
 		$renewal_order = WC_Helper_Order::create_order();
 		$source        = 'src_123abc';

--- a/tests/phpunit/compat/class-wc-stripe-subscription-renewal-test.php
+++ b/tests/phpunit/compat/class-wc-stripe-subscription-renewal-test.php
@@ -461,28 +461,30 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 
 		add_filter( 'pre_http_request', $pre_http_request_callback, 10, 3 );
 
-		// Act.
-		$this->wc_gateway_stripe->process_subscription_payment( 20, $renewal_order, false, false );
+		try {
+			// Act.
+			$this->wc_gateway_stripe->process_subscription_payment( 20, $renewal_order, false, false );
 
-		// Assert: the renewal order itself is marked as failed.
-		$order = wc_get_order( $renewal_order->get_id() );
-		$this->assertSame( OrderStatus::FAILED, $order->get_status() );
+			// Assert: the renewal order itself is marked as failed.
+			$order = wc_get_order( $renewal_order->get_id() );
+			$this->assertSame( OrderStatus::FAILED, $order->get_status() );
 
-		// Assert: the pending retry was transitioned to cancelled.
-		$this->assertSame( 'cancelled', $pending_retry->get_status() );
+			// Assert: the pending retry was transitioned to cancelled.
+			$this->assertSame( 'cancelled', $pending_retry->get_status() );
 
-		// Assert: the subscription's payment_retry date was cleared.
-		$this->assertSame( 0, $mock_subscription->get_date( 'payment_retry' ) );
+			// Assert: the subscription's payment_retry date was cleared.
+			$this->assertSame( 0, $mock_subscription->get_date( 'payment_retry' ) );
 
-		// Assert: a Radar note was attached to the subscription.
-		$subscription_notes = $mock_subscription->get_captured_notes();
-		$this->assertNotEmpty( $subscription_notes );
-		$this->assertStringContainsString( 'Stripe Radar blocked payment for the saved payment method', $subscription_notes[0] );
-
-		// Clean up.
-		remove_filter( 'pre_http_request', $pre_http_request_callback );
-		WC_Subscriptions_Helpers::$wcs_get_subscriptions_for_renewal_order = null;
-		WCS_Retry_Manager::mock_reset();
+			// Assert: a Radar note was attached to the subscription.
+			$subscription_notes = $mock_subscription->get_captured_notes();
+			$this->assertNotEmpty( $subscription_notes );
+			$this->assertStringContainsString( 'Stripe Radar blocked payment for the saved payment method', $subscription_notes[0] );
+		} finally {
+			// Clean up.
+			remove_filter( 'pre_http_request', $pre_http_request_callback );
+			WC_Subscriptions_Helpers::$wcs_get_subscriptions_for_renewal_order = null;
+			WCS_Retry_Manager::mock_reset();
+		}
 	}
 
 	/**
@@ -560,20 +562,22 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 		};
 		add_action( 'wc_stripe_subscription_renewal_blocked_by_radar', $listener, 10, 3 );
 
-		// Act.
-		$this->wc_gateway_stripe->process_subscription_payment( 20, $renewal_order, false, false );
+		try {
+			// Act.
+			$this->wc_gateway_stripe->process_subscription_payment( 20, $renewal_order, false, false );
 
-		// Assert: the hook fired exactly once with the expected arguments.
-		$this->assertCount( 1, $hook_args );
-		$this->assertSame( $renewal_order->get_id(), $hook_args[0][0]->get_id() );
-		$this->assertNotEmpty( $hook_args[0][1]->error );
-		$this->assertSame( 'highest_risk_level', $hook_args[0][2] );
-
-		// Clean up.
-		remove_action( 'wc_stripe_subscription_renewal_blocked_by_radar', $listener, 10 );
-		remove_filter( 'pre_http_request', $pre_http_request_callback );
-		WC_Subscriptions_Helpers::$wcs_get_subscriptions_for_renewal_order = null;
-		WCS_Retry_Manager::mock_reset();
+			// Assert: the hook fired exactly once with the expected arguments.
+			$this->assertCount( 1, $hook_args );
+			$this->assertSame( $renewal_order->get_id(), $hook_args[0][0]->get_id() );
+			$this->assertNotEmpty( $hook_args[0][1]->error );
+			$this->assertSame( 'highest_risk_level', $hook_args[0][2] );
+		} finally {
+			// Clean up.
+			remove_action( 'wc_stripe_subscription_renewal_blocked_by_radar', $listener, 10 );
+			remove_filter( 'pre_http_request', $pre_http_request_callback );
+			WC_Subscriptions_Helpers::$wcs_get_subscriptions_for_renewal_order = null;
+			WCS_Retry_Manager::mock_reset();
+		}
 	}
 
 	public function test_missing_customer() {


### PR DESCRIPTION
Fixes STRIPE-1226
Fixes #5601 

## Changes proposed in this Pull Request:
Adds a public action hook, `wc_stripe_subscription_renewal_blocked_by_radar`, that fires when a subscription renewal payment is identified as blocked by Stripe Radar.

```php
do_action(
    'wc_stripe_subscription_renewal_blocked_by_radar',
    $renewal_order, // WC_Order that was blocked
    $response,      // Stripe API error response
    $radar_reason   // Radar block reason, e.g. 'rule', 'highest_risk_level'
);
```

**Why**

The plugin already detects Radar-blocked renewals (is_charge_blocked_by_radar()), cancels WC Subscriptions retries, and adds order notes — but there was no public hook for third-party integrations to react to a Radar block specifically. This makes it hard to trigger custom workflows (notifications, CRM updates, fraud monitoring, subscription management) on that event, distinct from a generic renewal failure.

**Backward compatibility**

Purely additive — a new hook. No changes to existing hook names, signatures, option keys, or behavior. Nothing to migrate.



## Testing instructions
- Code review should be sufficient.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
