### PR TITLE
Prevent duplicate orders and charges when an interrupted checkout is resubmitted

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Send the admin New Order and customer Processing emails when an asynchronous payment method (iDEAL, Klarna, Bancontact) is confirmed via the deferred webhook path
 * Fix - Use the Amazon Pay custom button size setting on the product, cart, and checkout pages instead of falling back to the Apple Pay/Google Pay size
 * Tweak - Render the Express Checkout button on the cart and checkout from page-bootstrapped data, removing a cart-details request from the critical path to first button render
+* Fix - Prevent a duplicate order and charge when a checkout is resubmitted after its response is lost but payment already succeeded
 * Fix - Show the Stripe payment block as supported in the Checkout block editor when Optimized Checkout is enabled and only non-card methods (e.g. Cash App Pay) are active
 * Tweak - Memoize the Blocks Express Checkout button so it no longer re-renders the Stripe element on unrelated cart updates
 * Fix - Keep the subscription payment-method row in sync with the saved-card list when a card has been used both directly and through Apple Pay/Google Pay

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -758,10 +758,11 @@ class WC_Stripe_Intent_Controller {
 				]
 			);
 
-			if ( $order && $processing_started ) {
+			if ( $order instanceof WC_Order && $processing_started && ! $order->get_date_paid( 'edit' ) ) {
 				// Only fail the order for failures raised during gateway processing; failures before that
 				// (nonce/CSRF, order lookup, intent mismatch) act on untrusted POST data and must not fail
 				// an order the caller may not own. Skip saving here; update_status() below persists it.
+				// A throw after the charge (e.g. a completion hook) leaves the order paid; don't fail that one.
 				$order_helper->remove_payment_awaiting_action( $order, false );
 				$order->update_status( OrderStatus::FAILED );
 			}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2525,6 +2525,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			WC_Stripe_Logger::info( "Begin processing UPE redirect payment for order $order_id for the amount of {$order->get_total()}" );
 
 			$this->process_order_for_confirmed_intent( $order, $intent_id, $save_payment_method );
+
+			// A 3DS or redirect payment method finishes here, on the browser return from the challenge, rather than inside
+			// process_payment(), so record the marker on this leg too or a lost response could still resubmit the cart.
+			// Pay-for-order settles an existing order, so its cart isn't what was charged and must not be recorded.
+			if ( ! $is_pay_for_order && $order instanceof WC_Order && $order->get_date_paid( 'edit' ) ) {
+				$this->record_paid_cart_marker( $order );
+			}
 		} catch ( WC_Stripe_Payment_Cancelled_Exception $e ) {
 			if ( $order instanceof WC_Order ) {
 				$order_helper->delete_stripe_upe_waiting_for_redirect( $order );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -317,6 +317,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		// Add a notice about currency conversion when the order currency is different from the store currency on the order details page.
 		add_action( 'woocommerce_order_details_after_order_table', [ $this, 'add_currency_conversion_notice' ], 10 );
 
+		// Retire the duplicate-charge marker once the shopper has seen an order confirmed; both classic and Blocks fire this.
+		add_action( 'woocommerce_thankyou', [ $this, 'clear_paid_cart_marker_for_confirmed_order' ] );
+
 		// Add a notice about currency conversion in the order confirmation emails when the order currency is different from the store currency.
 		add_action( 'woocommerce_email_after_order_table', [ $this, 'add_email_currency_conversion_notice' ], 10, 3 );
 
@@ -1699,6 +1702,33 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			'billing_email' => (string) $marker['billing_email'],
 			'paid_at'       => (int) $marker['paid_at'],
 		];
+	}
+
+	/**
+	 * Retires the paid-cart marker once the shopper has reached an order's confirmation page.
+	 *
+	 * Reaching the thank-you page is proof the shopper saw the order succeed, so the cart they are now holding is a
+	 * deliberate new purchase rather than a resubmission of a response they never received. Without this a genuine
+	 * repurchase of the same items within the detection window would be mistaken for a duplicate and cancelled.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param int $order_id ID of the order whose confirmation page is being shown.
+	 * @return void
+	 */
+	public function clear_paid_cart_marker_for_confirmed_order( $order_id ): void {
+		$marker = $this->get_paid_cart_marker();
+
+		if ( null === $marker || (int) $order_id !== $marker['order_id'] ) {
+			return;
+		}
+
+		if ( ! WC()->session || ! method_exists( WC()->session, 'save_data' ) ) {
+			return;
+		}
+
+		WC()->session->set( self::PAID_CART_MARKER_SESSION_KEY, null );
+		WC()->session->save_data();
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1579,7 +1579,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		$paid_order = wc_get_order( $marker['order_id'] );
 
 		// The recorded order has to still be paid; a refunded or cancelled one means the shopper is legitimately buying again.
-		if ( ! $paid_order instanceof WC_Order || ! $paid_order->get_date_paid( 'edit' ) ) {
+		if ( ! $paid_order instanceof WC_Order
+			|| ! $paid_order->get_date_paid( 'edit' )
+			|| $paid_order->has_status( [ OrderStatus::CANCELLED, OrderStatus::REFUNDED, OrderStatus::FAILED ] ) ) {
 			return null;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1454,7 +1454,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 * @return array|null An array with result of payment and redirect URL, or nothing.
 	 */
 	public function process_payment( $order_id, $retry = true, $force_save_source = false, $previous_error = false, $use_order_source = false ) {
-		$duplicate_response = $this->maybe_prevent_duplicate_charge( $order_id );
+		// Decided here because the signals it reads decay once payment succeeds: needs_payment() flips, so a paid
+		// order-pay stops looking like one, and the marker is written from the finally block below.
+		$is_paying_for_session_cart = $this->is_paying_for_session_cart( $order_id );
+
+		$duplicate_response = $this->maybe_prevent_duplicate_charge( $order_id, $is_paying_for_session_cart );
 
 		if ( null !== $duplicate_response ) {
 			return $duplicate_response;
@@ -1482,8 +1486,47 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 
 			return $this->process_payment_with_deferred_intent( $order_id );
 		} finally {
-			$this->handle_paid_order_after_checkout( $order_id );
+			$this->handle_paid_order_after_checkout( $order_id, $is_paying_for_session_cart );
 		}
+	}
+
+	/**
+	 * Tells whether this request is paying for the cart the shopper is holding, rather than settling an existing order.
+	 *
+	 * Only meaningful before payment is taken; see the call site in {@see process_payment()}.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param int $order_id ID of the order being processed.
+	 * @return bool
+	 */
+	private function is_paying_for_session_cart( int $order_id ): bool {
+		return ! $this->is_changing_payment_method_for_subscription()
+			&& ! $this->is_on_add_payment_method_page()
+			&& ! $this->is_settling_an_existing_order( $order_id );
+	}
+
+	/**
+	 * Tells whether this request is settling an order that already exists, as pay-for-order and express checkout do.
+	 *
+	 * Keyed on the order key rather than the request path: paying by key is how WooCommerce settles an existing order
+	 * on both the classic order-pay page and the Store API, so this catches express checkout too, which the classic
+	 * is_valid_pay_for_order_endpoint() detector misses. Such an order's cart hash is its original purchase's.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param int $order_id ID of the order being processed.
+	 * @return bool
+	 */
+	private function is_settling_an_existing_order( int $order_id ): bool {
+		if ( empty( $_GET['key'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return false;
+		}
+
+		$order = wc_get_order( $order_id );
+
+		return $order instanceof WC_Order
+			&& hash_equals( $order->get_order_key(), wc_clean( wp_unslash( $_GET['key'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}
 
 	/**
@@ -1500,15 +1543,14 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 10.9.0
 	 *
-	 * @param int $order_id ID of the order that was processed.
+	 * @param int  $order_id ID of the order that was processed.
+	 * @param bool $is_paying_for_session_cart Whether this request was paying the shopper's cart, decided before payment.
 	 * @return void
 	 */
-	private function handle_paid_order_after_checkout( int $order_id ): void {
-		// These flows pay an existing order or no order at all, so the shopper's cart isn't what was charged and the
-		// order's hash is the original purchase's.
-		if ( $this->is_changing_payment_method_for_subscription()
-			|| $this->is_valid_pay_for_order_endpoint()
-			|| $this->is_on_add_payment_method_page() ) {
+	private function handle_paid_order_after_checkout( int $order_id, bool $is_paying_for_session_cart ): void {
+		// Settling an existing order means the shopper's cart isn't what was charged and the order's hash is the
+		// original purchase's.
+		if ( ! $is_paying_for_session_cart ) {
 			return;
 		}
 
@@ -1530,15 +1572,14 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 10.9.0
 	 *
-	 * @param int $order_id ID of the order being processed.
+	 * @param int  $order_id ID of the order being processed.
+	 * @param bool $is_paying_for_session_cart Whether this request is paying the shopper's cart.
 	 * @return array|null A response for the already-paid order, or null to carry on with payment.
 	 */
-	private function maybe_prevent_duplicate_charge( int $order_id ): ?array {
-		// These flows pay an existing order or no order at all, so the shopper's cart isn't what's being paid for and a hash
-		// match would prove nothing about it. Blocking a pay-for-order would strand a customer paying a legitimate invoice.
-		if ( $this->is_changing_payment_method_for_subscription()
-			|| $this->is_valid_pay_for_order_endpoint()
-			|| $this->is_on_add_payment_method_page() ) {
+	private function maybe_prevent_duplicate_charge( int $order_id, bool $is_paying_for_session_cart ): ?array {
+		// Settling an existing order means a hash match would prove nothing, and blocking one would strand a customer
+		// paying a legitimate invoice.
+		if ( ! $is_paying_for_session_cart ) {
 			return null;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -327,8 +327,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		// Add a notice about currency conversion when the order currency is different from the store currency on the order details page.
 		add_action( 'woocommerce_order_details_after_order_table', [ $this, 'add_currency_conversion_notice' ], 10 );
 
-		// Retire the duplicate-charge marker once the shopper has seen an order confirmed; both classic and Blocks fire this.
-		add_action( 'woocommerce_thankyou', [ $this, 'clear_paid_cart_marker_for_confirmed_order' ] );
+		// Retire the duplicate-charge marker once the shopper reaches the order-received page. Hooked on the page load
+		// rather than woocommerce_thankyou: on Blocks that action fires from an inner confirmation block a customized
+		// template can drop, which would leave the marker to swallow a genuine repurchase.
+		add_action( 'template_redirect', [ $this, 'clear_paid_cart_marker_on_confirmation' ] );
 
 		// Add a notice about currency conversion in the order confirmation emails when the order currency is different from the store currency.
 		add_action( 'woocommerce_email_after_order_table', [ $this, 'add_email_currency_conversion_notice' ], 10, 3 );
@@ -1780,21 +1782,24 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Retires the paid-cart marker once the shopper has reached an order's confirmation page.
+	 * Retires the marker once the shopper reaches the order-received page, whichever checkout rendered it.
 	 *
-	 * Reaching the thank-you page is proof the shopper saw the order succeed, so the cart they are now holding is a
-	 * deliberate new purchase rather than a resubmission of a response they never received. Without this a genuine
+	 * Reaching the confirmation page is proof the shopper saw the order succeed, so the cart they are now holding is a
+	 * deliberate new purchase rather than a resubmission of a response they never received; without this a genuine
 	 * repurchase of the same items within the detection window would be mistaken for a duplicate and cancelled.
+	 *
+	 * Keyed off the endpoint's order id rather than woocommerce_thankyou, whose Blocks inner block a customized
+	 * template can drop; the endpoint carries the id regardless of the template.
 	 *
 	 * @since 10.9.0
 	 *
-	 * @param int $order_id ID of the order whose confirmation page is being shown.
 	 * @return void
 	 */
-	public function clear_paid_cart_marker_for_confirmed_order( $order_id ): void {
-		$marker = $this->get_paid_cart_marker();
+	public function clear_paid_cart_marker_on_confirmation(): void {
+		$order_id = absint( get_query_var( 'order-received' ) );
+		$marker   = $this->get_paid_cart_marker();
 
-		if ( null === $marker || (int) $order_id !== $marker['order_id'] ) {
+		if ( 0 === $order_id || null === $marker || $order_id !== $marker['order_id'] ) {
 			return;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1588,6 +1588,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			]
 		);
 
+		$this->cancel_order_superseded_by( $order, $paid_order );
+
 		if ( WC()->cart ) {
 			WC()->cart->empty_cart();
 		}
@@ -1596,6 +1598,37 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			'result'   => 'success',
 			'redirect' => $this->get_return_url( $paid_order ),
 		];
+	}
+
+	/**
+	 * Cancels an order that will never be paid because its cart was charged under a different order.
+	 *
+	 * Core creates the order before handing over to the gateway, so by the time the duplicate is spotted the order
+	 * already exists and would otherwise sit pending: WooCommerce only sweeps unpaid orders up when the hold stock
+	 * setting is non-empty, so on a store that has cleared it the record would linger and read as an abandoned sale.
+	 *
+	 * Cancelling from pending or failed is inert beyond the status change. Stock was never reduced, so the restore
+	 * hook returns early, and the cancelled order email only fires out of processing or on-hold.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param WC_Order $order      The order to cancel.
+	 * @param WC_Order $paid_order The order whose charge supersedes it.
+	 * @return void
+	 */
+	private function cancel_order_superseded_by( WC_Order $order, WC_Order $paid_order ): void {
+		if ( ! $order->has_status( [ OrderStatus::PENDING, OrderStatus::FAILED ] ) ) {
+			return;
+		}
+
+		$order->update_status(
+			OrderStatus::CANCELLED,
+			sprintf(
+				/* translators: %s: order number of the order that already paid for this cart. */
+				__( 'Cancelled because this cart had already been paid for by order %s.', 'woocommerce-gateway-stripe' ),
+				$paid_order->get_order_number()
+			)
+		);
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -73,6 +73,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	public const OPTIMIZED_CHECKOUT_DEFAULT_LAYOUT = 'accordion';
 
 	/**
+	 * Session key recording the cart Stripe most recently charged, used to short-circuit a resubmission of that cart.
+	 *
+	 * @var string
+	 */
+	protected const PAID_CART_MARKER_SESSION_KEY = 'wc_stripe_paid_cart';
+
+	/**
 	 * Notices (array)
 	 *
 	 * @var array
@@ -1444,6 +1451,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 * @return array|null An array with result of payment and redirect URL, or nothing.
 	 */
 	public function process_payment( $order_id, $retry = true, $force_save_source = false, $previous_error = false, $use_order_source = false ) {
+		$duplicate_response = $this->maybe_prevent_duplicate_charge( $order_id );
+
+		if ( null !== $duplicate_response ) {
+			return $duplicate_response;
+		}
+
 		$payment_intent_id     = isset( $_POST['wc_payment_intent_id'] ) ? wc_clean( wp_unslash( $_POST['wc_payment_intent_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$checkout_session_id   = isset( $_POST['wc_stripe_checkout_session_id'] ) ? wc_clean( wp_unslash( $_POST['wc_stripe_checkout_session_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$selected_payment_type = $this->get_selected_payment_method_type_from_request();
@@ -1464,6 +1477,175 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		}
 
 		return $this->process_payment_with_deferred_intent( $order_id );
+	}
+
+	/**
+	 * Returns a success response pointing at an order Stripe already paid for this cart, when there is one.
+	 *
+	 * Core only resumes an order while it still needs payment. When a checkout response is lost the first order
+	 * is already paid, so core declines to resume it and builds a brand new one for a cart Stripe has charged.
+	 * Only the gateway knows about that charge, so this bails out ahead of the first Stripe API call.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param int $order_id ID of the order being processed.
+	 * @return array|null A response for the already-paid order, or null to carry on with payment.
+	 */
+	private function maybe_prevent_duplicate_charge( int $order_id ): ?array {
+		// These flows pay an existing order or no order at all, so matching them against the cart is meaningless.
+		if ( $this->is_changing_payment_method_for_subscription()
+			|| $this->is_valid_pay_for_order_endpoint()
+			|| $this->is_on_add_payment_method_page() ) {
+			return null;
+		}
+
+		// Checkout sessions carry their own already-paid guard and mutation lock.
+		if ( ! empty( $_POST['wc_stripe_checkout_session_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			return null;
+		}
+
+		$order = wc_get_order( $order_id );
+
+		if ( ! $order instanceof WC_Order ) {
+			return null;
+		}
+
+		$marker = $this->get_paid_cart_marker();
+
+		if ( null === $marker ) {
+			return null;
+		}
+
+		$cart_hash = $order->get_cart_hash();
+
+		if ( '' === $cart_hash || ! hash_equals( $marker['cart_hash'], $cart_hash ) ) {
+			return null;
+		}
+
+		// A shopper who changed their email is telling us this is a different purchase, not a retry of the recorded one.
+		if ( ! hash_equals( $marker['billing_email'], (string) $order->get_billing_email() ) ) {
+			return null;
+		}
+
+		$window_in_seconds = $this->get_duplicate_charge_detection_window( $order );
+
+		if ( $window_in_seconds <= 0 || time() - $marker['paid_at'] > $window_in_seconds ) {
+			return null;
+		}
+
+		$paid_order = wc_get_order( $marker['order_id'] );
+
+		// The recorded order has to still be paid; a refunded or cancelled one means the shopper is legitimately buying again.
+		if ( ! $paid_order instanceof WC_Order || ! $paid_order->get_date_paid( 'edit' ) ) {
+			return null;
+		}
+
+		WC_Stripe_Logger::info(
+			'Duplicate charge prevented; redirecting to the order already paid for this cart.',
+			[
+				'order_id'      => $order_id,
+				'paid_order_id' => $paid_order->get_id(),
+			]
+		);
+
+		if ( WC()->cart ) {
+			WC()->cart->empty_cart();
+		}
+
+		return [
+			'result'   => 'success',
+			'redirect' => $this->get_return_url( $paid_order ),
+		];
+	}
+
+	/**
+	 * Records that Stripe has charged the given order's cart, so a resubmission of the same cart can be short-circuited.
+	 *
+	 * Written to the session and flushed immediately: the response to the request that charged the card may never
+	 * reach the shopper, and a marker that only lands on shutdown is exactly the one that goes missing in that race.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param WC_Order $order The order that was just paid.
+	 * @return void
+	 */
+	private function record_paid_cart_marker( WC_Order $order ): void {
+		$cart_hash = $order->get_cart_hash();
+
+		if ( ! WC()->session || '' === $cart_hash ) {
+			return;
+		}
+
+		// save_data() lives on the concrete handlers rather than WC_Session, and the handler is swappable via woocommerce_session_handler.
+		if ( ! method_exists( WC()->session, 'save_data' ) ) {
+			return;
+		}
+
+		WC()->session->set(
+			self::PAID_CART_MARKER_SESSION_KEY,
+			[
+				'cart_hash'     => $cart_hash,
+				'order_id'      => $order->get_id(),
+				'billing_email' => (string) $order->get_billing_email(),
+				'paid_at'       => time(),
+			]
+		);
+
+		// A marker that only lands on shutdown is the one that goes missing when the response is lost, so flush it now.
+		WC()->session->save_data();
+	}
+
+	/**
+	 * Returns the recorded paid-cart marker, or null when there isn't a usable one.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @return array|null
+	 */
+	private function get_paid_cart_marker(): ?array {
+		if ( ! WC()->session ) {
+			return null;
+		}
+
+		$marker = WC()->session->get( self::PAID_CART_MARKER_SESSION_KEY );
+
+		if ( ! is_array( $marker ) ) {
+			return null;
+		}
+
+		// Session data is deserialized from storage, so treat a partial marker as no marker at all.
+		foreach ( [ 'cart_hash', 'order_id', 'billing_email', 'paid_at' ] as $key ) {
+			if ( ! isset( $marker[ $key ] ) ) {
+				return null;
+			}
+		}
+
+		return [
+			'cart_hash'     => (string) $marker['cart_hash'],
+			'order_id'      => (int) $marker['order_id'],
+			'billing_email' => (string) $marker['billing_email'],
+			'paid_at'       => (int) $marker['paid_at'],
+		];
+	}
+
+	/**
+	 * Returns how long after a charge a resubmission of the same cart still counts as a duplicate.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param WC_Order $order The order being processed.
+	 * @return int Window in seconds. Zero or less disables the guard.
+	 */
+	private function get_duplicate_charge_detection_window( WC_Order $order ): int {
+		/**
+		 * Filters how long after a charge a resubmission of the same cart is still treated as a duplicate.
+		 *
+		 * @since 10.9.0
+		 *
+		 * @param int      $window_in_seconds Detection window. Return zero or less to disable the guard.
+		 * @param WC_Order $order             The order being processed.
+		 */
+		return (int) apply_filters( 'wc_stripe_duplicate_charge_detection_window', 2 * MINUTE_IN_SECONDS, $order );
 	}
 
 	/**
@@ -1751,6 +1933,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			}
 
 			$order_helper->unlock_order_payment( $order );
+
+			// Reaching here doesn't mean the card was charged: intents awaiting 3DS or a redirect land here unpaid and settle later.
+			if ( $order instanceof WC_Order && $order->get_date_paid( 'edit' ) ) {
+				$this->record_paid_cart_marker( $order );
+			}
 
 			return array_merge(
 				[

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1472,11 +1472,50 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			}
 		}
 
-		if ( is_string( $checkout_session_id ) && ! empty( $checkout_session_id ) && ! WC_Stripe_Checkout_Session_Context::was_amount_mismatch_detected() ) {
-			return $this->process_payment_with_checkout_session( $order_id, $checkout_session_id, $save_payment_method, $selected_payment_type );
+		try {
+			if ( is_string( $checkout_session_id ) && ! empty( $checkout_session_id ) && ! WC_Stripe_Checkout_Session_Context::was_amount_mismatch_detected() ) {
+				return $this->process_payment_with_checkout_session( $order_id, $checkout_session_id, $save_payment_method, $selected_payment_type );
+			}
+
+			return $this->process_payment_with_deferred_intent( $order_id );
+		} finally {
+			$this->handle_paid_order_after_checkout( $order_id );
+		}
+	}
+
+	/**
+	 * Records that Stripe charged this cart, once the order has actually been paid for.
+	 *
+	 * The paid date decides, not how this request ended: a callback that throws after the charge fails a request whose
+	 * card was charged, while an intent awaiting 3DS returns success still unpaid. So this runs on the failure path too.
+	 *
+	 * Deliberately leaves the cart alone. Core rejects a checkout with an empty cart before the gateway is reached
+	 * (WC_Checkout::process_checkout(), and validate_cart_not_empty() on the Store API), so clearing it here would
+	 * bail the resubmission out with "your session has expired" instead of letting the guard return the shopper to
+	 * the order they already paid for. The cart is cleared once that redirect is underway, and on the happy path by
+	 * the order received page.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param int $order_id ID of the order that was processed.
+	 * @return void
+	 */
+	private function handle_paid_order_after_checkout( int $order_id ): void {
+		// These flows pay an existing order or no order at all, so the shopper's cart isn't what was charged and the
+		// order's hash is the original purchase's.
+		if ( $this->is_changing_payment_method_for_subscription()
+			|| $this->is_valid_pay_for_order_endpoint()
+			|| $this->is_on_add_payment_method_page() ) {
+			return;
 		}
 
-		return $this->process_payment_with_deferred_intent( $order_id );
+		$order = wc_get_order( $order_id );
+
+		if ( ! $order instanceof WC_Order || ! $order->get_date_paid( 'edit' ) ) {
+			return;
+		}
+
+		$this->record_paid_cart_marker( $order );
 	}
 
 	/**
@@ -1492,7 +1531,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 * @return array|null A response for the already-paid order, or null to carry on with payment.
 	 */
 	private function maybe_prevent_duplicate_charge( int $order_id ): ?array {
-		// These flows pay an existing order or no order at all, so matching them against the cart is meaningless.
+		// These flows pay an existing order or no order at all, so the shopper's cart isn't what's being paid for and a hash
+		// match would prove nothing about it. Blocking a pay-for-order would strand a customer paying a legitimate invoice.
 		if ( $this->is_changing_payment_method_for_subscription()
 			|| $this->is_valid_pay_for_order_endpoint()
 			|| $this->is_on_add_payment_method_page() ) {
@@ -1933,11 +1973,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			}
 
 			$order_helper->unlock_order_payment( $order );
-
-			// Reaching here doesn't mean the card was charged: intents awaiting 3DS or a redirect land here unpaid and settle later.
-			if ( $order instanceof WC_Order && $order->get_date_paid( 'edit' ) ) {
-				$this->record_paid_cart_marker( $order );
-			}
 
 			return array_merge(
 				[

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -80,6 +80,16 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	protected const PAID_CART_MARKER_SESSION_KEY = 'wc_stripe_paid_cart';
 
 	/**
+	 * Order meta flagging that this checkout was paying the shopper's cart, carried to the async completion leg.
+	 *
+	 * A 3DS or redirect payment finishes on a later request that can't re-derive that decision (the order key isn't
+	 * in the AJAX post), so process_payment() stamps it here for {@see process_order_for_confirmed_intent()} to read.
+	 *
+	 * @var string
+	 */
+	protected const PAID_CART_ELIGIBLE_META_KEY = '_wc_stripe_paid_cart_eligible';
+
+	/**
 	 * Notices (array)
 	 *
 	 * @var array
@@ -1484,7 +1494,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 				return $this->process_payment_with_checkout_session( $order_id, $checkout_session_id, $save_payment_method, $selected_payment_type );
 			}
 
-			return $this->process_payment_with_deferred_intent( $order_id );
+			return $this->process_payment_with_deferred_intent( $order_id, $is_paying_for_session_cart );
 		} finally {
 			$this->handle_paid_order_after_checkout( $order_id, $is_paying_for_session_cart );
 		}
@@ -1519,14 +1529,15 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 * @return bool
 	 */
 	private function is_settling_an_existing_order( int $order_id ): bool {
-		if ( empty( $_GET['key'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$provided_key = isset( $_GET['key'] ) ? wc_clean( wp_unslash( $_GET['key'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		if ( ! is_string( $provided_key ) || '' === $provided_key ) {
 			return false;
 		}
 
 		$order = wc_get_order( $order_id );
 
-		return $order instanceof WC_Order
-			&& hash_equals( $order->get_order_key(), wc_clean( wp_unslash( $_GET['key'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return $order instanceof WC_Order && hash_equals( $order->get_order_key(), $provided_key );
 	}
 
 	/**
@@ -1715,6 +1726,27 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
+	 * Records the marker on the async completion leg, when this order was flagged a cart checkout and is now paid.
+	 *
+	 * The eligibility meta is what keeps pay-for-order and other existing-order payments out; it is only set when the
+	 * original checkout was paying the shopper's cart. Cleared here once consumed. The clear is left for the order's
+	 * own save on the success path rather than an extra write; a throw leaves a benign flag on the paid order.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param WC_Order $order The order whose confirmed intent was just processed.
+	 * @return void
+	 */
+	private function maybe_record_paid_cart_marker_for_confirmed_order( WC_Order $order ): void {
+		if ( 'yes' !== $order->get_meta( self::PAID_CART_ELIGIBLE_META_KEY ) || ! $order->get_date_paid( 'edit' ) ) {
+			return;
+		}
+
+		$this->record_paid_cart_marker( $order );
+		$order->delete_meta_data( self::PAID_CART_ELIGIBLE_META_KEY );
+	}
+
+	/**
 	 * Returns the recorded paid-cart marker, or null when there isn't a usable one.
 	 *
 	 * @since 10.9.0
@@ -1797,16 +1829,17 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Process the payment for an order using a deferred intent.
 	 *
-	 * @param int $order_id WC Order ID to be paid for.
+	 * @param int  $order_id WC Order ID to be paid for.
+	 * @param bool $is_paying_for_session_cart Whether this request is paying the shopper's cart, decided before payment.
 	 *
 	 * @return array An array with the result of the payment processing, and a redirect URL on success.
 	 */
-	private function process_payment_with_deferred_intent( int $order_id ) {
+	private function process_payment_with_deferred_intent( int $order_id, bool $is_paying_for_session_cart = false ) {
 		if ( ! empty( $_POST['wc-stripe-confirmation-token'] ) ) {
 			return $this->process_payment_with_confirmation_token( $order_id );
 		}
 
-		return $this->process_payment_with_payment_method( $order_id );
+		return $this->process_payment_with_payment_method( $order_id, $is_paying_for_session_cart );
 	}
 
 	/**
@@ -1915,11 +1948,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Process the payment for an order that has a payment method attached.
 	 *
-	 * @param int $order_id ID of order to be processed.
+	 * @param int  $order_id ID of order to be processed.
+	 * @param bool $is_paying_for_session_cart Whether this request is paying the shopper's cart, decided before payment.
 	 *
 	 * @return array An array with the result of the payment processing, and a redirect URL on success.
 	 */
-	private function process_payment_with_payment_method( int $order_id ) {
+	private function process_payment_with_payment_method( int $order_id, bool $is_paying_for_session_cart = false ) {
 		if ( $this->is_changing_payment_method_for_subscription() ) {
 			return $this->process_change_subscription_payment_with_deferred_intent( $order_id );
 		}
@@ -2056,6 +2090,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 
 				// Prevent processing the payment intent webhooks while also processing the redirect payment (also prevents duplicate Stripe meta stored on the order).
 				$order_helper->update_stripe_upe_waiting_for_redirect( $order, true );
+
+				// Payment finishes on a later request (3DS/redirect return) that can't see this was a cart checkout, so
+				// carry the decision on the order for the completion leg to record the marker from.
+				if ( $is_paying_for_session_cart && $order instanceof WC_Order ) {
+					$order->update_meta_data( self::PAID_CART_ELIGIBLE_META_KEY, 'yes' );
+				}
+
 				$order->save();
 
 				$redirect = $this->get_redirect_url( $this->get_return_url( $order ), $payment_intent, $payment_information, $order, $payment_needed );
@@ -2568,13 +2609,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			WC_Stripe_Logger::info( "Begin processing UPE redirect payment for order $order_id for the amount of {$order->get_total()}" );
 
 			$this->process_order_for_confirmed_intent( $order, $intent_id, $save_payment_method );
-
-			// A 3DS or redirect payment method finishes here, on the browser return from the challenge, rather than inside
-			// process_payment(), so record the marker on this leg too or a lost response could still resubmit the cart.
-			// Pay-for-order settles an existing order, so its cart isn't what was charged and must not be recorded.
-			if ( ! $is_pay_for_order && $order instanceof WC_Order && $order->get_date_paid( 'edit' ) ) {
-				$this->record_paid_cart_marker( $order );
-			}
 		} catch ( WC_Stripe_Payment_Cancelled_Exception $e ) {
 			if ( $order instanceof WC_Order ) {
 				$order_helper->delete_stripe_upe_waiting_for_redirect( $order );
@@ -2592,6 +2626,14 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			$order_helper->unlock_order_payment( $order );
 
 			WC_Stripe_Logger::error( 'Error processing UPE redirect payment for order: ' . $order_id, [ 'error_message' => $e->getMessage() ] );
+
+			// A throw after the charge (e.g. a completion hook) leaves the order paid; send the shopper to it rather
+			// than failing a paid order and bouncing them back to checkout, where they could pay a second time.
+			if ( $order instanceof WC_Order && $order->get_date_paid( 'edit' ) ) {
+				wp_safe_redirect( wp_sanitize_redirect( $this->get_return_url( $order ) ) );
+				exit;
+			}
+
 			/* translators: localized exception message */
 			$order->update_status( OrderStatus::FAILED, sprintf( __( 'UPE payment failed: %s', 'woocommerce-gateway-stripe' ), $e->getMessage() ) );
 
@@ -2899,11 +2941,18 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		}
 
 		if ( ! $is_pre_order ) {
-			if ( $payment_needed ) {
-				// Use the last charge within the intent to proceed.
-				$this->process_response( $this->get_latest_charge_from_intent( $intent ), $order );
-			} else {
-				$order->payment_complete();
+			try {
+				if ( $payment_needed ) {
+					// Use the last charge within the intent to proceed.
+					$this->process_response( $this->get_latest_charge_from_intent( $intent ), $order );
+				} else {
+					$order->payment_complete();
+				}
+			} finally {
+				// payment_complete() runs before process_response()'s completion hook, so the order is already paid
+				// when a hook there throws. Record from the finally, gated on the paid date, or that lost response
+				// could still resubmit the cart it charged. Mirrors the synchronous path in handle_paid_order_after_checkout().
+				$this->maybe_record_paid_cart_marker_for_confirmed_order( $order );
 			}
 		}
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2061,7 +2061,7 @@ parameters:
 		-
 			message: '#^Cannot call method update_status\(\) on WC_Order\|WC_Order_Refund\|true\.$#'
 			identifier: method.nonObject
-			count: 2
+			count: 1
 			path: includes/class-wc-stripe-intent-controller.php
 
 		-
@@ -2126,12 +2126,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$order of method WC_Stripe_Order_Helper\:\:get_intent_id_from_order\(\) expects WC_Order, WC_Order\|WC_Order_Refund\|true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
-			message: '#^Parameter \#1 \$order of method WC_Stripe_Order_Helper\:\:remove_payment_awaiting_action\(\) expects WC_Order, WC_Order\|WC_Order_Refund\|true given\.$#'
 			identifier: argument.type
 			count: 1
 			path: includes/class-wc-stripe-intent-controller.php

--- a/readme.txt
+++ b/readme.txt
@@ -163,6 +163,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Send the admin New Order and customer Processing emails when an asynchronous payment method (iDEAL, Klarna, Bancontact) is confirmed via the deferred webhook path
 * Fix - Use the Amazon Pay custom button size setting on the product, cart, and checkout pages instead of falling back to the Apple Pay/Google Pay size
 * Tweak - Render the Express Checkout button on the cart and checkout from page-bootstrapped data, removing a cart-details request from the critical path to first button render
+* Fix - Prevent a duplicate order and charge when a checkout is resubmitted after its response is lost but payment already succeeded
 * Fix - Show the Stripe payment block as supported in the Checkout block editor when Optimized Checkout is enabled and only non-card methods (e.g. Cash App Pay) are active
 * Tweak - Memoize the Blocks Express Checkout button so it no longer re-renders the Stripe element on unrelated cart updates
 * Fix - Keep the subscription payment-method row in sync with the saved-card list when a card has been used both directly and through Apple Pay/Google Pay

--- a/tests/phpunit/class-wc-stripe-intent-controller-test.php
+++ b/tests/phpunit/class-wc-stripe-intent-controller-test.php
@@ -867,6 +867,58 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A throw after the charge has completed (e.g. a completion hook) leaves the order paid. That order must not be
+	 * failed: the charge stands, and failing it would let the duplicate-charge guard treat a later resubmit as new.
+	 */
+	public function test_update_order_status_ajax_does_not_fail_an_order_paid_before_the_throw() {
+		Ajax_Test_Helper::init_hooks();
+
+		$order     = WC_Helper_Order::create_order();
+		$intent_id = 'pi_paid_then_threw';
+		$order->update_meta_data( '_stripe_intent_id', $intent_id );
+		$order->save();
+		$order_id = $order->get_id();
+
+		$gateway = $this->getMockBuilder( 'WC_Stripe_UPE_Payment_Gateway' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'process_order_for_confirmed_intent' ] )
+			->getMock();
+
+		// The charge completes (order becomes paid), then processing throws, as a lost response after the charge would.
+		$gateway->expects( $this->once() )
+			->method( 'process_order_for_confirmed_intent' )
+			->willReturnCallback(
+				function ( $order ) {
+					$order->payment_complete();
+					throw new WC_Stripe_Exception( 'processing_error', 'simulated lost response' );
+				}
+			);
+
+		$controller = $this->getMockBuilder( 'WC_Stripe_Intent_Controller' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'get_gateway' ] )
+			->getMock();
+
+		$controller->expects( $this->any() )
+			->method( 'get_gateway' )
+			->willReturn( $gateway );
+
+		$_POST['order_id']       = $order_id;
+		$_POST['intent_id']      = $intent_id;
+		$_REQUEST['_ajax_nonce'] = wp_create_nonce( 'wc_stripe_update_order_status_nonce' );
+
+		ob_start();
+		$controller->update_order_status_ajax();
+		ob_get_clean();
+
+		$final_order = wc_get_order( $order_id );
+		$this->assertNotEquals( 'failed', $final_order->get_status(), 'An order the charge already paid must not be failed.' );
+		$this->assertNotNull( $final_order->get_date_paid( 'edit' ) );
+
+		Ajax_Test_Helper::remove_hooks();
+	}
+
+	/**
 	 * Test that confirm_change_payment rejects requests from users who do not own the subscription.
 	 */
 	public function test_confirm_change_payment_rejects_non_owner() {

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -1806,6 +1806,86 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * Arranges a redirect (3DS/APM return) that will pay the given order, and returns its id.
+	 *
+	 * @param string $cart_hash        Cart hash to stamp on the order.
+	 * @param string $payment_intent_id Intent id the return carries.
+	 * @return int
+	 */
+	private function arrange_redirect_payment( string $cart_hash, string $payment_intent_id = 'pi_mock' ): int {
+		$order = WC_Helper_Order::create_order();
+		list( $amount, $description, $metadata, $currency ) = $this->get_order_details( $order );
+		$order->set_payment_method( WC_Stripe_UPE_Payment_Gateway::ID );
+		$order->set_cart_hash( $cart_hash );
+		$order->save();
+
+		$payment_method_mock                     = self::MOCK_CARD_PAYMENT_METHOD_TEMPLATE;
+		$payment_method_mock['id']               = 'pm_mock';
+		$payment_method_mock['card']['exp_year'] = intval( gmdate( 'Y' ) ) + 1;
+
+		$payment_intent_mock                       = self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE;
+		$payment_intent_mock['id']                 = $payment_intent_id;
+		$payment_intent_mock['amount']             = $amount;
+		$payment_intent_mock['currency']           = $currency;
+		$payment_intent_mock['last_payment_error'] = [];
+		$payment_intent_mock['payment_method']     = $payment_method_mock;
+		$payment_intent_mock['latest_charge']      = 'ch_mock';
+
+		$this->mock_gateway->method( 'stripe_request' )->willReturn( $this->array_to_object( $payment_intent_mock ) );
+		$this->mock_gateway->method( 'get_latest_charge_from_intent' )->willReturn(
+			$this->array_to_object(
+				[
+					'id'                     => 'ch_mock',
+					'captured'               => true,
+					'status'                 => 'succeeded',
+					'payment_method_details' => $payment_method_mock,
+				]
+			)
+		);
+
+		return $order->get_id();
+	}
+
+	/**
+	 * A 3DS or redirect payment method completes on the browser return, so the marker must be recorded there too.
+	 *
+	 * @return void
+	 */
+	public function test_process_upe_redirect_payment_records_the_paid_cart_marker(): void {
+		WC()->session->init();
+		$order_id = $this->arrange_redirect_payment( 'redirect_hash' );
+
+		// Buffer output so the session cookie save_data() writes doesn't trip "headers already sent" under the test harness.
+		ob_start();
+		$this->mock_gateway->process_upe_redirect_payment( $order_id, 'pi_mock', false );
+		ob_end_clean();
+
+		$this->assertNotNull( wc_get_order( $order_id )->get_date_paid( 'edit' ) );
+
+		$marker = WC()->session->get( 'wc_stripe_paid_cart' );
+		$this->assertIsArray( $marker );
+		$this->assertEquals( $order_id, $marker['order_id'] );
+		$this->assertEquals( 'redirect_hash', $marker['cart_hash'] );
+	}
+
+	/**
+	 * Pay-for-order settles an existing order, so its cart is not what was charged and must not be recorded.
+	 *
+	 * @return void
+	 */
+	public function test_process_upe_redirect_payment_skips_the_marker_for_pay_for_order(): void {
+		WC()->session->init();
+		$order_id = $this->arrange_redirect_payment( 'redirect_hash' );
+
+		ob_start();
+		$this->mock_gateway->process_upe_redirect_payment( $order_id, 'pi_mock', false, true );
+		ob_end_clean();
+
+		$this->assertNotNull( wc_get_order( $order_id )->get_date_paid( 'edit' ) );
+		$this->assertNull( WC()->session->get( 'wc_stripe_paid_cart' ) );
+	}
+
+	/**
 	 * Test redirect payment processed only runs once.
 	 */
 	public function test_process_redirect_payment_only_runs_once() {

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -1024,6 +1024,162 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * Arranges a gateway that will charge a card successfully, and returns the order to charge.
+	 *
+	 * @param string $cart_hash     The cart hash to stamp on the order.
+	 * @param string $billing_email The billing email to set on the order.
+	 * @param int    $expected_charges How many times the gateway is expected to reach Stripe across the test.
+	 * @return WC_Order
+	 */
+	private function arrange_paid_cart_gateway( string $cart_hash, string $billing_email, int $expected_charges ): WC_Order {
+		$mock_intent = (object) wp_parse_args(
+			[ 'payment_method' => 'pm_mock' ],
+			self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE
+		);
+
+		$this->mock_gateway->intent_controller
+			->expects( $this->exactly( $expected_charges ) )
+			->method( 'create_and_confirm_payment_intent' )
+			->willReturn( $mock_intent );
+
+		$this->mock_gateway->method( 'get_stripe_customer_id' )->willReturn( 'cus_mock' );
+
+		// The shared mock stubs this to null, which would leave the order unpaid and never record the marker.
+		// Each charge needs its own id as Stripe would issue: process_response() rejects a charge already consumed by another order.
+		$charge_count = 0;
+		$this->mock_gateway->method( 'get_latest_charge_from_intent' )->willReturnCallback(
+			function () use ( &$charge_count ) {
+				++$charge_count;
+
+				return (object) [
+					'id'       => 'ch_mock_' . $charge_count,
+					'captured' => true,
+					'status'   => 'succeeded',
+				];
+			}
+		);
+
+		$_POST = [
+			'payment_method'               => 'stripe',
+			'wc-stripe-payment-method'     => 'pm_mock',
+			'wc-stripe-confirmation-token' => '',
+		];
+
+		return $this->create_checkout_order( $cart_hash, $billing_email );
+	}
+
+	/**
+	 * Creates an order that looks like it came from the given cart.
+	 *
+	 * @param string $cart_hash     The cart hash to stamp on the order.
+	 * @param string $billing_email The billing email to set on the order.
+	 * @return WC_Order
+	 */
+	private function create_checkout_order( string $cart_hash, string $billing_email ): WC_Order {
+		$order = WC_Helper_Order::create_order();
+		$order->set_cart_hash( $cart_hash );
+		$order->set_billing_email( $billing_email );
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * A lost checkout response leaves the cart intact, so core builds a second order for a cart Stripe already charged.
+	 *
+	 * @return void
+	 */
+	public function test_process_payment_prevents_a_duplicate_charge_for_the_same_cart(): void {
+		// Only the first submission may reach Stripe.
+		$first_order = $this->arrange_paid_cart_gateway( 'dupe_hash', 'shopper@example.com', 1 );
+
+		$first_response = $this->mock_gateway->process_payment( $first_order->get_id() );
+
+		$this->assertEquals( 'success', $first_response['result'] );
+		$this->assertNotNull( wc_get_order( $first_order->get_id() )->get_date_paid( 'edit' ) );
+
+		$second_order    = $this->create_checkout_order( 'dupe_hash', 'shopper@example.com' );
+		$second_response = $this->mock_gateway->process_payment( $second_order->get_id() );
+
+		$this->assertEquals( 'success', $second_response['result'] );
+		$this->assertNull( wc_get_order( $second_order->get_id() )->get_date_paid( 'edit' ), 'The resubmitted order must never be charged.' );
+	}
+
+	/**
+	 * The guard has to point the shopper at the order that was actually paid, not at the one they just resubmitted.
+	 *
+	 * @return void
+	 */
+	public function test_duplicate_charge_guard_redirects_to_the_paid_order(): void {
+		$first_order = $this->arrange_paid_cart_gateway( 'dupe_hash', 'shopper@example.com', 1 );
+		$this->mock_gateway->process_payment( $first_order->get_id() );
+
+		$second_order = $this->create_checkout_order( 'dupe_hash', 'shopper@example.com' );
+
+		// The shared mock stubs get_return_url to a constant, so only a real gateway can prove which order it points at.
+		// The guard returns ahead of the first Stripe call, so this short-circuits without touching the API.
+		$response = ( new WC_Stripe_UPE_Payment_Gateway() )->process_payment( $second_order->get_id() );
+
+		$this->assertEquals( 'success', $response['result'] );
+		$this->assertStringContainsString( $first_order->get_order_key(), $response['redirect'] );
+		$this->assertStringNotContainsString( $second_order->get_order_key(), $response['redirect'] );
+	}
+
+	/**
+	 * @param string $second_cart_hash     The cart hash on the second submission.
+	 * @param string $second_billing_email The billing email on the second submission.
+	 * @param bool   $disable_guard        Whether to switch the guard off through its filter.
+	 * @return void
+	 * @dataProvider provide_process_payment_charges_a_genuinely_new_submission
+	 */
+	public function test_process_payment_charges_a_genuinely_new_submission( string $second_cart_hash, string $second_billing_email, bool $disable_guard ): void {
+		// Both submissions are legitimate, so both must reach Stripe.
+		$first_order = $this->arrange_paid_cart_gateway( 'dupe_hash', 'shopper@example.com', 2 );
+
+		try {
+			if ( $disable_guard ) {
+				add_filter( 'wc_stripe_duplicate_charge_detection_window', '__return_zero' );
+			}
+
+			$this->mock_gateway->process_payment( $first_order->get_id() );
+
+			$second_order = $this->create_checkout_order( $second_cart_hash, $second_billing_email );
+			$this->mock_gateway->process_payment( $second_order->get_id() );
+
+			$this->assertNotNull( wc_get_order( $second_order->get_id() )->get_date_paid( 'edit' ) );
+		} finally {
+			if ( $disable_guard ) {
+				remove_filter( 'wc_stripe_duplicate_charge_detection_window', '__return_zero' );
+			}
+		}
+	}
+
+	/**
+	 * Data provider for `test_process_payment_charges_a_genuinely_new_submission`
+	 *
+	 * @return array
+	 */
+	public function provide_process_payment_charges_a_genuinely_new_submission(): array {
+		return [
+			'a different cart'             => [
+				'second_cart_hash'     => 'other_hash',
+				'second_billing_email' => 'shopper@example.com',
+				'disable_guard'        => false,
+			],
+			'a changed billing email'      => [
+				'second_cart_hash'     => 'dupe_hash',
+				'second_billing_email' => 'someone-else@example.com',
+				'disable_guard'        => false,
+			],
+			'the guard disabled by filter' => [
+				'second_cart_hash'     => 'dupe_hash',
+				'second_billing_email' => 'shopper@example.com',
+				'disable_guard'        => true,
+			],
+		];
+	}
+
+	/**
 	 * Provider for `test_process_payment_deferred_intent_returns_valid_response`.
 	 */
 	public function provide_process_payment_deferred_intent_returns_valid_response() {

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -1032,6 +1032,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	 * @return WC_Order
 	 */
 	private function arrange_paid_cart_gateway( string $cart_hash, string $billing_email, int $expected_charges ): WC_Order {
+		// The session outlives a single test, so a marker left by an earlier one would otherwise satisfy assertions here.
+		if ( WC()->session ) {
+			WC()->session->set( 'wc_stripe_paid_cart', null );
+		}
+
 		$mock_intent = (object) wp_parse_args(
 			[ 'payment_method' => 'pm_mock' ],
 			self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE
@@ -1231,6 +1236,53 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			'cancelled' => [ OrderStatus::CANCELLED ],
 			'refunded'  => [ OrderStatus::REFUNDED ],
 			'failed'    => [ OrderStatus::FAILED ],
+		];
+	}
+
+	/**
+	 * Paying an existing order by its key — classic pay-for-order and Store API express checkout alike — must not
+	 * stamp the shopper's current cart as charged, or their next genuine checkout of the same items is cancelled.
+	 *
+	 * @dataProvider provide_order_key_scenarios
+	 *
+	 * @param bool $send_matching_key Whether the request carries the order's own key.
+	 * @param bool $expected_marker   Whether a marker is expected afterwards.
+	 * @return void
+	 */
+	public function test_settling_an_existing_order_by_key_records_no_marker( bool $send_matching_key, bool $expected_marker ): void {
+		$order    = $this->arrange_paid_cart_gateway( 'existing_order_hash', 'shopper@example.com', 1 );
+		$original = isset( $_GET['key'] ) ? sanitize_text_field( wp_unslash( $_GET['key'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$_GET['key'] = $send_matching_key ? $order->get_order_key() : 'wc_order_unrelated';
+
+		try {
+			$this->mock_gateway->process_payment( $order->get_id() );
+		} finally {
+			if ( null === $original ) {
+				unset( $_GET['key'] );
+			} else {
+				$_GET['key'] = $original;
+			}
+		}
+
+		$this->assertNotNull( wc_get_order( $order->get_id() )->get_date_paid( 'edit' ), 'The order itself must still be paid.' );
+
+		if ( $expected_marker ) {
+			$this->assertIsArray( WC()->session->get( 'wc_stripe_paid_cart' ) );
+		} else {
+			$this->assertNull( WC()->session->get( 'wc_stripe_paid_cart' ), 'Settling an existing order by key must not record a paid-cart marker.' );
+		}
+	}
+
+	/**
+	 * @return array<string, array{0: bool, 1: bool}>
+	 */
+	public function provide_order_key_scenarios(): array {
+		return [
+			// The order's own key proves the request settles that existing order, not the session cart.
+			'matching key skips the marker' => [ true, false ],
+			// A key that isn't this order's is treated as an ordinary checkout, so a stale param can't disable the guard.
+			'unrelated key still records'   => [ false, true ],
 		];
 	}
 

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -1201,6 +1201,40 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * date_paid survives a refund or a cancellation, so the guard has to read status too.
+	 *
+	 * @dataProvider provide_statuses_that_invalidate_a_paid_order
+	 *
+	 * @param string $status Status the recorded order ends up in.
+	 * @return void
+	 */
+	public function test_duplicate_charge_guard_ignores_a_cancelled_refunded_or_failed_order( string $status ): void {
+		$first_order = $this->arrange_paid_cart_gateway( 'dupe_hash', 'shopper@example.com', 2 );
+		$this->mock_gateway->process_payment( $first_order->get_id() );
+
+		$paid_order = wc_get_order( $first_order->get_id() );
+		$paid_order->update_status( $status );
+
+		$this->assertNotNull( $paid_order->get_date_paid( 'edit' ), 'This test is only meaningful while the paid date survives the status change.' );
+
+		$repurchase = $this->create_checkout_order( 'dupe_hash', 'shopper@example.com' );
+		$this->mock_gateway->process_payment( $repurchase->get_id() );
+
+		$this->assertNotNull( wc_get_order( $repurchase->get_id() )->get_date_paid( 'edit' ), 'A repurchase must be charged once the recorded order has been reversed.' );
+	}
+
+	/**
+	 * @return array<string, string[]>
+	 */
+	public function provide_statuses_that_invalidate_a_paid_order(): array {
+		return [
+			'cancelled' => [ OrderStatus::CANCELLED ],
+			'refunded'  => [ OrderStatus::REFUNDED ],
+			'failed'    => [ OrderStatus::FAILED ],
+		];
+	}
+
+	/**
 	 * A confirmation page for an unrelated order must not retire a still-valid marker.
 	 *
 	 * @return void

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -1896,13 +1896,18 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	 *
 	 * @param string $cart_hash        Cart hash to stamp on the order.
 	 * @param string $payment_intent_id Intent id the return carries.
+	 * @param bool   $eligible          Whether the original checkout flagged this order a cart checkout.
 	 * @return int
 	 */
-	private function arrange_redirect_payment( string $cart_hash, string $payment_intent_id = 'pi_mock' ): int {
+	private function arrange_redirect_payment( string $cart_hash, string $payment_intent_id = 'pi_mock', bool $eligible = false ): int {
 		$order = WC_Helper_Order::create_order();
 		list( $amount, $description, $metadata, $currency ) = $this->get_order_details( $order );
 		$order->set_payment_method( WC_Stripe_UPE_Payment_Gateway::ID );
 		$order->set_cart_hash( $cart_hash );
+		if ( $eligible ) {
+			// Set by process_payment() when the initial request was paying the shopper's cart; the completion leg reads it.
+			$order->update_meta_data( '_wc_stripe_paid_cart_eligible', 'yes' );
+		}
 		$order->save();
 
 		$payment_method_mock                     = self::MOCK_CARD_PAYMENT_METHOD_TEMPLATE;
@@ -1939,7 +1944,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	 */
 	public function test_process_upe_redirect_payment_records_the_paid_cart_marker(): void {
 		WC()->session->init();
-		$order_id = $this->arrange_redirect_payment( 'redirect_hash' );
+		$order_id = $this->arrange_redirect_payment( 'redirect_hash', 'pi_mock', true );
 
 		// Buffer output so the session cookie save_data() writes doesn't trip "headers already sent" under the test harness.
 		ob_start();
@@ -1955,16 +1960,53 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
-	 * Pay-for-order settles an existing order, so its cart is not what was charged and must not be recorded.
+	 * A 3DS card completes over the update-order-status AJAX leg, and a hook throwing while the response is processed
+	 * must not lose the marker: the charge already happened, so a resubmit would double it.
+	 *
+	 * process_order_for_confirmed_intent() is the shared completion method for that leg; process_response() calls
+	 * payment_complete() before firing wc_gateway_stripe_process_response, so the order is paid when a hook throws.
 	 *
 	 * @return void
 	 */
-	public function test_process_upe_redirect_payment_skips_the_marker_for_pay_for_order(): void {
+	public function test_confirmed_intent_records_the_marker_even_when_response_processing_throws(): void {
+		WC()->session->init();
+		$order_id = $this->arrange_redirect_payment( 'threeds_hash', 'pi_mock', true );
+
+		$thrower = static function () {
+			throw new Exception( 'simulated lost response' );
+		};
+		add_action( 'wc_gateway_stripe_process_response', $thrower );
+
+		$threw = false;
+		ob_start();
+		try {
+			$this->mock_gateway->process_order_for_confirmed_intent( wc_get_order( $order_id ), 'pi_mock', false );
+		} catch ( Exception $e ) {
+			$threw = true;
+		} finally {
+			ob_end_clean();
+			remove_action( 'wc_gateway_stripe_process_response', $thrower );
+		}
+
+		$this->assertTrue( $threw, 'The completion hook must still surface its error.' );
+		$this->assertNotNull( wc_get_order( $order_id )->get_date_paid( 'edit' ), 'The charge succeeded, so the order is paid.' );
+
+		$marker = WC()->session->get( 'wc_stripe_paid_cart' );
+		$this->assertIsArray( $marker, 'The marker must be recorded from the finally despite the throw.' );
+		$this->assertEquals( $order_id, $marker['order_id'] );
+	}
+
+	/**
+	 * Without the cart-checkout flag — as when settling an existing order — the completion leg records no marker.
+	 *
+	 * @return void
+	 */
+	public function test_process_upe_redirect_payment_skips_the_marker_when_not_a_cart_checkout(): void {
 		WC()->session->init();
 		$order_id = $this->arrange_redirect_payment( 'redirect_hash' );
 
 		ob_start();
-		$this->mock_gateway->process_upe_redirect_payment( $order_id, 'pi_mock', false, true );
+		$this->mock_gateway->process_upe_redirect_payment( $order_id, 'pi_mock', false );
 		ob_end_clean();
 
 		$this->assertNotNull( wc_get_order( $order_id )->get_date_paid( 'edit' ) );

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -1192,17 +1192,33 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	 *
 	 * @return void
 	 */
-	public function test_process_payment_allows_a_repurchase_after_the_thankyou_page(): void {
+	public function test_process_payment_allows_a_repurchase_after_the_confirmation_page(): void {
 		$first_order = $this->arrange_paid_cart_gateway( 'dupe_hash', 'shopper@example.com', 2 );
 		$this->mock_gateway->process_payment( $first_order->get_id() );
 
-		// The shopper reaching the confirmation page is what tells the guard the next same-cart order is deliberate.
-		do_action( 'woocommerce_thankyou', $first_order->get_id() );
+		// Loading the order-received page is what tells the guard the next same-cart order is deliberate.
+		$this->arrive_at_order_received_page( $first_order->get_id() );
 
 		$repurchase = $this->create_checkout_order( 'dupe_hash', 'shopper@example.com' );
 		$this->mock_gateway->process_payment( $repurchase->get_id() );
 
 		$this->assertNotNull( wc_get_order( $repurchase->get_id() )->get_date_paid( 'edit' ), 'A repurchase after confirmation must be charged, not treated as a duplicate.' );
+	}
+
+	/**
+	 * Drives the marker-clearing hook the way a real order-received page load does: through the endpoint query var,
+	 * not woocommerce_thankyou, so the test exercises the template-independent path.
+	 *
+	 * @param int $order_id Order whose confirmation page is being simulated.
+	 * @return void
+	 */
+	private function arrive_at_order_received_page( int $order_id ): void {
+		set_query_var( 'order-received', $order_id );
+		try {
+			$this->mock_gateway->clear_paid_cart_marker_on_confirmation();
+		} finally {
+			set_query_var( 'order-received', '' );
+		}
 	}
 
 	/**
@@ -1291,12 +1307,12 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	 *
 	 * @return void
 	 */
-	public function test_thankyou_for_another_order_keeps_the_marker(): void {
+	public function test_confirmation_for_another_order_keeps_the_marker(): void {
 		$first_order = $this->arrange_paid_cart_gateway( 'dupe_hash', 'shopper@example.com', 1 );
 		$this->mock_gateway->process_payment( $first_order->get_id() );
 
 		// A different order's confirmation page is not proof this cart was seen, so the guard must still fire.
-		do_action( 'woocommerce_thankyou', $first_order->get_id() + 1000 );
+		$this->arrive_at_order_received_page( $first_order->get_id() + 1000 );
 
 		$second_order = $this->create_checkout_order( 'dupe_hash', 'shopper@example.com' );
 		$this->mock_gateway->process_payment( $second_order->get_id() );

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -1085,6 +1085,83 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * Fills the cart, so a test can tell a cart that was emptied from one that was never populated.
+	 *
+	 * @return void
+	 */
+	private function arrange_cart_with_a_product(): void {
+		WC()->session->init();
+		WC()->cart->empty_cart();
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+	}
+
+	/**
+	 * A declined card leaves the order unpaid, and the shopper still needs their cart to try another one.
+	 *
+	 * @return void
+	 */
+	public function test_process_payment_leaves_the_cart_when_the_charge_is_declined(): void {
+		$order = $this->create_checkout_order( 'declined_hash', 'shopper@example.com' );
+		$this->arrange_cart_with_a_product();
+
+		$_POST = [
+			'payment_method'               => 'stripe',
+			'wc-stripe-payment-method'     => 'pm_mock',
+			'wc-stripe-confirmation-token' => '',
+		];
+
+		$this->mock_gateway->method( 'get_stripe_customer_id' )->willReturn( 'cus_mock' );
+		$this->mock_gateway->intent_controller
+			->expects( $this->once() )
+			->method( 'create_and_confirm_payment_intent' )
+			->willThrowException( new WC_Stripe_Exception( 'card_declined', 'Your card was declined.' ) );
+
+		$response = $this->mock_gateway->process_payment( $order->get_id() );
+
+		$this->assertEquals( 'failure', $response['result'] );
+		$this->assertNull( wc_get_order( $order->get_id() )->get_date_paid( 'edit' ) );
+		$this->assertFalse( WC()->cart->is_empty(), 'A declined payment must leave the cart alone so the shopper can retry.' );
+	}
+
+	/**
+	 * An intent awaiting 3DS reaches the end of processing with no charge: the card is only charged once the shopper
+	 * authenticates, so clearing the cart here would strand a failed authentication with nothing to retry.
+	 *
+	 * @return void
+	 */
+	public function test_process_payment_leaves_the_cart_when_the_intent_still_needs_authentication(): void {
+		$order = $this->create_checkout_order( '3ds_hash', 'shopper@example.com' );
+		$this->arrange_cart_with_a_product();
+
+		$_POST = [
+			'payment_method'               => 'stripe',
+			'wc-stripe-payment-method'     => 'pm_mock',
+			'wc-stripe-confirmation-token' => '',
+		];
+
+		$mock_intent = (object) wp_parse_args(
+			[ 'payment_method' => 'pm_mock' ],
+			self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE
+		);
+
+		$this->mock_gateway->method( 'get_stripe_customer_id' )->willReturn( 'cus_mock' );
+		$this->mock_gateway->intent_controller
+			->expects( $this->once() )
+			->method( 'create_and_confirm_payment_intent' )
+			->willReturn( $mock_intent );
+
+		// The shared mock stubs get_latest_charge_from_intent() to null, which is the shape of an intent still awaiting 3DS.
+		$this->mock_gateway->process_payment( $order->get_id() );
+
+		$this->assertNull( wc_get_order( $order->get_id() )->get_date_paid( 'edit' ) );
+		$this->assertFalse( WC()->cart->is_empty(), 'An unauthenticated payment must leave the cart alone.' );
+	}
+
+	/**
 	 * A lost checkout response leaves the cart intact, so core builds a second order for a cart Stripe already charged.
 	 *
 	 * @return void
@@ -1103,6 +1180,89 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->assertEquals( 'success', $second_response['result'] );
 		$this->assertNull( wc_get_order( $second_order->get_id() )->get_date_paid( 'edit' ), 'The resubmitted order must never be charged.' );
+	}
+
+	/**
+	 * Once the shopper has seen an order's confirmation page, a genuine repurchase of the same items must go through.
+	 *
+	 * @return void
+	 */
+	public function test_process_payment_allows_a_repurchase_after_the_thankyou_page(): void {
+		$first_order = $this->arrange_paid_cart_gateway( 'dupe_hash', 'shopper@example.com', 2 );
+		$this->mock_gateway->process_payment( $first_order->get_id() );
+
+		// The shopper reaching the confirmation page is what tells the guard the next same-cart order is deliberate.
+		do_action( 'woocommerce_thankyou', $first_order->get_id() );
+
+		$repurchase = $this->create_checkout_order( 'dupe_hash', 'shopper@example.com' );
+		$this->mock_gateway->process_payment( $repurchase->get_id() );
+
+		$this->assertNotNull( wc_get_order( $repurchase->get_id() )->get_date_paid( 'edit' ), 'A repurchase after confirmation must be charged, not treated as a duplicate.' );
+	}
+
+	/**
+	 * A confirmation page for an unrelated order must not retire a still-valid marker.
+	 *
+	 * @return void
+	 */
+	public function test_thankyou_for_another_order_keeps_the_marker(): void {
+		$first_order = $this->arrange_paid_cart_gateway( 'dupe_hash', 'shopper@example.com', 1 );
+		$this->mock_gateway->process_payment( $first_order->get_id() );
+
+		// A different order's confirmation page is not proof this cart was seen, so the guard must still fire.
+		do_action( 'woocommerce_thankyou', $first_order->get_id() + 1000 );
+
+		$second_order = $this->create_checkout_order( 'dupe_hash', 'shopper@example.com' );
+		$this->mock_gateway->process_payment( $second_order->get_id() );
+
+		$this->assertNull( wc_get_order( $second_order->get_id() )->get_date_paid( 'edit' ), 'The resubmitted order must still be caught as a duplicate.' );
+	}
+
+	/**
+	 * Core creates the order before the gateway runs, so the resubmission leaves one behind that is never paid.
+	 *
+	 * @return void
+	 */
+	public function test_process_payment_cancels_the_order_superseded_by_the_paid_one(): void {
+		$first_order = $this->arrange_paid_cart_gateway( 'dupe_hash', 'shopper@example.com', 1 );
+		$this->mock_gateway->process_payment( $first_order->get_id() );
+
+		$second_order = $this->create_checkout_order( 'dupe_hash', 'shopper@example.com' );
+		$this->mock_gateway->process_payment( $second_order->get_id() );
+
+		$superseded = wc_get_order( $second_order->get_id() );
+
+		$this->assertEquals( OrderStatus::CANCELLED, $superseded->get_status(), 'The superseded order must not be left pending.' );
+		$this->assertNull( $superseded->get_date_paid( 'edit' ) );
+
+		$notes = wp_list_pluck( wc_get_order_notes( [ 'order_id' => $second_order->get_id() ] ), 'content' );
+		$this->assertStringContainsString( (string) $first_order->get_order_number(), implode( ' ', $notes ) );
+	}
+
+	/**
+	 * Core rejects a checkout with an empty cart before the gateway is reached, so clearing the cart on payment would
+	 * bail the resubmission out with "your session has expired" and the guard would never run to redirect the shopper.
+	 *
+	 * @return void
+	 */
+	public function test_process_payment_leaves_the_cart_for_the_duplicate_charge_guard(): void {
+		WC()->session->init();
+		WC()->cart->empty_cart();
+
+		try {
+			$product = WC_Helper_Product::create_simple_product();
+			$product->save();
+			WC()->cart->add_to_cart( $product->get_id(), 1 );
+			WC()->cart->calculate_totals();
+
+			$order = $this->arrange_paid_cart_gateway( 'dupe_hash', 'shopper@example.com', 1 );
+			$this->mock_gateway->process_payment( $order->get_id() );
+
+			$this->assertNotNull( wc_get_order( $order->get_id() )->get_date_paid( 'edit' ) );
+			$this->assertFalse( WC()->cart->is_empty(), 'The cart must survive payment or the guard becomes unreachable.' );
+		} finally {
+			WC()->cart->empty_cart();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Related to woocommerce/woocommerce-gateway-stripe#4878

## Changes proposed in this Pull Request:

When Stripe charges the cart but the checkout response never reaches the shopper (page reload, slow network, a hook that throws or corrupts the JSON response), the cart is left intact and the shopper resubmits. Core can't resume the first order because it's already paid, so it builds a second order — and Stripe charges the card again. Core has no way to prevent this on its own: only the gateway knows Stripe already charged this cart.

This adds a gateway-side guard:

* **Marker on payment.** When an order is actually paid (`get_date_paid()`), the gateway records `{cart_hash, order_id, billing_email, paid_at}` in the session and flushes it immediately, so it survives the lost response. Written on both the synchronous path (`process_payment()`) and the browser-side async return for 3DS/SCA and redirect APMs — iDEAL, Klarna, Bancontact (`process_upe_redirect_payment()`).
* **Guard at the top of** `process_payment()`**.** If the order being processed matches a recent, still-paid marker (same cart hash **and** billing email, within the window), the gateway skips payment, cancels the redundant order core just created, empties the cart, and redirects to the order that was already paid.
* **Marker cleared at order confirmation** (`woocommerce_thankyou`, fired by both classic and Blocks). Reaching the confirmation page proves the shopper saw the order succeed, so a later repurchase of the same items is treated as deliberate, not a duplicate.
* **Detection window** defaults to 2 minutes, filterable via `wc_stripe_duplicate_charge_detection_window` (return `0` to disable the guard).

Excluded flows: change-payment-method, pay-for-order, add-payment-method, and Adaptive Pricing checkout sessions (which carry their own guard).

**How can this break / what guards against it:**

* *Blocking a genuine repurchase of an identical cart.* Mitigated by clearing the marker at the confirmation page, scoping by billing email, and the short window; the filter is the escape hatch.
* *Matching a different shopper's order.* Scoped by billing email, not cart hash alone.
* Covered by PHPUnit across the sync path, async/redirect completion, marker clearing, stray-order cancellation, cart survival, and the customer/window/exclusion cases.

**Known limitations (out of scope):**

* Orders completed **only** via webhook (server-to-server, no session) don't get a marker — but that path has no resubmit risk, since the shopper isn't on checkout.
* Authorize-only (manual capture) orders have no `date_paid`, so they aren't covered.

## Testing instructions

1. **Lost response after charge (classic + Blocks).** Add this as a snippet

```
php
   add_action( 'wc_gateway_stripe_process_response', function () {
       throw new \Exception( 'simulated lost response' );
   } );
```

Check out with a test card. You'll see an error. Click Place order again. → No second charge; the redundant order is cancelled (see its order note); you land on the first order's received page. Check the orders list as an admin. Notice that there is a cancelled order with the following order note-

<img src="https://github.com/user-attachments/assets/f32396b5-790d-474b-b051-16faa7b49d7d " alt="Screenshot 2026-07-17 at 11 16 48 PM" width="315" data-linear-height="169" />

2. Genuine repurchase. Remove the snippet. Place an order and let it reach the confirmation page. Place another order with the same items. → It goes through and is charged normally.
3. 3DS. Use a 3DS-required test card (4000 0025 0000 3155), complete the challenge, and confirm the marker path works on the return leg.
4. Regression test: verify that checkout goes through correctly for different payment methods and the redirected thank-you page is always for the correct order.

### Changelog entry

- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

- [ ] Added testing instructions to the [Release Testing Instructions wiki page](<https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions>) (or does not apply)
- [ ] Added the [needs docs label](<https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs>) (or does not apply)
- [ ] Included this PR in the Release Thread scope (or does not apply)