### PR TITLE
Refund shoppers charged after cancelling their order

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -66,6 +66,7 @@ xxxx-xx-xx - version 10.9.0
 * Add - Add a wc_stripe_subscription_renewal_blocked_by_radar action hook that fires when Stripe Radar blocks a subscription renewal payment
 * Fix - Include the statement descriptor when creating payment intents for ACSS Debit and BLIK payments
 * Fix - Ensure all WordPress hooks have filter documentation
+* Fix - Refund the shopper when a Stripe payment is captured after the order was cancelled, instead of leaving them charged for a cancelled order
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -33,6 +33,15 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	protected const AGENTIC_SESSION_CLAIM_TTL = DAY_IN_SECONDS;
 
 	/**
+	 * Order meta flag recording that a late Stripe payment on a cancelled order was already
+	 * refunded/voided. Deferred webhooks are retried by Action Scheduler, and refunds are not
+	 * idempotent, so this guards against issuing a second refund on a retry.
+	 *
+	 * @var string
+	 */
+	protected const META_REFUNDED_AFTER_CANCELLATION = '_stripe_refunded_after_cancellation';
+
+	/**
 	 * Is test mode active?
 	 *
 	 * @var bool
@@ -1615,11 +1624,15 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 						throw new Exception( "Missing required data. 'intent_id' is missing for the deferred '{$webhook_type}' event." );
 					}
 
+					// Cancelled orders route to a refund instead of the mark-as-paid path below.
+					// @see handle_deferred_payment_for_cancelled_order() for why.
+					$order_cancelled = $order->has_status( OrderStatus::CANCELLED );
+
 					// Check if the order is still in a valid state to process the webhook.
 					/**
 					 * This filter is documented in includes/class-wc-stripe-webhook-handler.php.
 					 */
-					if ( ! $order->has_status( apply_filters( 'wc_stripe_allowed_payment_processing_statuses', [ OrderStatus::PENDING, OrderStatus::FAILED ], $order ) ) ) {
+					if ( ! $order_cancelled && ! $order->has_status( apply_filters( 'wc_stripe_allowed_payment_processing_statuses', [ OrderStatus::PENDING, OrderStatus::FAILED ], $order ) ) ) {
 						WC_Stripe_Logger::debug( "Skipped processing deferred webhook for Stripe PaymentIntent {$intent_id} for order {$order->get_id()} - payment already complete." );
 						return;
 					}
@@ -1636,7 +1649,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					}
 
 					try {
-						$this->handle_deferred_payment_intent_succeeded( $order, $intent_id );
+						if ( $order_cancelled ) {
+							$this->handle_deferred_payment_for_cancelled_order( $order, $intent_id );
+						} else {
+							$this->handle_deferred_payment_intent_succeeded( $order, $intent_id );
+						}
 					} finally {
 						$order_helper->unlock_order_payment( $order );
 					}
@@ -1825,6 +1842,112 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		$charge->is_webhook_response = true;
 		$this->process_response( $charge, $order );
+	}
+
+	/**
+	 * Handles a deferred payment webhook for an order the shopper already cancelled.
+	 *
+	 * A shopper can cancel an order while its payment is still settling in Stripe - for
+	 * example a slow 3DS confirmation that fails the return to checkout, after which the
+	 * shopper cancels the still-pending order. Stripe can then capture the payment and fire
+	 * payment_intent.succeeded (or authorise it and fire amount_capturable_updated) against
+	 * a cancelled order. Marking that order paid would silently run payment_complete(),
+	 * granting downloads, reducing stock and firing fulfilment hooks for an order nobody
+	 * wants. Instead we return the money: refund a captured charge, or void an uncaptured
+	 * authorisation, and record the details on the order for the merchant.
+	 *
+	 * @param WC_Order $order     The cancelled order.
+	 * @param string   $intent_id The PaymentIntent ID from the webhook payload.
+	 * @return void
+	 */
+	protected function handle_deferred_payment_for_cancelled_order( $order, $intent_id ) {
+		$intent = $this->get_intent_from_order( $order );
+
+		if ( ! $intent || $intent->id !== $intent_id ) {
+			WC_Stripe_Logger::debug( "Skipped refunding cancelled order {$order->get_id()} for Stripe PaymentIntent {$intent_id} - intent ID stored on the order doesn't match." );
+			return;
+		}
+
+		// Idempotency: Action Scheduler can retry this job, and issuing a refund twice would
+		// take the money from the shopper twice. The meta flag is the deterministic guard; the
+		// Stripe-state checks below catch a retry that lands before the flag was persisted.
+		if ( wc_string_to_bool( $order->get_meta( self::META_REFUNDED_AFTER_CANCELLATION ) ) ) {
+			WC_Stripe_Logger::debug( "Skipped refunding cancelled order {$order->get_id()} for Stripe PaymentIntent {$intent_id} - already refunded after cancellation." );
+			return;
+		}
+
+		if ( WC_Stripe_Intent_Status::CANCELED === $intent->status ) {
+			WC_Stripe_Logger::debug( "Skipped refunding cancelled order {$order->get_id()} for Stripe PaymentIntent {$intent_id} - the intent is already cancelled." );
+			return;
+		}
+
+		$charge    = $this->get_latest_charge_from_intent( $intent );
+		$charge_id = isset( $charge->id ) ? $charge->id : '';
+
+		if ( $charge && ! empty( $charge->refunded ) ) {
+			$this->mark_cancelled_order_refunded( $order );
+			WC_Stripe_Logger::debug( "Skipped refunding cancelled order {$order->get_id()} for Stripe PaymentIntent {$intent_id} - the charge is already refunded." );
+			return;
+		}
+
+		// process_refund() returns the money either way: it refunds a captured charge, or cancels a
+		// requires_capture intent to release the authorisation hold, recovering the charge ID from
+		// the stored intent (a cancelled order has no recorded transaction). Its amount handling is
+		// the subtle part - a null amount no-ops a captured refund, while a non-null amount makes the
+		// void path throw - so pass the order total to refund and null to void. Only a WP_Error is a
+		// failure; the void path can legitimately return null, so any non-error result is handled.
+		$is_authorization = WC_Stripe_Intent_Status::REQUIRES_CAPTURE === $intent->status;
+		$reason           = __( 'Payment received in Stripe after the order was cancelled by the customer. Automatically refunded.', 'woocommerce-gateway-stripe' );
+		$result           = $this->process_refund( $order->get_id(), $is_authorization ? null : $order->get_total(), $reason );
+
+		if ( is_wp_error( $result ) ) {
+			$order->add_order_note(
+				sprintf(
+					/* translators: %s: Stripe error message. */
+					__( 'Stripe took a payment after this order was cancelled, but the automatic refund failed: %s. Please refund it manually in the Stripe dashboard.', 'woocommerce-gateway-stripe' ),
+					$result->get_error_message()
+				)
+			);
+			WC_Stripe_Logger::error( "Failed to refund cancelled order {$order->get_id()} (PaymentIntent {$intent_id}) after a late Stripe payment: {$result->get_error_message()}" );
+			return;
+		}
+
+		// Record the outcome with the Stripe identifiers so the merchant can trace it. process_refund()
+		// adds its own note for a captured refund; this note also covers the voided-authorisation case
+		// and always carries the intent and charge IDs.
+		if ( $is_authorization ) {
+			$order->add_order_note(
+				sprintf(
+					/* translators: 1: Stripe PaymentIntent ID, 2: Stripe charge ID. */
+					__( 'Stripe authorised this payment after the order was cancelled, so the authorisation was voided to release the shopper\'s funds. PaymentIntent: %1$s. Charge: %2$s.', 'woocommerce-gateway-stripe' ),
+					$intent_id,
+					$charge_id
+				)
+			);
+		} else {
+			$order->add_order_note(
+				sprintf(
+					/* translators: 1: Stripe PaymentIntent ID, 2: Stripe charge ID. */
+					__( 'This payment was received in Stripe after the order was cancelled, so it was automatically refunded. PaymentIntent: %1$s. Charge: %2$s.', 'woocommerce-gateway-stripe' ),
+					$intent_id,
+					$charge_id
+				)
+			);
+		}
+		$this->mark_cancelled_order_refunded( $order );
+
+		WC_Stripe_Logger::info( "Returned the payment for cancelled order {$order->get_id()} (PaymentIntent {$intent_id}) after a late Stripe payment." );
+	}
+
+	/**
+	 * Records that a late Stripe payment on a cancelled order has been refunded/voided.
+	 *
+	 * @param WC_Order $order The cancelled order.
+	 * @return void
+	 */
+	private function mark_cancelled_order_refunded( $order ) {
+		$order->update_meta_data( self::META_REFUNDED_AFTER_CANCELLATION, 'yes' );
+		$order->save();
 	}
 
 	/**

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1919,9 +1919,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		// authorisation-void path instead needs null (any amount makes it throw).
 		$refund_amount = null;
 		if ( ! $is_authorization ) {
-			// Missing or delayed charge data: don't guess an amount and risk over-refunding. Leave the
-			// order unflagged so an Action Scheduler retry can settle it once the charge is available.
-			if ( ! is_object( $charge ) || ! isset( $charge->amount, $charge->currency ) ) {
+			// Skip if no charge amount to refund against.
+			if ( ! is_object( $charge ) || ! isset( $charge->amount ) ) {
 				WC_Stripe_Logger::warning( "Skipped refunding cancelled order {$order->get_id()} for Stripe PaymentIntent {$intent_id} - no charge amount available to refund." );
 				return;
 			}
@@ -1932,16 +1931,25 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				return;
 			}
 
-			$refund_amount = WC_Stripe_Helper::convert_from_stripe_amount( $refundable, $charge->currency );
+			// $refundable is in the smallest unit; convert with the order currency because process_refund()
+			// reconverts with the order currency. Using the charge currency here would corrupt the amount
+			// whenever the two currencies have different decimal exponents.
+			$refund_amount = WC_Stripe_Helper::convert_from_stripe_amount( $refundable, $order->get_currency() );
 		}
 
 		$reason = __( 'Payment received in Stripe after the order was cancelled by the customer. Automatically refunded.', 'woocommerce-gateway-stripe' );
 		$result = $this->process_refund( $order->get_id(), $refund_amount, $reason );
 
-		// The success contract is path-dependent: a captured refund must return true, while an
-		// authorisation void succeeds with false/null (there is no refund object to report). Treating
-		// any non-WP_Error as success would mark an unrefunded captured payment as handled.
-		$succeeded = $is_authorization ? ! is_wp_error( $result ) : ( true === $result );
+		// The success contract is path-dependent. A captured refund must return true. An authorisation
+		// void produces no refund object, so process_refund() returns false or null either way — an
+		// ambiguous signal — so re-read the intent and require a Stripe-confirmed cancellation before
+		// treating the void as settled. A WP_Error is always a failure.
+		if ( $is_authorization ) {
+			$confirmed_intent = is_wp_error( $result ) ? null : $this->get_intent_from_order( $order );
+			$succeeded        = $confirmed_intent && WC_Stripe_Intent_Status::CANCELED === $confirmed_intent->status;
+		} else {
+			$succeeded = ( true === $result );
+		}
 		if ( ! $succeeded ) {
 			$error_message = is_wp_error( $result ) ? $result->get_error_message() : '';
 			$order->add_order_note(

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1957,15 +1957,27 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		} else {
 			$succeeded = ( true === $result );
 		}
+		// Link the payment in the mode it was actually made in, which isn't necessarily the gateway's current mode.
+		$is_test_mode = empty( $intent->livemode );
+		$intent_url   = WC_Stripe_Helper::get_transaction_url_for_id( $intent_id, $is_test_mode );
+		$charge_url   = WC_Stripe_Helper::get_transaction_url_for_id( $charge_id, $is_test_mode );
+		$reference    = sprintf(
+			/* translators: 1: opening anchor tag for the PaymentIntent, 2: Stripe PaymentIntent ID, 3: opening anchor tag for the charge, 4: Stripe charge ID, 5: closing anchor tag. */
+			__( 'PaymentIntent: %1$s%2$s%5$s. Charge: %3$s%4$s%5$s.', 'woocommerce-gateway-stripe' ),
+			'<a href="' . esc_url( $intent_url ) . '" target="_blank" rel="noopener noreferrer">',
+			esc_html( $intent_id ),
+			'<a href="' . esc_url( $charge_url ) . '" target="_blank" rel="noopener noreferrer">',
+			esc_html( $charge_id ),
+			'</a>'
+		);
+
 		if ( ! $succeeded ) {
 			$error_message = is_wp_error( $result ) ? $result->get_error_message() : '';
 			$order->add_order_note(
-				trim(
-					sprintf(
-						/* translators: %s: Stripe error message. */
-						__( 'Stripe took a payment after this order was cancelled, but the automatic refund failed. Please refund it manually in the Stripe dashboard. %s', 'woocommerce-gateway-stripe' ),
-						$error_message
-					)
+				sprintf(
+					/* translators: %s: Stripe error message (may be empty) followed by the PaymentIntent and charge IDs linked to the Stripe dashboard. */
+					__( 'Stripe took a payment after this order was cancelled, but the automatic refund failed. Please refund it manually in the Stripe dashboard. %s', 'woocommerce-gateway-stripe' ),
+					trim( $error_message . ' ' . $reference )
 				)
 			);
 			WC_Stripe_Logger::error( "Failed to refund cancelled order {$order->get_id()} (PaymentIntent {$intent_id}) after a late Stripe payment: {$error_message}" );
@@ -1978,19 +1990,17 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		if ( $is_authorization ) {
 			$order->add_order_note(
 				sprintf(
-					/* translators: 1: Stripe PaymentIntent ID, 2: Stripe charge ID. */
-					__( 'Stripe authorised this payment after the order was cancelled, so the authorisation was voided to release the shopper\'s funds. PaymentIntent: %1$s. Charge: %2$s.', 'woocommerce-gateway-stripe' ),
-					$intent_id,
-					$charge_id
+					/* translators: %s: Stripe PaymentIntent and charge IDs, linked to the Stripe dashboard. */
+					__( 'Stripe authorised this payment after the order was cancelled, so the authorisation was voided to release the shopper\'s funds. %s', 'woocommerce-gateway-stripe' ),
+					$reference
 				)
 			);
 		} else {
 			$order->add_order_note(
 				sprintf(
-					/* translators: 1: Stripe PaymentIntent ID, 2: Stripe charge ID. */
-					__( 'This payment was received in Stripe after the order was cancelled, so it was automatically refunded. PaymentIntent: %1$s. Charge: %2$s.', 'woocommerce-gateway-stripe' ),
-					$intent_id,
-					$charge_id
+					/* translators: %s: Stripe PaymentIntent and charge IDs, linked to the Stripe dashboard. */
+					__( 'This payment was received in Stripe after the order was cancelled, so it was automatically refunded. %s', 'woocommerce-gateway-stripe' ),
+					$reference
 				)
 			);
 		}

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1861,6 +1861,22 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @return void
 	 */
 	protected function handle_deferred_payment_for_cancelled_order( $order, $intent_id ) {
+		/**
+		 * Filters whether a late Stripe payment on a cancelled order is automatically refunded.
+		 *
+		 * Return false to leave the payment in place (e.g. to reconcile it manually) instead of
+		 * refunding the charge or voiding the authorisation.
+		 *
+		 * @since 10.9.0
+		 *
+		 * @param bool     $auto_refund Whether to refund the payment automatically. Default true.
+		 * @param WC_Order $order       The cancelled order that received the payment.
+		 */
+		if ( ! apply_filters( 'wc_stripe_auto_refund_cancelled_order', true, $order ) ) {
+			WC_Stripe_Logger::debug( "Skipped refunding cancelled order {$order->get_id()} for Stripe PaymentIntent {$intent_id} - auto-refund disabled by the wc_stripe_auto_refund_cancelled_order filter." );
+			return;
+		}
+
 		$intent = $this->get_intent_from_order( $order );
 
 		if ( ! $intent || $intent->id !== $intent_id ) {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1906,25 +1906,54 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
+		$is_authorization = WC_Stripe_Intent_Status::REQUIRES_CAPTURE === $intent->status;
+
 		// process_refund() returns the money either way: it refunds a captured charge, or cancels a
 		// requires_capture intent to release the authorisation hold, recovering the charge ID from
-		// the stored intent (a cancelled order has no recorded transaction). Its amount handling is
-		// the subtle part - a null amount no-ops a captured refund, while a non-null amount makes the
-		// void path throw - so pass the order total to refund and null to void. Only a WP_Error is a
-		// failure; the void path can legitimately return null, so any non-error result is handled.
-		$is_authorization = WC_Stripe_Intent_Status::REQUIRES_CAPTURE === $intent->status;
-		$reason           = __( 'Payment received in Stripe after the order was cancelled by the customer. Automatically refunded.', 'woocommerce-gateway-stripe' );
-		$result           = $this->process_refund( $order->get_id(), $is_authorization ? null : $order->get_total(), $reason );
+		// the stored intent (a cancelled order has no recorded transaction).
+		//
+		// For a captured charge, refund the charge's remaining balance (amount minus any prior
+		// refund) rather than the order total, which can drift from what Stripe actually holds after
+		// a partial capture, an earlier partial refund, or an edited order total. process_refund()
+		// treats a null amount as a no-op for a captured charge, so a real amount is required; the
+		// authorisation-void path instead needs null (any amount makes it throw).
+		$refund_amount = null;
+		if ( ! $is_authorization ) {
+			// Missing or delayed charge data: don't guess an amount and risk over-refunding. Leave the
+			// order unflagged so an Action Scheduler retry can settle it once the charge is available.
+			if ( ! is_object( $charge ) || ! isset( $charge->amount, $charge->currency ) ) {
+				WC_Stripe_Logger::warning( "Skipped refunding cancelled order {$order->get_id()} for Stripe PaymentIntent {$intent_id} - no charge amount available to refund." );
+				return;
+			}
 
-		if ( is_wp_error( $result ) ) {
+			$refundable = (int) $charge->amount - (int) ( $charge->amount_refunded ?? 0 );
+			if ( $refundable <= 0 ) {
+				WC_Stripe_Logger::warning( "Skipped refunding cancelled order {$order->get_id()} for Stripe PaymentIntent {$intent_id} - the charge has no refundable balance." );
+				return;
+			}
+
+			$refund_amount = WC_Stripe_Helper::convert_from_stripe_amount( $refundable, $charge->currency );
+		}
+
+		$reason = __( 'Payment received in Stripe after the order was cancelled by the customer. Automatically refunded.', 'woocommerce-gateway-stripe' );
+		$result = $this->process_refund( $order->get_id(), $refund_amount, $reason );
+
+		// The success contract is path-dependent: a captured refund must return true, while an
+		// authorisation void succeeds with false/null (there is no refund object to report). Treating
+		// any non-WP_Error as success would mark an unrefunded captured payment as handled.
+		$succeeded = $is_authorization ? ! is_wp_error( $result ) : ( true === $result );
+		if ( ! $succeeded ) {
+			$error_message = is_wp_error( $result ) ? $result->get_error_message() : '';
 			$order->add_order_note(
-				sprintf(
-					/* translators: %s: Stripe error message. */
-					__( 'Stripe took a payment after this order was cancelled, but the automatic refund failed: %s. Please refund it manually in the Stripe dashboard.', 'woocommerce-gateway-stripe' ),
-					$result->get_error_message()
+				trim(
+					sprintf(
+						/* translators: %s: Stripe error message. */
+						__( 'Stripe took a payment after this order was cancelled, but the automatic refund failed. Please refund it manually in the Stripe dashboard. %s', 'woocommerce-gateway-stripe' ),
+						$error_message
+					)
 				)
 			);
-			WC_Stripe_Logger::error( "Failed to refund cancelled order {$order->get_id()} (PaymentIntent {$intent_id}) after a late Stripe payment: {$result->get_error_message()}" );
+			WC_Stripe_Logger::error( "Failed to refund cancelled order {$order->get_id()} (PaymentIntent {$intent_id}) after a late Stripe payment: {$error_message}" );
 			return;
 		}
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2877,11 +2877,17 @@ parameters:
 		-
 			message: '#^Access to an undefined property object\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 10
+			count: 11
 			path: includes/class-wc-stripe-webhook-handler.php
 
 		-
 			message: '#^Access to an undefined property object\:\:\$payment_method\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/class-wc-stripe-webhook-handler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$status\.$#'
 			identifier: property.notFound
 			count: 1
 			path: includes/class-wc-stripe-webhook-handler.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2889,7 +2889,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property object\:\:\$status\.$#'
 			identifier: property.notFound
-			count: 1
+			count: 2
 			path: includes/class-wc-stripe-webhook-handler.php
 
 		-

--- a/readme.txt
+++ b/readme.txt
@@ -221,5 +221,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Add a wc_stripe_subscription_renewal_blocked_by_radar action hook that fires when Stripe Radar blocks a subscription renewal payment
 * Fix - Include the statement descriptor when creating payment intents for ACSS Debit and BLIK payments
 * Fix - Ensure all WordPress hooks have filter documentation
+* Fix - Refund the shopper when a Stripe payment is captured after the order was cancelled, instead of leaving them charged for a cancelled order
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -378,18 +378,22 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	 * (uncaptured authorisation). The refund amount comes from the charge's remaining balance, and
 	 * the order is only flagged as handled when process_refund() reports the path-appropriate success.
 	 *
-	 * @param string $intent_status      PaymentIntent status.
-	 * @param int    $charge_amount      Charge amount in the smallest currency unit.
-	 * @param int    $amount_refunded    Already-refunded amount in the smallest currency unit.
-	 * @param bool   $is_captured        Whether the charge was captured.
-	 * @param mixed  $refund_return      The value process_refund() returns.
-	 * @param bool   $expect_null_amount Whether process_refund() should be called with a null amount.
-	 * @param string $expected_note      Substring the resulting order note must contain.
-	 * @param bool   $expect_flagged     Whether the order should be flagged as handled.
+	 * @param string $intent_status         PaymentIntent status.
+	 * @param int    $charge_amount         Charge amount in the smallest currency unit.
+	 * @param int    $amount_refunded       Already-refunded amount in the smallest currency unit.
+	 * @param bool   $is_captured           Whether the charge was captured.
+	 * @param string $order_currency        Order currency code.
+	 * @param string $charge_currency       Charge currency code (may differ in exponent from the order).
+	 * @param mixed  $refund_return         The value process_refund() returns.
+	 * @param string $confirm_intent_status Status of the intent re-read after a void, or null for no intent.
+	 * @param bool   $expect_null_amount    Whether process_refund() should be called with a null amount.
+	 * @param string $expected_note         Substring the resulting order note must contain.
+	 * @param bool   $expect_flagged        Whether the order should be flagged as handled.
 	 * @dataProvider provide_cancelled_order_refund_scenarios
 	 */
-	public function test_cancelled_order_refund_scenarios( $intent_status, $charge_amount, $amount_refunded, $is_captured, $refund_return, $expect_null_amount, $expected_note, $expect_flagged ) {
+	public function test_cancelled_order_refund_scenarios( $intent_status, $charge_amount, $amount_refunded, $is_captured, $order_currency, $charge_currency, $refund_return, $confirm_intent_status, $expect_null_amount, $expected_note, $expect_flagged ) {
 		$order = WC_Helper_Order::create_order();
+		$order->set_currency( $order_currency );
 		$order->set_status( OrderStatus::CANCELLED );
 		$order->save();
 
@@ -401,21 +405,29 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			[
 				'amount'          => $charge_amount,
 				'amount_refunded' => $amount_refunded,
-				'currency'        => 'usd',
+				'currency'        => $charge_currency,
 				'captured'        => $is_captured,
 			]
 		);
 
+		// The void path re-reads the intent after process_refund() to confirm Stripe cancelled it;
+		// the second read reflects the post-void status (null models an unreadable intent).
+		$confirm_intent = null === $confirm_intent_status
+			? null
+			: (object) array_merge( self::MOCK_PAYMENT_INTENT, [ 'status' => $confirm_intent_status ] );
+
 		// Run the real cancelled-order handler; mock only its dependencies.
 		$this->mock_webhook_handler( [ 'handle_deferred_payment_for_cancelled_order' ] );
 
-		$this->mock_webhook_handler->method( 'get_intent_from_order' )->willReturn( $intent );
+		$this->mock_webhook_handler->method( 'get_intent_from_order' )
+			->willReturnOnConsecutiveCalls( $intent, $confirm_intent );
 		$this->mock_webhook_handler->method( 'get_latest_charge_from_intent' )->willReturn( $charge );
 
-		// Captured charges refund the remaining balance; authorisation voids pass a null amount.
+		// The refundable balance is converted with the order currency because process_refund()
+		// reconverts with it; authorisation voids pass a null amount.
 		$expected_amount = $expect_null_amount
 			? null
-			: WC_Stripe_Helper::convert_from_stripe_amount( $charge_amount - $amount_refunded, 'usd' );
+			: WC_Stripe_Helper::convert_from_stripe_amount( $charge_amount - $amount_refunded, $order_currency );
 
 		$this->mock_webhook_handler->expects( $this->once() )
 			->method( 'process_refund' )
@@ -442,12 +454,21 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	 */
 	public function provide_cancelled_order_refund_scenarios() {
 		return [
-			'captured charge is refunded in full'          => [ WC_Stripe_Intent_Status::SUCCEEDED, 1000, 0, true, true, false, 'automatically refunded', true ],
-			'captured charge refunds remaining balance'    => [ WC_Stripe_Intent_Status::SUCCEEDED, 1000, 400, true, true, false, 'automatically refunded', true ],
-			'uncaptured authorisation is voided'           => [ WC_Stripe_Intent_Status::REQUIRES_CAPTURE, 1000, 0, false, false, true, 'voided', true ],
-			'captured refund returning false is a failure' => [ WC_Stripe_Intent_Status::SUCCEEDED, 1000, 0, true, false, false, 'automatic refund failed', false ],
-			'captured refund returning null is a failure'  => [ WC_Stripe_Intent_Status::SUCCEEDED, 1000, 0, true, null, false, 'automatic refund failed', false ],
-			'refund error is a failure'                    => [ WC_Stripe_Intent_Status::SUCCEEDED, 1000, 0, true, new WP_Error( 'stripe_error', 'boom' ), false, 'automatic refund failed', false ],
+			// intent_status, charge_amount, amount_refunded, is_captured, order_currency, charge_currency, refund_return, confirm_intent_status, expect_null_amount, expected_note, expect_flagged
+			'captured charge is refunded in full'          => [ WC_Stripe_Intent_Status::SUCCEEDED, 1000, 0, true, 'USD', 'usd', true, null, false, 'automatically refunded', true ],
+			'captured charge refunds remaining balance'    => [ WC_Stripe_Intent_Status::SUCCEEDED, 1000, 400, true, 'USD', 'usd', true, null, false, 'automatically refunded', true ],
+			// Order currency (0-decimal) differs in exponent from the charge currency; the amount must
+			// be converted with the order currency so process_refund() reconverts it losslessly.
+			'captured refund uses order currency exponent' => [ WC_Stripe_Intent_Status::SUCCEEDED, 1000, 0, true, 'JPY', 'usd', true, null, false, 'automatically refunded', true ],
+			// A real authorisation void returns false and cancels the intent; success is confirmed by the re-read.
+			'uncaptured authorisation is voided'           => [ WC_Stripe_Intent_Status::REQUIRES_CAPTURE, 1000, 0, false, 'USD', 'usd', false, WC_Stripe_Intent_Status::CANCELED, true, 'voided', true ],
+			// The intent is still not cancelled after process_refund(): treat the void as failed, don't flag.
+			'void unconfirmed by intent is a failure'      => [ WC_Stripe_Intent_Status::REQUIRES_CAPTURE, 1000, 0, false, 'USD', 'usd', null, WC_Stripe_Intent_Status::REQUIRES_CAPTURE, true, 'automatic refund failed', false ],
+			// The intent can't be re-read to confirm the void: treat as failed, don't flag.
+			'void with unreadable intent is a failure'     => [ WC_Stripe_Intent_Status::REQUIRES_CAPTURE, 1000, 0, false, 'USD', 'usd', false, null, true, 'automatic refund failed', false ],
+			'captured refund returning false is a failure' => [ WC_Stripe_Intent_Status::SUCCEEDED, 1000, 0, true, 'USD', 'usd', false, null, false, 'automatic refund failed', false ],
+			'captured refund returning null is a failure'  => [ WC_Stripe_Intent_Status::SUCCEEDED, 1000, 0, true, 'USD', 'usd', null, null, false, 'automatic refund failed', false ],
+			'refund error is a failure'                    => [ WC_Stripe_Intent_Status::SUCCEEDED, 1000, 0, true, 'USD', 'usd', new WP_Error( 'stripe_error', 'boom' ), null, false, 'automatic refund failed', false ],
 		];
 	}
 

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -497,6 +497,33 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Merchants can disable the auto-refund via the wc_stripe_auto_refund_cancelled_order filter.
+	 */
+	public function test_cancelled_order_refund_can_be_disabled_by_filter() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::CANCELLED );
+		$order->save();
+
+		list( $data, $notification ) = $this->build_deferred_intent_succeeded_payload( $order );
+
+		$this->mock_webhook_handler( [ 'handle_deferred_payment_for_cancelled_order' ] );
+
+		$this->mock_webhook_handler->expects( $this->never() )
+			->method( 'process_refund' );
+
+		add_filter( 'wc_stripe_auto_refund_cancelled_order', '__return_false' );
+		try {
+			$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data, $notification );
+		} finally {
+			remove_filter( 'wc_stripe_auto_refund_cancelled_order', '__return_false' );
+		}
+
+		$updated_order = wc_get_order( $order->get_id() );
+		$this->assertEquals( OrderStatus::CANCELLED, $updated_order->get_status() );
+		$this->assertEmpty( $updated_order->get_meta( self::META_REFUNDED_AFTER_CANCELLATION ) );
+	}
+
+	/**
 	 * Asserts that an order has at least one note containing the given substring.
 	 *
 	 * @param WC_Order $order  The order to inspect.

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -93,9 +93,11 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	private function mock_webhook_handler( $exclude_methods = [] ) {
 		$methods = [
 			'handle_deferred_payment_intent_succeeded',
+			'handle_deferred_payment_for_cancelled_order',
 			'get_intent_from_order',
 			'get_latest_charge_from_intent',
 			'process_response',
+			'process_refund',
 			'update_fees',
 			'send_failed_refund_emails',
 		];
@@ -316,6 +318,204 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			->method( 'process_response' );
 
 		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data, $notification );
+	}
+
+	/**
+	 * Order meta flag recording that a late payment on a cancelled order was refunded/voided.
+	 */
+	const META_REFUNDED_AFTER_CANCELLATION = '_stripe_refunded_after_cancellation';
+
+	/**
+	 * Builds a deferred payment_intent.succeeded payload for the given order.
+	 *
+	 * @param WC_Order $order The order the webhook targets.
+	 * @return array{0: array, 1: object} The additional data and notification.
+	 */
+	private function build_deferred_intent_succeeded_payload( $order ) {
+		$data         = [
+			'order_id'  => $order->get_id(),
+			'intent_id' => self::MOCK_PAYMENT_INTENT['id'],
+		];
+		$notification = (object) [
+			'type' => 'payment_intent.succeeded',
+			'data' => (object) [
+				'object' => (object) self::MOCK_PAYMENT_INTENT,
+			],
+		];
+
+		return [ $data, $notification ];
+	}
+
+	/**
+	 * A cancelled order is routed to the refund handler, not the mark-as-paid handler.
+	 */
+	public function test_deferred_webhook_routes_cancelled_order_to_refund_handler() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::CANCELLED );
+		$order->save();
+
+		list( $data, $notification ) = $this->build_deferred_intent_succeeded_payload( $order );
+
+		$this->mock_webhook_handler->expects( $this->never() )
+			->method( 'handle_deferred_payment_intent_succeeded' );
+
+		$this->mock_webhook_handler->expects( $this->once() )
+			->method( 'handle_deferred_payment_for_cancelled_order' )
+			->with(
+				$this->callback(
+					function ( $passed_order ) use ( $order ) {
+						return $passed_order instanceof WC_Order && $order->get_id() === $passed_order->get_id();
+					}
+				),
+				self::MOCK_PAYMENT_INTENT['id']
+			);
+
+		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data, $notification );
+	}
+
+	/**
+	 * A captured payment landing on a cancelled order is refunded, noted and flagged, and the
+	 * order stays cancelled.
+	 */
+	public function test_cancelled_order_captured_payment_is_refunded() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::CANCELLED );
+		$order->save();
+
+		list( $data, $notification ) = $this->build_deferred_intent_succeeded_payload( $order );
+
+		// Run the real cancelled-order handler; mock only its dependencies.
+		$this->mock_webhook_handler( [ 'handle_deferred_payment_for_cancelled_order' ] );
+
+		$this->mock_webhook_handler->method( 'get_intent_from_order' )
+			->willReturn( (object) self::MOCK_PAYMENT_INTENT );
+		$this->mock_webhook_handler->method( 'get_latest_charge_from_intent' )
+			->willReturn( (object) self::MOCK_PAYMENT_INTENT['charges']['data'][0] );
+
+		// A captured charge must be refunded for its full amount; a null amount would no-op.
+		$this->mock_webhook_handler->expects( $this->once() )
+			->method( 'process_refund' )
+			->with( $order->get_id(), $order->get_total(), $this->isType( 'string' ) )
+			->willReturn( true );
+
+		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data, $notification );
+
+		$updated_order = wc_get_order( $order->get_id() );
+		$this->assertEquals( OrderStatus::CANCELLED, $updated_order->get_status() );
+		$this->assertEquals( 'yes', $updated_order->get_meta( self::META_REFUNDED_AFTER_CANCELLATION ) );
+		$this->assertOrderHasNoteContaining( $updated_order, 'automatically refunded' );
+	}
+
+	/**
+	 * An already-flagged order is not refunded again when the deferred job is retried.
+	 */
+	public function test_cancelled_order_refund_is_idempotent() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::CANCELLED );
+		$order->update_meta_data( self::META_REFUNDED_AFTER_CANCELLATION, 'yes' );
+		$order->save();
+
+		list( $data, $notification ) = $this->build_deferred_intent_succeeded_payload( $order );
+
+		$this->mock_webhook_handler( [ 'handle_deferred_payment_for_cancelled_order' ] );
+
+		$this->mock_webhook_handler->method( 'get_intent_from_order' )
+			->willReturn( (object) self::MOCK_PAYMENT_INTENT );
+
+		$this->mock_webhook_handler->expects( $this->never() )
+			->method( 'process_refund' );
+
+		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data, $notification );
+	}
+
+	/**
+	 * An uncaptured authorisation is routed through process_refund() (which voids the intent) and
+	 * noted as a voided authorisation. process_refund() returns null on the void path, which is
+	 * treated as success.
+	 */
+	public function test_cancelled_order_uncaptured_authorization_is_voided() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::CANCELLED );
+		$order->save();
+
+		list( $data, $notification ) = $this->build_deferred_intent_succeeded_payload( $order );
+
+		$intent                 = (object) array_merge(
+			self::MOCK_PAYMENT_INTENT,
+			[ 'status' => WC_Stripe_Intent_Status::REQUIRES_CAPTURE ]
+		);
+		$uncaptured             = self::MOCK_PAYMENT_INTENT['charges']['data'][0];
+		$uncaptured['captured'] = false;
+
+		$this->mock_webhook_handler( [ 'handle_deferred_payment_for_cancelled_order' ] );
+
+		$this->mock_webhook_handler->method( 'get_intent_from_order' )
+			->willReturn( $intent );
+		$this->mock_webhook_handler->method( 'get_latest_charge_from_intent' )
+			->willReturn( (object) $uncaptured );
+
+		// process_refund() cancels the requires_capture intent internally and returns null.
+		$this->mock_webhook_handler->expects( $this->once() )
+			->method( 'process_refund' )
+			->with( $order->get_id(), null, $this->isType( 'string' ) )
+			->willReturn( null );
+
+		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data, $notification );
+
+		$updated_order = wc_get_order( $order->get_id() );
+		$this->assertEquals( OrderStatus::CANCELLED, $updated_order->get_status() );
+		$this->assertEquals( 'yes', $updated_order->get_meta( self::META_REFUNDED_AFTER_CANCELLATION ) );
+		$this->assertOrderHasNoteContaining( $updated_order, 'voided' );
+	}
+
+	/**
+	 * A failed refund leaves the order un-flagged so Action Scheduler can retry, and records a note.
+	 */
+	public function test_cancelled_order_refund_failure_adds_note_and_allows_retry() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::CANCELLED );
+		$order->save();
+
+		list( $data, $notification ) = $this->build_deferred_intent_succeeded_payload( $order );
+
+		$this->mock_webhook_handler( [ 'handle_deferred_payment_for_cancelled_order' ] );
+
+		$this->mock_webhook_handler->method( 'get_intent_from_order' )
+			->willReturn( (object) self::MOCK_PAYMENT_INTENT );
+		$this->mock_webhook_handler->method( 'get_latest_charge_from_intent' )
+			->willReturn( (object) self::MOCK_PAYMENT_INTENT['charges']['data'][0] );
+
+		$this->mock_webhook_handler->method( 'process_refund' )
+			->willReturn( new WP_Error( 'stripe_error', 'Refund failed for testing.' ) );
+
+		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data, $notification );
+
+		$updated_order = wc_get_order( $order->get_id() );
+		$this->assertEquals( OrderStatus::CANCELLED, $updated_order->get_status() );
+		$this->assertEmpty( $updated_order->get_meta( self::META_REFUNDED_AFTER_CANCELLATION ) );
+		$this->assertOrderHasNoteContaining( $updated_order, 'automatic refund failed' );
+	}
+
+	/**
+	 * Asserts that an order has at least one note containing the given substring.
+	 *
+	 * @param WC_Order $order  The order to inspect.
+	 * @param string   $needle The substring the note must contain.
+	 * @return void
+	 */
+	private function assertOrderHasNoteContaining( $order, $needle ) {
+		$notes    = wc_get_order_notes( [ 'order_id' => $order->get_id() ] );
+		$contents = wp_list_pluck( $notes, 'content' );
+
+		$this->assertNotEmpty(
+			array_filter(
+				$contents,
+				function ( $content ) use ( $needle ) {
+					return false !== strpos( $content, $needle );
+				}
+			),
+			sprintf( 'Expected an order note containing "%s".', $needle )
+		);
 	}
 
 	/**

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -466,6 +466,9 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			'void unconfirmed by intent is a failure'      => [ WC_Stripe_Intent_Status::REQUIRES_CAPTURE, 1000, 0, false, 'USD', 'usd', null, WC_Stripe_Intent_Status::REQUIRES_CAPTURE, true, 'automatic refund failed', false ],
 			// The intent can't be re-read to confirm the void: treat as failed, don't flag.
 			'void with unreadable intent is a failure'     => [ WC_Stripe_Intent_Status::REQUIRES_CAPTURE, 1000, 0, false, 'USD', 'usd', false, null, true, 'automatic refund failed', false ],
+			// The authorisation is captured in the window before the void confirms: fail closed with a
+			// manual-refund note and leave the order unflagged rather than mark an uncancelled intent settled.
+			'void captured mid-flight fails closed'        => [ WC_Stripe_Intent_Status::REQUIRES_CAPTURE, 1000, 0, false, 'USD', 'usd', true, WC_Stripe_Intent_Status::SUCCEEDED, true, 'automatic refund failed', false ],
 			'captured refund returning false is a failure' => [ WC_Stripe_Intent_Status::SUCCEEDED, 1000, 0, true, 'USD', 'usd', false, null, false, 'automatic refund failed', false ],
 			'captured refund returning null is a failure'  => [ WC_Stripe_Intent_Status::SUCCEEDED, 1000, 0, true, 'USD', 'usd', null, null, false, 'automatic refund failed', false ],
 			'refund error is a failure'                    => [ WC_Stripe_Intent_Status::SUCCEEDED, 1000, 0, true, 'USD', 'usd', new WP_Error( 'stripe_error', 'boom' ), null, false, 'automatic refund failed', false ],

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -374,36 +374,81 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A captured payment landing on a cancelled order is refunded, noted and flagged, and the
-	 * order stays cancelled.
+	 * A cancelled order that receives a late payment is refunded (captured charge) or voided
+	 * (uncaptured authorisation). The refund amount comes from the charge's remaining balance, and
+	 * the order is only flagged as handled when process_refund() reports the path-appropriate success.
+	 *
+	 * @param string $intent_status      PaymentIntent status.
+	 * @param int    $charge_amount      Charge amount in the smallest currency unit.
+	 * @param int    $amount_refunded    Already-refunded amount in the smallest currency unit.
+	 * @param bool   $is_captured        Whether the charge was captured.
+	 * @param mixed  $refund_return      The value process_refund() returns.
+	 * @param bool   $expect_null_amount Whether process_refund() should be called with a null amount.
+	 * @param string $expected_note      Substring the resulting order note must contain.
+	 * @param bool   $expect_flagged     Whether the order should be flagged as handled.
+	 * @dataProvider provide_cancelled_order_refund_scenarios
 	 */
-	public function test_cancelled_order_captured_payment_is_refunded() {
+	public function test_cancelled_order_refund_scenarios( $intent_status, $charge_amount, $amount_refunded, $is_captured, $refund_return, $expect_null_amount, $expected_note, $expect_flagged ) {
 		$order = WC_Helper_Order::create_order();
 		$order->set_status( OrderStatus::CANCELLED );
 		$order->save();
 
 		list( $data, $notification ) = $this->build_deferred_intent_succeeded_payload( $order );
 
+		$intent = (object) array_merge( self::MOCK_PAYMENT_INTENT, [ 'status' => $intent_status ] );
+		$charge = (object) array_merge(
+			self::MOCK_PAYMENT_INTENT['charges']['data'][0],
+			[
+				'amount'          => $charge_amount,
+				'amount_refunded' => $amount_refunded,
+				'currency'        => 'usd',
+				'captured'        => $is_captured,
+			]
+		);
+
 		// Run the real cancelled-order handler; mock only its dependencies.
 		$this->mock_webhook_handler( [ 'handle_deferred_payment_for_cancelled_order' ] );
 
-		$this->mock_webhook_handler->method( 'get_intent_from_order' )
-			->willReturn( (object) self::MOCK_PAYMENT_INTENT );
-		$this->mock_webhook_handler->method( 'get_latest_charge_from_intent' )
-			->willReturn( (object) self::MOCK_PAYMENT_INTENT['charges']['data'][0] );
+		$this->mock_webhook_handler->method( 'get_intent_from_order' )->willReturn( $intent );
+		$this->mock_webhook_handler->method( 'get_latest_charge_from_intent' )->willReturn( $charge );
 
-		// A captured charge must be refunded for its full amount; a null amount would no-op.
+		// Captured charges refund the remaining balance; authorisation voids pass a null amount.
+		$expected_amount = $expect_null_amount
+			? null
+			: WC_Stripe_Helper::convert_from_stripe_amount( $charge_amount - $amount_refunded, 'usd' );
+
 		$this->mock_webhook_handler->expects( $this->once() )
 			->method( 'process_refund' )
-			->with( $order->get_id(), $order->get_total(), $this->isType( 'string' ) )
-			->willReturn( true );
+			->with( $order->get_id(), $expected_amount, $this->isType( 'string' ) )
+			->willReturn( $refund_return );
 
 		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data, $notification );
 
 		$updated_order = wc_get_order( $order->get_id() );
 		$this->assertEquals( OrderStatus::CANCELLED, $updated_order->get_status() );
-		$this->assertEquals( 'yes', $updated_order->get_meta( self::META_REFUNDED_AFTER_CANCELLATION ) );
-		$this->assertOrderHasNoteContaining( $updated_order, 'automatically refunded' );
+
+		if ( $expect_flagged ) {
+			$this->assertEquals( 'yes', $updated_order->get_meta( self::META_REFUNDED_AFTER_CANCELLATION ) );
+		} else {
+			$this->assertEmpty( $updated_order->get_meta( self::META_REFUNDED_AFTER_CANCELLATION ) );
+		}
+		$this->assertOrderHasNoteContaining( $updated_order, $expected_note );
+	}
+
+	/**
+	 * Data provider for test_cancelled_order_refund_scenarios.
+	 *
+	 * @return array[]
+	 */
+	public function provide_cancelled_order_refund_scenarios() {
+		return [
+			'captured charge is refunded in full'          => [ WC_Stripe_Intent_Status::SUCCEEDED, 1000, 0, true, true, false, 'automatically refunded', true ],
+			'captured charge refunds remaining balance'    => [ WC_Stripe_Intent_Status::SUCCEEDED, 1000, 400, true, true, false, 'automatically refunded', true ],
+			'uncaptured authorisation is voided'           => [ WC_Stripe_Intent_Status::REQUIRES_CAPTURE, 1000, 0, false, false, true, 'voided', true ],
+			'captured refund returning false is a failure' => [ WC_Stripe_Intent_Status::SUCCEEDED, 1000, 0, true, false, false, 'automatic refund failed', false ],
+			'captured refund returning null is a failure'  => [ WC_Stripe_Intent_Status::SUCCEEDED, 1000, 0, true, null, false, 'automatic refund failed', false ],
+			'refund error is a failure'                    => [ WC_Stripe_Intent_Status::SUCCEEDED, 1000, 0, true, new WP_Error( 'stripe_error', 'boom' ), false, 'automatic refund failed', false ],
+		];
 	}
 
 	/**
@@ -426,74 +471,6 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			->method( 'process_refund' );
 
 		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data, $notification );
-	}
-
-	/**
-	 * An uncaptured authorisation is routed through process_refund() (which voids the intent) and
-	 * noted as a voided authorisation. process_refund() returns null on the void path, which is
-	 * treated as success.
-	 */
-	public function test_cancelled_order_uncaptured_authorization_is_voided() {
-		$order = WC_Helper_Order::create_order();
-		$order->set_status( OrderStatus::CANCELLED );
-		$order->save();
-
-		list( $data, $notification ) = $this->build_deferred_intent_succeeded_payload( $order );
-
-		$intent                 = (object) array_merge(
-			self::MOCK_PAYMENT_INTENT,
-			[ 'status' => WC_Stripe_Intent_Status::REQUIRES_CAPTURE ]
-		);
-		$uncaptured             = self::MOCK_PAYMENT_INTENT['charges']['data'][0];
-		$uncaptured['captured'] = false;
-
-		$this->mock_webhook_handler( [ 'handle_deferred_payment_for_cancelled_order' ] );
-
-		$this->mock_webhook_handler->method( 'get_intent_from_order' )
-			->willReturn( $intent );
-		$this->mock_webhook_handler->method( 'get_latest_charge_from_intent' )
-			->willReturn( (object) $uncaptured );
-
-		// process_refund() cancels the requires_capture intent internally and returns null.
-		$this->mock_webhook_handler->expects( $this->once() )
-			->method( 'process_refund' )
-			->with( $order->get_id(), null, $this->isType( 'string' ) )
-			->willReturn( null );
-
-		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data, $notification );
-
-		$updated_order = wc_get_order( $order->get_id() );
-		$this->assertEquals( OrderStatus::CANCELLED, $updated_order->get_status() );
-		$this->assertEquals( 'yes', $updated_order->get_meta( self::META_REFUNDED_AFTER_CANCELLATION ) );
-		$this->assertOrderHasNoteContaining( $updated_order, 'voided' );
-	}
-
-	/**
-	 * A failed refund leaves the order un-flagged so Action Scheduler can retry, and records a note.
-	 */
-	public function test_cancelled_order_refund_failure_adds_note_and_allows_retry() {
-		$order = WC_Helper_Order::create_order();
-		$order->set_status( OrderStatus::CANCELLED );
-		$order->save();
-
-		list( $data, $notification ) = $this->build_deferred_intent_succeeded_payload( $order );
-
-		$this->mock_webhook_handler( [ 'handle_deferred_payment_for_cancelled_order' ] );
-
-		$this->mock_webhook_handler->method( 'get_intent_from_order' )
-			->willReturn( (object) self::MOCK_PAYMENT_INTENT );
-		$this->mock_webhook_handler->method( 'get_latest_charge_from_intent' )
-			->willReturn( (object) self::MOCK_PAYMENT_INTENT['charges']['data'][0] );
-
-		$this->mock_webhook_handler->method( 'process_refund' )
-			->willReturn( new WP_Error( 'stripe_error', 'Refund failed for testing.' ) );
-
-		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data, $notification );
-
-		$updated_order = wc_get_order( $order->get_id() );
-		$this->assertEquals( OrderStatus::CANCELLED, $updated_order->get_status() );
-		$this->assertEmpty( $updated_order->get_meta( self::META_REFUNDED_AFTER_CANCELLATION ) );
-		$this->assertOrderHasNoteContaining( $updated_order, 'automatic refund failed' );
 	}
 
 	/**

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -525,6 +525,76 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The cancelled-order notes link both the PaymentIntent and the charge to the Stripe dashboard,
+	 * in the mode the intent itself was created in rather than the gateway's configured mode.
+	 *
+	 * @param string $intent_status         PaymentIntent status.
+	 * @param bool   $livemode              The intent's `livemode` value, or null to omit it entirely.
+	 * @param mixed  $refund_return         The value process_refund() returns.
+	 * @param string $confirm_intent_status Status of the intent re-read after a void, or null for no intent.
+	 * @param string $expected_base         Dashboard base URL both IDs must be linked against.
+	 * @dataProvider provide_cancelled_order_note_dashboard_links
+	 */
+	public function test_cancelled_order_notes_link_to_stripe_dashboard( $intent_status, $livemode, $refund_return, $confirm_intent_status, $expected_base ) {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::CANCELLED );
+		$order->save();
+
+		list( $data, $notification ) = $this->build_deferred_intent_succeeded_payload( $order );
+
+		$intent_overrides = [ 'status' => $intent_status ];
+		if ( null !== $livemode ) {
+			$intent_overrides['livemode'] = $livemode;
+		}
+		$intent = (object) array_merge( self::MOCK_PAYMENT_INTENT, $intent_overrides );
+		$charge = (object) array_merge(
+			self::MOCK_PAYMENT_INTENT['charges']['data'][0],
+			[
+				'amount'          => 1000,
+				'amount_refunded' => 0,
+				'currency'        => 'usd',
+			]
+		);
+
+		$confirm_intent = null === $confirm_intent_status
+			? null
+			: (object) array_merge( self::MOCK_PAYMENT_INTENT, [ 'status' => $confirm_intent_status ] );
+
+		$this->mock_webhook_handler( [ 'handle_deferred_payment_for_cancelled_order' ] );
+
+		$this->mock_webhook_handler->method( 'get_intent_from_order' )
+			->willReturnOnConsecutiveCalls( $intent, $confirm_intent );
+		$this->mock_webhook_handler->method( 'get_latest_charge_from_intent' )->willReturn( $charge );
+		$this->mock_webhook_handler->method( 'process_refund' )->willReturn( $refund_return );
+
+		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data, $notification );
+
+		$note = $this->get_latest_order_note_content( wc_get_order( $order->get_id() ) );
+
+		$this->assertStringContainsString( 'href="' . $expected_base . 'pi_mock"', $note );
+		$this->assertStringContainsString( 'href="' . $expected_base . 'ch_mock"', $note );
+	}
+
+	/**
+	 * Data provider for test_cancelled_order_notes_link_to_stripe_dashboard.
+	 *
+	 * @return array[]
+	 */
+	public function provide_cancelled_order_note_dashboard_links() {
+		$live = 'https://dashboard.stripe.com/payments/';
+		$test = 'https://dashboard.stripe.com/test/payments/';
+
+		return [
+			// intent_status, livemode, refund_return, confirm_intent_status, expected_base
+			'live refund links live dashboard'    => [ WC_Stripe_Intent_Status::SUCCEEDED, true, true, null, $live ],
+			'test refund links test dashboard'    => [ WC_Stripe_Intent_Status::SUCCEEDED, false, true, null, $test ],
+			'missing livemode falls back to test' => [ WC_Stripe_Intent_Status::SUCCEEDED, null, true, null, $test ],
+			'voided authorisation note is linked' => [ WC_Stripe_Intent_Status::REQUIRES_CAPTURE, false, false, WC_Stripe_Intent_Status::CANCELED, $test ],
+			'failed refund note is linked'        => [ WC_Stripe_Intent_Status::SUCCEEDED, false, new WP_Error( 'stripe_error', 'boom' ), null, $test ],
+		];
+	}
+
+	/**
 	 * Asserts that an order has at least one note containing the given substring.
 	 *
 	 * @param WC_Order $order  The order to inspect.


### PR DESCRIPTION
Fixes STRIPE-948

## Changes proposed in this Pull Request:
When a shopper cancels an order while its payment is still settling in Stripe — e.g. a slow 3DS confirmation that fails the return to checkout, after which they cancel the still-pending order — Stripe can still capture the payment and fire a deferred `payment_intent.succeeded` afterwards. The deferred webhook handler only processes orders in `pending`/`failed` status, so it skips the cancelled order: the money is taken in Stripe, the order stays cancelled, and nothing reflects the charge.

This PR refunds the shopper in that case instead of leaving them charged for a cancelled order.

- `process_deferred_webhook()` now routes a cancelled order to a new `handle_deferred_payment_for_cancelled_order()`. The existing `[pending, failed]` gate and the shared `wc_stripe_allowed_payment_processing_statuses` filter are left untouched — the cancelled branch runs before the gate.
- The handler refunds through the existing `process_refund()`: a full refund for a captured charge, or a void (intent cancel) for an uncaptured authorisation. The order stays `cancelled`, and a note records the PaymentIntent/Charge IDs and the outcome.
- Idempotent: guarded by a `_stripe_refunded_after_cancellation` meta flag plus Stripe-state checks, so an Action Scheduler retry can't refund twice.

## Testing instructions
- To reproduce the edge case, throw hard coded nonce error from [update_order_status_ajax](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/class-wc-stripe-intent-controller.php#L688) methods (`throw new WC_Stripe_Exception( 'missing-nonce', __( 'Verification failed.', 'woocommerce-gateway-stripe' ) );`)
- As a logged in shopper, add a product to your cart and go to the checkout page.
- Select card payment and use a [3DS card](https://docs.stripe.com/testing#regulatory-cards) to pay.
- Click the place order button.
- Wait for a while and then approve the payment in the 3DS modal.
- The checkout should fail.
- Go to **My Account > Orders** and cancel the latest order (this should be in pending payment state at this point).
- Go to the order edit page as an admin. The order should be in the cancelled state.
- Wait for a couple of minutes and refresh the order edit page.
- Go to **WooCommerce > Status > Scheduled Actions > Pending** and confirm that there is no deferred intent webhook action in the pending state for this order. If there is one, then run the action.
- Check the order notes in the order edit page.
- In `develop` branch, the order should still be in the cancelled state and there should be no transaction ID or related order notes. Check the Stripe dashboard of the connected account and notice that the transaction was successful for this order.
- In this branch, the order should be still in cancelled state but there should be relevant order notes and the payment should be refunded in the Stripe dashboard. 

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
