### PR TITLE
Move admin controller hook registration out of constructors (STRIPE-1291 tier 3, admin)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -78,6 +78,7 @@ xxxx-xx-xx - version 10.9.0
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Dev - Move hook registration out of the admin controller, notices, inbox notes, privacy, and bulk action constructors so repeated instantiation cannot duplicate callbacks
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -53,6 +53,16 @@ class WC_Stripe_Admin_Notices {
 	 * @since 4.1.0
 	 */
 	public function __construct() {
+	}
+
+	/**
+	 * Registers the notice hooks; called once by the bootstrap so
+	 * instantiation alone never stacks duplicate callbacks.
+	 *
+	 * @since 10.9.0
+	 * @return void
+	 */
+	public function register_hooks(): void {
 		add_action( 'admin_notices', [ $this, 'admin_notices' ] );
 		add_action( 'wp_loaded', [ $this, 'hide_notices' ] );
 	}

--- a/includes/admin/class-wc-stripe-amazon-pay-controller.php
+++ b/includes/admin/class-wc-stripe-amazon-pay-controller.php
@@ -8,6 +8,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Stripe_Amazon_Pay_Controller {
 	public function __construct() {
+	}
+
+	/**
+	 * Registers the controller's hooks; called once by the bootstrap so
+	 * instantiation alone never stacks duplicate callbacks.
+	 *
+	 * @since 10.9.0
+	 * @return void
+	 */
+	public function register_hooks(): void {
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_scripts' ] );
 		add_action( 'wc_stripe_gateway_admin_options_wrapper', [ $this, 'admin_options' ] );
 	}

--- a/includes/admin/class-wc-stripe-command-palette-controller.php
+++ b/includes/admin/class-wc-stripe-command-palette-controller.php
@@ -13,6 +13,16 @@ class WC_Stripe_Command_Palette_Controller {
 	 * Constructor.
 	 */
 	public function __construct() {
+	}
+
+	/**
+	 * Registers the palette hook; called once by the bootstrap so
+	 * instantiation alone never stacks duplicate callbacks.
+	 *
+	 * @since 10.9.0
+	 * @return void
+	 */
+	public function register_hooks(): void {
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_scripts' ] );
 	}
 

--- a/includes/admin/class-wc-stripe-express-checkout-controller.php
+++ b/includes/admin/class-wc-stripe-express-checkout-controller.php
@@ -13,6 +13,16 @@ class WC_Stripe_Express_Checkout_Controller {
 	 * Constructor.
 	 */
 	public function __construct() {
+	}
+
+	/**
+	 * Registers the controller's hooks; called once by the bootstrap so
+	 * instantiation alone never stacks duplicate callbacks.
+	 *
+	 * @since 10.9.0
+	 * @return void
+	 */
+	public function register_hooks(): void {
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_scripts' ] );
 		add_action( 'wc_stripe_gateway_admin_options_wrapper', [ $this, 'admin_options' ] );
 	}

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -17,6 +17,16 @@ class WC_Stripe_Inbox_Notes {
 	public const CAMPAIGN_2020_CLEANUP_ACTION = 'wc_stripe_apple_pay_2020_cleanup';
 
 	public function __construct() {
+	}
+
+	/**
+	 * Registers the note hooks and schedules cleanup; called once by the
+	 * bootstrap so instantiation alone never stacks duplicate callbacks.
+	 *
+	 * @since 10.9.0
+	 * @return void
+	 */
+	public function register_hooks(): void {
 		add_action( self::POST_SETUP_SUCCESS_ACTION, [ self::class, 'create_marketing_note' ] );
 		add_action( self::CAMPAIGN_2020_CLEANUP_ACTION, [ self::class, 'cleanup_campaign_2020' ] );
 		add_action( 'admin_init', [ self::class, 'create_upe_notes' ] );

--- a/includes/admin/class-wc-stripe-link-controller.php
+++ b/includes/admin/class-wc-stripe-link-controller.php
@@ -8,6 +8,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Stripe_Link_Controller {
 	public function __construct() {
+	}
+
+	/**
+	 * Registers the controller's hooks; called once by the bootstrap so
+	 * instantiation alone never stacks duplicate callbacks.
+	 *
+	 * @since 10.9.0
+	 * @return void
+	 */
+	public function register_hooks(): void {
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_scripts' ] );
 		add_action( 'wc_stripe_gateway_admin_options_wrapper', [ $this, 'admin_options' ] );
 	}

--- a/includes/admin/class-wc-stripe-payment-gateways-controller.php
+++ b/includes/admin/class-wc-stripe-payment-gateways-controller.php
@@ -27,6 +27,16 @@ class WC_Stripe_Payment_Gateways_Controller {
 	 */
 	public function __construct( WC_Stripe_Account $account ) {
 		$this->account = $account;
+	}
+
+	/**
+	 * Registers the controller's hooks; called once by the bootstrap so
+	 * instantiation alone never stacks duplicate callbacks.
+	 *
+	 * @since 10.9.0
+	 * @return void
+	 */
+	public function register_hooks(): void {
 		// If UPE is enabled and there are enabled payment methods, we need to load the disable Stripe confirmation modal.
 		$stripe_settings              = WC_Stripe_Helper::get_stripe_settings();
 		$enabled_upe_payment_methods  = WC_Stripe_Payment_Method_Configurations::get_upe_enabled_payment_method_ids();

--- a/includes/admin/class-wc-stripe-plugins-page-controller.php
+++ b/includes/admin/class-wc-stripe-plugins-page-controller.php
@@ -24,7 +24,16 @@ class WC_Stripe_Plugins_Page_Controller {
 	 */
 	public function __construct( WC_Stripe_Account $account ) {
 		$this->account = $account;
+	}
 
+	/**
+	 * Registers the controller's hooks; called once by the bootstrap so
+	 * instantiation alone never stacks duplicate callbacks.
+	 *
+	 * @since 10.9.0
+	 * @return void
+	 */
+	public function register_hooks(): void {
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 		add_action( 'admin_footer', [ $this, 'render_container' ] );
 		add_filter( 'plugin_row_meta', [ $this, 'add_release_notes_link' ], 10, 2 );

--- a/includes/admin/class-wc-stripe-privacy.php
+++ b/includes/admin/class-wc-stripe-privacy.php
@@ -9,7 +9,17 @@ class WC_Stripe_Privacy extends WC_Abstract_Privacy {
 	 */
 	public function __construct() {
 		parent::__construct();
+	}
 
+	/**
+	 * Registers this class's own hooks; called once by the bootstrap so
+	 * instantiation alone never stacks duplicate callbacks. The parent
+	 * WC_Abstract_Privacy constructor still registers its own machinery.
+	 *
+	 * @since 10.9.0
+	 * @return void
+	 */
+	public function register_hooks(): void {
 		add_action( 'init', [ $this, 'register_erasers_exporters' ] );
 		add_filter( 'woocommerce_get_settings_account', [ $this, 'account_settings' ] );
 	}

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -35,7 +35,16 @@ class WC_Stripe_Settings_Controller {
 	public function __construct( WC_Stripe_Account $account, ?WC_Stripe_Payment_Gateway $gateway = null ) {
 		$this->account = $account;
 		$this->gateway = $gateway;
+	}
 
+	/**
+	 * Registers the controller's hooks; called once by the bootstrap so
+	 * instantiation alone never stacks duplicate callbacks.
+	 *
+	 * @since 10.9.0
+	 * @return void
+	 */
+	public function register_hooks(): void {
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_scripts' ] );
 		add_action( 'wc_stripe_gateway_admin_options_wrapper', [ $this, 'admin_options' ] );
 		add_action( 'woocommerce_order_item_add_action_buttons', [ $this, 'hide_refund_button_for_uncaptured_orders' ] );

--- a/includes/admin/class-wc-stripe-subscription-detached-bulk-action.php
+++ b/includes/admin/class-wc-stripe-subscription-detached-bulk-action.php
@@ -12,6 +12,16 @@ class WC_Stripe_Subscription_Detached_Bulk_Action {
 	 * Constructor.
 	 */
 	public function __construct() {
+	}
+
+	/**
+	 * Registers the bulk action hooks; called once by the bootstrap so
+	 * instantiation alone never stacks duplicate callbacks.
+	 *
+	 * @since 10.9.0
+	 * @return void
+	 */
+	public function register_hooks(): void {
 		if ( WC_Stripe_Woo_Compat_Utils::is_custom_orders_table_enabled() ) {
 			add_filter( 'bulk_actions-woocommerce_page_wc-orders--shop_subscription', [ $this, 'subscriptions_bulk_actions' ] );
 			add_filter( 'handle_bulk_actions-woocommerce_page_wc-orders--shop_subscription', [ $this, 'handle_subscription_detachment_check' ], 10, 3 );

--- a/includes/admin/class-wc-stripe-upe-compatibility-controller.php
+++ b/includes/admin/class-wc-stripe-upe-compatibility-controller.php
@@ -11,6 +11,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Stripe_UPE_Compatibility_Controller {
 	public function __construct() {
+	}
+
+	/**
+	 * Registers the notice hook; called once by the bootstrap so
+	 * instantiation alone never stacks duplicate callbacks.
+	 *
+	 * @since 10.9.0
+	 * @return void
+	 */
+	public function register_hooks(): void {
 		add_action( 'admin_notices', [ $this, 'add_compatibility_notice' ] );
 	}
 

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -117,7 +117,7 @@ class WC_Stripe {
 
 		if ( is_admin() && self::$instance === $this ) {
 			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-privacy.php';
-			new WC_Stripe_Privacy();
+			( new WC_Stripe_Privacy() )->register_hooks();
 		}
 
 		if ( file_exists( WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-feature-flags.php' ) ) {
@@ -197,7 +197,7 @@ class WC_Stripe {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-intent-controller.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-inbox-notes.php';
 		if ( self::$instance === $this ) {
-			new WC_Stripe_Inbox_Notes();
+			( new WC_Stripe_Inbox_Notes() )->register_hooks();
 		}
 
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-account.php';
@@ -227,7 +227,7 @@ class WC_Stripe {
 		if ( is_admin() ) {
 			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-admin-notices.php';
 			if ( self::$instance === $this ) {
-				new WC_Stripe_Admin_Notices();
+				( new WC_Stripe_Admin_Notices() )->register_hooks();
 			}
 
 			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-settings-controller.php';
@@ -236,41 +236,41 @@ class WC_Stripe {
 			if ( in_array( $area, [ 'express_checkout', 'payment_requests' ], true ) ) {
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-express-checkout-controller.php';
 				if ( self::$instance === $this ) {
-					new WC_Stripe_Express_Checkout_Controller();
+					( new WC_Stripe_Express_Checkout_Controller() )->register_hooks();
 				}
 			} elseif ( 'amazon_pay' === $area ) {
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-amazon-pay-controller.php';
 				if ( self::$instance === $this ) {
-					new WC_Stripe_Amazon_Pay_Controller();
+					( new WC_Stripe_Amazon_Pay_Controller() )->register_hooks();
 				}
 			} elseif ( 'link' === $area ) {
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-link-controller.php';
 				if ( self::$instance === $this ) {
-					new WC_Stripe_Link_Controller();
+					( new WC_Stripe_Link_Controller() )->register_hooks();
 				}
 			} elseif ( self::$instance === $this ) {
-				new WC_Stripe_Settings_Controller( $this->account );
+				( new WC_Stripe_Settings_Controller( $this->account ) )->register_hooks();
 			}
 
 			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-payment-gateways-controller.php';
 			if ( self::$instance === $this ) {
-				new WC_Stripe_Payment_Gateways_Controller( $this->account );
+				( new WC_Stripe_Payment_Gateways_Controller( $this->account ) )->register_hooks();
 			}
 
 			if ( self::$instance === $this ) {
-				new WC_Stripe_Plugins_Page_Controller( $this->account );
+				( new WC_Stripe_Plugins_Page_Controller( $this->account ) )->register_hooks();
 			}
 
 			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-command-palette-controller.php';
 			if ( self::$instance === $this ) {
-				new WC_Stripe_Command_Palette_Controller();
+				( new WC_Stripe_Command_Palette_Controller() )->register_hooks();
 			}
 
 			if ( WC_Stripe_Subscriptions_Helper::is_subscriptions_enabled() ) {
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-subscription-detached-bulk-action.php';
 
 				if ( self::$instance === $this ) {
-					new WC_Stripe_Subscription_Detached_Bulk_Action();
+					( new WC_Stripe_Subscription_Detached_Bulk_Action() )->register_hooks();
 				}
 			}
 		}
@@ -298,7 +298,7 @@ class WC_Stripe {
 		}
 
 		if ( self::$instance === $this ) {
-			new WC_Stripe_UPE_Compatibility_Controller();
+			( new WC_Stripe_UPE_Compatibility_Controller() )->register_hooks();
 		}
 
 		if ( self::$instance === $this ) {

--- a/readme.txt
+++ b/readme.txt
@@ -235,5 +235,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Dev - Move hook registration out of the admin controller, notices, inbox notes, privacy, and bulk action constructors so repeated instantiation cannot duplicate callbacks
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Towards STRIPE-1291

## Changes proposed in this Pull Request:

Tier 3 (chunk 2 of 3) of STRIPE-1291: the admin-area classes move their `add_action`/`add_filter` calls from `__construct()` into a public `register_hooks()` that the bootstrap calls exactly once — the same convention as the core-handlers chunk (#5723).

Covered: `WC_Stripe_Settings_Controller`, `WC_Stripe_Payment_Gateways_Controller`, `WC_Stripe_Plugins_Page_Controller`, `WC_Stripe_Express_Checkout_Controller`, `WC_Stripe_Amazon_Pay_Controller`, `WC_Stripe_Link_Controller`, `WC_Stripe_Command_Palette_Controller`, `WC_Stripe_UPE_Compatibility_Controller`, `WC_Stripe_Admin_Notices`, `WC_Stripe_Inbox_Notes` (including its campaign-cleanup scheduling), `WC_Stripe_Subscription_Detached_Bulk_Action`, and `WC_Stripe_Privacy`. All 12 bootstrap call sites in `WC_Stripe::init()` now do `( new X(...) )->register_hooks()`.

Two deliberate exceptions:
- `WC_Stripe_Privacy` still calls `parent::__construct()` — `WC_Abstract_Privacy` registers its own machinery there and that's WC's framework pattern; only this plugin's two hooks moved.
- `WC_Stripe_Payment_Requests_Controller` is never instantiated anywhere (dead code) and is left untouched.

**BC impact:** no signatures, hooks, options, or hook timing change. Direct instantiation (tests only today) no longer registers hooks — previously that was a duplicate-callback bug, not a feature. Flagging per the BC checklist since these are public classes.

## Testing instructions

1. Load wp-admin and the Stripe settings pages (main, express checkout, Amazon Pay, Link areas) — scripts, notices, and the gateway container render as before; the plugins page shows the release-notes link; the subscriptions list still offers the "Check for payment method detachment" bulk action.
2. Unit coverage: `npm run test:php -- --filter "WC_Stripe_Admin_Notices_Test|WC_Stripe_Inbox_Notes_Test|WC_Stripe_Settings_Controller_Test|WC_Stripe_UPE_Compatibility_Controller_Test|WC_Stripe_Subscription_Detached_Bulk_Action_Test|WC_Stripe_Test"`.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

Changelog entries added to `changelog.txt` and `readme.txt` under 10.9.0 (Dev).

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
