### PR TITLE
Reuse the express checkout Elements group on cart/checkout updates instead of re-initialising

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.9.0
-* Fix - Reuse the Apple Pay/Google Pay/Link express checkout buttons on the cart and checkout when the total changes, instead of re-initialising them on every update — preventing duplicate stacked buttons and a repeated Stripe payment-session request on each cart recalculation
+* Fix - Stop duplicate express checkout buttons stacking when the cart or checkout total changes, and reuse the existing buttons on checkout instead of rebuilding them on every update
 * Fix - Surface an error and block checkout when the Adaptive Pricing order total can't be synced with Stripe, instead of silently letting the buyer pay a stale amount
 * Fix - Stop attaching Level 3 data to captures and payments for non-card methods
 * Fix - Add the missing order and customer metadata to Adaptive Pricing payment intents

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 10.9.0
+* Fix - Reuse the Apple Pay/Google Pay/Link express checkout buttons on the cart and checkout when the total changes, instead of re-initialising them on every update — preventing duplicate stacked buttons and a repeated Stripe payment-session request on each cart recalculation
 * Fix - Surface an error and block checkout when the Adaptive Pricing order total can't be synced with Stripe, instead of silently letting the buyer pay a stale amount
 * Fix - Stop attaching Level 3 data to captures and payments for non-card methods
 * Fix - Add the missing order and customer metadata to Adaptive Pricing payment intents

--- a/client/entrypoints/express-checkout/__tests__/index.test.js
+++ b/client/entrypoints/express-checkout/__tests__/index.test.js
@@ -352,3 +352,151 @@ describe( 'Express Checkout product page variation breakdown', () => {
 		} );
 	} );
 } );
+describe( 'Express Checkout cart in-place amount update', () => {
+	const cartParams = () => ( {
+		...baseParams(),
+		stripe: {
+			publishable_key: 'pk_test_123',
+			locale: 'en',
+			is_express_checkout_enabled: true,
+		},
+		cart: {
+			total: 1500,
+			currency: 'usd',
+			requestShipping: false,
+			requestPhone: false,
+			displayItems: [],
+		},
+	} );
+
+	// Stripe stub whose elements() factory is a spy, so a full re-init (which
+	// creates a new group) is distinguishable from an in-place elements.update().
+	const stubStripe = () => {
+		const elementsList = [];
+		const button = {
+			on: () => button,
+			mount: jest.fn(),
+			destroy: jest.fn(),
+		};
+		const elementsFactory = jest.fn( () => {
+			const elements = {
+				create: jest.fn( () => button ),
+				update: jest.fn(),
+			};
+			elementsList.push( elements );
+			return elements;
+		} );
+		mockGetStripe.mockReturnValue( { elements: elementsFactory } );
+		return { elementsList, elementsFactory, button };
+	};
+
+	// The cart-details total flows through the mocked transformPrice.
+	const setCartTotal = ( amount ) => {
+		// eslint-disable-next-line global-require
+		require( 'wcstripe/express-checkout/transformers/wc-to-stripe' ).transformPrice.mockReturnValue(
+			amount
+		);
+	};
+
+	// Fire a cart update and drain the debounced handler + the cart-details
+	// promise chain it kicks off.
+	const triggerCartUpdate = async () => {
+		// eslint-disable-next-line global-require
+		require( 'jquery' )( document.body ).trigger( 'updated_cart_totals' );
+		try {
+			await jest.advanceTimersByTimeAsync( 300 );
+		} finally {
+			jest.useRealTimers();
+		}
+	};
+
+	beforeEach( () => {
+		jest.resetModules();
+		jest.useFakeTimers();
+		mockGetStripe.mockReset();
+		mockGetCartDetails.mockReset();
+		mockGetCartDetails.mockResolvedValue( {
+			totals: { total_price: '2500', total_refund: '0' },
+			needs_shipping: false,
+		} );
+		document.body.innerHTML =
+			'<div id="wc-stripe-express-checkout-element"></div>';
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+		delete global.wc_stripe_express_checkout_params;
+	} );
+
+	it( 'pushes the new amount to the existing groups without re-creating them on a second cart event', async () => {
+		global.wc_stripe_express_checkout_params = cartParams();
+		const { elementsList, elementsFactory } = stubStripe();
+		setCartTotal( 2500 );
+
+		loadEntrypoint();
+
+		// First paint mounts one Elements group per express method from the snapshot.
+		const groupsAfterFirstPaint = elementsFactory.mock.calls.length;
+		expect( groupsAfterFirstPaint ).toBeGreaterThan( 0 );
+		elementsList.forEach( ( e ) =>
+			expect( e.update ).not.toHaveBeenCalled()
+		);
+
+		await triggerCartUpdate();
+
+		// No new Elements group was created (no fresh /v1/elements/sessions) ...
+		expect( elementsFactory.mock.calls.length ).toBe(
+			groupsAfterFirstPaint
+		);
+		// ... and every existing group had the new amount pushed in place.
+		elementsList.forEach( ( e ) =>
+			expect( e.update ).toHaveBeenCalledWith( { amount: 2500 } )
+		);
+	} );
+
+	it( 'rebuilds the group when the shipping requirement changes', async () => {
+		global.wc_stripe_express_checkout_params = cartParams();
+		const { elementsFactory, button } = stubStripe();
+		setCartTotal( 2500 );
+		// The recalc now needs shipping: a structural change elements.update()
+		// can't express, so the group must be torn down and rebuilt.
+		mockGetCartDetails.mockResolvedValue( {
+			totals: { total_price: '2500', total_refund: '0' },
+			needs_shipping: true,
+		} );
+
+		loadEntrypoint();
+		const groupsAfterFirstPaint = elementsFactory.mock.calls.length;
+
+		await triggerCartUpdate();
+
+		expect( button.destroy ).toHaveBeenCalled();
+		expect( elementsFactory.mock.calls.length ).toBeGreaterThan(
+			groupsAfterFirstPaint
+		);
+	} );
+
+	it( 'hides the buttons when the cart total drops to zero', async () => {
+		global.wc_stripe_express_checkout_params = cartParams();
+		const { elementsList, elementsFactory } = stubStripe();
+		setCartTotal( 0 );
+
+		loadEntrypoint();
+		const groupsAfterFirstPaint = elementsFactory.mock.calls.length;
+
+		await triggerCartUpdate();
+
+		// Zero total hides rather than pushing an invalid amount: no in-place
+		// update, no rebuild.
+		expect(
+			document.getElementById( 'wc-stripe-express-checkout-element' )
+				.style.display
+		).toBe( 'none' );
+		expect( elementsFactory.mock.calls.length ).toBe(
+			groupsAfterFirstPaint
+		);
+		elementsList.forEach( ( e ) =>
+			expect( e.update ).not.toHaveBeenCalled()
+		);
+	} );
+} );

--- a/client/entrypoints/express-checkout/__tests__/index.test.js
+++ b/client/entrypoints/express-checkout/__tests__/index.test.js
@@ -506,6 +506,42 @@ describe( 'Express Checkout cart in-place amount update', () => {
 		);
 	} );
 
+	it( 'rebuilds when the cart page swaps the container node (classic quantity update)', async () => {
+		global.wc_stripe_express_checkout_params = cartParams();
+		const { elementsFactory, button, handlers } = stubStripe();
+		setCartTotal( 2500 );
+
+		loadEntrypoint();
+		const groupsAfterFirstPaint = elementsFactory.mock.calls.length;
+
+		// WooCommerce's cart.js replaces `.cart_totals` wholesale and only then
+		// fires `updated_cart_totals`, so the container the buttons were mounted
+		// into is detached and a fresh, empty one takes its place.
+		const stale = document.getElementById(
+			'wc-stripe-express-checkout-element'
+		);
+		const fresh = document.createElement( 'div' );
+		fresh.id = 'wc-stripe-express-checkout-element';
+		fresh.style.display = 'none';
+		stale.replaceWith( fresh );
+
+		await triggerCartUpdate();
+
+		// A stale registry must not win: the buttons have to be rebuilt into the
+		// new node rather than refreshed in place against the detached one.
+		expect( button.destroy ).toHaveBeenCalled();
+		expect( elementsFactory.mock.calls.length ).toBeGreaterThan(
+			groupsAfterFirstPaint
+		);
+
+		// The rebuilt button reveals the element from its own 'ready' event, so
+		// the buttons are only actually visible again if the rebuild re-bound it
+		// against the new node.
+		expect( button.mount ).toHaveBeenCalled();
+		handlers.ready( { availablePaymentMethods: { applePay: true } } );
+		expect( fresh.style.display ).not.toBe( 'none' );
+	} );
+
 	it( 'does not reveal an empty container on refresh when no wallet is available', async () => {
 		global.wc_stripe_express_checkout_params = cartParams();
 		const { elementsList } = stubStripe();

--- a/client/entrypoints/express-checkout/__tests__/index.test.js
+++ b/client/entrypoints/express-checkout/__tests__/index.test.js
@@ -352,6 +352,7 @@ describe( 'Express Checkout product page variation breakdown', () => {
 		} );
 	} );
 } );
+
 describe( 'Express Checkout cart in-place amount update', () => {
 	const cartParams = () => ( {
 		...baseParams(),
@@ -372,9 +373,13 @@ describe( 'Express Checkout cart in-place amount update', () => {
 	// Stripe stub whose elements() factory is a spy, so a full re-init (which
 	// creates a new group) is distinguishable from an in-place elements.update().
 	const stubStripe = () => {
+		const handlers = {};
 		const elementsList = [];
 		const button = {
-			on: () => button,
+			on: ( evt, cb ) => {
+				handlers[ evt ] = cb;
+				return button;
+			},
 			mount: jest.fn(),
 			destroy: jest.fn(),
 		};
@@ -387,7 +392,7 @@ describe( 'Express Checkout cart in-place amount update', () => {
 			return elements;
 		} );
 		mockGetStripe.mockReturnValue( { elements: elementsFactory } );
-		return { elementsList, elementsFactory, button };
+		return { handlers, elementsList, elementsFactory, button };
 	};
 
 	// The cart-details total flows through the mocked transformPrice.
@@ -426,6 +431,7 @@ describe( 'Express Checkout cart in-place amount update', () => {
 	afterEach( () => {
 		jest.useRealTimers();
 		delete global.wc_stripe_express_checkout_params;
+		delete global.jQuery;
 	} );
 
 	it( 'pushes the new amount to the existing groups without re-creating them on a second cart event', async () => {
@@ -497,6 +503,162 @@ describe( 'Express Checkout cart in-place amount update', () => {
 		);
 		elementsList.forEach( ( e ) =>
 			expect( e.update ).not.toHaveBeenCalled()
+		);
+	} );
+
+	it( 'does not reveal an empty container on refresh when no wallet is available', async () => {
+		global.wc_stripe_express_checkout_params = cartParams();
+		const { elementsList } = stubStripe();
+		setCartTotal( 2500 );
+
+		loadEntrypoint();
+
+		// Simulate a browser that offers no wallet: the button ready handler
+		// has removed every per-method container and the element is hidden.
+		const container = document.getElementById(
+			'wc-stripe-express-checkout-element'
+		);
+		container.innerHTML = '';
+		container.style.display = 'none';
+
+		await triggerCartUpdate();
+
+		// The refresh still runs (the registry is untouched) ...
+		elementsList.forEach( ( e ) =>
+			expect( e.update ).toHaveBeenCalledWith( { amount: 2500 } )
+		);
+		// ... but it must not un-hide an empty container.
+		expect( container.style.display ).toBe( 'none' );
+	} );
+
+	it( 'refreshes the click line items and shipping rates on an in-place update', async () => {
+		global.wc_stripe_express_checkout_params = {
+			...cartParams(),
+			allowed_shipping_countries: [],
+			cart: {
+				total: 500,
+				currency: 'usd',
+				requestShipping: true,
+				requestPhone: false,
+				displayItems: [],
+			},
+		};
+
+		// onClickHandler() calls blockUI(), which uses the global jQuery.blockUI.
+		// eslint-disable-next-line global-require
+		global.jQuery = require( 'jquery' );
+		global.jQuery.blockUI = jest.fn();
+		global.jQuery.unblockUI = jest.fn();
+
+		// eslint-disable-next-line global-require
+		const transformers = require( 'wcstripe/express-checkout/transformers/wc-to-stripe' );
+		transformers.transformLabeledDisplayItems.mockReturnValue( [
+			{ key: 'total_shipping', name: 'Shipping', amount: 500 },
+		] );
+		const updatedItems = [
+			{ key: 'total_shipping', name: 'Shipping', amount: 800 },
+			{ name: 'Subtotal', amount: 2000 },
+		];
+		transformers.transformCartDataForDisplayItems.mockReturnValue(
+			updatedItems
+		);
+		transformers.transformPrice.mockReturnValue( 2800 );
+		mockGetCartDetails.mockResolvedValue( {
+			totals: { total_price: '2800', total_refund: '0' },
+			needs_shipping: true,
+		} );
+
+		const { handlers } = stubStripe();
+
+		loadEntrypoint();
+		await triggerCartUpdate();
+
+		// Resolving a click after the in-place update must see the refreshed
+		// breakdown, not an amount-only stale closure.
+		const event = { resolve: jest.fn(), expressPaymentType: 'googlePay' };
+		await handlers.click( event );
+
+		expect( event.resolve ).toHaveBeenCalledTimes( 1 );
+		const clickOptions = event.resolve.mock.calls[ 0 ][ 0 ];
+		expect( clickOptions.lineItems ).toEqual( updatedItems );
+		expect( clickOptions.shippingRates ).toEqual( [
+			{ id: 'rate-shipping', amount: 800, displayName: 'Shipping' },
+		] );
+	} );
+
+	it( 'discards a stale overlapping cart fetch so the newer total wins', async () => {
+		global.wc_stripe_express_checkout_params = cartParams();
+		const { elementsList } = stubStripe();
+
+		// Identity transform so the total is just total_price - total_refund.
+		// eslint-disable-next-line global-require
+		const transformers = require( 'wcstripe/express-checkout/transformers/wc-to-stripe' );
+		transformers.transformPrice.mockImplementation( ( amount ) => amount );
+
+		let resolveStale;
+		let resolveFresh;
+		const stale = new Promise( ( r ) => {
+			resolveStale = r;
+		} );
+		const fresh = new Promise( ( r ) => {
+			resolveFresh = r;
+		} );
+		mockGetCartDetails
+			.mockReturnValueOnce( stale ) // leading edge, older total
+			.mockReturnValueOnce( fresh ); // trailing edge, newer total
+
+		loadEntrypoint();
+
+		// Two rapid updates: leading fetch (gen 1) then trailing fetch (gen 2).
+		// eslint-disable-next-line global-require
+		const jq = require( 'jquery' );
+		jq( document.body ).trigger( 'updated_cart_totals' );
+		jq( document.body ).trigger( 'updated_cart_totals' );
+		await jest.advanceTimersByTimeAsync( 300 );
+		jest.useRealTimers();
+
+		// The newer (trailing) response lands first and applies 2100 ...
+		resolveFresh( {
+			totals: { total_price: '2100', total_refund: '0' },
+			needs_shipping: false,
+		} );
+		await flushPromises();
+		// ... then the older (leading) response lands late and must be ignored.
+		resolveStale( {
+			totals: { total_price: '2300', total_refund: '0' },
+			needs_shipping: false,
+		} );
+		await flushPromises();
+
+		elementsList.forEach( ( e ) => {
+			expect( e.update ).toHaveBeenCalledWith( { amount: 2100 } );
+			expect( e.update ).not.toHaveBeenCalledWith( { amount: 2300 } );
+		} );
+	} );
+
+	it( 'rebuilds the group when the live cart currency changes (multi-currency switch)', async () => {
+		global.wc_stripe_express_checkout_params = cartParams(); // snapshot currency usd
+		const { elementsFactory, button } = stubStripe();
+		setCartTotal( 2500 );
+		// A currency switcher flips the live cart currency while the localized
+		// param stays usd; the group must rebuild in the new currency.
+		mockGetCartDetails.mockResolvedValue( {
+			totals: {
+				total_price: '2500',
+				total_refund: '0',
+				currency_code: 'EUR',
+			},
+			needs_shipping: false,
+		} );
+
+		loadEntrypoint();
+		const groupsAfterFirstPaint = elementsFactory.mock.calls.length;
+
+		await triggerCartUpdate();
+
+		expect( button.destroy ).toHaveBeenCalled();
+		expect( elementsFactory.mock.calls.length ).toBeGreaterThan(
+			groupsAfterFirstPaint
 		);
 	} );
 } );

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -1155,13 +1155,22 @@ jQuery( function ( $ ) {
 		wcStripeECE.init();
 	}
 
-	// We need to refresh ECE data when total is updated.
-	$( document.body ).on( 'updated_cart_totals', () => {
-		wcStripeECE.init();
-	} );
-
-	// We need to refresh ECE data when total is updated.
-	$( document.body ).on( 'updated_checkout', () => {
-		wcStripeECE.init();
-	} );
+	// Refresh ECE when the cart total changes. Debounced on the leading
+	// edge so the first event (which paints the buttons on checkout) fires
+	// immediately, while the burst of follow-up events an address change or
+	// recalc emits is coalesced into a single trailing reconcile — one
+	// Store API cart fetch instead of one per event.
+	const refreshExpressCheckoutOnCartChange = debounce(
+		() => wcStripeECE.init(),
+		300,
+		{ leading: true, trailing: true }
+	);
+	$( document.body ).on(
+		'updated_cart_totals',
+		refreshExpressCheckoutOnCartChange
+	);
+	$( document.body ).on(
+		'updated_checkout',
+		refreshExpressCheckoutOnCartChange
+	);
 } );

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -715,9 +715,16 @@ jQuery( function ( $ ) {
 					// Prefer the live cart currency so an AJAX currency switch (e.g. a
 					// multi-currency plugin) is reflected; fall back to the localized
 					// param. Store API returns it upper-cased; Stripe wants lower-case.
-					const currency =
-						cart.totals.currency_code?.toLowerCase() ??
-						getExpressCheckoutData( 'checkout' )?.currency_code;
+					// Truthiness (not ??) so an empty currency_code also falls back
+					// instead of forcing a rebuild every update.
+					// Caveat: the amount is still scaled by transformPrice() using the
+					// page-load currency_decimals, so a no-reload switch to a currency
+					// with different decimals (e.g. USD→JPY) can mis-scale it. Reload-
+					// based switchers — the common case — are unaffected.
+					const liveCurrency = cart.totals.currency_code;
+					const currency = liveCurrency
+						? liveCurrency.toLowerCase()
+						: getExpressCheckoutData( 'checkout' )?.currency_code;
 					const requestShipping = cart.needs_shipping === true;
 					const displayItems =
 						transformCartDataForDisplayItems( cart );

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -235,15 +235,9 @@ jQuery( function ( $ ) {
 					return getExpressCheckoutData( 'product' )?.shippingOptions;
 				}
 
-				return options.displayItems
-					.filter( ( i ) => i.key && i.key === 'total_shipping' )
-					.map( ( i ) => ( {
-						id: 'rate-shipping',
-						amount: i.amount,
-						displayName: useLegacyDisplayItems
-							? i.label ?? i.name
-							: i.name,
-					} ) );
+				return wcStripeECE.deriveCartShippingRates(
+					options.displayItems
+				);
 			};
 
 			const shippingRates = getShippingRates();
@@ -459,12 +453,15 @@ jQuery( function ( $ ) {
 
 			wcStripeECE.renderButton( eceButton, expressPaymentType );
 
-			// Retain the button alongside its group so a later cart update can push the new
-			// amount to every group and, on a structural change, tear the old buttons down cleanly.
+			// Retain the button and its click-closure options alongside the group,
+			// so a later cart update can push the new amount to every group,
+			// refresh each button's line items, and tear the old buttons down
+			// cleanly on a structural change.
 			wcStripeECE.expressCheckoutElements.push( {
 				elements,
 				button: eceButton,
 				expressPaymentType,
+				options,
 			} );
 
 			eceButton.on( 'click', async function ( event ) {
@@ -1060,6 +1057,39 @@ jQuery( function ( $ ) {
 		updateExpressCheckoutAmount: ( amount ) => {
 			( wcStripeECE.expressCheckoutElements ?? [] ).forEach(
 				( { elements } ) => elements.update( { amount } )
+			);
+		},
+
+		// Derive wallet shipping rates from cart/checkout display items: the
+		// `total_shipping` line becomes the selected rate. Shared by the initial
+		// render and the in-place refresh so the rate and the line items always
+		// come from the same source.
+		deriveCartShippingRates: ( displayItems ) =>
+			( displayItems ?? [] )
+				.filter( ( i ) => i.key && i.key === 'total_shipping' )
+				.map( ( i ) => ( {
+					id: 'rate-shipping',
+					amount: i.amount,
+					displayName: useLegacyDisplayItems
+						? i.label ?? i.name
+						: i.name,
+				} ) ),
+
+		// In-place refresh for a cart/checkout amount change: push the new
+		// amount to every mounted Elements group and refresh each button's click
+		// closure (line items + derived shipping rates), so the wallet sheet
+		// stays correct without re-creating the group — no /v1/elements/sessions
+		// call, no wallet re-probe. Only valid when the structural signature is
+		// unchanged; the caller falls back to a full rebuild otherwise.
+		refreshExpressCheckoutAmount: ( { total, displayItems } ) => {
+			const shippingRates =
+				wcStripeECE.deriveCartShippingRates( displayItems );
+			( wcStripeECE.expressCheckoutElements ?? [] ).forEach(
+				( entry ) => {
+					entry.elements.update( { amount: total } );
+					entry.options.displayItems = displayItems;
+					entry.options.shippingRates = shippingRates;
+				}
 			);
 		},
 

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -694,15 +694,46 @@ jQuery( function ( $ ) {
 						return;
 					}
 
+					const currency =
+						getExpressCheckoutData( 'checkout' )?.currency_code;
+					const requestShipping = cart.needs_shipping === true;
+					const displayItems =
+						transformCartDataForDisplayItems( cart );
+
+					// A typical cart recalc only moves the amount and its
+					// line-item breakdown. If a group is already mounted and
+					// the structural signature — currency and shipping
+					// requirement, the only inputs elements.update() cannot
+					// change — is unchanged, refresh in place instead of
+					// re-creating the group, which would re-hit
+					// /v1/elements/sessions and leak the old group. A
+					// structural change, or nothing mounted, falls through
+					// to a full (re)build.
+					const isMounted =
+						( wcStripeECE.expressCheckoutElements ?? [] ).length >
+						0;
+					const signatureUnchanged =
+						wcStripeECE.renderSignature?.currency === currency &&
+						wcStripeECE.renderSignature?.requestShipping ===
+							requestShipping;
+
+					if ( isMounted && signatureUnchanged ) {
+						wcStripeECE.refreshExpressCheckoutAmount( {
+							total,
+							displayItems,
+						} );
+						wcStripeECE.show();
+						return;
+					}
+
 					wcStripeECE.startExpressCheckout( {
 						total,
-						currency:
-							getExpressCheckoutData( 'checkout' )?.currency_code,
-						requestShipping: cart.needs_shipping === true,
+						currency,
+						requestShipping,
 						requestPhone:
 							getExpressCheckoutData( 'checkout' )
 								?.needs_payer_phone,
-						displayItems: transformCartDataForDisplayItems( cart ),
+						displayItems,
 					} );
 				} );
 			}

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -84,6 +84,12 @@ jQuery( function ( $ ) {
 	// Snapshot is first-paint only; re-inits reconcile via AJAX (see init() below).
 	let cartBootstrapConsumed = false;
 
+	// Monotonic id for cart-details fetches. Debounced update bursts on
+	// classic checkout can leave more than one fetch in flight; only the
+	// latest one may apply, so an out-of-order older response can't overwrite
+	// the current total in the reused Elements group.
+	let cartFetchGeneration = 0;
+
 	const hasVariationForm = $( '.variations_form' ).length > 0;
 	const hasBookingForm = $( '.wc-bookings-booking-form' ).length > 0;
 
@@ -279,8 +285,9 @@ jQuery( function ( $ ) {
 			// Tear down the previous render's buttons/groups before building new
 			// ones so re-inits don't stack duplicate buttons or leak the old
 			// wallet iframes/telemetry, and record this render's structural
-			// signature so a later cart update can tell an in-place amount change
-			// from one that needs a full rebuild.
+			// signature (currency + shipping requirement) so a later cart update
+			// can tell an in-place amount change from one that needs a full
+			// rebuild.
 			wcStripeECE.teardownExpressCheckout();
 			wcStripeECE.renderSignature = {
 				currency: options.currency,
@@ -679,7 +686,14 @@ jQuery( function ( $ ) {
 					return;
 				}
 
+				const fetchGeneration = ++cartFetchGeneration;
 				api.expressCheckoutGetCartDetails().then( ( cart ) => {
+					// A newer fetch was started after this one; discard the stale
+					// response so an older total can't win the last-writer race.
+					if ( fetchGeneration !== cartFetchGeneration ) {
+						return;
+					}
+
 					const total = transformPrice(
 						parseInt( cart.totals.total_price, 10 ) -
 							parseInt( cart.totals.total_refund || 0, 10 ),
@@ -690,25 +704,33 @@ jQuery( function ( $ ) {
 						total === 0 &&
 						! getExpressCheckoutData( 'has_free_trial' )
 					) {
+						// Amount 0 is invalid in payment mode. Hide rather than push it,
+						// and intentionally leave the group mounted (hidden, so
+						// unclickable): a return above 0 then refreshes it in place
+						// below instead of paying for a full rebuild.
 						wcStripeECE.hide();
 						return;
 					}
 
+					// Prefer the live cart currency so an AJAX currency switch (e.g. a
+					// multi-currency plugin) is reflected; fall back to the localized
+					// param. Store API returns it upper-cased; Stripe wants lower-case.
 					const currency =
+						cart.totals.currency_code?.toLowerCase() ??
 						getExpressCheckoutData( 'checkout' )?.currency_code;
 					const requestShipping = cart.needs_shipping === true;
 					const displayItems =
 						transformCartDataForDisplayItems( cart );
 
 					// A typical cart recalc only moves the amount and its
-					// line-item breakdown. If a group is already mounted and
-					// the structural signature — currency and shipping
-					// requirement, the only inputs elements.update() cannot
-					// change — is unchanged, refresh in place instead of
-					// re-creating the group, which would re-hit
-					// /v1/elements/sessions and leak the old group. A
-					// structural change, or nothing mounted, falls through
-					// to a full (re)build.
+					// line-item breakdown. If a group is already mounted and the
+					// structural signature — currency and shipping requirement, the
+					// inputs elements.update() cannot change, both taken live from the
+					// cart response — is unchanged, refresh in place instead of
+					// re-creating the group, which would re-hit /v1/elements/sessions
+					// and leak the old group. A currency switch (multi-currency
+					// plugin), a shipping-requirement change, or nothing mounted,
+					// falls through to a full (re)build.
 					const isMounted =
 						( wcStripeECE.expressCheckoutElements ?? [] ).length >
 						0;
@@ -722,7 +744,14 @@ jQuery( function ( $ ) {
 							total,
 							displayItems,
 						} );
-						wcStripeECE.show();
+						// Only reveal if a wallet container actually survived — the
+						// button 'ready' handler removes the container for methods the
+						// browser can't offer, and un-hiding an empty flex box would
+						// leave a blank gap. Mirror hide() by restoring the separator.
+						if ( wcStripeECE.getElements().children().length ) {
+							wcStripeECE.show();
+							wcStripeECE.getButtonSeparator().show();
+						}
 						return;
 					}
 

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -90,6 +90,15 @@ jQuery( function ( $ ) {
 	// win the last-writer race against the mounted Elements group.
 	let cartFetchGeneration = 0;
 
+	// Structural inputs elements.update() cannot change, so a change in either
+	// forces a rebuild rather than an in-place refresh.
+	let renderSignature = null;
+
+	// Container the current buttons are mounted in. WooCommerce replaces
+	// `.cart_totals` wholesale before firing `updated_cart_totals`, so a live
+	// re-query can return a different node than the one we built into.
+	let mountedContainer = null;
+
 	const hasVariationForm = $( '.variations_form' ).length > 0;
 	const hasBookingForm = $( '.wc-bookings-booking-form' ).length > 0;
 
@@ -157,6 +166,16 @@ jQuery( function ( $ ) {
 		const variationSelected = variationId && variationId !== '0';
 		return isVariationProduct && ! variationSelected;
 	};
+
+	// An in-place refresh is only valid while the buttons are still mounted in
+	// the live container and the structural inputs are unchanged; anything else
+	// has to rebuild, which re-hits /v1/elements/sessions.
+	const canRefreshInPlace = ( currency, requestShipping ) =>
+		( wcStripeECE.expressCheckoutElements ?? [] ).length > 0 &&
+		!! mountedContainer &&
+		mountedContainer === wcStripeECE.getElements()[ 0 ] &&
+		renderSignature?.currency === currency &&
+		renderSignature?.requestShipping === requestShipping;
 
 	const wcStripeECE = {
 		createButton: ( elements, options ) =>
@@ -281,13 +300,14 @@ jQuery( function ( $ ) {
 				isLinkEnabled && EXPRESS_PAYMENT_METHOD_SETTING_LINK,
 			].filter( Boolean );
 
-			// Record the structural signature so a later cart update can tell an
-			// in-place amount change from one that needs a full rebuild.
+			// Record what this render was built against, so a later cart update
+			// can tell an in-place amount change from one that needs a rebuild.
 			wcStripeECE.teardownExpressCheckout();
-			wcStripeECE.renderSignature = {
+			renderSignature = {
 				currency: options.currency,
 				requestShipping: options.requestShipping,
 			};
+			mountedContainer = wcStripeECE.getElements()[ 0 ];
 
 			expressPaymentTypes.forEach( ( expressPaymentType ) => {
 				wcStripeECE.createExpressCheckoutElement( expressPaymentType, {
@@ -716,18 +736,7 @@ jQuery( function ( $ ) {
 					const displayItems =
 						transformCartDataForDisplayItems( cart );
 
-					// elements.update() cannot change currency or shipping requirement,
-					// so only an unchanged signature may refresh in place; anything
-					// else rebuilds, re-hitting /v1/elements/sessions.
-					const isMounted =
-						( wcStripeECE.expressCheckoutElements ?? [] ).length >
-						0;
-					const signatureUnchanged =
-						wcStripeECE.renderSignature?.currency === currency &&
-						wcStripeECE.renderSignature?.requestShipping ===
-							requestShipping;
-
-					if ( isMounted && signatureUnchanged ) {
+					if ( canRefreshInPlace( currency, requestShipping ) ) {
 						wcStripeECE.refreshExpressCheckoutAmount( {
 							total,
 							displayItems,

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -168,6 +168,27 @@ jQuery( function ( $ ) {
 			wcStripeECE.getButtonSeparator().hide();
 		},
 
+		// Destroy the buttons/groups from the previous render and drop their
+		// containers before a re-init, so re-inits don't stack duplicate buttons
+		// or leave the abandoned wallet iframes and telemetry the old groups
+		// spun up alive.
+		teardownExpressCheckout: () => {
+			( wcStripeECE.expressCheckoutElements ?? [] ).forEach(
+				( { button } ) => {
+					try {
+						button.destroy();
+					} catch ( e ) {
+						// Button may already be destroyed/unmounted; ignore.
+					}
+				}
+			);
+			wcStripeECE.expressCheckoutElements = [];
+			wcStripeECE
+				.getElements()
+				.find( '[id^="wc-stripe-express-checkout-element-"]' )
+				.remove();
+		},
+
 		renderButton: ( eceButton, expressPaymentType ) => {
 			if ( $( '#wc-stripe-express-checkout-element' ).length ) {
 				const containerName = `wc-stripe-express-checkout-element-${ expressPaymentType }`;
@@ -261,11 +282,12 @@ jQuery( function ( $ ) {
 				isLinkEnabled && EXPRESS_PAYMENT_METHOD_SETTING_LINK,
 			].filter( Boolean );
 
-			// Reset the registry so variation/qty updates only touch the buttons
-			// mounted for this render, and record this render's structural
+			// Tear down the previous render's buttons/groups before building new
+			// ones so re-inits don't stack duplicate buttons or leak the old
+			// wallet iframes/telemetry, and record this render's structural
 			// signature so a later cart update can tell an in-place amount change
 			// from one that needs a full rebuild.
-			wcStripeECE.expressCheckoutElements = [];
+			wcStripeECE.teardownExpressCheckout();
 			wcStripeECE.renderSignature = {
 				currency: options.currency,
 				requestShipping: options.requestShipping,

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -262,8 +262,14 @@ jQuery( function ( $ ) {
 			].filter( Boolean );
 
 			// Reset the registry so variation/qty updates only touch the buttons
-			// mounted for this render.
+			// mounted for this render, and record this render's structural
+			// signature so a later cart update can tell an in-place amount change
+			// from one that needs a full rebuild.
 			wcStripeECE.expressCheckoutElements = [];
+			wcStripeECE.renderSignature = {
+				currency: options.currency,
+				requestShipping: options.requestShipping,
+			};
 
 			expressPaymentTypes.forEach( ( expressPaymentType ) => {
 				wcStripeECE.createExpressCheckoutElement( expressPaymentType, {
@@ -404,11 +410,6 @@ jQuery( function ( $ ) {
 					getPaymentMethodTypesForExpressMethod( expressPaymentType ),
 			} );
 
-			// A product page can mount several express buttons (Apple Pay,
-			// Google Pay, …), each with its own Elements group. Track them so a
-			// variation/qty change updates every group's amount.
-			wcStripeECE.expressCheckoutElements.push( elements );
-
 			const buttonStyleSettings =
 				getExpressCheckoutButtonStyleSettings( expressPaymentType );
 
@@ -435,6 +436,14 @@ jQuery( function ( $ ) {
 			} );
 
 			wcStripeECE.renderButton( eceButton, expressPaymentType );
+
+			// Retain the button alongside its group so a later cart update can push the new
+			// amount to every group and, on a structural change, tear the old buttons down cleanly.
+			wcStripeECE.expressCheckoutElements.push( {
+				elements,
+				button: eceButton,
+				expressPaymentType,
+			} );
 
 			eceButton.on( 'click', async function ( event ) {
 				// If login is required for checkout, display redirect confirmation dialog.
@@ -1028,7 +1037,7 @@ jQuery( function ( $ ) {
 		// refreshed line items exceed that stale amount.
 		updateExpressCheckoutAmount: ( amount ) => {
 			( wcStripeECE.expressCheckoutElements ?? [] ).forEach(
-				( elements ) => elements.update( { amount } )
+				( { elements } ) => elements.update( { amount } )
 			);
 		},
 

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -84,10 +84,10 @@ jQuery( function ( $ ) {
 	// Snapshot is first-paint only; re-inits reconcile via AJAX (see init() below).
 	let cartBootstrapConsumed = false;
 
-	// Monotonic id for cart-details fetches. Debounced update bursts on
-	// classic checkout can leave more than one fetch in flight; only the
-	// latest one may apply, so an out-of-order older response can't overwrite
-	// the current total in the reused Elements group.
+	// Monotonic id for cart-details fetches. The leading+trailing debounce on
+	// cart-update events can leave two fetches in flight, and responses may
+	// arrive out of order — drop any but the latest so a stale total can't
+	// win the last-writer race against the mounted Elements group.
 	let cartFetchGeneration = 0;
 
 	const hasVariationForm = $( '.variations_form' ).length > 0;
@@ -174,10 +174,9 @@ jQuery( function ( $ ) {
 			wcStripeECE.getButtonSeparator().hide();
 		},
 
-		// Destroy the buttons/groups from the previous render and drop their
-		// containers before a re-init, so re-inits don't stack duplicate buttons
-		// or leave the abandoned wallet iframes and telemetry the old groups
-		// spun up alive.
+		// Destroy the previous render's buttons and drop their containers, so a
+		// re-init neither stacks duplicate buttons nor leaks the wallet iframes
+		// the abandoned groups keep alive.
 		teardownExpressCheckout: () => {
 			( wcStripeECE.expressCheckoutElements ?? [] ).forEach(
 				( { button } ) => {
@@ -282,12 +281,8 @@ jQuery( function ( $ ) {
 				isLinkEnabled && EXPRESS_PAYMENT_METHOD_SETTING_LINK,
 			].filter( Boolean );
 
-			// Tear down the previous render's buttons/groups before building new
-			// ones so re-inits don't stack duplicate buttons or leak the old
-			// wallet iframes/telemetry, and record this render's structural
-			// signature (currency + shipping requirement) so a later cart update
-			// can tell an in-place amount change from one that needs a full
-			// rebuild.
+			// Record the structural signature so a later cart update can tell an
+			// in-place amount change from one that needs a full rebuild.
 			wcStripeECE.teardownExpressCheckout();
 			wcStripeECE.renderSignature = {
 				currency: options.currency,
@@ -460,10 +455,10 @@ jQuery( function ( $ ) {
 
 			wcStripeECE.renderButton( eceButton, expressPaymentType );
 
-			// Retain the button and its click-closure options alongside the group,
-			// so a later cart update can push the new amount to every group,
-			// refresh each button's line items, and tear the old buttons down
-			// cleanly on a structural change.
+			// A page can mount several express buttons (Apple Pay, Google Pay, …),
+			// each with its own Elements group. Retain each button alongside its
+			// group and click-closure options so a cart update can refresh every
+			// one, and a structural change can tear them all down.
 			wcStripeECE.expressCheckoutElements.push( {
 				elements,
 				button: eceButton,
@@ -688,8 +683,7 @@ jQuery( function ( $ ) {
 
 				const fetchGeneration = ++cartFetchGeneration;
 				api.expressCheckoutGetCartDetails().then( ( cart ) => {
-					// A newer fetch was started after this one; discard the stale
-					// response so an older total can't win the last-writer race.
+					// A newer fetch has since started; drop this stale response.
 					if ( fetchGeneration !== cartFetchGeneration ) {
 						return;
 					}
@@ -704,23 +698,16 @@ jQuery( function ( $ ) {
 						total === 0 &&
 						! getExpressCheckoutData( 'has_free_trial' )
 					) {
-						// Amount 0 is invalid in payment mode. Hide rather than push it,
-						// and intentionally leave the group mounted (hidden, so
-						// unclickable): a return above 0 then refreshes it in place
-						// below instead of paying for a full rebuild.
+						// Amount 0 is invalid in payment mode, so hide rather than push
+						// it. The group stays mounted (hidden, so unclickable) to let a
+						// later non-zero total refresh in place instead of rebuilding.
 						wcStripeECE.hide();
 						return;
 					}
 
-					// Prefer the live cart currency so an AJAX currency switch (e.g. a
-					// multi-currency plugin) is reflected; fall back to the localized
-					// param. Store API returns it upper-cased; Stripe wants lower-case.
-					// Truthiness (not ??) so an empty currency_code also falls back
-					// instead of forcing a rebuild every update.
-					// Caveat: the amount is still scaled by transformPrice() using the
-					// page-load currency_decimals, so a no-reload switch to a currency
-					// with different decimals (e.g. USD→JPY) can mis-scale it. Reload-
-					// based switchers — the common case — are unaffected.
+					// Live cart currency reflects AJAX multi-currency switches; empty
+					// falls back to the localized param (truthiness, not ??, or every
+					// update would force a rebuild).
 					const liveCurrency = cart.totals.currency_code;
 					const currency = liveCurrency
 						? liveCurrency.toLowerCase()
@@ -729,15 +716,9 @@ jQuery( function ( $ ) {
 					const displayItems =
 						transformCartDataForDisplayItems( cart );
 
-					// A typical cart recalc only moves the amount and its
-					// line-item breakdown. If a group is already mounted and the
-					// structural signature — currency and shipping requirement, the
-					// inputs elements.update() cannot change, both taken live from the
-					// cart response — is unchanged, refresh in place instead of
-					// re-creating the group, which would re-hit /v1/elements/sessions
-					// and leak the old group. A currency switch (multi-currency
-					// plugin), a shipping-requirement change, or nothing mounted,
-					// falls through to a full (re)build.
+					// elements.update() cannot change currency or shipping requirement,
+					// so only an unchanged signature may refresh in place; anything
+					// else rebuilds, re-hitting /v1/elements/sessions.
 					const isMounted =
 						( wcStripeECE.expressCheckoutElements ?? [] ).length >
 						0;
@@ -751,10 +732,9 @@ jQuery( function ( $ ) {
 							total,
 							displayItems,
 						} );
-						// Only reveal if a wallet container actually survived — the
-						// button 'ready' handler removes the container for methods the
-						// browser can't offer, and un-hiding an empty flex box would
-						// leave a blank gap. Mirror hide() by restoring the separator.
+						// Only reveal if a container survived: the 'ready' handler removes
+						// containers for methods the browser can't offer, and un-hiding
+						// an empty flex box leaves a blank gap. Separator mirrors hide().
 						if ( wcStripeECE.getElements().children().length ) {
 							wcStripeECE.show();
 							wcStripeECE.getButtonSeparator().show();
@@ -1127,10 +1107,9 @@ jQuery( function ( $ ) {
 			);
 		},
 
-		// Derive wallet shipping rates from cart/checkout display items: the
-		// `total_shipping` line becomes the selected rate. Shared by the initial
-		// render and the in-place refresh so the rate and the line items always
-		// come from the same source.
+		// The `total_shipping` display item becomes the wallet's selected rate.
+		// Shared by the initial render and the in-place refresh so the rate and
+		// the line items can't drift apart.
 		deriveCartShippingRates: ( displayItems ) =>
 			( displayItems ?? [] )
 				.filter( ( i ) => i.key && i.key === 'total_shipping' )
@@ -1142,12 +1121,10 @@ jQuery( function ( $ ) {
 						: i.name,
 				} ) ),
 
-		// In-place refresh for a cart/checkout amount change: push the new
-		// amount to every mounted Elements group and refresh each button's click
-		// closure (line items + derived shipping rates), so the wallet sheet
-		// stays correct without re-creating the group — no /v1/elements/sessions
-		// call, no wallet re-probe. Only valid when the structural signature is
-		// unchanged; the caller falls back to a full rebuild otherwise.
+		// Push the new amount to every mounted group and refresh each button's
+		// click closure, so the wallet sheet stays correct without re-creating
+		// the group. Callers must check the structural signature first — this
+		// cannot change currency or shipping requirement.
 		refreshExpressCheckoutAmount: ( { total, displayItems } ) => {
 			const shippingRates =
 				wcStripeECE.deriveCartShippingRates( displayItems );
@@ -1191,11 +1168,9 @@ jQuery( function ( $ ) {
 		wcStripeECE.init();
 	}
 
-	// Refresh ECE when the cart total changes. Debounced on the leading
-	// edge so the first event (which paints the buttons on checkout) fires
-	// immediately, while the burst of follow-up events an address change or
-	// recalc emits is coalesced into a single trailing reconcile — one
-	// Store API cart fetch instead of one per event.
+	// Refresh ECE when the cart total changes. Leading edge so the first event
+	// paints the buttons immediately; trailing edge coalesces the burst an
+	// address change or recalc emits into one Store API fetch, not one per event.
 	const refreshExpressCheckoutOnCartChange = debounce(
 		() => wcStripeECE.init(),
 		300,

--- a/readme.txt
+++ b/readme.txt
@@ -156,6 +156,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.9.0 - xxxx-xx-xx =
+* Fix - Reuse the Apple Pay/Google Pay/Link express checkout buttons on the cart and checkout when the total changes, instead of re-initialising them on every update — preventing duplicate stacked buttons and a repeated Stripe payment-session request on each cart recalculation
 * Fix - Surface an error and block checkout when the Adaptive Pricing order total can't be synced with Stripe, instead of silently letting the buyer pay a stale amount
 * Fix - Stop attaching Level 3 data to captures and payments for non-card methods
 * Fix - Add the missing order and customer metadata to Adaptive Pricing payment intents

--- a/readme.txt
+++ b/readme.txt
@@ -156,7 +156,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.9.0 - xxxx-xx-xx =
-* Fix - Reuse the Apple Pay/Google Pay/Link express checkout buttons on the cart and checkout when the total changes, instead of re-initialising them on every update — preventing duplicate stacked buttons and a repeated Stripe payment-session request on each cart recalculation
+* Fix - Stop duplicate express checkout buttons stacking when the cart or checkout total changes, and reuse the existing buttons on checkout instead of rebuilding them on every update
 * Fix - Surface an error and block checkout when the Adaptive Pricing order total can't be synced with Stripe, instead of silently letting the buyer pay a stale amount
 * Fix - Stop attaching Level 3 data to captures and payments for non-card methods
 * Fix - Add the missing order and customer metadata to Adaptive Pricing payment intents


### PR DESCRIPTION
Related to STRIPE-1224

## Changes proposed in this Pull Request:
On the cart and checkout pages, every `updated_cart_totals` / `updated_checkout` event ran the full express checkout `init()`, which re-created the Stripe `elements()` group from scratch. On a typical recalc (coupon, quantity, shipping-method change) the only thing that actually moves is the amount — yet re-creating the group re-hit `GET /v1/elements/sessions`, re-probed the Apple Pay / Google Pay capability, and, because the previous group was dropped without being unmounted, stacked duplicate buttons and leaked the abandoned wallet iframes and telemetry. This produced the request flood and button stacking reported in the issue.

This PR makes the cart/checkout path reuse the mounted group:

- **In-place update.** When a group is already mounted and the structural signature — `currency` and `requestShipping`, the only inputs `elements.update()` can't change — is unchanged, the new amount, line items, and derived shipping rates are pushed to every mounted button in place. No new group, no `/v1/elements/sessions`, no wallet re-probe.
- **Rebuild only on a structural change.** A currency or shipping-requirement change (or nothing currently mounted) still does a full rebuild, which now first tears down the old buttons (`destroy()` + container cleanup) so nothing stacks or leaks.
- **Zero total.** A drop to a `0` total hides the buttons rather than pushing an invalid amount, and a return above `0` refreshes the still-mounted group in place.
- **Debounce.** The two handlers share a leading-edge debounce, so a burst of `updated_checkout` (e.g. address fields on classic checkout) coalesces into one Store API cart fetch while first paint stays immediate.

**Why this shape:** the shipping rates are derived from the same display items as the line items, so both are refreshed together — refreshing the items but not the rates would leave the wallet sheet summing to a stale total and the click would be rejected. The in-place path lives inside the cart/checkout branch of `init()`, so the setup-mode change-payment page and pay-for-order (handled in their own branches) never reach `elements.update()`.

**How this can break, and what guards it:** the risk is reusing a group whose structural inputs actually changed. The signature check is exact — both varying inputs (`currency`, `needs_shipping`) come straight from the cart-details response already fetched each update, and anything that changes them forces a rebuild. Unit tests lock in the in-place-vs-rebuild decision, the teardown, and the zero-total path.

## Testing instructions
**Prerequisite**: Stripe enabled with Express Checkout (Apple Pay / Google Pay / Link) turned on for Cart and Checkout, in a browser where a wallet button renders (e.g. Safari for Apple Pay, or Chrome signed in to Google Pay).

1. **Checkout — no repeated sessions.** On classic checkout, open DevTools → Network, filter `elements/sessions`. Change the address / shipping method / quantity a few times. Expected: the buttons stay put (no flicker/stacking) and you do **not** see a new `elements/sessions` per update — the group is reused. (Before: one per update.)
2. **Cart — clean rebuild, correct button.** On the cart page, change quantity / apply a coupon. Expected: the express buttons stay visible and update, with exactly one set of buttons (no duplicates stacking). Note: a single `elements/sessions` per cart update is expected here — WooCommerce rebuilds the cart totals container each update.
3. **No leaks.** Repeat updates on both pages and confirm the number of Stripe wallet iframes / background requests stays flat instead of climbing.
4. **Zero total.** Empty the cart / reach a $0 total.
   - Expected: the express buttons hide. Add an item again → they reappear with the correct amount.
5. **Other pages unaffected.** Confirm express checkout still works on the change-payment-method and pay-for-order pages.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
