### PR TITLE
Ignore PHPStan `missingType.generics` errors for `WP_REST_Request` type hints

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1105,70 +1105,10 @@ parameters:
 			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
 
 		-
-			message: '#^Method WC_REST_Stripe_Account_Keys_Controller\:\:configure_webhooks\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
-
-		-
 			message: '#^Method WC_REST_Stripe_Account_Keys_Controller\:\:mask_key_value\(\) has parameter \$value with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Account_Keys_Controller\:\:set_account_keys\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Account_Keys_Controller\:\:test_account_keys\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Account_Keys_Controller\:\:validate_publishable_key\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Account_Keys_Controller\:\:validate_secret_key\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Account_Keys_Controller\:\:validate_stripe_param\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Account_Keys_Controller\:\:validate_test_publishable_key\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Account_Keys_Controller\:\:validate_test_secret_key\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Agentic_Commerce_Controller\:\:update_agentic_settings\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Connection_Tokens_Controller\:\:create_token\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-connection-tokens-controller.php
 
 		-
 			message: '#^Access to an undefined property object\:\:\$country\.$#'
@@ -1219,42 +1159,6 @@ parameters:
 			path: includes/admin/class-wc-rest-stripe-locations-controller.php
 
 		-
-			message: '#^Method WC_REST_Stripe_Locations_Controller\:\:create_location\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-locations-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Locations_Controller\:\:delete_location\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-locations-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Locations_Controller\:\:get_all_locations\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-locations-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Locations_Controller\:\:get_location\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-locations-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Locations_Controller\:\:get_store_location\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-locations-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Locations_Controller\:\:update_location\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-locations-controller.php
-
-		-
 			message: '#^Parameter \#1 \$var of function count expects array\|Countable, array\|object given\.$#'
 			identifier: argument.type
 			count: 1
@@ -1273,18 +1177,6 @@ parameters:
 			path: includes/admin/class-wc-rest-stripe-orders-controller.php
 
 		-
-			message: '#^Method WC_REST_Stripe_Orders_Controller\:\:capture_terminal_payment\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-orders-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Orders_Controller\:\:create_customer\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-orders-controller.php
-
-		-
 			message: '#^Parameter \#1 \$response of method WC_Stripe_Payment_Gateway\:\:process_response\(\) expects object, object\|string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -1297,130 +1189,10 @@ parameters:
 			path: includes/admin/class-wc-rest-stripe-orders-controller.php
 
 		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:dismiss_customization_notice\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:dismiss_notice\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:get_payment_method_ids_to_enable\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
 			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:record_payment_method_settings_event\(\) is unused\.$#'
 			identifier: method.unused
 			count: 1
 			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:update_amazon_pay_settings\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:update_express_checkout_settings\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:update_is_debug_log_enabled\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:update_is_express_checkout_enabled_for_legacy_checkout\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:update_is_manual_capture_enabled\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:update_is_saved_cards_enabled\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:update_is_sepa_tokens_for_bancontact_enabled\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:update_is_sepa_tokens_for_ideal_enabled\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:update_is_separate_card_form_enabled\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:update_is_short_account_statement_enabled\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:update_is_stripe_enabled\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:update_is_test_mode_enabled\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:update_link_settings\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:update_oc_settings\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:update_payment_methods_order\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:update_settings\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Tokens_Controller\:\:get_token\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-tokens-controller.php
 
 		-
 			message: '#^Constant WC_Stripe_Admin_Notices\:\:STRIPE_CUSTOMER_PAGE_BASE_URL is unused\.$#'
@@ -1547,12 +1319,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: includes/admin/class-wc-stripe-privacy.php
-
-		-
-			message: '#^Method WC_Stripe_REST_OC_Setting_Toggle_Controller\:\:set_setting\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-stripe-rest-oc-setting-toggle-controller.php
 
 		-
 			message: '#^Access to an undefined property WooCommerce\:\:\$payment_gateways\.$#'
@@ -3743,18 +3509,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Custom_Fields\:\:get_custom_checkout_data_from_request\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Custom_Fields\:\:process_custom_checkout_data\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
 
 		-
 			message: '#^Parameter \#2 \$pieces of function implode expects array, array\|string given\.$#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,6 +22,14 @@ parameters:
 	ignoreErrors:
 		-
 			identifier: missingType.iterableValue
+		# The WordPress stubs declare WP_REST_Request as generic over its parameter shape
+		# (@phpstan-template T of array), so PHPStan asks every type hint to spell out
+		# WP_REST_Request<T>. Our REST handlers treat request params as mixed (get_param()
+		# or untyped array access) and never depend on a per-route param shape, so
+		# specifying T on every handler adds noise without adding safety.
+		-
+			message: '#generic class WP_REST_Request (but )?does not specify its types#'
+			identifier: missingType.generics
 		# WCS_Retry / WCS_Retry_Manager are provided by the WooCommerce Subscriptions plugin,
 		# which is an optional runtime dependency. The phpstan-stubs/ and tests/phpunit/helpers/
 		# stand-ins declare these methods so PHPStan can resolve the calls, but the defensive


### PR DESCRIPTION
Fixes STRIPE-935
Fixes #4973

## Changes proposed in this Pull Request:

The WordPress stubs declare `WP_REST_Request` as generic over its parameter types (`@phpstan-template T of array`), so every plain `WP_REST_Request` type hint raises `missingType.generics` at level 8 — the source of all 41 such entries in our baseline.

This PR replaces those entries with a single scoped `ignoreErrors` rule (identifier plus a message regex that only matches `WP_REST_Request`), as suggested in the issue:

- New un-parameterized `WP_REST_Request` hints no longer fail analysis — baseline entries only cover the exact file and method they were generated for, so they never prevented new occurrences; this rule does.
- `missingType.generics` for other generic classes is still reported.
- The generic stays opt-in: a handler can still declare `WP_REST_Request<array{...}>` and get full type checking.

Our handlers treat request params as `mixed` and validate at runtime, so requiring `T` on every handler adds annotation noise without safety — a `T` annotation is a hand-maintained copy of the route's `args` schema, and PHPStan can't warn when the two drift apart.

## Testing instructions

Developer-tooling change only, no runtime behavior; verify via PHPStan:

1. `composer install`, then `npm run phpstan` → `[OK] No errors`.
2. Check the baseline diff: 246 deletions (41 entries, all `missingType.generics` for `WP_REST_Request`), no additions.
3. Prevention: add a temp file in `includes/` with a method typed `WP_REST_Request $request` → still green (this fails on `develop`).
4. Scope: change that param type to `ArrayObject $things` → `missingType.generics` is reported. Delete the temp file.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️) — static-analysis config only; running PHPStan is the verification.
-   [x] Tested on mobile (or does not apply) — does not apply.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Developer-tooling change only (PHPStan configuration and baseline); no user-facing or runtime behavior change.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

> *Drafted with Claude Code; reviewed by me.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)






