### PR TITLE
Agentic Commerce: reserve stock at order completion so concurrent sessions cannot oversell

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -78,7 +78,7 @@ xxxx-xx-xx - version 10.9.0
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
-* Fix - Reserve stock when completing agentic checkout orders so concurrent sessions cannot oversell; a paid order that loses the stock race is parked on-hold for review instead of driving stock negative
+* Fix - Reserve stock when completing agentic checkout orders so concurrent sessions cannot oversell; orders losing the race are set on-hold instead of driving stock negative
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/changelog.txt
+++ b/changelog.txt
@@ -78,6 +78,7 @@ xxxx-xx-xx - version 10.9.0
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Fix - Reserve stock when completing agentic checkout orders so concurrent sessions cannot oversell; a paid order that loses the stock race is parked on-hold for review instead of driving stock negative
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-manual-approval.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-manual-approval.php
@@ -133,10 +133,8 @@ class WC_Stripe_Agentic_Commerce_Manual_Approval {
 			$stock_quantity = $product->get_stock_quantity();
 			$quantity       = $line_item->get_quantity();
 
-			// Subtract stock already held by concurrent checkouts (store cart
-			// or other agentic sessions) so finalize doesn't approve units
-			// another session has claimed. This is advisory only — the atomic
-			// guard is the reservation placed at order creation.
+			// Subtract stock held by concurrent checkouts. Advisory only — the
+			// atomic guard is the reservation placed at order creation.
 			$held      = function_exists( 'wc_get_held_stock_quantity' ) ? (int) wc_get_held_stock_quantity( $product ) : 0;
 			$available = null === $stock_quantity ? null : $stock_quantity - $held;
 

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-manual-approval.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-manual-approval.php
@@ -129,18 +129,25 @@ class WC_Stripe_Agentic_Commerce_Manual_Approval {
 			];
 		}
 
-		if ( $product->managing_stock() ) {
+		if ( $product->managing_stock() && ! $product->backorders_allowed() ) {
 			$stock_quantity = $product->get_stock_quantity();
 			$quantity       = $line_item->get_quantity();
 
-			if ( null === $stock_quantity || $quantity > $stock_quantity ) {
+			// Subtract stock already held by concurrent checkouts (store cart
+			// or other agentic sessions) so finalize doesn't approve units
+			// another session has claimed. This is advisory only — the atomic
+			// guard is the reservation placed at order creation.
+			$held      = function_exists( 'wc_get_held_stock_quantity' ) ? (int) wc_get_held_stock_quantity( $product ) : 0;
+			$available = null === $stock_quantity ? null : $stock_quantity - $held;
+
+			if ( null === $available || $quantity > $available ) {
 				return [
 					'code'   => 'insufficient_stock',
 					'reason' => sprintf(
 						/* translators: 1: product name, 2: available quantity */
 						__( 'Insufficient stock for %1$s. Only %2$d available.', 'woocommerce-gateway-stripe' ),
 						$product->get_name(),
-						(int) $stock_quantity
+						max( 0, (int) $available )
 					),
 				];
 			}

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
@@ -8,6 +8,8 @@
  * @since   10.6.0
  */
 
+use Automattic\WooCommerce\Enums\OrderStatus;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -351,7 +353,7 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 
 		try {
 			$order->update_status(
-				'on-hold',
+				OrderStatus::ON_HOLD,
 				sprintf(
 					/* translators: %s: reason stock could not be secured */
 					__( 'Stripe captured the payment, but stock could not be secured for every item: %s Review stock, then process or refund this order manually.', 'woocommerce-gateway-stripe' ),

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
@@ -33,6 +33,18 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 	public const CREATED_VIA = 'stripe-agentic-commerce';
 
 	/**
+	 * Minutes to hold reserved stock while the order completes payment.
+	 *
+	 * The hold only needs to outlive the moments between reserve_stock() and
+	 * payment_complete() below — stock reduction releases it. It is passed
+	 * explicitly so the merchant's `woocommerce_hold_stock_minutes` setting
+	 * (blank disables holds for the cart flow) cannot switch this guard off.
+	 *
+	 * @var int
+	 */
+	private const STOCK_HOLD_MINUTES = 10;
+
+	/**
 	 * Creates a WooCommerce order from a Stripe checkout session.
 	 *
 	 * @since 10.6.0
@@ -71,6 +83,19 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 		} catch ( Throwable $e ) {
 			$order->delete( true );
 			throw $e;
+		}
+
+		// Atomically hold stock before taking the order live. This is the only
+		// point that serializes concurrent agentic sessions on stock:
+		// finalize_checkout validates availability without reserving anything,
+		// so N sessions can all pass validation for the same last units.
+		// ReserveStock's insert-with-availability-check either claims the
+		// units or throws.
+		try {
+			$this->reserve_stock( $order );
+		} catch ( \Automattic\WooCommerce\Checkout\Helpers\ReserveStockException $e ) {
+			$this->hold_order_for_insufficient_stock( $order, $session, $e );
+			return $order;
 		}
 
 		// Complete payment outside the delete-on-failure block, since
@@ -292,6 +317,72 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 		}
 
 		return $item;
+	}
+
+	/**
+	 * Places an atomic stock hold for every managed-stock item on the order.
+	 *
+	 * Products with backorders enabled (and unmanaged in-stock products) are
+	 * skipped by ReserveStock itself, so backorders keep working.
+	 *
+	 * @since 10.9.0
+	 * @param WC_Order $order The order with mapped line items.
+	 * @throws \Automattic\WooCommerce\Checkout\Helpers\ReserveStockException When stock cannot be secured for an item.
+	 */
+	private function reserve_stock( WC_Order $order ): void {
+		$reserve_stock = new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock();
+		$reserve_stock->reserve_stock_for_order( $order, self::STOCK_HOLD_MINUTES );
+	}
+
+	/**
+	 * Parks a paid order that lost the stock race instead of overselling.
+	 *
+	 * Payment is already captured by Stripe when checkout.session.completed
+	 * arrives, so the order can be neither declined nor deleted. Keep it
+	 * on-hold with the transaction id (refundable from the order screen) and
+	 * suppress the on-hold stock reduction — reducing would drive the oversold
+	 * product negative, which is the exact outcome the hold guards against.
+	 *
+	 * @since 10.9.0
+	 * @param WC_Order                                                  $order   The created order.
+	 * @param WC_Stripe_Agentic_Checkout_Session                        $session The checkout session wrapper.
+	 * @param \Automattic\WooCommerce\Checkout\Helpers\ReserveStockException $e  The reservation failure.
+	 */
+	private function hold_order_for_insufficient_stock( WC_Order $order, WC_Stripe_Agentic_Checkout_Session $session, \Automattic\WooCommerce\Checkout\Helpers\ReserveStockException $e ): void {
+		$order->set_transaction_id( $session->get_payment_intent_id() ?? '' );
+
+		// woocommerce_payment_complete_reduce_order_stock (not
+		// woocommerce_can_reduce_order_stock): the latter blocks the reduction
+		// but still lets wc_maybe_reduce_stock_levels() mark the order
+		// stock-reduced, so a later cancel/refund would wrongly restock units
+		// that were never taken.
+		$order_id        = $order->get_id();
+		$block_reduction = static function ( $trigger_reduce, $target_order_id ) use ( $order_id ) {
+			return (int) $target_order_id === $order_id ? false : $trigger_reduce;
+		};
+		add_filter( 'woocommerce_payment_complete_reduce_order_stock', $block_reduction, 10, 2 );
+
+		try {
+			$order->update_status(
+				'on-hold',
+				sprintf(
+					/* translators: %s: reason stock could not be secured */
+					__( 'Stripe captured the payment, but stock could not be secured for every item: %s Review stock, then process or refund this order manually.', 'woocommerce-gateway-stripe' ),
+					$e->getMessage()
+				)
+			);
+		} finally {
+			remove_filter( 'woocommerce_payment_complete_reduce_order_stock', $block_reduction );
+		}
+
+		WC_Stripe_Logger::error(
+			'Agentic order mapper: stock could not be secured at completion; order placed on hold.',
+			[
+				'session_id' => $session->get_id(),
+				'order_id'   => $order_id,
+				'reason'     => $e->getMessage(),
+			]
+		);
 	}
 
 	/**

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
@@ -33,12 +33,9 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 	public const CREATED_VIA = 'stripe-agentic-commerce';
 
 	/**
-	 * Minutes to hold reserved stock while the order completes payment.
-	 *
-	 * The hold only needs to outlive the moments between reserve_stock() and
-	 * payment_complete() below — stock reduction releases it. It is passed
-	 * explicitly so the merchant's `woocommerce_hold_stock_minutes` setting
-	 * (blank disables holds for the cart flow) cannot switch this guard off.
+	 * Minutes to hold reserved stock while payment completes. Passed explicitly
+	 * so a blank `woocommerce_hold_stock_minutes` cannot disable the guard;
+	 * payment_complete()'s stock reduction releases the hold.
 	 *
 	 * @var int
 	 */
@@ -85,12 +82,9 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 			throw $e;
 		}
 
-		// Atomically hold stock before taking the order live. This is the only
-		// point that serializes concurrent agentic sessions on stock:
-		// finalize_checkout validates availability without reserving anything,
-		// so N sessions can all pass validation for the same last units.
-		// ReserveStock's insert-with-availability-check either claims the
-		// units or throws.
+		// The only point that serializes concurrent agentic sessions on stock —
+		// finalize_checkout validates without reserving, so N sessions can all
+		// pass for the same last units. ReserveStock either claims them or throws.
 		try {
 			$this->reserve_stock( $order );
 		} catch ( \Automattic\WooCommerce\Checkout\Helpers\ReserveStockException $e ) {
@@ -320,14 +314,12 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 	}
 
 	/**
-	 * Places an atomic stock hold for every managed-stock item on the order.
-	 *
-	 * Products with backorders enabled (and unmanaged in-stock products) are
-	 * skipped by ReserveStock itself, so backorders keep working.
+	 * Places an atomic stock hold for the order's managed-stock items;
+	 * ReserveStock itself skips backorder-enabled products.
 	 *
 	 * @since 10.9.0
 	 * @param WC_Order $order The order with mapped line items.
-	 * @throws \Automattic\WooCommerce\Checkout\Helpers\ReserveStockException When stock cannot be secured for an item.
+	 * @throws \Automattic\WooCommerce\Checkout\Helpers\ReserveStockException When stock cannot be secured.
 	 */
 	private function reserve_stock( WC_Order $order ): void {
 		$reserve_stock = new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock();
@@ -337,11 +329,9 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 	/**
 	 * Parks a paid order that lost the stock race instead of overselling.
 	 *
-	 * Payment is already captured by Stripe when checkout.session.completed
-	 * arrives, so the order can be neither declined nor deleted. Keep it
-	 * on-hold with the transaction id (refundable from the order screen) and
-	 * suppress the on-hold stock reduction — reducing would drive the oversold
-	 * product negative, which is the exact outcome the hold guards against.
+	 * Payment is already captured, so the order can't be declined or deleted:
+	 * keep it on-hold with the transaction id and suppress the on-hold stock
+	 * reduction that would drive the oversold product negative.
 	 *
 	 * @since 10.9.0
 	 * @param WC_Order                                                  $order   The created order.
@@ -351,11 +341,8 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 	private function hold_order_for_insufficient_stock( WC_Order $order, WC_Stripe_Agentic_Checkout_Session $session, \Automattic\WooCommerce\Checkout\Helpers\ReserveStockException $e ): void {
 		$order->set_transaction_id( $session->get_payment_intent_id() ?? '' );
 
-		// woocommerce_payment_complete_reduce_order_stock (not
-		// woocommerce_can_reduce_order_stock): the latter blocks the reduction
-		// but still lets wc_maybe_reduce_stock_levels() mark the order
-		// stock-reduced, so a later cancel/refund would wrongly restock units
-		// that were never taken.
+		// Not woocommerce_can_reduce_order_stock: that still marks the order
+		// stock-reduced, so a later cancel/refund would restock units never taken.
 		$order_id        = $order->get_id();
 		$block_reduction = static function ( $trigger_reduce, $target_order_id ) use ( $order_id ) {
 			return (int) $target_order_id === $order_id ? false : $trigger_reduce;

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
@@ -87,9 +87,13 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 		// The only point that serializes concurrent agentic sessions on stock —
 		// finalize_checkout validates without reserving, so N sessions can all
 		// pass for the same last units. ReserveStock either claims them or throws.
+		// Throwable, not just ReserveStockException: third-party callbacks can
+		// throw anything from inside the reservation, and payment is already
+		// captured — every failure must land on the parked-order path rather
+		// than escape with neither payment_complete() nor the fallback run.
 		try {
 			$this->reserve_stock( $order );
-		} catch ( \Automattic\WooCommerce\Checkout\Helpers\ReserveStockException $e ) {
+		} catch ( \Throwable $e ) {
 			$this->hold_order_for_insufficient_stock( $order, $session, $e );
 			return $order;
 		}
@@ -336,11 +340,11 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 	 * reduction that would drive the oversold product negative.
 	 *
 	 * @since 10.9.0
-	 * @param WC_Order                                                  $order   The created order.
-	 * @param WC_Stripe_Agentic_Checkout_Session                        $session The checkout session wrapper.
-	 * @param \Automattic\WooCommerce\Checkout\Helpers\ReserveStockException $e  The reservation failure.
+	 * @param WC_Order                           $order   The created order.
+	 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
+	 * @param Throwable                          $e       The reservation failure.
 	 */
-	private function hold_order_for_insufficient_stock( WC_Order $order, WC_Stripe_Agentic_Checkout_Session $session, \Automattic\WooCommerce\Checkout\Helpers\ReserveStockException $e ): void {
+	private function hold_order_for_insufficient_stock( WC_Order $order, WC_Stripe_Agentic_Checkout_Session $session, Throwable $e ): void {
 		$order->set_transaction_id( $session->get_payment_intent_id() ?? '' );
 
 		// Not woocommerce_can_reduce_order_stock: that still marks the order
@@ -356,7 +360,7 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 				OrderStatus::ON_HOLD,
 				sprintf(
 					/* translators: %s: reason stock could not be secured */
-					__( 'Stripe captured the payment, but stock could not be secured for every item: %s Review stock, then process or refund this order manually.', 'woocommerce-gateway-stripe' ),
+					__( 'Stripe captured the payment, but stock could not be secured for every item. Review stock, then process or refund this order manually. Reason: %s', 'woocommerce-gateway-stripe' ),
 					$e->getMessage()
 				)
 			);

--- a/readme.txt
+++ b/readme.txt
@@ -235,6 +235,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
-* Fix - Reserve stock when completing agentic checkout orders so concurrent sessions cannot oversell; a paid order that loses the stock race is parked on-hold for review instead of driving stock negative
+* Fix - Reserve stock when completing agentic checkout orders so concurrent sessions cannot oversell; orders losing the race are set on-hold instead of driving stock negative
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -235,5 +235,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Fix - Reserve stock when completing agentic checkout orders so concurrent sessions cannot oversell; a paid order that loses the stock race is parked on-hold for review instead of driving stock negative
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-manual-approval-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-manual-approval-test.php
@@ -300,8 +300,7 @@ class WC_Stripe_Agentic_Commerce_Manual_Approval_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that a backorder-enabled product is approved beyond its stock
-	 * quantity — backorders are a permitted oversell, not a decline.
+	 * Test that a backorder-enabled product is approved beyond its stock quantity.
 	 */
 	public function test_approves_backordered_product_beyond_stock(): void {
 		$product = $this->create_product(
@@ -319,9 +318,8 @@ class WC_Stripe_Agentic_Commerce_Manual_Approval_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that units held by a concurrent checkout (WC reserved stock) count
-	 * against availability at finalize, so two sessions can't both be approved
-	 * for the same last units.
+	 * Test that units held by a concurrent checkout count against availability
+	 * at finalize.
 	 */
 	public function test_declines_when_stock_is_held_by_concurrent_checkout(): void {
 		$product = $this->create_product(

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-manual-approval-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-manual-approval-test.php
@@ -9,6 +9,7 @@ namespace WooCommerce\Stripe\Tests;
 
 require_once __DIR__ . '/trait-agentic-commerce-test-helpers.php';
 
+use Automattic\WooCommerce\Enums\OrderStatus;
 use WP_UnitTestCase;
 use WC_Helper_Product;
 use WC_Stripe_Agentic_Commerce_Manual_Approval;
@@ -329,7 +330,7 @@ class WC_Stripe_Agentic_Commerce_Manual_Approval_Test extends WP_UnitTestCase {
 			]
 		);
 
-		$competing = wc_create_order( [ 'status' => 'pending' ] );
+		$competing = wc_create_order( [ 'status' => OrderStatus::PENDING ] );
 		$competing->add_product( wc_get_product( $product->get_id() ), 2 );
 		$competing->save();
 		( new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock() )->reserve_stock_for_order( $competing, 10 );

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-manual-approval-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-manual-approval-test.php
@@ -300,6 +300,52 @@ class WC_Stripe_Agentic_Commerce_Manual_Approval_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that a backorder-enabled product is approved beyond its stock
+	 * quantity — backorders are a permitted oversell, not a decline.
+	 */
+	public function test_approves_backordered_product_beyond_stock(): void {
+		$product = $this->create_product(
+			[
+				'manage_stock'   => true,
+				'stock_quantity' => 1,
+				'backorders'     => 'yes',
+			]
+		);
+
+		$event    = $this->build_finalize_event( [ $product ], [ 5 ] );
+		$response = $this->approval->validate( $event );
+
+		$this->assertSame( 'approved', $response['manual_approval_details']['type'] );
+	}
+
+	/**
+	 * Test that units held by a concurrent checkout (WC reserved stock) count
+	 * against availability at finalize, so two sessions can't both be approved
+	 * for the same last units.
+	 */
+	public function test_declines_when_stock_is_held_by_concurrent_checkout(): void {
+		$product = $this->create_product(
+			[
+				'manage_stock'   => true,
+				'stock_quantity' => 2,
+			]
+		);
+
+		$competing = wc_create_order( [ 'status' => 'pending' ] );
+		$competing->add_product( wc_get_product( $product->get_id() ), 2 );
+		$competing->save();
+		( new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock() )->reserve_stock_for_order( $competing, 10 );
+
+		$event    = $this->build_finalize_event( [ $product ], [ 1 ] );
+		$response = $this->approval->validate( $event );
+
+		$this->assertSame( 'declined', $response['manual_approval_details']['type'] );
+		$this->assertStringContainsString( 'Only 0 available', $response['manual_approval_details']['declined']['reason'] );
+
+		$competing->delete( true );
+	}
+
+	/**
 	 * Creates a simple product and tracks it for cleanup.
 	 *
 	 * @param array $args Product property overrides.

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Stripe\Tests
  */
 
+use Automattic\WooCommerce\Enums\OrderStatus;
+
 /**
  * Class WC_Stripe_Agentic_Commerce_Order_Mapper_Test
  *
@@ -1582,7 +1584,7 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 
 		$order = $this->mapper->create_order_from_checkout_session( $session );
 
-		$this->assertEquals( 'processing', $order->get_status() );
+		$this->assertEquals( OrderStatus::PROCESSING, $order->get_status() );
 		$this->assertSame( 1, wc_get_product( $product->get_id() )->get_stock_quantity() );
 		$this->assertSame( 0, (int) wc_get_held_stock_quantity( wc_get_product( $product->get_id() ) ) );
 
@@ -1600,7 +1602,7 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 		$product = $this->create_managed_stock_product( 1 );
 
 		// Simulate the concurrent session that won the race.
-		$competing = wc_create_order( [ 'status' => 'pending' ] );
+		$competing = wc_create_order( [ 'status' => OrderStatus::PENDING ] );
 		$competing->add_product( wc_get_product( $product->get_id() ), 1 );
 		$competing->save();
 		( new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock() )->reserve_stock_for_order( $competing, 10 );
@@ -1608,7 +1610,7 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 		$session = $this->build_stock_session( $product, 1 );
 		$order   = $this->mapper->create_order_from_checkout_session( $session );
 
-		$this->assertEquals( 'on-hold', $order->get_status() );
+		$this->assertEquals( OrderStatus::ON_HOLD, $order->get_status() );
 		$this->assertSame( 1, wc_get_product( $product->get_id() )->get_stock_quantity(), 'Stock must not be reduced for the oversold order.' );
 		$this->assertSame( 'pi_test_456', $order->get_transaction_id() );
 
@@ -1639,7 +1641,7 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 
 		$order = $this->mapper->create_order_from_checkout_session( $session );
 
-		$this->assertEquals( 'on-hold', $order->get_status() );
+		$this->assertEquals( OrderStatus::ON_HOLD, $order->get_status() );
 		$this->assertSame( 1, wc_get_product( $product->get_id() )->get_stock_quantity(), 'Stock must not go negative.' );
 
 		$order->delete( true );
@@ -1656,7 +1658,7 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 
 		$order = $this->mapper->create_order_from_checkout_session( $session );
 
-		$this->assertEquals( 'processing', $order->get_status() );
+		$this->assertEquals( OrderStatus::PROCESSING, $order->get_status() );
 		$this->assertSame( -2, wc_get_product( $product->get_id() )->get_stock_quantity() );
 
 		$order->delete( true );

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
@@ -1572,6 +1572,155 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that completion places a stock hold, reduces stock via
+	 * payment_complete(), and leaves no lingering reservation.
+	 */
+	public function test_completion_reserves_and_reduces_stock() {
+		update_option( 'woocommerce_manage_stock', 'yes' );
+		$product = $this->create_managed_stock_product( 3 );
+		$session = $this->build_stock_session( $product, 2 );
+
+		$order = $this->mapper->create_order_from_checkout_session( $session );
+
+		$this->assertEquals( 'processing', $order->get_status() );
+		$this->assertSame( 1, wc_get_product( $product->get_id() )->get_stock_quantity() );
+		$this->assertSame( 0, (int) wc_get_held_stock_quantity( wc_get_product( $product->get_id() ) ) );
+
+		$order->delete( true );
+		$product->delete( true );
+	}
+
+	/**
+	 * Regression test for the concurrent-session oversell race: when another
+	 * (concurrent) order already holds the last units via WC's reserved-stock
+	 * table, completion must not oversell — the paid order is parked on-hold,
+	 * stock is untouched, and the transaction id is preserved for refunding.
+	 */
+	public function test_completion_holds_order_when_stock_already_reserved_by_concurrent_order() {
+		update_option( 'woocommerce_manage_stock', 'yes' );
+		$product = $this->create_managed_stock_product( 1 );
+
+		// Simulate the concurrent session that won the race: a separate order
+		// holding the last unit in the wc_reserved_stock table.
+		$competing = wc_create_order( [ 'status' => 'pending' ] );
+		$competing->add_product( wc_get_product( $product->get_id() ), 1 );
+		$competing->save();
+		( new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock() )->reserve_stock_for_order( $competing, 10 );
+
+		$session = $this->build_stock_session( $product, 1 );
+		$order   = $this->mapper->create_order_from_checkout_session( $session );
+
+		$this->assertEquals( 'on-hold', $order->get_status() );
+		$this->assertSame( 1, wc_get_product( $product->get_id() )->get_stock_quantity(), 'Stock must not be reduced for the oversold order.' );
+		$this->assertSame( 'pi_test_456', $order->get_transaction_id() );
+
+		$notes = wc_get_order_notes( [ 'order_id' => $order->get_id() ] );
+		$this->assertNotEmpty(
+			array_filter(
+				$notes,
+				static function ( $note ) {
+					return false !== strpos( $note->content, 'stock could not be secured' );
+				}
+			),
+			'The on-hold order must carry a note explaining the stock failure.'
+		);
+
+		$order->delete( true );
+		$competing->delete( true );
+		$product->delete( true );
+	}
+
+	/**
+	 * Test that completion for more units than are in stock parks the order
+	 * on-hold instead of completing and driving stock negative.
+	 */
+	public function test_completion_holds_order_when_stock_insufficient() {
+		update_option( 'woocommerce_manage_stock', 'yes' );
+		$product = $this->create_managed_stock_product( 1 );
+		$session = $this->build_stock_session( $product, 2 );
+
+		$order = $this->mapper->create_order_from_checkout_session( $session );
+
+		$this->assertEquals( 'on-hold', $order->get_status() );
+		$this->assertSame( 1, wc_get_product( $product->get_id() )->get_stock_quantity(), 'Stock must not go negative.' );
+
+		$order->delete( true );
+		$product->delete( true );
+	}
+
+	/**
+	 * Test that products with backorders enabled complete normally and may go
+	 * negative — the reservation guard must not block permitted backorders.
+	 */
+	public function test_completion_allows_backordered_products() {
+		update_option( 'woocommerce_manage_stock', 'yes' );
+		$product = $this->create_managed_stock_product( 1, [ 'backorders' => 'yes' ] );
+		$session = $this->build_stock_session( $product, 3 );
+
+		$order = $this->mapper->create_order_from_checkout_session( $session );
+
+		$this->assertEquals( 'processing', $order->get_status() );
+		$this->assertSame( -2, wc_get_product( $product->get_id() )->get_stock_quantity() );
+
+		$order->delete( true );
+		$product->delete( true );
+	}
+
+	/**
+	 * Creates a managed-stock product priced at 10.00.
+	 *
+	 * @param int   $stock Stock quantity.
+	 * @param array $extra Additional product props.
+	 * @return \WC_Product
+	 */
+	private function create_managed_stock_product( int $stock, array $extra = [] ): \WC_Product {
+		return WC_Helper_Product::create_simple_product(
+			true,
+			array_merge(
+				[
+					'regular_price'  => '10.00',
+					'price'          => '10.00',
+					'sku'            => 'MAPPER-STOCK-' . uniqid(),
+					'manage_stock'   => true,
+					'stock_quantity' => $stock,
+				],
+				$extra
+			)
+		);
+	}
+
+	/**
+	 * Builds a session for $quantity units of a 10.00 product with matching totals.
+	 *
+	 * @param \WC_Product $product  The product to order.
+	 * @param int         $quantity Units to order.
+	 * @return WC_Stripe_Agentic_Checkout_Session
+	 */
+	private function build_stock_session( \WC_Product $product, int $quantity ): WC_Stripe_Agentic_Checkout_Session {
+		$amount = 1000 * $quantity;
+
+		return $this->build_checkout_session(
+			[
+				'amount_total'    => $amount,
+				'amount_subtotal' => $amount,
+				'line_items'      => $this->build_line_items(
+					[
+						[
+							'lookup_key'      => (string) $product->get_sku(),
+							'quantity'        => $quantity,
+							'unit_amount'     => 1000,
+							'amount_total'    => $amount,
+							'amount_subtotal' => $amount,
+							'amount_tax'      => 0,
+						],
+					]
+				),
+			],
+			$product
+		);
+	}
+
+	/**
 	 * Builds a Stripe checkout session wrapper for testing.
 	 *
 	 * @param array<string, mixed>  $overrides Fields to override on the default session.

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
@@ -1592,16 +1592,14 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 
 	/**
 	 * Regression test for the concurrent-session oversell race: when another
-	 * (concurrent) order already holds the last units via WC's reserved-stock
-	 * table, completion must not oversell — the paid order is parked on-hold,
-	 * stock is untouched, and the transaction id is preserved for refunding.
+	 * order already holds the last unit, completion must park the paid order
+	 * on-hold with the transaction id, leaving stock untouched.
 	 */
 	public function test_completion_holds_order_when_stock_already_reserved_by_concurrent_order() {
 		update_option( 'woocommerce_manage_stock', 'yes' );
 		$product = $this->create_managed_stock_product( 1 );
 
-		// Simulate the concurrent session that won the race: a separate order
-		// holding the last unit in the wc_reserved_stock table.
+		// Simulate the concurrent session that won the race.
 		$competing = wc_create_order( [ 'status' => 'pending' ] );
 		$competing->add_product( wc_get_product( $product->get_id() ), 1 );
 		$competing->save();
@@ -1631,8 +1629,8 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that completion for more units than are in stock parks the order
-	 * on-hold instead of completing and driving stock negative.
+	 * Test that completing more units than are in stock parks the order
+	 * on-hold instead of driving stock negative.
 	 */
 	public function test_completion_holds_order_when_stock_insufficient() {
 		update_option( 'woocommerce_manage_stock', 'yes' );
@@ -1649,8 +1647,7 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that products with backorders enabled complete normally and may go
-	 * negative — the reservation guard must not block permitted backorders.
+	 * Test that backorder-enabled products complete normally and may go negative.
 	 */
 	public function test_completion_allows_backordered_products() {
 		update_option( 'woocommerce_manage_stock', 'yes' );

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
@@ -1625,8 +1625,43 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 			'The on-hold order must carry a note explaining the stock failure.'
 		);
 
+		// Cancelling the parked order must not restock units that were never
+		// taken — the reason woocommerce_payment_complete_reduce_order_stock
+		// (not woocommerce_can_reduce_order_stock) suppresses the reduction.
+		$order->update_status( OrderStatus::CANCELLED );
+		$this->assertSame( 1, wc_get_product( $product->get_id() )->get_stock_quantity(), 'Cancelling must not restock never-taken units.' );
+
 		$order->delete( true );
 		$competing->delete( true );
+		$product->delete( true );
+	}
+
+	/**
+	 * Test that a non-ReserveStockException failure inside the reservation
+	 * (e.g. a third-party callback) also parks the paid order on-hold instead
+	 * of escaping with neither payment_complete() nor the fallback run.
+	 */
+	public function test_completion_holds_order_when_reservation_throws_generic_error() {
+		update_option( 'woocommerce_manage_stock', 'yes' );
+		$product = $this->create_managed_stock_product( 3 );
+		$session = $this->build_stock_session( $product, 1 );
+
+		$thrower = static function () {
+			throw new RuntimeException( 'third-party callback failure' );
+		};
+		add_filter( 'woocommerce_order_hold_stock_minutes', $thrower );
+
+		try {
+			$order = $this->mapper->create_order_from_checkout_session( $session );
+		} finally {
+			remove_filter( 'woocommerce_order_hold_stock_minutes', $thrower );
+		}
+
+		$this->assertEquals( OrderStatus::ON_HOLD, $order->get_status() );
+		$this->assertSame( 3, wc_get_product( $product->get_id() )->get_stock_quantity() );
+		$this->assertSame( 'pi_test_456', $order->get_transaction_id() );
+
+		$order->delete( true );
 		$product->delete( true );
 	}
 


### PR DESCRIPTION
Fixes STRIPE-1256

## Changes proposed in this Pull Request:

The agentic checkout flow validated stock at `finalize_checkout` without holding it, then created and completed the order after Stripe had already captured the payment, with no re-check. Concurrent sessions could each pass validation for the same last units and all complete — driving stock negative with paid but unfulfillable orders.

- **Atomic hold at order creation:** the order mapper now places a WC `ReserveStock` hold before `payment_complete()`, so concurrent completions serialize on the `wc_reserved_stock` table. The hold duration is passed explicitly so a blank `woocommerce_hold_stock_minutes` can't disable the guard; `payment_complete()`'s stock reduction releases it moments later.
- **Explicit oversell handling:** if the hold fails, the already-paid order is parked **on-hold** with the transaction id and an explanatory note. Stock reduction is suppressed via `woocommerce_payment_complete_reduce_order_stock` (not `woocommerce_can_reduce_order_stock`, which would still flag the order stock-reduced and make a later cancel/refund restock units never taken).
- **Backorders honored:** `ReserveStock` skips backorder-enabled products, and finalize validation no longer declines quantities backorders permit. Finalize also subtracts `wc_get_held_stock_quantity()` so it stops approving units concurrent checkouts already hold.

**BC impact:** no public signatures, hooks, or options change. An out-of-stock-at-completion agentic order now ends `on-hold` instead of `processing` with negative stock; `ReserveStock` exists throughout the supported WC range.

## Testing instructions

1. With the agentic feature flag on, set a product to managed stock, quantity 1.
2. Run two overlapping agentic checkouts for it (or insert a `wc_reserved_stock` row for another order to simulate the second). One order completes as `processing` with stock 0; the other is created `on-hold` with a note, stock never goes to −1, and the payment intent is on the order for refunding.
3. With backorders set to "Allow", both complete and stock may go negative.
4. `npm run test:php -- --filter "WC_Stripe_Agentic_Commerce_Order_Mapper_Test|WC_Stripe_Agentic_Commerce_Manual_Approval_Test"` includes a regression test for the concurrent race.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

Changelog entries added to `changelog.txt` and `readme.txt` under 10.9.0.

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
