### PR TITLE
Clear the Adaptive Pricing resync notice on recovery and guard the resync UI-block

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -66,6 +66,7 @@ xxxx-xx-xx - version 10.9.0
 * Add - Add a wc_stripe_subscription_renewal_blocked_by_radar action hook that fires when Stripe Radar blocks a subscription renewal payment
 * Fix - Include the statement descriptor when creating payment intents for ACSS Debit and BLIK payments
 * Fix - Ensure all WordPress hooks have filter documentation
+* Fix - Clear the Adaptive Pricing order total error notice once a later update succeeds
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/client/blocks/checkout-sessions/__tests__/hooks.test.js
+++ b/client/blocks/checkout-sessions/__tests__/hooks.test.js
@@ -16,10 +16,11 @@ jest.mock( '@wordpress/element', () => ( {
 
 jest.mock( '@wordpress/data', () => {
 	const createErrorNotice = jest.fn();
+	const removeNotice = jest.fn();
 	return {
 		select: jest.fn(),
 		useSelect: jest.fn( () => '' ),
-		dispatch: jest.fn( () => ( { createErrorNotice } ) ),
+		dispatch: jest.fn( () => ( { createErrorNotice, removeNotice } ) ),
 	};
 } );
 
@@ -777,7 +778,10 @@ describe( 'CheckoutSessions hook tests', () => {
 			} );
 			expect( createErrorNotice ).toHaveBeenCalledWith(
 				STALE_TOTAL_MESSAGE,
-				{ context: 'wc/checkout/payments' }
+				{
+					id: 'wc-stripe-stale-checkout-total',
+					context: 'wc/checkout/payments',
+				}
 			);
 		} );
 
@@ -814,6 +818,12 @@ describe( 'CheckoutSessions hook tests', () => {
 			await waitFor( () => {
 				expect( syncFailedRef.current ).toBe( false );
 			} );
+
+			// The notice a prior failed resync showed must be retracted, not left stale.
+			expect( dispatch().removeNotice ).toHaveBeenCalledWith(
+				'wc-stripe-stale-checkout-total',
+				'wc/checkout/payments'
+			);
 		} );
 	} );
 } );

--- a/client/blocks/checkout-sessions/hooks.js
+++ b/client/blocks/checkout-sessions/hooks.js
@@ -429,11 +429,15 @@ export const useCheckoutSessionTotalsSync = (
 					console.error( error );
 				}
 			} finally {
-				unblockUI(
-					jQuery(
-						'.wc-block-checkout__payment-method, .wc-block-components-checkout-place-order-button'
-					)
-				);
+				// A superseded resync must not lift the block a newer, still
+				// in-flight resync is holding on the payment area.
+				if ( ! cancelled ) {
+					unblockUI(
+						jQuery(
+							'.wc-block-checkout__payment-method, .wc-block-components-checkout-place-order-button'
+						)
+					);
+				}
 			}
 		};
 

--- a/client/blocks/checkout-sessions/hooks.js
+++ b/client/blocks/checkout-sessions/hooks.js
@@ -381,6 +381,9 @@ export const useCheckoutSessionTotalsSync = (
 
 		let cancelled = false;
 
+		// Stable id so a later successful resync can retract the notice a failed one showed.
+		const STALE_TOTAL_NOTICE_ID = 'wc-stripe-stale-checkout-total';
+
 		const markSyncFailed = () => {
 			if ( cancelled ) {
 				return;
@@ -390,7 +393,20 @@ export const useCheckoutSessionTotalsSync = (
 			}
 			dispatch( 'core/notices' )?.createErrorNotice(
 				getStaleCheckoutTotalMessage(),
-				{ context: 'wc/checkout/payments' }
+				{
+					id: STALE_TOTAL_NOTICE_ID,
+					context: 'wc/checkout/payments',
+				}
+			);
+		};
+
+		const clearSyncFailed = () => {
+			if ( syncFailedRef ) {
+				syncFailedRef.current = false;
+			}
+			dispatch( 'core/notices' )?.removeNotice(
+				STALE_TOTAL_NOTICE_ID,
+				'wc/checkout/payments'
 			);
 		};
 
@@ -418,9 +434,9 @@ export const useCheckoutSessionTotalsSync = (
 					markSyncFailed();
 					// eslint-disable-next-line no-console
 					console.error( result.error );
-				} else if ( ! cancelled && syncFailedRef ) {
-					// Totals are back in sync; lift any prior block.
-					syncFailedRef.current = false;
+				} else if ( ! cancelled ) {
+					// Totals are back in sync; lift the block and retract the notice.
+					clearSyncFailed();
 				}
 			} catch ( error ) {
 				if ( ! cancelled ) {

--- a/client/classic/upe/__tests__/payment-processing.test.js
+++ b/client/classic/upe/__tests__/payment-processing.test.js
@@ -33,6 +33,7 @@ jest.mock( 'wcstripe/stripe-utils', () => ( {
 		.mockReturnValue(
 			"We couldn't update your order total. Please refresh the page and try again."
 		),
+	clearStaleCheckoutTotalNotice: jest.fn(),
 
 	isLinkEnabled: jest.fn().mockReturnValue( false ),
 	resetBlockCheckoutPaymentState: jest.fn(),
@@ -1308,6 +1309,30 @@ describe( 'payment-processing', () => {
 				);
 
 				expect( stripeUtils.showErrorCheckout ).not.toHaveBeenCalled();
+			} );
+
+			it( 'retracts the stale-total notice once a later resync succeeds', async () => {
+				const checkoutElements = createMockElements();
+				const api = createMockApi( checkoutElements );
+				await mountElement( api, checkoutElements );
+
+				// First resync fails and leaves a notice on the page.
+				checkoutElements.checkoutActions.runServerUpdate.mockResolvedValueOnce(
+					{ type: 'error', error: { message: 'boom' } }
+				);
+				await paymentProcessing.maybeUpdateAdaptivePricingCheckoutSession(
+					api
+				);
+				stripeUtils.clearStaleCheckoutTotalNotice.mockClear();
+
+				// A later clean resync must clear that lingering notice.
+				await paymentProcessing.maybeUpdateAdaptivePricingCheckoutSession(
+					api
+				);
+
+				expect(
+					stripeUtils.clearStaleCheckoutTotalNotice
+				).toHaveBeenCalled();
 			} );
 
 			it( 'blocks payment while the session is stale, then allows it after a clean resync', async () => {

--- a/client/classic/upe/__tests__/payment-processing.test.js
+++ b/client/classic/upe/__tests__/payment-processing.test.js
@@ -75,14 +75,31 @@ const mockJQueryTrigger = jest.fn();
 // uses the same mock as assertions below. global.jQuery is also set for any
 // code that accesses window.jQuery directly.
 jest.mock( 'jquery', () => {
-	const jq = jest.fn( () => {
+	// Record block/unblock per selector on globalThis so counts survive
+	// jest.resetModules() (which otherwise desyncs the mock instance the code
+	// under test captured at import from the one a test would grab here).
+	const jq = jest.fn( ( selector ) => {
 		const chain = {
 			on: jest.fn(),
 			trigger: jest.fn(),
 			addClass: jest.fn( () => chain ),
 			removeClass: jest.fn( () => chain ),
-			block: jest.fn( () => chain ),
-			unblock: jest.fn( () => chain ),
+			block: jest.fn( () => {
+				if ( typeof selector === 'string' ) {
+					global.__wcStripeBlockCounts ??= {};
+					global.__wcStripeBlockCounts[ selector ] =
+						( global.__wcStripeBlockCounts[ selector ] ?? 0 ) + 1;
+				}
+				return chain;
+			} ),
+			unblock: jest.fn( () => {
+				if ( typeof selector === 'string' ) {
+					global.__wcStripeUnblockCounts ??= {};
+					global.__wcStripeUnblockCounts[ selector ] =
+						( global.__wcStripeUnblockCounts[ selector ] ?? 0 ) + 1;
+				}
+				return chain;
+			} ),
 		};
 		return chain;
 	} );
@@ -1296,6 +1313,67 @@ describe( 'payment-processing', () => {
 				// The superseded failure must not resurrect the stale-total
 				// block after the newer resync cleared it.
 				expect( stripeUtils.showErrorCheckout ).not.toHaveBeenCalled();
+			} );
+
+			it( 'clears the payment-area block when the superseding resync never blocks of its own', async () => {
+				const SELECTOR = 'form.checkout #payment';
+				const blockCount = () =>
+					global.__wcStripeBlockCounts?.[ SELECTOR ] ?? 0;
+				const unblockCount = () =>
+					global.__wcStripeUnblockCounts?.[ SELECTOR ] ?? 0;
+				const blocksBefore = blockCount();
+				const unblocksBefore = unblockCount();
+
+				const checkoutElements = createMockElements();
+				const api = createMockApi( checkoutElements );
+				await mountElement( api, checkoutElements );
+
+				// Make the next resync enter the block branch regardless of the
+				// mount's one-shot loadActions.
+				checkoutElements.loadActions.mockResolvedValue( {
+					type: 'success',
+					actions: checkoutElements.checkoutActions,
+				} );
+
+				// Hold the older resync open so its finally runs after the newer
+				// generation takes over.
+				let resolveOlder;
+				checkoutElements.checkoutActions.runServerUpdate.mockImplementationOnce(
+					() =>
+						new Promise( ( resolve ) => {
+							resolveOlder = () =>
+								resolve( {
+									type: 'success',
+									session: {
+										id: MOCK_AP_CHECKOUT_SESSION_ID,
+									},
+								} );
+						} )
+				);
+
+				// Gen A blocks the payment area, then parks mid-update.
+				const olderResync =
+					paymentProcessing.maybeUpdateAdaptivePricingCheckoutSession(
+						api
+					);
+				await flushPromises();
+				expect( blockCount() ).toBe( blocksBefore + 1 );
+
+				// Element tears down before the newer resync, so it skips the
+				// block/guarded-unblock branch entirely (no loadActions).
+				delete checkoutElements.loadActions;
+
+				// Gen B (now current) completes without blocking.
+				await paymentProcessing.maybeUpdateAdaptivePricingCheckoutSession(
+					api
+				);
+
+				// Gen A settles last; superseded, so it skips its guarded unblock.
+				resolveOlder();
+				await olderResync;
+
+				// Gen B's final cleanup must have lifted the block Gen A stranded.
+				expect( unblockCount() ).toBeGreaterThan( unblocksBefore );
 			} );
 
 			it( 'does not show a notice when the resync succeeds', async () => {

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -221,6 +221,10 @@ export async function maybeUpdateAdaptivePricingCheckoutSession( api ) {
 		return;
 	}
 
+	// Clear any overlay a superseded resync left up; as the current generation
+	// with none newer in flight, this can't lift a block still in use.
+	unblockUI( jQuery( 'form.checkout #payment' ) );
+
 	adaptivePricingSyncFailed = resyncFailed;
 
 	if ( resyncFailed ) {

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -198,7 +198,11 @@ export async function maybeUpdateAdaptivePricingCheckoutSession( api ) {
 				// eslint-disable-next-line no-console
 				console.error( error );
 			} finally {
-				unblockUI( jQuery( 'form.checkout #payment' ) );
+				// A superseded resync must not lift the block a newer, still
+				// in-flight resync is holding on the payment area.
+				if ( generation === adaptivePricingSyncGeneration ) {
+					unblockUI( jQuery( 'form.checkout #payment' ) );
+				}
 			}
 		}
 

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -20,6 +20,7 @@ import {
 	getBillingDetailsForDeferredFlow,
 	normalizeReturnUrl,
 	getStaleCheckoutTotalMessage,
+	clearStaleCheckoutTotalNotice,
 } from '../../stripe-utils';
 import {
 	initializeUPEAppearance,
@@ -224,6 +225,9 @@ export async function maybeUpdateAdaptivePricingCheckoutSession( api ) {
 
 	if ( resyncFailed ) {
 		showErrorCheckout( getStaleCheckoutTotalMessage() );
+	} else {
+		// Retract the notice a prior failed resync left behind now that totals sync.
+		clearStaleCheckoutTotalNotice();
 	}
 }
 

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -800,6 +800,20 @@ export const getStaleCheckoutTotalMessage = () =>
 	);
 
 /**
+ * Remove a stale-total notice a prior failed resync left on the classic checkout.
+ *
+ * WooCommerce's `updated_checkout` refresh doesn't clear notices prepended to the
+ * notices wrapper, so a later successful resync must retract it itself. Matched by
+ * message text to avoid removing unrelated checkout errors.
+ */
+export const clearStaleCheckoutTotalNotice = () => {
+	const message = getStaleCheckoutTotalMessage();
+	jQuery( '.woocommerce-notices-wrapper .woocommerce-error' )
+		.filter( ( index, element ) => element.textContent.trim() === message )
+		.remove();
+};
+
+/**
  * Show error notice at top of checkout form.
  * Will try to use a translatable message using the message code if available.
  *

--- a/readme.txt
+++ b/readme.txt
@@ -221,5 +221,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Add a wc_stripe_subscription_renewal_blocked_by_radar action hook that fires when Stripe Radar blocks a subscription renewal payment
 * Fix - Include the statement descriptor when creating payment intents for ACSS Debit and BLIK payments
 * Fix - Ensure all WordPress hooks have filter documentation
+* Fix - Clear the Adaptive Pricing order total error notice once a later update succeeds
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Part of STRIPE-1066

## Changes proposed in this Pull Request:
Two follow-ups to #5682

1. **Clear the stale-total notice once a later resync succeeds.** #5682 shows the "We couldn't update your order total…" notice on a failed resync but never retracts it — if a later checkout change triggers a resync that succeeds, the block is lifted but the notice lingers on the page. 
Now a successful resync removes it: on classic checkout it's matched by message text so unrelated checkout errors are left alone, and on Blocks it's removed via a stable notice id + removeNotice.
2. **Guard the resync UI-block against superseded resyncs.** Back-to-back `updated_checkout` events can overlap two resyncs. The older one's finally was unblocking the payment area while a newer resync was still in flight — a premature unblock during exactly the rapid-shipping-change flow this feature targets. 
The unblock is now gated so only the latest resync lifts the block: classic via the existing generation counter, Blocks via the effect's cancelled flag.

## Testing instructions
Test on both classic and Blocks checkout.

**Setup**:
- Enable Adaptive Pricing.
- Have 2–3 shipping methods and a product in the cart; go to checkout.
- To force a failed resync, return an error early from update_checkout_session (https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/ajax-handlers/class-wc-stripe-checkout-sessions-ajax-handler.php#L119):
wp_send_json_error( [ 'message' => 'test failure' ] );

**Notice clears on recovery**
1. With the forced failure in place, change the shipping method → the "We couldn't update your order total…" notice appears and Place order is blocked.
2. Remove the forced-failure line so the resync succeeds again.
3. Change the shipping method again → the notice disappears and Place order is unblocked (previously the notice stayed on the page).

**No premature / stuck UI-block**
- With resyncs working normally, switch shipping methods a few times in quick succession. The payment area shows the processing overlay only while a resync is in flight and clears once the latest one finishes — it shouldn't flash unblocked mid-resync, and shouldn't get stuck blocked.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
