### PR TITLE
Only attach Level 3 data to card payments and captures

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.9.0
+* Fix - Stop attaching Level 3 data to captures and payments for non-card methods
 * Fix - Add the missing order and customer metadata to Adaptive Pricing payment intents
 * Add - Show a "Paid by customer" row with the Adaptive Pricing amount and currency on the order edit page
 * Fix - Send the admin New Order and customer Processing emails when an asynchronous payment method (iDEAL, Klarna, Bancontact) is confirmed via the deferred webhook path

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -454,10 +454,14 @@ class WC_Stripe_API {
 		// 3. Do not try to add level3 data if merchant is not based in the US.
 		// https://docs.stripe.com/level3#level-iii-usage-requirements
 		// (Needs to be authenticated with a level3 gated account to see above docs).
+		// 4. Do not add level3 data for non-card payment methods (e.g. Affirm,
+		// Klarna, Afterpay/Clearpay, Amazon Pay). Level 3 is card-network only, and
+		// Stripe rejects the request when it's attached to those methods.
 		if (
 			empty( $level3_data ) ||
 			get_transient( 'wc_stripe_level3_not_allowed' ) ||
-			'US' !== WC()->countries->get_base_country()
+			'US' !== WC()->countries->get_base_country() ||
+			! WC_Stripe_Helper::order_supports_level3_data( $order )
 		) {
 			return self::request(
 				$request,

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1530,6 +1530,21 @@ class WC_Stripe_Helper {
 	}
 
 	/**
+	 * Determines whether Level 3 data should be sent to Stripe for the given order.
+	 *
+	 * Level 3 data is card-network only. Non-card methods that support manual capture
+	 * (Affirm, Klarna, Afterpay/Clearpay, Amazon Pay) reject requests containing level3,
+	 * so it must not be attached for them.
+	 *
+	 * @param WC_Order $order The order being processed.
+	 * @return bool Whether Level 3 data applies to the order's payment method.
+	 */
+	public static function order_supports_level3_data( $order ) {
+		$payment_method_type = WC_Stripe_Order_Helper::get_instance()->get_stripe_upe_payment_type( $order );
+		return ! in_array( $payment_method_type, WC_Stripe_Payment_Methods::NON_CARD_MANUAL_CAPTURE_METHODS, true );
+	}
+
+	/**
 	 * Verifies if the provided order contains the identifier for a wallet method.
 	 *
 	 * @param WC_Order $order The order.

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1552,16 +1552,23 @@ class WC_Stripe_Helper {
 	/**
 	 * Determines whether Level 3 data should be sent to Stripe for the given order.
 	 *
-	 * Level 3 data is card-network only. Non-card methods that support manual capture
-	 * (Affirm, Klarna, Afterpay/Clearpay, Amazon Pay) reject requests containing level3,
-	 * so it must not be attached for them.
+	 * Level 3 is card-network only. Sending it for a non-card method draws a rejection that
+	 * sets the account-wide wc_stripe_level3_not_allowed transient, disabling level3 for
+	 * legitimate card orders too — so gate strictly to card payment types.
 	 *
 	 * @param WC_Order $order The order being processed.
 	 * @return bool Whether Level 3 data applies to the order's payment method.
 	 */
 	public static function order_supports_level3_data( $order ) {
 		$payment_method_type = WC_Stripe_Order_Helper::get_instance()->get_stripe_upe_payment_type( $order );
-		return ! in_array( $payment_method_type, WC_Stripe_Payment_Methods::NON_CARD_MANUAL_CAPTURE_METHODS, true );
+
+		// Legacy WC_Gateway_Stripe orders and the charge-based capture fallback never write the
+		// UPE payment-type meta but are card payments, so an unset type must keep sending level3.
+		if ( empty( $payment_method_type ) ) {
+			return true;
+		}
+
+		return in_array( $payment_method_type, WC_Stripe_Payment_Methods::LEVEL3_SUPPORTED_PAYMENT_METHODS, true );
 	}
 
 	/**

--- a/includes/constants/class-wc-stripe-payment-methods.php
+++ b/includes/constants/class-wc-stripe-payment-methods.php
@@ -96,6 +96,21 @@ class WC_Stripe_Payment_Methods {
 	];
 
 	/**
+	 * Non-card payment methods that support manual capture.
+	 *
+	 * Level 3 data is card-network only, so it must not be attached to requests for
+	 * these methods — Stripe rejects a request containing level3 for them.
+	 *
+	 * @var array
+	 */
+	public const NON_CARD_MANUAL_CAPTURE_METHODS = [
+		self::AFFIRM,
+		self::AFTERPAY_CLEARPAY,
+		self::KLARNA,
+		self::AMAZON_PAY,
+	];
+
+	/**
 	 * List of express payment methods labels. Amazon Pay and Link are not included,
 	 * as they have their own payment method classes.
 	 */

--- a/includes/constants/class-wc-stripe-payment-methods.php
+++ b/includes/constants/class-wc-stripe-payment-methods.php
@@ -96,18 +96,14 @@ class WC_Stripe_Payment_Methods {
 	];
 
 	/**
-	 * Non-card payment methods that support manual capture.
-	 *
-	 * Level 3 data is card-network only, so it must not be attached to requests for
-	 * these methods — Stripe rejects a request containing level3 for them.
+	 * Payment method types that Stripe accepts Level 3 data for.
+	 * Level 3 is card-network only.
 	 *
 	 * @var array
 	 */
-	public const NON_CARD_MANUAL_CAPTURE_METHODS = [
-		self::AFFIRM,
-		self::AFTERPAY_CLEARPAY,
-		self::KLARNA,
-		self::AMAZON_PAY,
+	public const LEVEL3_SUPPORTED_PAYMENT_METHODS = [
+		self::CARD,
+		self::CARD_PRESENT,
 	];
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -156,6 +156,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.9.0 - xxxx-xx-xx =
+* Fix - Stop attaching Level 3 data to captures and payments for non-card methods
 * Fix - Add the missing order and customer metadata to Adaptive Pricing payment intents
 * Add - Show a "Paid by customer" row with the Adaptive Pricing amount and currency on the order edit page
 * Fix - Send the admin New Order and customer Processing emails when an asynchronous payment method (iDEAL, Klarna, Bancontact) is confirmed via the deferred webhook path

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -734,6 +734,43 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
+	 * Test for `order_supports_level3_data`.
+	 *
+	 * Level 3 data is card-network only, so it must be attached for card (and
+	 * legacy orders with no stored UPE type) but never for the non-card methods
+	 * that support manual capture (Affirm, Klarna, Afterpay/Clearpay, Amazon Pay).
+	 *
+	 * @param string $upe_payment_type The stored Stripe UPE payment type.
+	 * @param bool   $expected         Whether Level 3 data applies to the order.
+	 * @dataProvider provide_order_supports_level3_data
+	 * @return void
+	 */
+	public function test_order_supports_level3_data( string $upe_payment_type, bool $expected ): void {
+		$order = WC_Helper_Order::create_order();
+		if ( '' !== $upe_payment_type ) {
+			WC_Stripe_Order_Helper::get_instance()->update_stripe_upe_payment_type( $order, $upe_payment_type );
+		}
+
+		$this->assertSame( $expected, WC_Stripe_Helper::order_supports_level3_data( $order ) );
+	}
+
+	/**
+	 * Provider for `test_order_supports_level3_data`.
+	 *
+	 * @return array
+	 */
+	public function provide_order_supports_level3_data(): array {
+		return [
+			'card'              => [ WC_Stripe_Payment_Methods::CARD, true ],
+			'no stored type'    => [ '', true ],
+			'Affirm'            => [ WC_Stripe_Payment_Methods::AFFIRM, false ],
+			'Klarna'            => [ WC_Stripe_Payment_Methods::KLARNA, false ],
+			'Afterpay/Clearpay' => [ WC_Stripe_Payment_Methods::AFTERPAY_CLEARPAY, false ],
+			'Amazon Pay'        => [ WC_Stripe_Payment_Methods::AMAZON_PAY, false ],
+		];
+	}
+
+	/**
 	 * Provider for `test_payment_method_allows_manual_capture`
 	 *
 	 * @return array

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -736,9 +736,8 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	/**
 	 * Test for `order_supports_level3_data`.
 	 *
-	 * Level 3 data is card-network only, so it must be attached for card (and
-	 * legacy orders with no stored UPE type) but never for the non-card methods
-	 * that support manual capture (Affirm, Klarna, Afterpay/Clearpay, Amazon Pay).
+	 * Level 3 is card-network only: it applies to card orders (and legacy orders with no
+	 * stored UPE type, which are card payments) but never to non-card payment methods.
 	 *
 	 * @param string $upe_payment_type The stored Stripe UPE payment type.
 	 * @param bool   $expected         Whether Level 3 data applies to the order.
@@ -761,12 +760,16 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 */
 	public function provide_order_supports_level3_data(): array {
 		return [
-			'card'              => [ WC_Stripe_Payment_Methods::CARD, true ],
-			'no stored type'    => [ '', true ],
-			'Affirm'            => [ WC_Stripe_Payment_Methods::AFFIRM, false ],
-			'Klarna'            => [ WC_Stripe_Payment_Methods::KLARNA, false ],
-			'Afterpay/Clearpay' => [ WC_Stripe_Payment_Methods::AFTERPAY_CLEARPAY, false ],
-			'Amazon Pay'        => [ WC_Stripe_Payment_Methods::AMAZON_PAY, false ],
+			'card'                  => [ WC_Stripe_Payment_Methods::CARD, true ],
+			'card present'          => [ WC_Stripe_Payment_Methods::CARD_PRESENT, true ],
+			'no stored type'        => [ '', true ],
+			'Affirm'                => [ WC_Stripe_Payment_Methods::AFFIRM, false ],
+			'Klarna'                => [ WC_Stripe_Payment_Methods::KLARNA, false ],
+			'Afterpay/Clearpay'     => [ WC_Stripe_Payment_Methods::AFTERPAY_CLEARPAY, false ],
+			'Amazon Pay'            => [ WC_Stripe_Payment_Methods::AMAZON_PAY, false ],
+			'Link'                  => [ WC_Stripe_Payment_Methods::LINK, false ],
+			'Cash App Pay'          => [ WC_Stripe_Payment_Methods::CASHAPP_PAY, false ],
+			'ACH (us_bank_account)' => [ WC_Stripe_Payment_Methods::ACH, false ],
 		];
 	}
 


### PR DESCRIPTION
Fixes STRIPE-1220

## Changes proposed in this Pull Request:
Level 3 data is card-network only, but we were attaching it to captures and payments for non-card methods that support manual capture (Affirm, Klarna, Afterpay/Clearpay, Amazon Pay). Stripe rejects requests that carry level3 for
those methods.

This PR adds a `WC_Stripe_Helper::order_supports_level3_data()` check gated on the order's stored Stripe UPE payment type, and skips level3 for the non-card manual-capture methods (new `WC_Stripe_Payment_Methods::NON_CARD_MANUAL_CAPTURE_METHODS` constant). Card orders keep sending level3 as before.

## Testing instructions
- Connect to a US Stripe account and set your store currency to USD.
- Enable **Affirm** (or Klarna / Afterpay).
- Enable manual capture.
- As a shopper, place and order with Affirm.
- As an admin, capture the order from the order edit page (change order status to processing).
- Check the logs for this transaction.
- In `develop` branch, notice that there is an error related to level3 data.
- In this branch, no level3 data related error is logged.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
