### PR TITLE
Fix Level 3 data on orders with a negative fee so it matches the capture amount

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -61,6 +61,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Prevent Adaptive Pricing payments from failing when the checkout return URL is relative
 * Add - Add a wc_stripe_subscription_renewal_blocked_by_radar action hook that fires when Stripe Radar blocks a subscription renewal payment
 * Fix - Include the statement descriptor when creating payment intents for ACSS Debit and BLIK payments
+* Fix - Represent negative fees and taxes as discounts in Level 3 data so manually capturing an order edited to include a negative fee no longer fails
 
 2026-06-22 - version 10.8.3
 * Fix - Ensure Adaptive Pricing appears on the checkout page when enabled

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1616,9 +1616,22 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 					WC_Stripe_Logger::error( $error_msg );
 					throw new WC_Stripe_Exception( $error_msg );
 				}
-				$unit_cost       = WC_Stripe_Helper::get_stripe_amount( ( $subtotal / $quantity ), $currency );
-				$tax_amount      = WC_Stripe_Helper::get_stripe_amount( $item->get_total_tax(), $currency );
-				$discount_amount = WC_Stripe_Helper::get_stripe_amount( $subtotal - $item->get_total(), $currency );
+				$total_tax = $item->get_total_tax();
+
+				if ( $subtotal >= 0 ) {
+					$unit_cost       = WC_Stripe_Helper::get_stripe_amount( ( $subtotal / $quantity ), $currency );
+					$discount_amount = WC_Stripe_Helper::get_stripe_amount( $subtotal - $item->get_total(), $currency );
+				} else {
+					$unit_cost       = 0;
+					$discount_amount = WC_Stripe_Helper::get_stripe_amount( ( $subtotal / $quantity ), $currency );
+				}
+
+				// Tax must not be negative either; fold a negative tax into the discount.
+				$tax_amount = WC_Stripe_Helper::get_stripe_amount( $total_tax, $currency );
+				if ( $total_tax < 0 ) {
+					$discount_amount += $tax_amount;
+					$tax_amount       = 0;
+				}
 
 				return (object) [
 					'product_code'        => (string) $product_id, // Up to 12 characters that uniquely identify the product.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1616,14 +1616,15 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 					WC_Stripe_Logger::error( $error_msg );
 					throw new WC_Stripe_Exception( $error_msg );
 				}
-				$total_tax = $item->get_total_tax();
+				$total_tax  = $item->get_total_tax();
+				$item_total = $item->get_total();
 
 				if ( $subtotal >= 0 ) {
 					$unit_cost       = WC_Stripe_Helper::get_stripe_amount( ( $subtotal / $quantity ), $currency );
-					$discount_amount = WC_Stripe_Helper::get_stripe_amount( $subtotal - $item->get_total(), $currency );
+					$discount_amount = WC_Stripe_Helper::get_stripe_amount( $subtotal - $item_total, $currency );
 				} else {
 					$unit_cost       = 0;
-					$discount_amount = WC_Stripe_Helper::get_stripe_amount( ( $subtotal / $quantity ), $currency );
+					$discount_amount = WC_Stripe_Helper::get_stripe_amount( $item_total, $currency );
 				}
 
 				// Tax must not be negative either; fold a negative tax into the discount.

--- a/readme.txt
+++ b/readme.txt
@@ -216,5 +216,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Prevent Adaptive Pricing payments from failing when the checkout return URL is relative
 * Add - Add a wc_stripe_subscription_renewal_blocked_by_radar action hook that fires when Stripe Radar blocks a subscription renewal payment
 * Fix - Include the statement descriptor when creating payment intents for ACSS Debit and BLIK payments
+* Fix - Represent negative fees and taxes as discounts in Level 3 data so manually capturing an order edited to include a negative fee no longer fails
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-level3-data-test.php
+++ b/tests/phpunit/class-wc-stripe-level3-data-test.php
@@ -297,6 +297,86 @@ class WC_Stripe_Level3_Data_Test extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * A negative fee and its tax must reduce the Level 3 total, not inflate it, so it still
+	 * matches the capture amount.
+	 */
+	public function test_level3_data_with_negative_fee() {
+		$mock_item = $this->getMockBuilder( WC_Order_Item_Product::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'get_name', 'get_quantity', 'get_subtotal', 'get_total_tax', 'get_total', 'get_variation_id', 'get_product_id' ] )
+			->getMock();
+
+		$mock_item->method( 'get_name' )->willReturn( 'Beanie with Logo' );
+		$mock_item->method( 'get_quantity' )->willReturn( 1 );
+		$mock_item->method( 'get_total' )->willReturn( 18 );
+		$mock_item->method( 'get_subtotal' )->willReturn( 18 );
+		$mock_item->method( 'get_total_tax' )->willReturn( 3.6 );
+		$mock_item->method( 'get_variation_id' )->willReturn( false );
+		$mock_item->method( 'get_product_id' )->willReturn( 30 );
+
+		$mock_fee = $this->getMockBuilder( WC_Order_Item_Fee::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'get_name', 'get_quantity', 'get_total_tax', 'get_total' ] )
+			->getMock();
+
+		$mock_fee->method( 'get_name' )->willReturn( 'Discount' );
+		$mock_fee->method( 'get_quantity' )->willReturn( 1 );
+		$mock_fee->method( 'get_total' )->willReturn( -5 );
+		$mock_fee->method( 'get_total_tax' )->willReturn( -1 );
+
+		$mock_order = $this->getMockBuilder( WC_Order::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'get_id', 'get_items', 'get_currency', 'get_shipping_total', 'get_shipping_tax', 'get_shipping_postcode' ] )
+			->getMock();
+
+		$mock_order->method( 'get_id' )->willReturn( 210 );
+		$mock_order->method( 'get_items' )->willReturn( [ $mock_item, $mock_fee ] );
+		$mock_order->method( 'get_currency' )->willReturn( WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR );
+		$mock_order->method( 'get_shipping_total' )->willReturn( 0 );
+		$mock_order->method( 'get_shipping_tax' )->willReturn( 0 );
+		$mock_order->method( 'get_shipping_postcode' )->willReturn( '98012' );
+
+		$gateway = new WC_Stripe_UPE_Payment_Gateway();
+		$result  = $gateway->get_level3_data_from_order( $mock_order );
+
+		// The negative fee is represented as a zero-cost line item with an equivalent discount
+		// (fee 5.00 + fee tax 1.00 = 600 minor units) so the Level 3 total nets down correctly.
+		$this->assertEquals(
+			[
+				(object) [
+					'product_code'        => '30',
+					'product_description' => 'Beanie with Logo',
+					'unit_cost'           => 1800,
+					'quantity'            => 1,
+					'tax_amount'          => 360,
+					'discount_amount'     => 0,
+				],
+				(object) [
+					'product_code'        => 'discount',
+					'product_description' => 'Discount',
+					'unit_cost'           => 0,
+					'quantity'            => 1,
+					'tax_amount'          => 0,
+					'discount_amount'     => 600,
+				],
+			],
+			$result['line_items']
+		);
+
+		// The Level 3 total must equal the capture amount (order total 15.60 => 1560).
+		$level3_total  = array_reduce(
+			$result['line_items'],
+			function ( $sum, $item ) {
+				return $sum + ( $item->quantity * $item->unit_cost ) - $item->discount_amount + $item->tax_amount;
+			},
+			0
+		);
+		$level3_total += $result['shipping_amount'];
+
+		$this->assertEquals( 1560, $level3_total );
+	}
+
 	public function test_full_level3_data_with_fee() {
 		$expected_data = [
 			'merchant_reference'   => '210',


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-1268

## Changes proposed in this Pull Request:

When a store sends Level 3 data, we send a per-item breakdown that it sends to Stripe alongside the amount being
charged. Stripe requires that breakdown to add up to the amount.

If an order includes a negative fee, for example an admin adds a manual discount to an authorized order before capturing it, we were turning that negative fee, and any negative tax on it, into positive values. The breakdown then added up to more than the amount being charged, so Stripe rejected it.

<img width="275" height="275" alt="CleanShot 2026-07-10 at 14 28 33@2x" src="https://github.com/user-attachments/assets/6e6c748a-7ad3-43db-8efe-b77bc5751129" />

Currently, when Stripe rejects the breakdown, we drop the Level 3 data and retry the charge, which succeeds. So orders
still capture, but every affected capture makes an extra failed request to Stripe and loses the Level 3 data it was meant to send.

Following a similar fix in WooPayments (https://github.com/Automattic/woocommerce-payments/pull/10796), this PR treats a negative fee, and a negative tax, as a discount instead of flipping it to a positive charge. 



<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

Setup:
Clear out the `wc_stripe_level3_not_allowed` transient or comment out the bail out logic in [this branch](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/3c84cf86e72243028380694fa5127885293be373/includes/class-wc-stripe-api.php#L457)

1. Enable manual capture in the Stripe settings.
2. Place an order.
3. As a merchant, edit the order and add a negative fee that is smaller than the total (e.g. a -$5.00 fee ). Save/recalculate. The new total should be lower than the authorized amount.
<img width="2882" height="414" alt="CleanShot 2026-07-10 at 14 32 44@2x" src="https://github.com/user-attachments/assets/b0bd29f1-9036-494e-8fdf-1adad72ff352" />


4. Change the order status to Processing to trigger the capture.
5. Confirm the order captures successfully without an error.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
