### PR TITLE
Include the statement descriptor when creating payment intents for ACSS Debit and BLIK

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -59,6 +59,7 @@ xxxx-xx-xx - version 10.9.0
 * Update - Move the checkout sessions availability check to WC_Stripe_Helper and remove the deprecated wc_stripe_is_checkout_sessions_available filter
 * Fix - Prevent Adaptive Pricing payments from failing when the checkout return URL is relative
 * Add - Add a wc_stripe_subscription_renewal_blocked_by_radar action hook that fires when Stripe Radar blocks a subscription renewal payment
+* Fix - Include the statement descriptor when creating payment intents for ACSS Debit and BLIK payments
 
 2026-06-22 - version 10.8.3
 * Fix - Ensure Adaptive Pricing appears on the checkout page when enabled

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -407,6 +407,13 @@ class WC_Stripe_Intent_Controller {
 			'capture_method'       => $capture ? 'automatic' : 'manual',
 		];
 
+		if ( ! empty( $payment_method_type ) && WC_Stripe_Payment_Methods::CARD !== $payment_method_type ) {
+			$statement_descriptor = $gateway->get_full_statement_descriptor();
+			if ( ! empty( $statement_descriptor ) ) {
+				$request['statement_descriptor'] = $statement_descriptor;
+			}
+		}
+
 		$request = $this->maybe_add_mandate_options( $request, $payment_method_type );
 
 		$payment_intent = WC_Stripe_API::request( $request, 'payment_intents' );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3337,6 +3337,23 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
+	 * Returns the full bank statement descriptor to use for non-card payments.
+	 *
+	 * Uses the locally configured statement descriptor, falling back to the Stripe account-level descriptor.
+	 *
+	 * @return string The cleaned statement descriptor, or an empty string when none is configured.
+	 */
+	public function get_full_statement_descriptor() {
+		$full_statement_descriptor = WC_Stripe_Helper::clean_statement_descriptor( (string) $this->statement_descriptor );
+		if ( empty( $full_statement_descriptor ) ) {
+			$account_data              = WC_Stripe::get_instance()->account->get_cached_account_data();
+			$full_statement_descriptor = WC_Stripe_Helper::clean_statement_descriptor( $account_data['settings']['payments']['statement_descriptor'] ?? '' );
+		}
+
+		return $full_statement_descriptor;
+	}
+
+	/**
 	 * Collects the payment information needed for processing a payment intent.
 	 *
 	 * @param WC_Order $order The WC Order to be paid for.
@@ -3449,12 +3466,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		if ( WC_Stripe_Payment_Methods::CARD === $selected_payment_type && $is_short_statement_descriptor_enabled ) {
 			$payment_information['statement_descriptor_suffix'] = WC_Stripe_Helper::get_dynamic_statement_descriptor_suffix( $order );
 		} elseif ( WC_Stripe_Payment_Methods::CARD !== $selected_payment_type ) {
-			// Use the locally configured statement descriptor, falling back to the Stripe account-level descriptor.
-			$full_statement_descriptor = WC_Stripe_Helper::clean_statement_descriptor( (string) $this->statement_descriptor );
-			if ( empty( $full_statement_descriptor ) ) {
-				$account_data              = WC_Stripe::get_instance()->account->get_cached_account_data();
-				$full_statement_descriptor = WC_Stripe_Helper::clean_statement_descriptor( $account_data['settings']['payments']['statement_descriptor'] ?? '' );
-			}
+			$full_statement_descriptor = $this->get_full_statement_descriptor();
 			if ( ! empty( $full_statement_descriptor ) ) {
 				$payment_information['statement_descriptor'] = $full_statement_descriptor;
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -214,5 +214,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Move the checkout sessions availability check to WC_Stripe_Helper and remove the deprecated wc_stripe_is_checkout_sessions_available filter
 * Fix - Prevent Adaptive Pricing payments from failing when the checkout return URL is relative
 * Add - Add a wc_stripe_subscription_renewal_blocked_by_radar action hook that fires when Stripe Radar blocks a subscription renewal payment
+* Fix - Include the statement descriptor when creating payment intents for ACSS Debit and BLIK payments
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-intent-controller-test.php
+++ b/tests/phpunit/class-wc-stripe-intent-controller-test.php
@@ -31,11 +31,21 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
+		$this->order = WC_Helper_Order::create_order();
+		$this->create_gateway_and_controller();
+	}
+
+	/**
+	 * Creates the mocked gateway and controller under test.
+	 *
+	 * The gateway snapshots the main Stripe settings in its constructor, so tests that
+	 * change those settings must call this again for the new values to take effect.
+	 */
+	private function create_gateway_and_controller() {
 		$mock_account = $this->getMockBuilder( 'WC_Stripe_Account' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->order           = WC_Helper_Order::create_order();
 		$this->gateway         = $this->getMockBuilder( 'WC_Stripe_UPE_Payment_Gateway' )
 			->setConstructorArgs( [ $mock_account ] )
 			->setMethods( [ 'maybe_process_upe_redirect', 'has_subscription' ] )
@@ -154,6 +164,83 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		return [
 			'uses order currency when order exists' => [ 'USD', 'CAD', 'usd' ],
 			'uses global currency without order'    => [ null, 'EUR', 'eur' ],
+		];
+	}
+
+	/**
+	 * Test that create_payment_intent includes the bank statement descriptor for non-card
+	 * payment methods that create their intent upfront (non-deferred, e.g. ACSS Debit and BLIK).
+	 *
+	 * @param string|null $payment_method_type The payment method type requested for the intent.
+	 * @param string      $local_descriptor    The locally configured statement descriptor.
+	 * @param array       $account_data        The Stripe account data to mock.
+	 * @param string|null $expected_descriptor The expected statement_descriptor in the request, or null if it must not be set.
+	 *
+	 * @dataProvider provide_create_payment_intent_statement_descriptor_data
+	 */
+	public function test_create_payment_intent_statement_descriptor( $payment_method_type, $local_descriptor, $account_data, $expected_descriptor ) {
+		$stripe_settings                         = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['statement_descriptor'] = $local_descriptor;
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		$this->create_gateway_and_controller();
+
+		WC_Stripe::get_instance()->account = $this->getMockBuilder( 'WC_Stripe_Account' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'get_cached_account_data' ] )
+			->getMock();
+		WC_Stripe::get_instance()->account->method( 'get_cached_account_data' )->willReturn( $account_data );
+
+		$request_body = null;
+		$test_request = function ( $preempt, $parsed_args ) use ( &$request_body ) {
+			$request_body = $parsed_args['body'];
+
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => json_encode(
+					[
+						'id'            => 'pi_mock',
+						'client_secret' => 'cs_mock',
+					]
+				),
+			];
+		};
+
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		$this->mock_controller->create_payment_intent( $this->order->get_id(), $payment_method_type );
+
+		$this->assertIsArray( $request_body, 'The payment intent creation request should have been made.' );
+
+		if ( null === $expected_descriptor ) {
+			$this->assertArrayNotHasKey( 'statement_descriptor', $request_body );
+		} else {
+			$this->assertArrayHasKey( 'statement_descriptor', $request_body );
+			$this->assertSame( $expected_descriptor, $request_body['statement_descriptor'] );
+		}
+	}
+
+	/**
+	 * Data provider for test_create_payment_intent_statement_descriptor.
+	 *
+	 * @return array[] [ payment_method_type, local_descriptor, account_data, expected_descriptor ]
+	 */
+	public function provide_create_payment_intent_statement_descriptor_data() {
+		$account_with_descriptor = [
+			'settings' => [
+				'payments' => [
+					'statement_descriptor' => 'ACCOUNT DESCRIPTOR',
+				],
+			],
+		];
+
+		return [
+			'blik uses the local descriptor'          => [ WC_Stripe_UPE_Payment_Method_BLIK::STRIPE_ID, 'WOO STORE', $account_with_descriptor, 'WOO STORE' ],
+			'acss falls back to account descriptor'   => [ WC_Stripe_UPE_Payment_Method_ACSS::STRIPE_ID, '', $account_with_descriptor, 'ACCOUNT DESCRIPTOR' ],
+			'no descriptor available leaves it unset' => [ WC_Stripe_UPE_Payment_Method_BLIK::STRIPE_ID, '', [], null ],
+			'card payments do not set the descriptor' => [ WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID, 'WOO STORE', $account_with_descriptor, null ],
+			'no payment method type leaves it unset'  => [ null, 'WOO STORE', $account_with_descriptor, null ],
 		];
 	}
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-1197

## Changes proposed in this Pull Request:

This is a follow-up to #5221 to make sure statement descriptors are sent to Stripe when using ACSS Debit (Pre-Authorized Debit) and BLIK. These two methods create their payment intent earlier in the checkout flow, through a path the earlier fix didn't touch, so their transactions still showed a blank statement descriptor in the Stripe dashboard.

Before
<img width="330" height="275" alt="CleanShot 2026-07-09 at 10 18 34@2x" src="https://github.com/user-attachments/assets/6a171d4f-7de0-4b7b-9547-9831742a22f1" />

After
<img width="330" height="275" alt="CleanShot 2026-07-09 at 10 18 52@2x" src="https://github.com/user-attachments/assets/00cf0766-2e08-4cc0-8953-cfaf1b49fd3a" />

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

**ACSS Debit** (requires a Canadian or US Stripe account):
1. Set the store currency to CAD and enable Pre-Authorized Debit in the Stripe payment methods settings.
2. Place an order using ACSS
3. In the Stripe dashboard, open the resulting payment and confirm the statement descriptor is populated instead of blank.

**BLIK:**
1. Set the store currency to PLN and enable BLIK.
2. Place an order using the test BLIK code.
3. Confirm the payment in the Stripe dashboard shows the statement descriptor.

Also verify a regular card payment still behaves as before (its descriptor handling is unchanged).

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
