### PR TITLE
Show a clear message when manual capture is blocking Adaptive Pricing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -61,6 +61,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Prevent Adaptive Pricing payments from failing when the checkout return URL is relative
 * Add - Add a wc_stripe_subscription_renewal_blocked_by_radar action hook that fires when Stripe Radar blocks a subscription renewal payment
 * Fix - Include the statement descriptor when creating payment intents for ACSS Debit and BLIK payments
+* Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 
 2026-06-22 - version 10.8.3
 * Fix - Ensure Adaptive Pricing appears on the checkout page when enabled

--- a/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
+++ b/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
@@ -117,6 +117,27 @@ describe( 'Optimized Checkout Element feature setting', () => {
 		).toBeDisabled();
 	} );
 
+	it( 'disables Adaptive Pricing and explains why when manual capture is enabled', () => {
+		global.wc_stripe_settings_params = {
+			is_cs_available: false,
+			adaptive_pricing_unavailable_reason: 'manual-capture',
+		};
+
+		useIsOCEnabled.mockReturnValue( [ true, jest.fn() ] );
+
+		render( <OptimizedCheckoutFeature isOCAvailable={ true } /> );
+
+		expect(
+			screen.getByText( /Adaptive Pricing requires automatic capture/i )
+		).toBeInTheDocument();
+
+		expect(
+			screen.getByLabelText(
+				'Let customers pay in their local currency with Adaptive Pricing'
+			)
+		).toBeDisabled();
+	} );
+
 	it( 'triggers the hook when changing the Adaptive Pricing setting', async () => {
 		global.wc_stripe_settings_params = {
 			is_cs_available: true,

--- a/client/settings/advanced-settings-section/optimized-checkout-feature.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-feature.js
@@ -74,6 +74,11 @@ const getAdaptivePricingUnavailableText = (
 				'Adaptive Pricing requires working webhooks. Your Stripe webhooks are currently disabled, so it can’t be enabled.',
 				'woocommerce-gateway-stripe'
 			);
+		case 'manual-capture':
+			return __(
+				'Adaptive Pricing requires automatic capture. It’s unavailable while "Issue an authorization on checkout, and capture later" is enabled.',
+				'woocommerce-gateway-stripe'
+			);
 		default:
 			return __(
 				'Adaptive Pricing is currently unavailable.',

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -232,8 +232,11 @@ class WC_Stripe_Settings_Controller {
 			&& ! $is_ap_enabled
 			&& 'yes' === get_option( 'wc_stripe_show_ocs_only_banner', 'no' );
 
-		$adaptive_pricing_unavailable_reason = WC_Stripe_Helper::get_adaptive_pricing_unavailable_reason();
-		$is_checkout_sessions_available      = null === $adaptive_pricing_unavailable_reason;
+		$adaptive_pricing_unavailable_reason = WC_Stripe_Helper::get_adaptive_pricing_account_unavailable_reason();
+		if ( null === $adaptive_pricing_unavailable_reason && ! WC_Stripe_Helper::is_checkout_sessions_available() ) {
+			$adaptive_pricing_unavailable_reason = 'disabled';
+		}
+		$is_checkout_sessions_available = null === $adaptive_pricing_unavailable_reason;
 
 		$params = [
 			'time'                                  => time(),

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -232,14 +232,8 @@ class WC_Stripe_Settings_Controller {
 			&& ! $is_ap_enabled
 			&& 'yes' === get_option( 'wc_stripe_show_ocs_only_banner', 'no' );
 
-		$is_checkout_sessions_available      = false;
-		$adaptive_pricing_unavailable_reason = 'disabled';
-		if ( WC_Stripe_Helper::is_checkout_sessions_available() ) {
-			$adaptive_pricing_unavailable_reason = WC_Stripe_Helper::get_adaptive_pricing_account_unavailable_reason();
-			if ( null === $adaptive_pricing_unavailable_reason ) {
-				$is_checkout_sessions_available = true;
-			}
-		}
+		$adaptive_pricing_unavailable_reason = WC_Stripe_Helper::get_adaptive_pricing_unavailable_reason();
+		$is_checkout_sessions_available      = null === $adaptive_pricing_unavailable_reason;
 
 		$params = [
 			'time'                                  => time(),

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1217,6 +1217,28 @@ class WC_Stripe_Helper {
 	}
 
 	/**
+	 * Returns the reason why Adaptive Pricing is unavailable for the store, or null if it is available.
+	 *
+	 * Checks for:
+	 * - Account level restrictions
+	 * - Store level restrictions (manual capture disabled)
+	 *
+	 * @return string|null The reason why Adaptive Pricing is unavailable, or null if it is available.
+	 */
+	public static function get_adaptive_pricing_unavailable_reason(): ?string {
+		if ( ! self::is_checkout_sessions_available() ) {
+			$is_automatic_capture_enabled = ( self::get_stripe_settings()['capture'] ?? 'yes' ) === 'yes';
+			if ( ! $is_automatic_capture_enabled ) {
+				return 'manual-capture';
+			}
+
+			return 'disabled';
+		}
+
+		return self::get_adaptive_pricing_account_unavailable_reason();
+	}
+
+	/**
 	 * Returns whether adaptive pricing is supported for the current checkout.
 	 *
 	 * When on the checkout page, adaptive pricing is not supported if the cart contains

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1204,6 +1204,11 @@ class WC_Stripe_Helper {
 			return 'amount-mismatch-detected';
 		}
 
+		// Adaptive Pricing requires automatic capture.
+		if ( 'yes' !== ( self::get_stripe_settings()['capture'] ?? 'yes' ) ) {
+			return 'manual-capture';
+		}
+
 		// If we are in test mode, payout details are often missing and currency-based rules
 		// are not enforced.
 		if ( WC_Stripe_Mode::is_test() ) {
@@ -1224,28 +1229,6 @@ class WC_Stripe_Helper {
 		}
 
 		return null;
-	}
-
-	/**
-	 * Returns the reason why Adaptive Pricing is unavailable for the store, or null if it is available.
-	 *
-	 * Checks for:
-	 * - Account level restrictions
-	 * - Store level restrictions (manual capture disabled)
-	 *
-	 * @return string|null The reason why Adaptive Pricing is unavailable, or null if it is available.
-	 */
-	public static function get_adaptive_pricing_unavailable_reason(): ?string {
-		if ( ! self::is_checkout_sessions_available() ) {
-			$is_automatic_capture_enabled = ( self::get_stripe_settings()['capture'] ?? 'yes' ) === 'yes';
-			if ( ! $is_automatic_capture_enabled ) {
-				return 'manual-capture';
-			}
-
-			return 'disabled';
-		}
-
-		return self::get_adaptive_pricing_account_unavailable_reason();
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -216,5 +216,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Prevent Adaptive Pricing payments from failing when the checkout return URL is relative
 * Add - Add a wc_stripe_subscription_renewal_blocked_by_radar action hook that fires when Stripe Radar blocks a subscription renewal payment
 * Fix - Include the statement descriptor when creating payment intents for ACSS Debit and BLIK payments
+* Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/admin/class-wc-stripe-settings-controller-test.php
+++ b/tests/phpunit/admin/class-wc-stripe-settings-controller-test.php
@@ -117,7 +117,8 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 	public function test_admin_scripts_sets_checkout_sessions_availability_with_country_restrictions(
 		string $account_country,
 		bool $is_checkout_sessions_feature_available,
-		bool $expected_checkout_sessions_availability
+		bool $expected_checkout_sessions_availability,
+		?string $expected_adaptive_pricing_unavailable_reason = null
 	): void {
 		global $current_tab, $current_section;
 
@@ -184,6 +185,10 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 			$this->assertIsArray( $params );
 			$expected_cs_param = $expected_checkout_sessions_availability ? '1' : '';
 			$this->assertSame( $expected_cs_param, $params['is_cs_available'] );
+			$this->assertSame(
+				$expected_adaptive_pricing_unavailable_reason,
+				$params['adaptive_pricing_unavailable_reason']
+			);
 			$this->assertSame( 'accordion', $params['oc_layout'] );
 		} finally {
 			if ( isset( $stripe_singleton_account_backup ) ) {
@@ -196,10 +201,10 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 
 	public function provide_test_admin_scripts_checkout_sessions_country_restrictions(): array {
 		return [
-			'US account + feature available'   => [ 'US', true, true ],
-			'IN account + feature available'   => [ 'IN', true, false ],
-			'DE account + feature available'   => [ 'DE', true, true ],
-			'US account + feature unavailable' => [ 'US', false, false ],
+			'US account + feature available'   => [ 'US', true, true, null ],
+			'IN account + feature available'   => [ 'IN', true, false, 'account-country' ],
+			'DE account + feature available'   => [ 'DE', true, true, null ],
+			'US account + feature unavailable' => [ 'US', false, false, 'disabled' ],
 		];
 	}
 }

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -816,6 +816,21 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that `get_adaptive_pricing_unavailable_reason` reports manual capture specifically,
+	 * so merchants know that the "Issue an authorization on checkout, and capture later" setting
+	 * is what blocks Adaptive Pricing rather than seeing the generic reason.
+	 *
+	 * @return void
+	 */
+	public function test_get_adaptive_pricing_unavailable_reason_for_manual_capture() {
+		WC_Stripe_Helper::update_main_stripe_settings( [ 'capture' => 'no' ] );
+
+		$this->assertSame( 'manual-capture', WC_Stripe_Helper::get_adaptive_pricing_unavailable_reason() );
+
+		WC_Stripe_Helper::delete_main_stripe_settings();
+	}
+
+	/**
 	 * Test for `get_klarna_preferred_locale`.
 	 * @return void
 	 */

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -856,21 +856,6 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that `get_adaptive_pricing_unavailable_reason` reports manual capture specifically,
-	 * so merchants know that the "Issue an authorization on checkout, and capture later" setting
-	 * is what blocks Adaptive Pricing rather than seeing the generic reason.
-	 *
-	 * @return void
-	 */
-	public function test_get_adaptive_pricing_unavailable_reason_for_manual_capture() {
-		WC_Stripe_Helper::update_main_stripe_settings( [ 'capture' => 'no' ] );
-
-		$this->assertSame( 'manual-capture', WC_Stripe_Helper::get_adaptive_pricing_unavailable_reason() );
-
-		WC_Stripe_Helper::delete_main_stripe_settings();
-	}
-
-	/**
 	 * Test for `get_klarna_preferred_locale`.
 	 * @return void
 	 */
@@ -2064,6 +2049,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 * @param ?string $expected                 Expected return value.
 	 * @param bool    $webhook_enabled          Whether the Stripe webhook endpoint is enabled. Defaults to true.
 	 * @param bool    $amount_mismatch_detected Whether Adaptive Pricing was disabled due to amount mismatches. Defaults to false.
+	 * @param bool    $manual_capture           Whether manual capture is enabled. Defaults to false.
 	 * @return void
 	 * @dataProvider provide_test_get_adaptive_pricing_account_unavailable_reason
 	 */
@@ -2073,11 +2059,13 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		string $store_currency,
 		?string $expected,
 		bool $webhook_enabled = true,
-		bool $amount_mismatch_detected = false
+		bool $amount_mismatch_detected = false,
+		bool $manual_capture = false
 	): void {
 		$original_settings    = WC_Stripe_Helper::get_stripe_settings();
 		$settings             = $original_settings;
 		$settings['testmode'] = $test_mode ? 'yes' : 'no';
+		$settings['capture']  = $manual_capture ? 'no' : 'yes';
 		if ( $webhook_enabled ) {
 			$settings['webhook_data']      = [
 				'id'     => 'we_live',
@@ -2141,6 +2129,22 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'test_mode'      => false,
 				'store_currency' => 'USD',
 				'expected'       => 'account-country',
+			],
+			'Manual capture → manual-capture'                                               => [
+				'account_data'             => [
+					'country'           => 'US',
+					'external_accounts' => [
+						'data' => [
+							[ 'currency' => 'usd' ],
+						],
+					],
+				],
+				'test_mode'                => false,
+				'store_currency'           => 'USD',
+				'expected'                 => 'manual-capture',
+				'webhook_enabled'          => true,
+				'amount_mismatch_detected' => false,
+				'manual_capture'           => true,
 			],
 			'India account (lowercase) → account-country'                                   => [
 				'account_data'   => [


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-1267

## Changes proposed in this Pull Request:

Adaptive Pricing can't be used together with the "Issue an authorization on checkout, and capture later" setting. When that setting is on, Adaptive Pricing is correctly turned off behind the scenes, but the settings screen only showed a
generic "Adaptive Pricing is currently unavailable" message, giving merchants no idea why or how to fix it.

This updates that message to say specifically that manual capture is the reason, so merchants know which setting to change. This is a text/help change only, it does not alter when Adaptive Pricing actually runs.

Before
<img width="1452" height="260" alt="CleanShot 2026-07-10 at 14 00 00@2x" src="https://github.com/user-attachments/assets/6a898854-c2e5-4684-ae28-4fb0e1f37ba7" />


Now
<img width="1448" height="316" alt="CleanShot 2026-07-10 at 13 59 23@2x" src="https://github.com/user-attachments/assets/157dbc7c-f9fb-43da-8fc8-467587c1a718" />


<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. Enable the Optimized Checkout Suite in the Stripe settings.
2. Turn on the "Issue an authorization on checkout, and capture later" setting.
3. Open the Stripe settings and find the Adaptive Pricing option.
4. Confirm the option is disabled and the help text now explains that Adaptive Pricing requires automatic capture and is unavailable while manual capture is enabled.
5. Turn manual capture back off and confirm the message disappears, and Adaptive Pricing becomes available again

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
