### PR TITLE
Agentic Commerce: reject out-of-bounds line item quantity and unit_amount in shipping packages

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -78,6 +78,7 @@ xxxx-xx-xx - version 10.9.0
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Fix - Reject agentic checkout line items with a zero or negative quantity, or a negative amount, when building shipping packages, instead of quoting rates from corrupted totals
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
@@ -208,7 +208,7 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 	 * @since 10.6.0
 	 * @param WC_Order                           $order   The WooCommerce order.
 	 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
-	 * @throws Exception When a product cannot be found for a line item.
+	 * @throws Exception When a product cannot be found for a line item, or a line item has a non-positive quantity.
 	 */
 	private function map_line_items( WC_Order $order, WC_Stripe_Agentic_Checkout_Session $session ): void {
 		$currency   = $session->get_currency() ?? '';
@@ -236,7 +236,21 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 
 			$product = WC_Stripe_Agentic_Commerce_Product_Resolver::resolve_product( $product_id );
 
-			$quantity   = $line_item->get_quantity();
+			$quantity = $line_item->get_quantity();
+
+			// The getter only casts to int, and the line-total reconciliation
+			// below can't catch a payload that is internally consistent with a
+			// non-positive quantity (e.g. quantity 0 with amount_total 0).
+			if ( $quantity < 1 ) {
+				throw new Exception(
+					sprintf(
+						'Line item %s has an invalid quantity (%d).',
+						$line_item->get_id(),
+						$quantity
+					)
+				);
+			}
+
 			$line_total = WC_Stripe_Helper::convert_from_stripe_amount(
 				$line_item->get_amount_total() - $line_item->get_amount_tax(),
 				$currency

--- a/includes/agentic-commerce/class-wc-stripe-agentic-shipping-package-builder.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-shipping-package-builder.php
@@ -70,7 +70,7 @@ class WC_Stripe_Agentic_Shipping_Package_Builder {
 	 * @param WC_Stripe_Agentic_Customize_Checkout_Event $event    The customization hook event.
 	 * @param string                                     $currency The three-letter currency code.
 	 * @return array Cart-item-format entries keyed by line item ID.
-	 * @throws Exception When a line item's sku_id cannot be resolved to a product, or the product has no catalog price to fall back on.
+	 * @throws Exception When a line item's sku_id cannot be resolved to a product, its quantity or unit_amount is out of bounds, or the product has no catalog price to fall back on.
 	 */
 	public static function build_contents_from_event( WC_Stripe_Agentic_Customize_Checkout_Event $event, string $currency ): array {
 		$contents = [];
@@ -96,6 +96,20 @@ class WC_Stripe_Agentic_Shipping_Package_Builder {
 
 			$quantity    = $line_item->get_quantity();
 			$unit_amount = $line_item->get_unit_amount();
+
+			// The event getters only cast to int, so a malformed payload can
+			// carry a zero/negative quantity or a negative unit_amount; either
+			// would corrupt line totals, so fail the request instead.
+			if ( $quantity < 1 || ( null !== $unit_amount && $unit_amount < 0 ) ) {
+				throw new Exception(
+					sprintf(
+						'Shipping package builder: invalid quantity or unit_amount for line item %s (quantity %d, unit_amount %s).',
+						$line_item->get_id(),
+						$quantity,
+						null === $unit_amount ? 'null' : (string) $unit_amount
+					)
+				);
+			}
 
 			if ( null !== $unit_amount ) {
 				$line_total = WC_Stripe_Helper::convert_from_stripe_amount( $unit_amount * $quantity, $currency );

--- a/readme.txt
+++ b/readme.txt
@@ -235,5 +235,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Fix - Reject agentic checkout line items with a zero or negative quantity, or a negative amount, when building shipping packages, instead of quoting rates from corrupted totals
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
@@ -1061,6 +1061,57 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Data provider for non-positive line item quantities whose amounts are
+	 * internally consistent, so the price reconciliation alone would pass.
+	 *
+	 * @return array<string, array{quantity: int, amount: int}>
+	 */
+	public function non_positive_quantity_provider(): array {
+		return [
+			'zero quantity'     => [
+				'quantity' => 0,
+				'amount'   => 0,
+			],
+			'negative quantity' => [
+				'quantity' => -2,
+				'amount'   => -2000,
+			],
+		];
+	}
+
+	/**
+	 * Test that a line item with a non-positive quantity throws even when its
+	 * amounts reconcile with the catalog price.
+	 *
+	 * @dataProvider non_positive_quantity_provider
+	 */
+	public function test_exception_thrown_for_non_positive_quantity( int $quantity, int $amount ) {
+		$session = $this->build_checkout_session(
+			[
+				'amount_total'    => $amount,
+				'amount_subtotal' => $amount,
+				'line_items'      => $this->build_line_items(
+					[
+						[
+							'lookup_key'      => (string) $this->default_product->get_sku(),
+							'quantity'        => $quantity,
+							'unit_amount'     => 1000,
+							'amount_total'    => $amount,
+							'amount_subtotal' => $amount,
+							'amount_tax'      => 0,
+						],
+					]
+				),
+			]
+		);
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'invalid quantity' );
+
+		$this->mapper->create_order_from_checkout_session( $session );
+	}
+
+	/**
 	 * Test creating an order with multiple line items.
 	 *
 	 * @return void

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-shipping-calculator-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-shipping-calculator-test.php
@@ -303,6 +303,67 @@ class WC_Stripe_Agentic_Shipping_Calculator_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Data provider for out-of-bounds line item quantity/unit_amount values.
+	 *
+	 * @return array<string, array{quantity: int, unit_amount: int}>
+	 */
+	public function invalid_line_item_bounds_provider(): array {
+		return [
+			'zero quantity'        => [
+				'quantity'    => 0,
+				'unit_amount' => 1000,
+			],
+			'negative quantity'    => [
+				'quantity'    => -2,
+				'unit_amount' => 1000,
+			],
+			'negative unit_amount' => [
+				'quantity'    => 1,
+				'unit_amount' => -500,
+			],
+		];
+	}
+
+	/**
+	 * Test that a non-positive quantity or negative unit_amount makes the
+	 * calculator throw instead of computing rates from corrupted line totals.
+	 *
+	 * @dataProvider invalid_line_item_bounds_provider
+	 */
+	public function test_throws_on_out_of_bounds_line_item_values( int $quantity, int $unit_amount ) {
+		$product = \WC_Helper_Product::create_simple_product(
+			true,
+			[
+				'regular_price' => '10.00',
+				'price'         => '10.00',
+				'sku'           => 'SHIPCALC-BOUNDS-' . uniqid(),
+			]
+		);
+
+		$this->shipping_zone = $this->create_shipping_zone_with_flat_rate( 'US', '[cost]' );
+
+		$event = $this->build_event_from_raw_items(
+			[
+				[
+					'id'          => 'li_bounds',
+					'sku_id'      => (string) $product->get_sku(),
+					'quantity'    => $quantity,
+					'unit_amount' => $unit_amount,
+				],
+			]
+		);
+
+		try {
+			$this->expectException( \Exception::class );
+			$this->expectExceptionMessage( 'invalid quantity or unit_amount' );
+
+			$this->calculator->calculate( $event, 'usd' );
+		} finally {
+			$product->delete( true );
+		}
+	}
+
+	/**
 	 * Test that a line item without unit_amount whose product has no catalog
 	 * price makes the calculator throw instead of quoting a 0.00 package.
 	 */


### PR DESCRIPTION
Towards STRIPE-986

Follow-up to #5551, addressing [this review comment](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5551#discussion_r3623607250).

## Changes proposed in this Pull Request:

The customize_checkout event line item getters only cast payload values to `int`, so a malformed payload could feed a zero or negative quantity, or a negative `unit_amount`, into the shipping package's line totals — corrupting content-dependent rate calculations (`[qty]`/`[cost]` expressions, contents_cost).

This PR makes `WC_Stripe_Agentic_Shipping_Package_Builder::build_contents_from_event()` throw on out-of-bounds values (quantity < 1, unit_amount < 0), consistent with its existing behavior for unresolvable products and missing catalog prices. The webhook handler surfaces the exception as a failed customization request instead of returning corrupted quotes.

The order-mapping path gets a matching guard in `map_line_items()`: its line-total reconciliation (WC catalog price × quantity vs Stripe's pre-tax total) catches inconsistent quantities, but not a payload internally consistent with a non-positive quantity (e.g. quantity 0 with amount_total 0), so those now throw before the order is created.

**BC impact:** none — this only tightens validation of webhook payload values inside a private flow; no public signatures, hooks, or options change.

## Testing instructions

1. Run `npm run test:php -- --filter WC_Stripe_Agentic_Shipping_Calculator_Test` — the new `test_throws_on_out_of_bounds_line_item_values` cases cover zero quantity, negative quantity, and negative unit_amount.
2. Optionally, send a `v1.delegated_checkout.customize_checkout` webhook (see #5551's testing instructions) with `"quantity": -2` on a line item — the request should fail instead of returning shipping options.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

Changelog entries added to `changelog.txt` and `readme.txt` under 10.9.0.

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

