### PR TITLE
Move SEPA token repairer hook registration out of its constructor (STRIPE-1291 tier 3, final)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -78,6 +78,7 @@ xxxx-xx-xx - version 10.9.0
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Dev - Move hook registration out of the legacy SEPA token repairer constructor so repeated instantiation cannot duplicate callbacks
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -970,6 +970,7 @@ class WC_Stripe {
 		$logger  = wc_get_logger();
 		$updater = new WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens( $logger );
 
+		$updater->register_hooks();
 		$updater->init();
 		$updater->maybe_update();
 	}

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -53,7 +53,16 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends \WCS_Backgroun
 		$this->scheduled_hook = 'wc_stripe_schedule_subscriptions_legacy_sepa_token_repairs';
 		$this->repair_hook    = 'wc_stripe_subscriptions_legacy_sepa_token_repair';
 		$this->log_handle     = 'woocommerce-gateway-stripe-subscriptions-legacy-sepa-tokens-repairs';
+	}
 
+	/**
+	 * Registers the repairer's hooks; called once by the bootstrap so
+	 * instantiation alone never stacks duplicate callbacks.
+	 *
+	 * @since 10.9.0
+	 * @return void
+	 */
+	public function register_hooks(): void {
 		// Repair subscriptions prior to renewal as a backstop. Hooked onto 0 to run before the actual renewal.
 		add_action( 'woocommerce_scheduled_subscription_payment', [ $this, 'maybe_migrate_before_renewal' ], 0 );
 

--- a/readme.txt
+++ b/readme.txt
@@ -235,5 +235,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Dev - Move hook registration out of the legacy SEPA token repairer constructor so repeated instantiation cannot duplicate callbacks
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Towards STRIPE-1291

## Changes proposed in this Pull Request:

Tier 3 (chunk 3 of 3) of STRIPE-1291, closing out the constructor-hook sweep.

`WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens` moves its three constructor hooks — including `woocommerce_scheduled_subscription_payment` at priority 0, which sits on the renewal path — into a public `register_hooks()` called by `initialize_subscriptions_updater()` alongside the existing `init()`/`maybe_update()` calls. `register_hooks()` (our convention) rather than overriding `init()`, since `init()` is an upstream `WCS_Background_Repairer` contract.

Two classes are intentionally left as-is, ending the sweep:
- `WC_Stripe_Email_Failed_Renewal_Authentication` / `WC_Stripe_Email_Failed_Preorder_Authentication`: `WC_Email` registers trigger hooks in constructors by framework design, and WC's mailer singleton instantiates each email class once — no duplication path exists.

**BC impact:** no signatures, hooks, options, or hook timing change. Direct instantiation of the repairer no longer registers hooks (tests construct it and call methods directly; no other consumers exist).

## Testing instructions

1. With WooCommerce Subscriptions active, load wp-admin — the legacy SEPA repair notice and the WooCommerce debug tool entry behave as before, and a scheduled renewal still runs the pre-renewal migration backstop.
2. Unit coverage: `npm run test:php -- --filter WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens_Test`.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

Changelog entries added to `changelog.txt` and `readme.txt` under 10.9.0 (Dev).

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
