### PR TITLE
Register payment method constructor hooks only once per request (STRIPE-1291 tier 2)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -78,6 +78,7 @@ xxxx-xx-xx - version 10.9.0
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Fix - Register Multibanco, OXXO, Boleto, Link, and Cash App Pay hooks only once per request so email instructions and thank-you page content are not duplicated
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/includes/constants/class-wc-stripe-hook-categories.php
+++ b/includes/constants/class-wc-stripe-hook-categories.php
@@ -18,4 +18,12 @@ class WC_Stripe_Hook_Categories {
 	 * @var string
 	 */
 	public const SUBSCRIPTIONS = 'subscriptions';
+
+	/**
+	 * A payment method's general (non-subscription) instance hooks.
+	 *
+	 * @since 10.9.0
+	 * @var string
+	 */
+	public const GENERAL = 'general';
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-boleto.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-boleto.php
@@ -47,7 +47,11 @@ class WC_Stripe_UPE_Payment_Method_Boleto extends WC_Stripe_UPE_Payment_Method {
 			'woocommerce-gateway-stripe'
 		);
 
-		add_filter( 'wc_stripe_allowed_payment_processing_statuses', [ $this, 'add_allowed_payment_processing_statuses' ], 10, 2 );
+		$this->register_instance_hooks_once(
+			function () {
+				add_filter( 'wc_stripe_allowed_payment_processing_statuses', [ $this, 'add_allowed_payment_processing_statuses' ], 10, 2 );
+			}
+		);
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
@@ -55,7 +55,11 @@ class WC_Stripe_UPE_Payment_Method_Cash_App_Pay extends WC_Stripe_UPE_Payment_Me
 		// Cash App Pay supports subscriptions. Init subscriptions so it can process subscription payments.
 		$this->maybe_init_subscriptions();
 
-		add_filter( 'woocommerce_thankyou_order_received_text', [ $this, 'order_received_text_for_wallet_failure' ], 10, 2 );
+		$this->register_instance_hooks_once(
+			function () {
+				add_filter( 'woocommerce_thankyou_order_received_text', [ $this, 'order_received_text_for_wallet_failure' ], 10, 2 );
+			}
+		);
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
@@ -39,7 +39,11 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 			'Link'
 		);
 
-		add_filter( 'woocommerce_gateway_title', [ $this, 'filter_gateway_title' ], 10, 2 );
+		$this->register_instance_hooks_once(
+			function () {
+				add_filter( 'woocommerce_gateway_title', [ $this, 'filter_gateway_title' ], 10, 2 );
+			}
+		);
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-multibanco.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-multibanco.php
@@ -76,11 +76,15 @@ class WC_Stripe_UPE_Payment_Method_Multibanco extends WC_Stripe_UPE_Payment_Meth
 			'woocommerce-gateway-stripe'
 		);
 
-		add_filter( 'wc_stripe_allowed_payment_processing_statuses', [ $this, 'add_allowed_payment_processing_statuses' ], 10, 2 );
+		$this->register_instance_hooks_once(
+			function () {
+				add_filter( 'wc_stripe_allowed_payment_processing_statuses', [ $this, 'add_allowed_payment_processing_statuses' ], 10, 2 );
 
-		add_action( 'wc_gateway_stripe_process_payment_intent_requires_action', [ $this, 'save_instructions' ], 10, 2 );
-		add_action( 'woocommerce_thankyou_stripe_multibanco', [ $this, 'thankyou_page' ] );
-		add_action( 'woocommerce_email_before_order_table', [ $this, 'email_instructions' ], 10, 3 );
+				add_action( 'wc_gateway_stripe_process_payment_intent_requires_action', [ $this, 'save_instructions' ], 10, 2 );
+				add_action( 'woocommerce_thankyou_stripe_multibanco', [ $this, 'thankyou_page' ] );
+				add_action( 'woocommerce_email_before_order_table', [ $this, 'email_instructions' ], 10, 3 );
+			}
+		);
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-oxxo.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-oxxo.php
@@ -47,7 +47,11 @@ class WC_Stripe_UPE_Payment_Method_Oxxo extends WC_Stripe_UPE_Payment_Method {
 			'woocommerce-gateway-stripe'
 		);
 
-		add_filter( 'wc_stripe_allowed_payment_processing_statuses', [ $this, 'add_allowed_payment_processing_statuses' ], 10, 2 );
+		$this->register_instance_hooks_once(
+			function () {
+				add_filter( 'wc_stripe_allowed_payment_processing_statuses', [ $this, 'add_allowed_payment_processing_statuses' ], 10, 2 );
+			}
+		);
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -183,6 +183,20 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	}
 
 	/**
+	 * Runs $register only for the first instance of this payment method, so
+	 * repeated instantiation (the gateway constructor, factories, admin
+	 * checks) doesn't stack duplicate hook callbacks.
+	 *
+	 * @param callable $register Registers this instance's hooks.
+	 * @return void
+	 */
+	protected function register_instance_hooks_once( callable $register ): void {
+		if ( WC_Stripe_Hook_Manager::get_instance()->register_payment_method_hooks( $this->id, WC_Stripe_Hook_Categories::GENERAL ) ) {
+			$register();
+		}
+	}
+
+	/**
 	 * Magic method to get properties.
 	 * Used for backwards compatibility with deprecated properties.
 	 *

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -191,7 +191,17 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	 * @return void
 	 */
 	protected function register_instance_hooks_once( callable $register ): void {
-		if ( WC_Stripe_Hook_Manager::get_instance()->register_payment_method_hooks( $this->id, WC_Stripe_Hook_Categories::GENERAL ) ) {
+		$hook_manager = WC_Stripe_Hook_Manager::get_instance();
+
+		// The manager only tracks Stripe-prefixed ids. A third-party subclass
+		// with a foreign id can't be deduplicated, so fail open and register
+		// per instance rather than silently dropping its hooks.
+		if ( ! $hook_manager->is_valid_payment_method_id( $this->id ) ) {
+			$register();
+			return;
+		}
+
+		if ( $hook_manager->register_payment_method_hooks( $this->id, WC_Stripe_Hook_Categories::GENERAL ) ) {
 			$register();
 		}
 	}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -201,7 +201,10 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 			return;
 		}
 
-		if ( $hook_manager->register_payment_method_hooks( $this->id, WC_Stripe_Hook_Categories::GENERAL ) ) {
+		// Key on the concrete class too: a third-party subclass that keeps a
+		// core id must still register its (possibly overridden) callbacks, and
+		// must not suppress the core instance's — whichever constructs first.
+		if ( $hook_manager->register_payment_method_hooks( $this->id . ':' . get_class( $this ), WC_Stripe_Hook_Categories::GENERAL ) ) {
 			$register();
 		}
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -235,5 +235,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Fix - Register Multibanco, OXXO, Boleto, Link, and Cash App Pay hooks only once per request so email instructions and thank-you page content are not duplicated
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -111,6 +111,7 @@ require_once __DIR__ . '/helpers/class-oc-test-helper.php';
 require_once __DIR__ . '/helpers/class-pmc-test-helper.php';
 require_once __DIR__ . '/helpers/class-upe-test-helper.php';
 require_once __DIR__ . '/helpers/class-wc-stripe-test-helper.php';
+require_once __DIR__ . '/helpers/trait-wc-stripe-hook-manager-reset.php';
 
 // Pre-create HPOS (Custom Orders Table) schema so that parallel workers don't
 // race to create it when tests toggle `woocommerce_custom_orders_table_enabled`.

--- a/tests/phpunit/class-wc-stripe-hook-manager-test.php
+++ b/tests/phpunit/class-wc-stripe-hook-manager-test.php
@@ -7,6 +7,8 @@
  */
 class WC_Stripe_Hook_Manager_Test extends WP_UnitTestCase {
 
+	use WC_Stripe_Hook_Manager_Reset_Trait;
+
 	/**
 	 * A second arbitrary hook category used to assert category isolation.
 	 *
@@ -16,33 +18,6 @@ class WC_Stripe_Hook_Manager_Test extends WP_UnitTestCase {
 	 * @var string
 	 */
 	const OTHER_CATEGORY = 'pre_orders';
-
-	/**
-	 * @inheritDoc
-	 */
-	public function set_up() {
-		parent::set_up();
-		$this->reset_hook_manager_singleton();
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function tear_down() {
-		$this->reset_hook_manager_singleton();
-		parent::tear_down();
-	}
-
-	/**
-	 * Resets the private static singleton so each test starts from a clean slate.
-	 *
-	 * @return void
-	 */
-	private function reset_hook_manager_singleton() {
-		$reflection = new ReflectionProperty( WC_Stripe_Hook_Manager::class, 'instance' );
-		$reflection->setAccessible( true );
-		$reflection->setValue( null, null );
-	}
 
 	/**
 	 * `get_instance()` always returns the same instance.

--- a/tests/phpunit/compat/class-wc-stripe-subscriptions-hook-registration-test.php
+++ b/tests/phpunit/compat/class-wc-stripe-subscriptions-hook-registration-test.php
@@ -110,32 +110,7 @@ class WC_Stripe_Subscriptions_Hook_Registration_Test extends WP_UnitTestCase {
 		],
 	];
 
-	/**
-	 * @inheritDoc
-	 */
-	public function set_up() {
-		parent::set_up();
-		$this->reset_hook_manager_singleton();
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function tear_down() {
-		$this->reset_hook_manager_singleton();
-		parent::tear_down();
-	}
-
-	/**
-	 * Resets the hook manager singleton so each test starts from a clean slate.
-	 *
-	 * @return void
-	 */
-	private function reset_hook_manager_singleton() {
-		$reflection = new ReflectionProperty( WC_Stripe_Hook_Manager::class, 'instance' );
-		$reflection->setAccessible( true );
-		$reflection->setValue( null, null );
-	}
+	use WC_Stripe_Hook_Manager_Reset_Trait;
 
 	/**
 	 * Builds a UPE gateway instance with the constructor disabled and a test ID.

--- a/tests/phpunit/helpers/trait-wc-stripe-hook-manager-reset.php
+++ b/tests/phpunit/helpers/trait-wc-stripe-hook-manager-reset.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Resets the WC_Stripe_Hook_Manager singleton around each test.
+ *
+ * @package WooCommerce\Stripe\Tests
+ */
+
+/**
+ * WP_UnitTestCase restores `$wp_filter` between tests but not the hook
+ * manager's registered state, so without this reset the first test to
+ * register a payment method id short-circuits registration for every
+ * later test in the process.
+ */
+trait WC_Stripe_Hook_Manager_Reset_Trait {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->reset_hook_manager_singleton();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function tear_down() {
+		$this->reset_hook_manager_singleton();
+		parent::tear_down();
+	}
+
+	/**
+	 * Resets the private static singleton so each test starts from a clean slate.
+	 *
+	 * @return void
+	 */
+	private function reset_hook_manager_singleton() {
+		$reflection = new ReflectionProperty( WC_Stripe_Hook_Manager::class, 'instance' );
+		$reflection->setAccessible( true );
+		$reflection->setValue( null, null );
+	}
+}

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-hooks-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-hooks-test.php
@@ -10,34 +10,7 @@
  */
 class WC_Stripe_UPE_Payment_Method_Hooks_Test extends WP_UnitTestCase {
 
-	/**
-	 * @inheritDoc
-	 */
-	public function set_up() {
-		parent::set_up();
-		$this->reset_hook_manager_singleton();
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function tear_down() {
-		$this->reset_hook_manager_singleton();
-		parent::tear_down();
-	}
-
-	/**
-	 * Resets the hook manager singleton so each test's first instantiation
-	 * actually exercises the registration path: WP_UnitTestCase restores
-	 * `$wp_filter` between tests but not the singleton's registered state.
-	 *
-	 * @return void
-	 */
-	private function reset_hook_manager_singleton() {
-		$reflection = new ReflectionProperty( WC_Stripe_Hook_Manager::class, 'instance' );
-		$reflection->setAccessible( true );
-		$reflection->setValue( null, null );
-	}
+	use WC_Stripe_Hook_Manager_Reset_Trait;
 
 	/**
 	 * Data provider mapping each hook-registering payment method class to a
@@ -97,6 +70,27 @@ class WC_Stripe_UPE_Payment_Method_Hooks_Test extends WP_UnitTestCase {
 		WC_Stripe_UPE_Payment_Gateway::get_payment_method_instance( WC_Stripe_Payment_Methods::MULTIBANCO );
 
 		$this->assertSame( $after_first, $this->count_hook_callbacks( 'woocommerce_email_before_order_table' ) );
+	}
+
+	/**
+	 * Test that a subclass keeping a core id still registers its callbacks
+	 * after the core class has: dedup is keyed per concrete class, so neither
+	 * suppresses the other, and each class still registers only once.
+	 */
+	public function test_same_id_subclass_registers_independently_of_core_class() {
+		new WC_Stripe_UPE_Payment_Method_Multibanco();
+		$after_core = $this->count_hook_callbacks( 'woocommerce_email_before_order_table' );
+
+		$make_subclass = function () {
+			return new class() extends WC_Stripe_UPE_Payment_Method_Multibanco {};
+		};
+
+		$make_subclass();
+		$after_subclass = $this->count_hook_callbacks( 'woocommerce_email_before_order_table' );
+		$this->assertGreaterThan( $after_core, $after_subclass );
+
+		$make_subclass();
+		$this->assertSame( $after_subclass, $this->count_hook_callbacks( 'woocommerce_email_before_order_table' ) );
 	}
 
 	/**

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-hooks-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-hooks-test.php
@@ -100,6 +100,38 @@ class WC_Stripe_UPE_Payment_Method_Hooks_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that a subclass whose id the hook manager can't track (no `stripe`
+	 * prefix) still registers its hooks — the guard fails open, per instance.
+	 */
+	public function test_foreign_id_subclass_registers_hooks_per_instance() {
+		$make = function () {
+			return new class() extends WC_Stripe_UPE_Payment_Method_Multibanco {
+				public function __construct() {
+					parent::__construct();
+					$this->id = 'foreign_multibanco';
+					$this->register_instance_hooks_once(
+						function () {
+							// A fresh closure per instance: identical string
+							// callbacks would collapse into one wp_filter slot.
+							add_action(
+								'wc_stripe_test_foreign_hook',
+								static function () {}
+							);
+						}
+					);
+				}
+			};
+		};
+
+		$make();
+		$this->assertSame( 1, $this->count_hook_callbacks( 'wc_stripe_test_foreign_hook' ) );
+
+		// No dedup possible for untracked ids: each instance registers.
+		$make();
+		$this->assertSame( 2, $this->count_hook_callbacks( 'wc_stripe_test_foreign_hook' ) );
+	}
+
+	/**
 	 * Helper: count callbacks registered on `$hook` across all priorities.
 	 *
 	 * @param string $hook Hook name.

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-hooks-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-hooks-test.php
@@ -11,6 +11,35 @@
 class WC_Stripe_UPE_Payment_Method_Hooks_Test extends WP_UnitTestCase {
 
 	/**
+	 * @inheritDoc
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->reset_hook_manager_singleton();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function tear_down() {
+		$this->reset_hook_manager_singleton();
+		parent::tear_down();
+	}
+
+	/**
+	 * Resets the hook manager singleton so each test's first instantiation
+	 * actually exercises the registration path: WP_UnitTestCase restores
+	 * `$wp_filter` between tests but not the singleton's registered state.
+	 *
+	 * @return void
+	 */
+	private function reset_hook_manager_singleton() {
+		$reflection = new ReflectionProperty( WC_Stripe_Hook_Manager::class, 'instance' );
+		$reflection->setAccessible( true );
+		$reflection->setValue( null, null );
+	}
+
+	/**
 	 * Data provider mapping each hook-registering payment method class to a
 	 * hook only its constructor registers.
 	 *

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-hooks-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-hooks-test.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Tests that UPE payment method constructor hooks register only once.
+ *
+ * @package WooCommerce\Stripe\Tests
+ */
+
+/**
+ * Class WC_Stripe_UPE_Payment_Method_Hooks_Test
+ */
+class WC_Stripe_UPE_Payment_Method_Hooks_Test extends WP_UnitTestCase {
+
+	/**
+	 * Data provider mapping each hook-registering payment method class to a
+	 * hook only its constructor registers.
+	 *
+	 * @return array<string, array{class: string, hook: string}>
+	 */
+	public function payment_method_hook_provider(): array {
+		return [
+			'multibanco email instructions' => [
+				'class' => WC_Stripe_UPE_Payment_Method_Multibanco::class,
+				'hook'  => 'woocommerce_email_before_order_table',
+			],
+			'oxxo processing statuses'      => [
+				'class' => WC_Stripe_UPE_Payment_Method_Oxxo::class,
+				'hook'  => 'wc_stripe_allowed_payment_processing_statuses',
+			],
+			'boleto processing statuses'    => [
+				'class' => WC_Stripe_UPE_Payment_Method_Boleto::class,
+				'hook'  => 'wc_stripe_allowed_payment_processing_statuses',
+			],
+			'link gateway title'            => [
+				'class' => WC_Stripe_UPE_Payment_Method_Link::class,
+				'hook'  => 'woocommerce_gateway_title',
+			],
+			'cash app thankyou text'        => [
+				'class' => WC_Stripe_UPE_Payment_Method_Cash_App_Pay::class,
+				'hook'  => 'woocommerce_thankyou_order_received_text',
+			],
+		];
+	}
+
+	/**
+	 * Test that instantiating a payment method repeatedly does not stack
+	 * duplicate hook callbacks — only the first instance registers.
+	 *
+	 * @dataProvider payment_method_hook_provider
+	 */
+	public function test_repeated_instantiation_does_not_duplicate_hooks( string $class, string $hook ) {
+		new $class();
+		$after_first = $this->count_hook_callbacks( $hook );
+
+		new $class();
+		new $class();
+
+		$this->assertSame( $after_first, $this->count_hook_callbacks( $hook ) );
+	}
+
+	/**
+	 * Test that the factory used on the payment path does not stack duplicate
+	 * hook callbacks either.
+	 */
+	public function test_get_payment_method_instance_does_not_duplicate_hooks() {
+		WC_Stripe_UPE_Payment_Gateway::get_payment_method_instance( WC_Stripe_Payment_Methods::MULTIBANCO );
+		$after_first = $this->count_hook_callbacks( 'woocommerce_email_before_order_table' );
+
+		WC_Stripe_UPE_Payment_Gateway::get_payment_method_instance( WC_Stripe_Payment_Methods::MULTIBANCO );
+
+		$this->assertSame( $after_first, $this->count_hook_callbacks( 'woocommerce_email_before_order_table' ) );
+	}
+
+	/**
+	 * Helper: count callbacks registered on `$hook` across all priorities.
+	 *
+	 * @param string $hook Hook name.
+	 * @return int
+	 */
+	private function count_hook_callbacks( string $hook ): int {
+		global $wp_filter;
+
+		if ( ! isset( $wp_filter[ $hook ] ) ) {
+			return 0;
+		}
+
+		$count = 0;
+		foreach ( $wp_filter[ $hook ]->callbacks as $priority_callbacks ) {
+			$count += count( $priority_callbacks );
+		}
+
+		return $count;
+	}
+}


### PR DESCRIPTION
Towards STRIPE-1291

## Changes proposed in this Pull Request:

Tier 2 of STRIPE-1291. Five UPE payment method classes register hooks in their constructors — Multibanco (email instructions, thank-you page, payment-processing statuses), OXXO and Boleto (payment-processing statuses), Link (gateway title), Cash App Pay (thank-you text). These classes are instantiated repeatedly: the gateway constructor builds all of them, `get_payment_method_instance()` mints a fresh instance per call on the payment path (8 call sites), and the admin environment check builds them all again. Each instance stacked another copy of its callbacks, so a single request could render Multibanco's email instructions or thank-you content multiple times.

The fix guards registration with the existing `WC_Stripe_Hook_Manager` — the same first-instance-wins mechanism the subscriptions hooks already use:

- New `WC_Stripe_Hook_Categories::GENERAL` category for a method's non-subscription instance hooks.
- New `register_instance_hooks_once()` helper on the `WC_Stripe_UPE_Payment_Method` base class; the five constructors route their hook registration through it.
- No factory/instantiation-site changes needed: once constructors are idempotent, per-call `new` is harmless.

**BC impact:** the hooks, their priorities, and their behavior are unchanged; only duplicate registration is prevented. Callbacks are bound to the first instance constructed in a request (as the subscriptions hooks already are) — these callbacks are stateless, reading everything from hook arguments.

## Testing instructions

1. With Multibanco enabled, place a Multibanco order and check the order emails and thank-you page — payment instructions must appear exactly once.
2. Unit coverage: `npm run test:php -- --filter WC_Stripe_UPE_Payment_Method_Hooks_Test` — asserts, per method class, that repeated instantiation (and the `get_payment_method_instance()` factory) leaves the hook callback count unchanged.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

Changelog entries added to `changelog.txt` and `readme.txt` under 10.9.0.

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
