### PR TITLE
Fix Adaptive Payments failing at checkout when the return URL is relative

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -55,6 +55,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Prevent an error when creating the Adaptive Pricing checkout session for logged-in customers without a saved billing address
 * Tweak - Break down the Agentic Commerce feed preview's excluded product count by reason so subscriptions are no longer mistaken for a merchant-configured filter
 * Fix - Render the Express Checkout settings button preview background based on the button color
+* Fix - Prevent Adaptive Pricing payments from failing when the checkout return URL is relative
 
 2026-06-22 - version 10.8.3
 * Fix - Ensure Adaptive Pricing appears on the checkout page when enabled

--- a/client/blocks/checkout-sessions/__tests__/hooks.test.js
+++ b/client/blocks/checkout-sessions/__tests__/hooks.test.js
@@ -254,8 +254,13 @@ describe( 'CheckoutSessions hook tests', () => {
 			},
 		};
 
+		let originalLocation;
+
 		beforeEach( () => {
 			document.body.innerHTML = '';
+			originalLocation = window.location;
+			delete window.location;
+			window.location = { origin: 'https://example.com' };
 			onCheckoutSuccess.mockImplementation( ( fn ) => {
 				const onCheckoutProcessingData = {
 					processingResponse: {
@@ -266,6 +271,10 @@ describe( 'CheckoutSessions hook tests', () => {
 				};
 				onCheckoutSuccessResultPromise = fn( onCheckoutProcessingData );
 			} );
+		} );
+
+		afterEach( () => {
+			window.location = originalLocation;
 		} );
 
 		it( 'checkoutState.type is not success', async () => {
@@ -334,6 +343,43 @@ describe( 'CheckoutSessions hook tests', () => {
 				redirect: 'if_required',
 				savePaymentMethod: false,
 			} );
+		} );
+
+		it( 'confirms with an absolute returnUrl when the server returns a relative redirect', async () => {
+			onCheckoutSuccess.mockImplementation( ( fn ) => {
+				const onCheckoutProcessingData = {
+					processingResponse: {
+						paymentDetails: {
+							redirect: '/order-received/123/?key=abc',
+						},
+					},
+				};
+				onCheckoutSuccessResultPromise = fn( onCheckoutProcessingData );
+			} );
+
+			const mockConfirm = jest.fn().mockResolvedValue( {
+				type: 'success',
+			} );
+			const checkoutState = {
+				type: 'success',
+				checkout: { email: '', confirm: mockConfirm },
+			};
+			useCheckoutSuccessHandler(
+				checkoutState,
+				onCheckoutSuccess,
+				billing,
+				false,
+				false,
+				shippingData
+			);
+			await onCheckoutSuccessResultPromise;
+
+			expect( mockConfirm ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					returnUrl:
+						'https://example.com/order-received/123/?key=abc',
+				} )
+			);
 		} );
 
 		it( 'success', async () => {

--- a/client/blocks/checkout-sessions/hooks.js
+++ b/client/blocks/checkout-sessions/hooks.js
@@ -2,6 +2,7 @@ import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { select, useSelect } from '@wordpress/data';
 import { isSavePaymentMethodCheckboxChecked } from 'wcstripe/blocks/utils';
+import { normalizeReturnUrl } from 'wcstripe/stripe-utils/normalize-return-url';
 import { waitForPaymentElementCompletion } from 'wcstripe/blocks/wait-for-payment-element-completion';
 
 /**
@@ -177,7 +178,7 @@ export const useCheckoutSuccessHandler = (
 								postal_code: billingAddress?.postcode,
 							},
 						},
-						returnUrl: redirect,
+						returnUrl: normalizeReturnUrl( redirect ),
 						redirect: 'if_required',
 					};
 

--- a/client/classic/upe/__tests__/payment-processing.test.js
+++ b/client/classic/upe/__tests__/payment-processing.test.js
@@ -731,6 +731,22 @@ describe( 'payment-processing', () => {
 		} );
 
 		describe( 'processPayment', () => {
+			let originalLocation;
+
+			beforeEach( () => {
+				originalLocation = window.location;
+				delete window.location;
+				window.location = {
+					href: '',
+					origin: 'https://shop.com',
+					assign: jest.fn(),
+				};
+			} );
+
+			afterEach( () => {
+				window.location = originalLocation;
+			} );
+
 			/**
 			 * Mount the payment element, setting up loadActions to return success
 			 * during mount, then configure it for the subsequent processPayment call.
@@ -755,14 +771,6 @@ describe( 'payment-processing', () => {
 			};
 
 			it( 'submits form via AJAX, then confirms with order-received URL', async () => {
-				const originalLocation = window.location;
-				delete window.location;
-				window.location = {
-					href: '',
-					origin: 'https://shop.com',
-					assign: jest.fn(),
-				};
-
 				const orderReceivedUrl =
 					'https://shop.com/checkout/order-received/123/';
 				const mockActions = {
@@ -807,18 +815,9 @@ describe( 'payment-processing', () => {
 				} );
 				// After confirm resolves, navigates to the order-received page.
 				expect( window.location.href ).toBe( orderReceivedUrl );
-				window.location = originalLocation;
 			} );
 
 			it( 'confirms with an absolute returnUrl when the server returns a relative redirect', async () => {
-				const originalLocation = window.location;
-				delete window.location;
-				window.location = {
-					href: '',
-					origin: 'https://shop.com',
-					assign: jest.fn(),
-				};
-
 				const relativeRedirect =
 					'/checkout/order-received/123/?key=abc';
 				const mockActions = {
@@ -849,19 +848,9 @@ describe( 'payment-processing', () => {
 						'https://shop.com/checkout/order-received/123/?key=abc',
 					redirect: 'if_required',
 				} );
-
-				window.location = originalLocation;
 			} );
 
 			it( 'passes savePaymentMethod true when logged in and the save card checkbox is checked', async () => {
-				const originalLocation = window.location;
-				delete window.location;
-				window.location = {
-					href: '',
-					origin: 'https://shop.com',
-					assign: jest.fn(),
-				};
-
 				const orderReceivedUrl =
 					'https://shop.com/checkout/order-received/123/';
 				const mockActions = {
@@ -900,19 +889,9 @@ describe( 'payment-processing', () => {
 					redirect: 'if_required',
 					savePaymentMethod: true,
 				} );
-
-				window.location = originalLocation;
 			} );
 
 			it( 'does not pass savePaymentMethod for guests even when the save card checkbox is checked', async () => {
-				const originalLocation = window.location;
-				delete window.location;
-				window.location = {
-					href: '',
-					origin: 'https://shop.com',
-					assign: jest.fn(),
-				};
-
 				const orderReceivedUrl =
 					'https://shop.com/checkout/order-received/123/';
 				const mockActions = {
@@ -950,8 +929,6 @@ describe( 'payment-processing', () => {
 					returnUrl: orderReceivedUrl,
 					redirect: 'if_required',
 				} );
-
-				window.location = originalLocation;
 			} );
 
 			it( 'shows error and skips confirm when checkout AJAX fails', async () => {

--- a/client/classic/upe/__tests__/payment-processing.test.js
+++ b/client/classic/upe/__tests__/payment-processing.test.js
@@ -14,6 +14,9 @@ jest.mock( 'wcstripe/stripe-utils', () => ( {
 	getExcludedPaymentMethodTypes: jest.fn().mockReturnValue( [] ),
 	getPaymentMethodTypes: jest.fn().mockReturnValue( [ 'card' ] ),
 	getUserDataForCheckoutSession: jest.fn().mockReturnValue( {} ),
+	normalizeReturnUrl: jest.requireActual(
+		'wcstripe/stripe-utils/normalize-return-url'
+	).normalizeReturnUrl,
 	getStripeServerData: jest.fn().mockReturnValue( {
 		paymentMethodsConfig: {
 			card: { supportsDeferredIntent: true },
@@ -754,7 +757,11 @@ describe( 'payment-processing', () => {
 			it( 'submits form via AJAX, then confirms with order-received URL', async () => {
 				const originalLocation = window.location;
 				delete window.location;
-				window.location = { href: '', assign: jest.fn() };
+				window.location = {
+					href: '',
+					origin: 'https://shop.com',
+					assign: jest.fn(),
+				};
 
 				const orderReceivedUrl =
 					'https://shop.com/checkout/order-received/123/';
@@ -803,10 +810,57 @@ describe( 'payment-processing', () => {
 				window.location = originalLocation;
 			} );
 
+			it( 'confirms with an absolute returnUrl when the server returns a relative redirect', async () => {
+				const originalLocation = window.location;
+				delete window.location;
+				window.location = {
+					href: '',
+					origin: 'https://shop.com',
+					assign: jest.fn(),
+				};
+
+				const relativeRedirect =
+					'/checkout/order-received/123/?key=abc';
+				const mockActions = {
+					getSession: jest.fn().mockResolvedValue( {} ),
+					confirm: jest.fn().mockResolvedValue( {
+						session: { id: 'cs_session_xyz' },
+					} ),
+				};
+				const checkoutElements = createMockElements();
+				const api = createMockApi( checkoutElements );
+
+				mockJQueryAjax.mockResolvedValue( {
+					result: 'success',
+					redirect: relativeRedirect,
+				} );
+
+				await mountAndConfigureForProcess( api, checkoutElements, {
+					type: 'success',
+					actions: mockActions,
+				} );
+
+				const form = createMockForm();
+				paymentProcessing.processPayment( api, form, 'card' );
+				await flushPromises();
+
+				expect( mockActions.confirm ).toHaveBeenCalledWith( {
+					returnUrl:
+						'https://shop.com/checkout/order-received/123/?key=abc',
+					redirect: 'if_required',
+				} );
+
+				window.location = originalLocation;
+			} );
+
 			it( 'passes savePaymentMethod true when logged in and the save card checkbox is checked', async () => {
 				const originalLocation = window.location;
 				delete window.location;
-				window.location = { href: '', assign: jest.fn() };
+				window.location = {
+					href: '',
+					origin: 'https://shop.com',
+					assign: jest.fn(),
+				};
 
 				const orderReceivedUrl =
 					'https://shop.com/checkout/order-received/123/';
@@ -853,7 +907,11 @@ describe( 'payment-processing', () => {
 			it( 'does not pass savePaymentMethod for guests even when the save card checkbox is checked', async () => {
 				const originalLocation = window.location;
 				delete window.location;
-				window.location = { href: '', assign: jest.fn() };
+				window.location = {
+					href: '',
+					origin: 'https://shop.com',
+					assign: jest.fn(),
+				};
 
 				const orderReceivedUrl =
 					'https://shop.com/checkout/order-received/123/';

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -18,6 +18,7 @@ import {
 	getExcludedPaymentMethodTypes,
 	getUserDataForCheckoutSession,
 	getBillingDetailsForDeferredFlow,
+	normalizeReturnUrl,
 } from '../../stripe-utils';
 import {
 	initializeUPEAppearance,
@@ -1133,7 +1134,10 @@ export const processPayment = (
 				// the customer to the thank-you page instead of checkout.
 				const confirmArgs = {
 					...getUserDataForCheckoutSession( session ),
-					returnUrl: checkoutResponse.redirect,
+					returnUrl: normalizeReturnUrl(
+						checkoutResponse.redirect,
+						getStripeServerData()?.orderReceivedURL
+					),
 					redirect: 'if_required',
 				};
 

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -1134,10 +1134,7 @@ export const processPayment = (
 				// the customer to the thank-you page instead of checkout.
 				const confirmArgs = {
 					...getUserDataForCheckoutSession( session ),
-					returnUrl: normalizeReturnUrl(
-						checkoutResponse.redirect,
-						getStripeServerData()?.orderReceivedURL
-					),
+					returnUrl: normalizeReturnUrl( checkoutResponse.redirect ),
 					redirect: 'if_required',
 				};
 

--- a/client/stripe-utils/__tests__/normalize-return-url.test.js
+++ b/client/stripe-utils/__tests__/normalize-return-url.test.js
@@ -17,29 +17,16 @@ describe( 'normalizeReturnUrl', () => {
 		).toBe( `${ ORIGIN }/order-received/123/?key=abc` );
 	} );
 
-	it( 'falls back for a cross-origin URL', () => {
-		const fallback = `${ ORIGIN }/checkout/order-received/`;
-		expect(
-			normalizeReturnUrl( 'https://evil.example/steal', fallback )
-		).toBe( fallback );
-	} );
-
-	it( 'returns null for a cross-origin URL when no fallback is given', () => {
+	it( 'returns null for a cross-origin URL', () => {
 		expect( normalizeReturnUrl( 'https://evil.example/steal' ) ).toBeNull();
 	} );
 
-	it( 'falls back for an empty value', () => {
-		const fallback = `${ ORIGIN }/checkout/order-received/`;
-		expect( normalizeReturnUrl( '', fallback ) ).toBe( fallback );
-	} );
-
-	it( 'falls back for a null/undefined value', () => {
-		const fallback = `${ ORIGIN }/checkout/order-received/`;
-		expect( normalizeReturnUrl( null, fallback ) ).toBe( fallback );
-		expect( normalizeReturnUrl( undefined, fallback ) ).toBe( fallback );
-	} );
-
-	it( 'defaults the fallback to null', () => {
+	it( 'returns null for an empty value', () => {
 		expect( normalizeReturnUrl( '' ) ).toBeNull();
+	} );
+
+	it( 'returns null for a null/undefined value', () => {
+		expect( normalizeReturnUrl( null ) ).toBeNull();
+		expect( normalizeReturnUrl( undefined ) ).toBeNull();
 	} );
 } );

--- a/client/stripe-utils/__tests__/normalize-return-url.test.js
+++ b/client/stripe-utils/__tests__/normalize-return-url.test.js
@@ -1,0 +1,45 @@
+import { normalizeReturnUrl } from '../normalize-return-url';
+
+// jsdom serves pages from http://localhost by default, so that is the origin
+// every relative path resolves against here.
+const ORIGIN = 'http://localhost';
+
+describe( 'normalizeReturnUrl', () => {
+	it( 'resolves a relative path to an absolute same-origin URL', () => {
+		expect(
+			normalizeReturnUrl( '/order-received/123/?key=wc_order_abc' )
+		).toBe( `${ ORIGIN }/order-received/123/?key=wc_order_abc` );
+	} );
+
+	it( 'returns an already-absolute same-origin URL effectively unchanged', () => {
+		expect(
+			normalizeReturnUrl( `${ ORIGIN }/order-received/123/?key=abc` )
+		).toBe( `${ ORIGIN }/order-received/123/?key=abc` );
+	} );
+
+	it( 'falls back for a cross-origin URL', () => {
+		const fallback = `${ ORIGIN }/checkout/order-received/`;
+		expect(
+			normalizeReturnUrl( 'https://evil.example/steal', fallback )
+		).toBe( fallback );
+	} );
+
+	it( 'returns null for a cross-origin URL when no fallback is given', () => {
+		expect( normalizeReturnUrl( 'https://evil.example/steal' ) ).toBeNull();
+	} );
+
+	it( 'falls back for an empty value', () => {
+		const fallback = `${ ORIGIN }/checkout/order-received/`;
+		expect( normalizeReturnUrl( '', fallback ) ).toBe( fallback );
+	} );
+
+	it( 'falls back for a null/undefined value', () => {
+		const fallback = `${ ORIGIN }/checkout/order-received/`;
+		expect( normalizeReturnUrl( null, fallback ) ).toBe( fallback );
+		expect( normalizeReturnUrl( undefined, fallback ) ).toBe( fallback );
+	} );
+
+	it( 'defaults the fallback to null', () => {
+		expect( normalizeReturnUrl( '' ) ).toBeNull();
+	} );
+} );

--- a/client/stripe-utils/index.js
+++ b/client/stripe-utils/index.js
@@ -1,2 +1,3 @@
 export * from './get-stripe-dev-widget-options';
+export * from './normalize-return-url';
 export * from './utils';

--- a/client/stripe-utils/normalize-return-url.js
+++ b/client/stripe-utils/normalize-return-url.js
@@ -1,0 +1,22 @@
+/**
+ * Resolves a possibly-relative URL to an absolute same-origin URL. Returns the
+ * fallback when the input is empty, unparseable, or resolves to a different origin.
+ *
+ * @param {string}  rawUrl        The URL to normalize (may be relative).
+ * @param {?string} [fallbackUrl] Fallback returned when rawUrl cannot be used.
+ * @return {?string} An absolute same-origin URL, the fallback, or null.
+ */
+export const normalizeReturnUrl = ( rawUrl, fallbackUrl = null ) => {
+	if ( rawUrl ) {
+		try {
+			const resolved = new URL( rawUrl, window.location.origin );
+			if ( resolved.origin === window.location.origin ) {
+				return resolved.href;
+			}
+		} catch ( e ) {
+			// Fall through to the fallback below.
+		}
+	}
+
+	return fallbackUrl;
+};

--- a/client/stripe-utils/normalize-return-url.js
+++ b/client/stripe-utils/normalize-return-url.js
@@ -1,12 +1,11 @@
 /**
- * Resolves a possibly-relative URL to an absolute same-origin URL. Returns the
- * fallback when the input is empty, unparseable, or resolves to a different origin.
+ * Resolves a possibly-relative URL to an absolute same-origin URL, or null when
+ * the input is empty, unparseable, or resolves to a different origin.
  *
- * @param {string}  rawUrl        The URL to normalize (may be relative).
- * @param {?string} [fallbackUrl] Fallback returned when rawUrl cannot be used.
- * @return {?string} An absolute same-origin URL, the fallback, or null.
+ * @param {string} rawUrl The URL to normalize (may be relative).
+ * @return {?string} An absolute same-origin URL, or null.
  */
-export const normalizeReturnUrl = ( rawUrl, fallbackUrl = null ) => {
+export const normalizeReturnUrl = ( rawUrl ) => {
 	if ( rawUrl ) {
 		try {
 			const resolved = new URL( rawUrl, window.location.origin );
@@ -14,9 +13,9 @@ export const normalizeReturnUrl = ( rawUrl, fallbackUrl = null ) => {
 				return resolved.href;
 			}
 		} catch ( e ) {
-			// Fall through to the fallback below.
+			// Fall through.
 		}
 	}
 
-	return fallbackUrl;
+	return null;
 };

--- a/readme.txt
+++ b/readme.txt
@@ -210,5 +210,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Show the selected variation's line items in the Apple Pay/Google Pay payment sheet on variable product pages, instead of the previously selected variation's breakdown
 * Tweak - Break down the Agentic Commerce feed preview's excluded product count by reason so subscriptions are no longer mistaken for a merchant-configured filter
 * Fix - Render the Express Checkout settings button preview background based on the button color
+* Fix - Prevent Adaptive Pricing payments from failing when the checkout return URL is relative
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-1260

## Changes proposed in this Pull Request:

Stripe requires an absolute URL when confirming the payment for checkout sessions. It's possible for the server to send a relative URL depending on other plugins they may enabled. When a relative URL is returned, checkout fails with an "invalid return URL" error. 

<img width="1700" height="320" alt="CleanShot 2026-07-07 at 10 06 09@2x" src="https://github.com/user-attachments/assets/f6e00f09-37c8-4130-96aa-a3b507945d78" />


This PR makes the return URL absolute before the payment is confirmed, on both the classic and Blocks checkout. 

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. Enable Optimized Checkout and Adaptive Pricing on a test store.
2. Temporarily force a relative return URL by adding this snippet:
   `add_filter( 'woocommerce_get_return_url', fn( $url ) => wp_make_link_relative( $url ), 999 );`
3. Place a card order on the classic (shortcode) checkout. It should complete and and on the order-received page. Before this change, it failed with an "invalid return URL" error.
4. Repeat on a Blocks checkout page.
5. Remove the snippet and confirm normal checkout still works on both

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
