### PR TITLE
Fix Apple Pay address error for provinces entered with a curly apostrophe

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -61,6 +61,7 @@ xxxx-xx-xx - version 10.9.0
 * Add - Add a wc_stripe_subscription_renewal_blocked_by_radar action hook that fires when Stripe Radar blocks a subscription renewal payment
 * Fix - Include the statement descriptor when creating payment intents for ACSS Debit and BLIK payments
 * Fix - Ensure all WordPress hooks have filter documentation
+* Fix - Accept express checkout addresses whose province is entered with a curly apostrophe, so Apple Pay no longer reject them
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/changelog.txt
+++ b/changelog.txt
@@ -64,7 +64,7 @@ xxxx-xx-xx - version 10.9.0
 * Add - Add a wc_stripe_subscription_renewal_blocked_by_radar action hook that fires when Stripe Radar blocks a subscription renewal payment
 * Fix - Include the statement descriptor when creating payment intents for ACSS Debit and BLIK payments
 * Fix - Ensure all WordPress hooks have filter documentation
-* Fix - Accept express checkout addresses whose province is entered with a curly apostrophe, so Apple Pay no longer reject them
+* Fix - Accept express checkout addresses whose province is entered with a curly apostrophe, so Apple Pay no longer rejects them
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -1458,8 +1458,8 @@ class WC_Stripe_Express_Checkout_Helper {
 			return $state;
 		}
 
+		$sanitized_state_string = $this->sanitize_string( $state );
 		foreach ( $pr_states[ $country ] as $wc_state_abbr => $pr_state ) {
-			$sanitized_state_string = $this->sanitize_string( $state );
 			// Checks if input state matches with Payment Request state code (0), name (1) or localName (2).
 			if (
 				( ! empty( $pr_state[0] ) && $sanitized_state_string === $this->sanitize_string( $pr_state[0] ) ) ||

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -1434,6 +1434,11 @@ class WC_Stripe_Express_Checkout_Helper {
 	 * @return string The sanitized string.
 	 */
 	public function sanitize_string( $string ) {
+		// Remap apostrophe variants to U+0027 APOSTROPHE so the comparison is insensitive to
+		// which glyph the customer's keyboard produced.
+		// See https://www.unicode.org/Public/security/latest/confusables.txt.
+		$string = str_replace( [ "\u{2019}", "\u{2018}", "\u{02BC}", "\u{FF07}", "\u{00B4}", '`' ], "'", $string );
+
 		return trim( wc_strtolower( remove_accents( $string ) ) );
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -219,6 +219,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Add a wc_stripe_subscription_renewal_blocked_by_radar action hook that fires when Stripe Radar blocks a subscription renewal payment
 * Fix - Include the statement descriptor when creating payment intents for ACSS Debit and BLIK payments
 * Fix - Ensure all WordPress hooks have filter documentation
-* Fix - Accept express checkout addresses whose province is entered with a curly apostrophe, so Apple Pay no longer reject them
+* Fix - Accept express checkout addresses whose province is entered with a curly apostrophe, so Apple Pay no longer rejects them
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -216,5 +216,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Add a wc_stripe_subscription_renewal_blocked_by_radar action hook that fires when Stripe Radar blocks a subscription renewal payment
 * Fix - Include the statement descriptor when creating payment intents for ACSS Debit and BLIK payments
 * Fix - Ensure all WordPress hooks have filter documentation
+* Fix - Accept express checkout addresses whose province is entered with a curly apostrophe, so Apple Pay no longer reject them
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-helper-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-helper-test.php
@@ -1708,6 +1708,16 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 				'country'  => 'ES',
 				'expected' => 'BI',
 			],
+			'IT straight apostrophe L\'Aquila normalizes to AQ'             => [
+				'state'    => "L'Aquila",
+				'country'  => 'IT',
+				'expected' => 'AQ',
+			],
+			'IT curly apostrophe L’Aquila normalizes to AQ'                 => [
+				'state'    => "L\u{2019}Aquila",
+				'country'  => 'IT',
+				'expected' => 'AQ',
+			],
 		];
 	}
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-1270

## Changes proposed in this Pull Request:

When paying with Apple Pay, checkout can fail because the province field has a curly ("smart") apostrophe instead of a straight one (eg: L’Aquila instead of L'Aquila). 

To validate the address, the plugin looks up the province name in the list of valid Italian provinces to find its code. The curly and straight apostrophes didn't match, the lookup failed, resulting in an error on the payment sheet.

<img width="760" height="202" alt="CleanShot 2026-07-14 at 13 44 41@2x" src="https://github.com/user-attachments/assets/a56c0c31-fd9d-4aed-939a-9bd7de2fe677" />


This PR makes that lookup ignore which style of apostrophe is used based on the UTF-8 literals in https://www.unicode.org/Public/security/latest/confusables.txt

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. On checkout, select Apple Pay
2. Add a new Address with a curly apostrophe as the shipping address 
eg: 
```
Street: Corso Vittorio Emanuele II
City: L’Aquila
Province: L’Aquila
Postal code:  67100
Country: Italy
```
3. Select the above address as the shipping address
4. On **develop**: payment sheet will show an error. On this branch, you should be able to place the order with no errors
5. (Optional) On Stripe dashboard under payment intent data, you should see that state is mapped to `AQ`

<img width="3052" height="778" alt="CleanShot 2026-07-14 at 14 01 18@2x" src="https://github.com/user-attachments/assets/bbfc6a79-f2b0-4cc8-a8bf-0d3db6a9a31f" />


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
