### PR TITLE
Prevent deferred payment methods from using the PaymentIntent creation endpoint

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -66,6 +66,7 @@ xxxx-xx-xx - version 10.9.0
 * Add - Add a wc_stripe_subscription_renewal_blocked_by_radar action hook that fires when Stripe Radar blocks a subscription renewal payment
 * Fix - Include the statement descriptor when creating payment intents for ACSS Debit and BLIK payments
 * Fix - Ensure all WordPress hooks have filter documentation
+* Fix - Restrict payment intent creation to payment methods that do not support deferred intent
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -401,6 +401,19 @@ class WC_Stripe_Intent_Controller {
 
 		$gateway                 = $this->get_upe_gateway();
 		$enabled_payment_methods = $payment_method_type ? [ $payment_method_type ] : $gateway->get_upe_enabled_at_checkout_payment_method_ids( $order_id );
+		$enabled_payment_methods = array_values(
+			array_filter(
+				$enabled_payment_methods,
+				function ( $payment_method_id ) use ( $gateway ) {
+					$payment_method = $gateway->payment_methods[ $payment_method_id ] ?? null;
+					return $payment_method && ! $payment_method->supports_deferred_intent();
+				}
+			)
+		);
+
+		if ( empty( $enabled_payment_methods ) ) {
+			throw new Exception( __( 'Unable to process your request. Please reload the page and try again.', 'woocommerce-gateway-stripe' ) );
+		}
 
 		$capture = $gateway->is_automatic_capture_enabled();
 		$request = [

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -400,7 +400,10 @@ class WC_Stripe_Intent_Controller {
 		}
 
 		$gateway                 = $this->get_upe_gateway();
-		$enabled_payment_methods = $payment_method_type ? [ $payment_method_type ] : $gateway->get_upe_enabled_at_checkout_payment_method_ids( $order_id );
+		$enabled_payment_methods = $gateway->get_upe_enabled_at_checkout_payment_method_ids( $order_id );
+		if ( $payment_method_type ) {
+			$enabled_payment_methods = in_array( $payment_method_type, $enabled_payment_methods, true ) ? [ $payment_method_type ] : [];
+		}
 		$enabled_payment_methods = array_values(
 			array_filter(
 				$enabled_payment_methods,

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -664,7 +664,27 @@ class WC_Stripe_Intent_Controller {
 	 * @throws Exception If customer for the current user cannot be read/found.
 	 */
 	public function init_setup_intent( $payment_method_type = null ) {
-		// Determine the customer managing the payment methods, create one if we don't have one already.
+		// Resolve enabled methods before creating the customer so a rejected request creates no Stripe customer.
+		$gateway                 = $this->get_upe_gateway();
+		$enabled_payment_methods = array_values( array_filter( $gateway->get_upe_enabled_payment_method_ids(), [ $gateway, 'is_enabled_for_saved_payments' ] ) );
+		if ( $payment_method_type ) {
+			$enabled_payment_methods = in_array( $payment_method_type, $enabled_payment_methods, true ) ? [ $payment_method_type ] : [];
+		}
+
+		$enabled_payment_methods = array_values(
+			array_filter(
+				$enabled_payment_methods,
+				function ( $payment_method_id ) use ( $gateway ) {
+					$payment_method = $gateway->payment_methods[ $payment_method_id ] ?? null;
+					return $payment_method && ! $payment_method->supports_deferred_intent();
+				}
+			)
+		);
+
+		if ( empty( $enabled_payment_methods ) ) {
+			throw new Exception( __( 'Unable to process your request. Please reload the page and try again.', 'woocommerce-gateway-stripe' ) );
+		}
+
 		$user     = wp_get_current_user();
 		$customer = new WC_Stripe_Customer( $user->ID );
 
@@ -673,9 +693,6 @@ class WC_Stripe_Intent_Controller {
 		} else {
 			$customer_id = $customer->update_customer();
 		}
-
-		$gateway                 = $this->get_upe_gateway();
-		$enabled_payment_methods = $payment_method_type ? [ $payment_method_type ] : array_values( array_filter( $gateway->get_upe_enabled_payment_method_ids(), [ $gateway, 'is_enabled_for_saved_payments' ] ) );
 
 		$request = [
 			'customer'             => $customer_id,

--- a/readme.txt
+++ b/readme.txt
@@ -221,5 +221,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Add a wc_stripe_subscription_renewal_blocked_by_radar action hook that fires when Stripe Radar blocks a subscription renewal payment
 * Fix - Include the statement descriptor when creating payment intents for ACSS Debit and BLIK payments
 * Fix - Ensure all WordPress hooks have filter documentation
+* Fix - Restrict payment intent creation to payment methods that do not support deferred intent
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-intent-controller-test.php
+++ b/tests/phpunit/class-wc-stripe-intent-controller-test.php
@@ -48,7 +48,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 
 		$this->gateway         = $this->getMockBuilder( 'WC_Stripe_UPE_Payment_Gateway' )
 			->setConstructorArgs( [ $mock_account ] )
-			->setMethods( [ 'maybe_process_upe_redirect', 'has_subscription' ] )
+			->setMethods( [ 'maybe_process_upe_redirect', 'has_subscription', 'get_upe_enabled_at_checkout_payment_method_ids' ] )
 			->getMock();
 		$this->mock_controller = $this->getMockBuilder( 'WC_Stripe_Intent_Controller' )
 			->disableOriginalConstructor()
@@ -71,6 +71,8 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_test_capture_method
 	 */
 	public function test_capture_method( ?string $capture_setting, string $expected_method ) {
+		$this->gateway->method( 'get_upe_enabled_at_checkout_payment_method_ids' )->willReturn( [ WC_Stripe_Payment_Methods::BLIK ] );
+
 		if ( null !== $capture_setting ) {
 			$this->gateway->settings['capture'] = $capture_setting;
 		}
@@ -120,6 +122,8 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_create_payment_intent_currency_data
 	 */
 	public function test_create_payment_intent_chooses_currency( $order_currency, $global_currency, $expected_currency ) {
+		$this->gateway->method( 'get_upe_enabled_at_checkout_payment_method_ids' )->willReturn( [ WC_Stripe_Payment_Methods::BLIK ] );
+
 		$order_id = null;
 
 		if ( null !== $order_currency ) {
@@ -174,6 +178,8 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_unsupported_create_payment_intent_types
 	 */
 	public function test_create_payment_intent_rejects_deferred_or_invalid_payment_method_types( $payment_method_type ) {
+		$this->gateway->method( 'get_upe_enabled_at_checkout_payment_method_ids' )->willReturn( [] );
+
 		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'Unable to process your request.' );
 
@@ -186,6 +192,32 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	 * @return array[]
 	 */
 	public function provide_unsupported_create_payment_intent_types() {
+		return [
+			'card supports deferred intent creation' => [ WC_Stripe_Payment_Methods::CARD ],
+			'missing payment method type'            => [ null ],
+			'unknown payment method type'            => [ 'unknown' ],
+		];
+	}
+
+	/**
+	 * Test that setup intents can only be created upfront for payment methods that do not support deferred intent creation.
+	 *
+	 * @param string|null $payment_method_type The requested payment method type.
+	 * @dataProvider provide_unsupported_init_setup_intent_types
+	 */
+	public function test_init_setup_intent_rejects_deferred_or_invalid_payment_method_types( $payment_method_type ) {
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Unable to process your request.' );
+
+		$this->mock_controller->init_setup_intent( $payment_method_type );
+	}
+
+	/**
+	 * Data provider for test_init_setup_intent_rejects_deferred_or_invalid_payment_method_types.
+	 *
+	 * @return array[]
+	 */
+	public function provide_unsupported_init_setup_intent_types() {
 		return [
 			'card supports deferred intent creation' => [ WC_Stripe_Payment_Methods::CARD ],
 			'missing payment method type'            => [ null ],
@@ -210,6 +242,8 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
 		$this->create_gateway_and_controller();
+
+		$this->gateway->method( 'get_upe_enabled_at_checkout_payment_method_ids' )->willReturn( [ $payment_method_type ] );
 
 		WC_Stripe::get_instance()->account = $this->getMockBuilder( 'WC_Stripe_Account' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/class-wc-stripe-intent-controller-test.php
+++ b/tests/phpunit/class-wc-stripe-intent-controller-test.php
@@ -93,7 +93,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 
 		add_filter( 'pre_http_request', $test_request, 10, 3 );
 
-		$this->mock_controller->create_payment_intent( $this->order->get_id() );
+		$this->mock_controller->create_payment_intent( $this->order->get_id(), WC_Stripe_Payment_Methods::BLIK );
 	}
 
 	/**
@@ -150,7 +150,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 
 		add_filter( 'pre_http_request', $test_request, 10, 3 );
 
-		$this->mock_controller->create_payment_intent( $order_id );
+		$this->mock_controller->create_payment_intent( $order_id, WC_Stripe_Payment_Methods::BLIK );
 
 		remove_filter( 'woocommerce_currency', $currency_callback );
 	}
@@ -164,6 +164,32 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		return [
 			'uses order currency when order exists' => [ 'USD', 'CAD', 'usd' ],
 			'uses global currency without order'    => [ null, 'EUR', 'eur' ],
+		];
+	}
+
+	/**
+	 * Test that intents can only be created upfront for payment methods that do not support deferred intent creation.
+	 *
+	 * @param string|null $payment_method_type The requested payment method type.
+	 * @dataProvider provide_unsupported_create_payment_intent_types
+	 */
+	public function test_create_payment_intent_rejects_deferred_or_invalid_payment_method_types( $payment_method_type ) {
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Unable to process your request.' );
+
+		$this->mock_controller->create_payment_intent( $this->order->get_id(), $payment_method_type );
+	}
+
+	/**
+	 * Data provider for test_create_payment_intent_rejects_deferred_or_invalid_payment_method_types.
+	 *
+	 * @return array[]
+	 */
+	public function provide_unsupported_create_payment_intent_types() {
+		return [
+			'card supports deferred intent creation' => [ WC_Stripe_Payment_Methods::CARD ],
+			'missing payment method type'            => [ null ],
+			'unknown payment method type'            => [ 'unknown' ],
 		];
 	}
 
@@ -239,8 +265,6 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 			'blik uses the local descriptor'          => [ WC_Stripe_UPE_Payment_Method_BLIK::STRIPE_ID, 'WOO STORE', $account_with_descriptor, 'WOO STORE' ],
 			'acss falls back to account descriptor'   => [ WC_Stripe_UPE_Payment_Method_ACSS::STRIPE_ID, '', $account_with_descriptor, 'ACCOUNT DESCRIPTOR' ],
 			'no descriptor available leaves it unset' => [ WC_Stripe_UPE_Payment_Method_BLIK::STRIPE_ID, '', [], null ],
-			'card payments do not set the descriptor' => [ WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID, 'WOO STORE', $account_with_descriptor, null ],
-			'no payment method type leaves it unset'  => [ null, 'WOO STORE', $account_with_descriptor, null ],
 		];
 	}
 

--- a/tests/phpunit/class-wc-stripe-intent-controller-test.php
+++ b/tests/phpunit/class-wc-stripe-intent-controller-test.php
@@ -178,7 +178,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_unsupported_create_payment_intent_types
 	 */
 	public function test_create_payment_intent_rejects_deferred_or_invalid_payment_method_types( $payment_method_type ) {
-		$this->gateway->method( 'get_upe_enabled_at_checkout_payment_method_ids' )->willReturn( [] );
+		$this->gateway->method( 'get_upe_enabled_at_checkout_payment_method_ids' )->willReturn( [ WC_Stripe_Payment_Methods::CARD ] );
 
 		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'Unable to process your request.' );


### PR DESCRIPTION
Fixes STRIPE-1278
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:

Restricts the checkout PaymentIntent creation endpoint to only payment methods that do not support deferred intent creation.

The existing enabled payment methods lookup is preserved, but methods that support deferred intents (such as card) are filtered out. Currently only ACSS Debit and BLIK can continue creating PaymentIntents.

```
curl -ksS 'https://stripe.local/?wc-ajax=wc_stripe_create_payment_intent' --data-urlencode '_ajax_nonce=<NONCE>' --data-urlencode 'payment_method_type=card'
```

## Testing instructions

- The linear issue has reproduction steps, but you can use [this script](https://mc.a8c.com/includes/img-uploader/files/1784229176-wcstripe-create-payment-intent-repro.mjs) to automate the test:
    ```
    node wcstripe-create-payment-intent-repro.mjs --base_url=https://scallop-of-macaronis.jurassic.ninja
    ```
    In develop, an intent is created/returned:
    ```
    {
      "intent_created": true,
      "fix_behavior_observed": false
    }
    ```
    With this branch no intent is created/returned:
    ```
    {
      "intent_created": false,
      "fix_behavior_observed": true
    }
    ```

- Test that Credit Card still work as expected (regression tests): 
1. Add a product to the cart
2. Navigate to the Blocks checkout
3. Place the order using Credit Card (use 4242424242424242 for example)
4. Verify the checkout completes without error

- Test that ACSS/BLIK still work as expected (regression tests): 
1. Make sure ACSS and BLIK are enabled in the plugin settings
2. Add a product to the cart
5. Navigate to the Blocks checkout
6. Place the order using ACSS/BLIK


---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
