### PR TITLE
 Fix WP/WC version inputs being ignored by E2E tests in CI

### DIFF
--- a/.github/workflows/manual-e2e-tests.yml
+++ b/.github/workflows/manual-e2e-tests.yml
@@ -13,7 +13,7 @@ on:
         default: 'latest'
         required: true
       woocommerce-version:
-        description: WooCommerce version number. Defaults to 'latest' (the latest version).
+        description: WooCommerce version number, or 'beta'/'rc' for the latest beta/RC release. Defaults to 'latest' (the latest stable version).
         type: string
         default: 'latest'
         required: true

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Prepare test environment
         env:
           GITHUB_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
+          WP_VERSION: ${{ inputs.wp-version }}
+          WC_VERSION: ${{ inputs.wc-version }}
           STRIPE_PUB_KEY: ${{ matrix.project == 'blik' && secrets.E2E_STRIPE_PUBLISHABLE_KEY_PL || matrix.project == 'becs' && secrets.E2E_STRIPE_PUBLISHABLE_KEY_AU || secrets.E2E_STRIPE_PUBLISHABLE_KEY }}
           STRIPE_SECRET_KEY: ${{ matrix.project == 'blik' && secrets.E2E_STRIPE_SECRET_KEY_PL || matrix.project == 'becs' && secrets.E2E_STRIPE_SECRET_KEY_AU || secrets.E2E_STRIPE_SECRET_KEY }}
         run: npm run test:e2e-setup

--- a/tests/e2e/bin/setup.sh
+++ b/tests/e2e/bin/setup.sh
@@ -86,18 +86,12 @@ redirect_output cli wp plugin install disable-emails --activate
 
 # Install WooCommerce
 if [[ -n "$WC_VERSION" && $WC_VERSION != 'latest' ]]; then
-	# If specified version is 'beta', fetch the latest beta version from WordPress.org API.
+	# If specified version is 'beta' or 'rc', fetch the latest matching version from WordPress.org API.
 	# jq sorts keys lexically ("9.9.0-beta.1" > "11.0.0-beta.1"), so sort with PHP's
 	# version_compare instead to get the actual latest version.
-	if [[ $WC_VERSION == 'beta' ]]; then
+	if [[ $WC_VERSION == 'beta' || $WC_VERSION == 'rc' ]]; then
 		WC_VERSION=$(curl -s https://api.wordpress.org/plugins/info/1.0/woocommerce.json | \
-			jq -r '.versions | keys[] | select(match("beta";"i"))' | \
-			php -r '$v = array_filter( array_map( "trim", file( "php://stdin" ) ) ); usort( $v, "version_compare" ); echo end( $v ) ?: "";')
-	fi
-
-	if [[ $WC_VERSION == 'rc' ]]; then
-		WC_VERSION=$(curl -s https://api.wordpress.org/plugins/info/1.0/woocommerce.json | \
-			jq -r '.versions | keys[] | select(match("rc";"i"))' | \
+			jq -r --arg type "$WC_VERSION" '.versions | keys[] | select(match($type;"i"))' | \
 			php -r '$v = array_filter( array_map( "trim", file( "php://stdin" ) ) ); usort( $v, "version_compare" ); echo end( $v ) ?: "";')
 	fi
 

--- a/tests/e2e/bin/setup.sh
+++ b/tests/e2e/bin/setup.sh
@@ -26,6 +26,7 @@ cd "$CWD"
 check_dep 'docker'
 check_dep 'curl'
 check_dep 'jq'
+check_dep 'php'
 
 if ! docker info > /dev/null 2>&1; then
 	echo

--- a/tests/e2e/bin/setup.sh
+++ b/tests/e2e/bin/setup.sh
@@ -86,13 +86,19 @@ redirect_output cli wp plugin install disable-emails --activate
 
 # Install WooCommerce
 if [[ -n "$WC_VERSION" && $WC_VERSION != 'latest' ]]; then
-	# If specified version is 'beta', fetch the latest beta version from WordPress.org API
+	# If specified version is 'beta', fetch the latest beta version from WordPress.org API.
+	# jq sorts keys lexically ("9.9.0-beta.1" > "11.0.0-beta.1"), so sort with PHP's
+	# version_compare instead to get the actual latest version.
 	if [[ $WC_VERSION == 'beta' ]]; then
-		WC_VERSION=$(curl https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.versions | with_entries(select(.key|match("beta";"i"))) | keys[-1]' --sort-keys)
+		WC_VERSION=$(curl -s https://api.wordpress.org/plugins/info/1.0/woocommerce.json | \
+			jq -r '.versions | keys[] | select(match("beta";"i"))' | \
+			php -r '$v = array_filter( array_map( "trim", file( "php://stdin" ) ) ); usort( $v, "version_compare" ); echo end( $v ) ?: "";')
 	fi
 
 	if [[ $WC_VERSION == 'rc' ]]; then
-		WC_VERSION=$(curl https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.versions | with_entries(select(.key|match("rc";"i"))) | keys[0]' --sort-keys)
+		WC_VERSION=$(curl -s https://api.wordpress.org/plugins/info/1.0/woocommerce.json | \
+			jq -r '.versions | keys[] | select(match("rc";"i"))' | \
+			php -r '$v = array_filter( array_map( "trim", file( "php://stdin" ) ) ); usort( $v, "version_compare" ); echo end( $v ) ?: "";')
 	fi
 
 	step "Installing WooCommerce ${WC_VERSION}"

--- a/tests/e2e/bin/setup.sh
+++ b/tests/e2e/bin/setup.sh
@@ -91,9 +91,15 @@ if [[ -n "$WC_VERSION" && $WC_VERSION != 'latest' ]]; then
 	# jq sorts keys lexically ("9.9.0-beta.1" > "11.0.0-beta.1"), so sort with PHP's
 	# version_compare instead to get the actual latest version.
 	if [[ $WC_VERSION == 'beta' || $WC_VERSION == 'rc' ]]; then
+		REQUESTED_WC_VERSION=$WC_VERSION
 		WC_VERSION=$(curl -s https://api.wordpress.org/plugins/info/1.0/woocommerce.json | \
 			jq -r --arg type "$WC_VERSION" '.versions | keys[] | select(match($type;"i"))' | \
 			php -r '$v = array_filter( array_map( "trim", file( "php://stdin" ) ) ); usort( $v, "version_compare" ); echo end( $v ) ?: "";')
+
+		if [[ -z "$WC_VERSION" ]]; then
+			error "Could not resolve the latest WooCommerce '${REQUESTED_WC_VERSION}' version from the WordPress.org API."
+			exit 1
+		fi
 	fi
 
 	step "Installing WooCommerce ${WC_VERSION}"


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

The [Manual E2E workflow](https://github.com/woocommerce/woocommerce-gateway-stripe/actions/workflows/manual-e2e-tests.yml) accepts WordPress and WooCommerce version inputs, but they were never passed through to the test environment setup, so E2E runs always installed the latest stable versions regardless of the requested version.

Additionally, the beta and rc keywords resolved the target WooCommerce version using a lexicographic sort of the available versions, which picks the wrong release once major versions have differing digit counts (e.g. beta resolved to 9.9.0-beta.1 instead of 11.0.0-beta.1). Version resolution now uses PHP's version_compare, matching how the [unit-test setup already handles this](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5005).
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Trigger the[ manual E2E workflow](https://github.com/woocommerce/woocommerce-gateway-stripe/actions/workflows/manual-e2e-tests.yml) from this branch with the WooCommerce version input set to `beta`.
2. In the "Prepare test environment" step logs, confirm the version summary shows the latest WooCommerce beta (currently 11.0.0-beta.1) instead of the latest stable.

<img width="1208" height="352" alt="CleanShot 2026-07-16 at 13 23 16@2x" src="https://github.com/user-attachments/assets/1340b9cd-7fe7-45a6-9a43-0eace7c15611" />

Test run: https://github.com/woocommerce/woocommerce-gateway-stripe/actions/runs/29523382665

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This is a CI change. No changelog necessary.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
