### PR TITLE
Match Google Pay express checkout button height to Apple Pay

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.9.0
+* Fix - Match the Google Pay express checkout button height to Apple Pay when using the Light or Outline button theme
 * Fix - Surface an error and block checkout when the Adaptive Pricing order total can't be synced with Stripe, instead of silently letting the buyer pay a stale amount
 * Fix - Stop attaching Level 3 data to captures and payments for non-card methods
 * Fix - Add the missing order and customer metadata to Adaptive Pricing payment intents

--- a/client/blocks/express-checkout/__tests__/express-checkout-component.test.js
+++ b/client/blocks/express-checkout/__tests__/express-checkout-component.test.js
@@ -1,0 +1,146 @@
+import { render } from '@testing-library/react';
+import { ExpressCheckoutElement } from '@stripe/react-stripe-js';
+import ExpressCheckoutComponent from '../express-checkout-component';
+import { useExpressCheckout } from '../hooks';
+import {
+	EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY,
+	EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY,
+} from 'wcstripe/stripe-utils/constants';
+
+jest.mock( '@stripe/react-stripe-js', () => ( {
+	ExpressCheckoutElement: jest.fn( () => <div /> ),
+} ) );
+
+jest.mock( '../hooks', () => ( {
+	useExpressCheckout: jest.fn(),
+} ) );
+
+jest.mock( 'wcstripe/express-checkout/event-handler', () => ( {
+	shippingAddressChangeHandler: jest.fn(),
+	shippingRateChangeHandler: jest.fn(),
+} ) );
+
+const componentProps = {
+	api: {},
+	billing: {},
+	shippingData: {},
+	setExpressPaymentError: jest.fn(),
+	onClick: jest.fn(),
+	onClose: jest.fn(),
+};
+
+beforeEach( () => {
+	jest.clearAllMocks();
+} );
+
+const getElementOptions = ( {
+	expressPaymentMethod,
+	buttonHeight,
+	buttonTheme,
+} ) => {
+	useExpressCheckout.mockReturnValue( {
+		buttonOptions: { buttonHeight, buttonTheme },
+		onButtonClick: jest.fn(),
+		onConfirm: jest.fn(),
+		onCancel: jest.fn(),
+		elements: {},
+	} );
+
+	render(
+		<ExpressCheckoutComponent
+			{ ...componentProps }
+			expressPaymentMethod={ expressPaymentMethod }
+		/>
+	);
+
+	expect( ExpressCheckoutElement ).toHaveBeenCalledTimes( 1 );
+	return ExpressCheckoutElement.mock.calls[ 0 ][ 0 ].options;
+};
+
+// The merchant picks one theme for the whole row, which Stripe applies per method.
+// Google Pay has no outlined variant, so both Light and Outline send it 'white'.
+const whiteGooglePayThemes = [
+	[ 'Light', { applePay: 'white', googlePay: 'white' } ],
+	[ 'Outline', { applePay: 'white-outline', googlePay: 'white' } ],
+];
+
+describe.each( whiteGooglePayThemes )(
+	'ExpressCheckoutComponent with the %s theme',
+	( _themeName, buttonTheme ) => {
+		// Above the 40px floor the clamp no longer hides a downward adjustment, so
+		// these heights are the ones that expose a Google Pay/Apple Pay mismatch.
+		it.each( [ 44, 48, 55 ] )(
+			'renders Google Pay at the shared %dpx height',
+			( buttonHeight ) => {
+				const options = getElementOptions( {
+					expressPaymentMethod:
+						EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY,
+					buttonHeight,
+					buttonTheme,
+				} );
+
+				expect( options.buttonHeight ).toBe( buttonHeight );
+			}
+		);
+
+		it.each( [ 44, 48, 55 ] )(
+			'renders Apple Pay at the same shared %dpx height',
+			( buttonHeight ) => {
+				const options = getElementOptions( {
+					expressPaymentMethod:
+						EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY,
+					buttonHeight,
+					buttonTheme,
+				} );
+
+				expect( options.buttonHeight ).toBe( buttonHeight );
+			}
+		);
+	}
+);
+
+describe( 'ExpressCheckoutComponent with the Dark theme', () => {
+	const buttonTheme = { applePay: 'black', googlePay: 'black' };
+
+	it( 'keeps the black Apple Pay compensation', () => {
+		const options = getElementOptions( {
+			expressPaymentMethod: EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY,
+			buttonHeight: 48,
+			buttonTheme,
+		} );
+
+		expect( options.buttonHeight ).toBe( 48.4 );
+	} );
+
+	it( 'clamps the compensated Apple Pay height to the 55px maximum', () => {
+		const options = getElementOptions( {
+			expressPaymentMethod: EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY,
+			buttonHeight: 55,
+			buttonTheme,
+		} );
+
+		expect( options.buttonHeight ).toBe( 55 );
+	} );
+
+	it( 'leaves Google Pay at the shared height', () => {
+		const options = getElementOptions( {
+			expressPaymentMethod: EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY,
+			buttonHeight: 48,
+			buttonTheme,
+		} );
+
+		expect( options.buttonHeight ).toBe( 48 );
+	} );
+} );
+
+describe( 'ExpressCheckoutComponent height clamping', () => {
+	it( 'clamps a below-minimum height to 40px', () => {
+		const options = getElementOptions( {
+			expressPaymentMethod: EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY,
+			buttonHeight: 32,
+			buttonTheme: { applePay: 'white', googlePay: 'white' },
+		} );
+
+		expect( options.buttonHeight ).toBe( 40 );
+	} );
+} );

--- a/client/blocks/express-checkout/express-checkout-component.js
+++ b/client/blocks/express-checkout/express-checkout-component.js
@@ -48,14 +48,6 @@ const adjustButtonHeights = ( buttonOptions, expressPaymentMethod ) => {
 		buttonHeight = buttonHeight + 0.4;
 	}
 
-	// GooglePay with the white theme has a 2px height difference due to its border.
-	if (
-		expressPaymentMethod === EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY &&
-		buttonOptions.buttonTheme.googlePay === 'white'
-	) {
-		buttonHeight = buttonHeight - 2;
-	}
-
 	return {
 		...buttonOptions,
 		// Clamp the button height to the allowed range 40px to 55px.

--- a/client/blocks/express-checkout/express-checkout-component.js
+++ b/client/blocks/express-checkout/express-checkout-component.js
@@ -40,7 +40,7 @@ const getPaymentMethodsOverride = ( enabledPaymentMethod ) => {
 const adjustButtonHeights = ( buttonOptions, expressPaymentMethod ) => {
 	let buttonHeight = buttonOptions.buttonHeight;
 
-	// Apple Pay has a nearly imperceptible height difference. We increase it by 1px here.
+	// Apple Pay has a nearly imperceptible height difference. We increase it by 0.4px here.
 	if (
 		buttonOptions.buttonTheme.applePay === 'black' &&
 		expressPaymentMethod === EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY

--- a/readme.txt
+++ b/readme.txt
@@ -158,6 +158,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.9.0 - xxxx-xx-xx =
+* Fix - Match the Google Pay express checkout button height to Apple Pay when using the Light or Outline button theme
 * Fix - Surface an error and block checkout when the Adaptive Pricing order total can't be synced with Stripe, instead of silently letting the buyer pay a stale amount
 * Fix - Stop attaching Level 3 data to captures and payments for non-card methods
 * Fix - Add the missing order and customer metadata to Adaptive Pricing payment intents


### PR DESCRIPTION
Fixes STRIPE-1275

## Changes proposed in this Pull Request:

On the Cart and Checkout blocks, the Google Pay express checkout button renders shorter than Apple Pay when the button theme is set to Light or Outline.

`adjustButtonHeights()` subtracted 2px from the merchant's configured height whenever Google Pay's Stripe theme is `white`, on the basis that the white button draws a border outside that height. Stripe's `buttonHeight` is the total rendered height, so the subtraction simply makes the button shorter. Google Pay has no outlined variant and so receives the `white` theme under both the Light and Outline settings, which is why both themes show the mismatch and Dark does not.

This PR removes that subtraction, so Google Pay uses the same height as every other express button. The Apple Pay black-button compensation is unchanged. The offset was introduced in #3484.

## Testing instructions

1. Set up a store using the Cart and Checkout blocks, with Stripe connected in test mode and Express Checkout enabled on both pages.
2. Go to **WooCommerce → Settings → Payments → Stripe → Express Checkout** and set **Size** to **Default** and **Theme** to **Light**.
3. Add a product to the cart and open the Checkout page. Confirm the Apple Pay and Google Pay buttons are the same height — on `develop`, Google Pay is visibly shorter.
4. Repeat on the Cart page.
5. Repeat steps 3 and 4 with **Theme** set to **Outline**, and again with **Size** set to **Large**.
6. As a regression check, set **Theme** to **Dark** and confirm the buttons still line up.

<!-- Before/after screenshots: drag them in here (Light and Outline themes). -->

Test in Safari, or another browser where both buttons render — Chrome on macOS without Apple Pay configured shows Google Pay only. Note that the **Small** size will not show the difference either way, because the reduced height clamps back up to the 40px minimum.

`npm run test:js -- client/blocks/express-checkout` covers the Light, Outline and Dark themes across the supported button heights. The Google Pay cases fail on `develop` and pass here.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

Changelog entries added to `changelog.txt` and `readme.txt` under 10.9.0.

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

> *Drafted with Claude Code; reviewed by me.*
