### PR TITLE
Add E2E coverage for SEPA, iDEAL, and Bancontact (new eur-lpms project)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        project: ['default', 'isk', 'acss', 'optimized-checkout', 'blik', 'becs']
+        project: ['default', 'isk', 'acss', 'optimized-checkout', 'blik', 'becs', 'eur-lpms']
 
     name: E2E - ${{ matrix.project }} WP=latest, WC=latest, PHP=7.4
     steps:

--- a/package.json
+++ b/package.json
@@ -183,6 +183,8 @@
     "test:e2e-lpm-blik-debug": "npm run test:e2e-lpm-blik -- --debug",
     "test:e2e-lpm-becs": "./tests/e2e/bin/run-tests.sh --project=becs",
     "test:e2e-lpm-becs-debug": "npm run test:e2e-lpm-becs -- --debug",
+    "test:e2e-lpm-eur": "./tests/e2e/bin/run-tests.sh --project=eur-lpms",
+    "test:e2e-lpm-eur-debug": "npm run test:e2e-lpm-eur -- --debug",
     "test:e2e-isk": "./tests/e2e/bin/run-tests.sh --project=isk",
     "test:e2e-isk-debug": "npm run test:e2e-isk -- --debug",
     "changelog": "node bin/changelog.js",

--- a/tests/e2e/AGENTS.md
+++ b/tests/e2e/AGENTS.md
@@ -18,7 +18,7 @@ For repository-wide rules, always read the root `AGENTS.md` first.
 | --- | --- | --- |
 | Full setup | `npm run test:e2e-setup -- --base_url=<url>` | Remote setup path. Can install/configure WooCommerce and Stripe settings. |
 | Run default project | `npm run test:e2e -- --base_url=<url>` | Uses `default` Playwright project. |
-| Run specific project | `npm run test:e2e-run -- --project=<name> --base_url=<url>` | Project names include `default`, `acss`, `becs`, `blik`, `optimized-checkout`. |
+| Run specific project | `npm run test:e2e-run -- --project=<name> --base_url=<url>` | Project names include `default`, `acss`, `becs`, `blik`, `eur-lpms`, `optimized-checkout`. |
 | Debug run | `npm run test:e2e-debug -- --base_url=<url>` | Playwright debug mode. |
 | Docker setup/run | `npm run test:e2e-setup` then `npm run test:e2e` | Local Docker path (`http://localhost:8088`). |
 | Tear down Docker | `npm run test:e2e-down` | Stops E2E containers. |

--- a/tests/e2e/config/playwright.config.js
+++ b/tests/e2e/config/playwright.config.js
@@ -91,6 +91,9 @@ const config = {
 				'**/blik.spec.js',
 				'**/becs.spec.js',
 				'**/isk.spec.js',
+				'**/sepa.spec.js',
+				'**/ideal.spec.js',
+				'**/bancontact.spec.js',
 			],
 			dependencies: [ 'default-setup' ],
 			use: { ...devices[ 'Desktop Chrome' ] },
@@ -133,6 +136,21 @@ const config = {
 			name: 'optimized-checkout',
 			testMatch: '**/*optimized-checkout.spec.js',
 			dependencies: [ 'oc-setup' ],
+			use: { ...devices[ 'Desktop Chrome' ] },
+		},
+		{
+			name: 'eur-lpms-setup',
+			testMatch: '/eur-lpms.setup.js',
+			use: { ...devices[ 'Desktop Chrome' ] },
+		},
+		{
+			name: 'eur-lpms',
+			testMatch: [
+				'**/sepa.spec.js',
+				'**/ideal.spec.js',
+				'**/bancontact.spec.js',
+			],
+			dependencies: [ 'eur-lpms-setup' ],
 			use: { ...devices[ 'Desktop Chrome' ] },
 		},
 		{

--- a/tests/e2e/test-data/default.json
+++ b/tests/e2e/test-data/default.json
@@ -133,6 +133,66 @@
 				"country_iso": "AU"
 			}
 		},
+		"customer_netherlands": {
+			"billing": {
+				"first_name": "Customer",
+				"last_name": "Customerson",
+				"company": "",
+				"country": "Netherlands",
+				"country_iso": "NL",
+				"address_1": "Kalverstraat 1",
+				"address_2": "billing",
+				"city": "Amsterdam",
+				"state": "",
+				"state_iso": "",
+				"postcode": "1012 NX",
+				"phone": "2025550104",
+				"email": "e2e-customer-billing@woocommerce.com"
+			},
+			"shipping": {
+				"first_name": "Recipient",
+				"last_name": "Recipientson",
+				"company": "",
+				"country": "Netherlands",
+				"country_iso": "NL",
+				"address_1": "Kalverstraat 1",
+				"address_2": "shipping",
+				"city": "Amsterdam",
+				"state": "",
+				"state_iso": "",
+				"postcode": "1012 NX"
+			}
+		},
+		"customer_belgium": {
+			"billing": {
+				"first_name": "Customer",
+				"last_name": "Customerson",
+				"company": "",
+				"country": "Belgium",
+				"country_iso": "BE",
+				"address_1": "Grasmarkt 1",
+				"address_2": "billing",
+				"city": "Brussels",
+				"state": "",
+				"state_iso": "",
+				"postcode": "1000",
+				"phone": "2025550104",
+				"email": "e2e-customer-billing@woocommerce.com"
+			},
+			"shipping": {
+				"first_name": "Recipient",
+				"last_name": "Recipientson",
+				"company": "",
+				"country": "Belgium",
+				"country_iso": "BE",
+				"address_1": "Grasmarkt 1",
+				"address_2": "shipping",
+				"city": "Brussels",
+				"state": "",
+				"state_iso": "",
+				"postcode": "1000"
+			}
+		},
 		"customer_poland": {
 			"billing": {
 				"first_name": "Customer",
@@ -351,6 +411,9 @@
 			"cvc": "626",
 			"label": "3DS not supported"
 		}
+	},
+	"sepa": {
+		"iban": "AT611904300234573201"
 	},
 	"becs": {
 		"valid": {

--- a/tests/e2e/tests/checkout/blocks/lpms/bancontact.spec.js
+++ b/tests/e2e/tests/checkout/blocks/lpms/bancontact.spec.js
@@ -1,0 +1,25 @@
+import { test } from '@playwright/test';
+import config from 'config';
+import { payments } from '../../../../utils';
+
+const {
+	clickPlaceOrder,
+	setupEuroLPMCheckout,
+	handleHostedTestPaymentPage,
+	waitForOrderReceivedPage,
+} = payments;
+
+test.describe( 'Bancontact payment tests @blocks @bancontact', () => {
+	test( 'customer can pay with Bancontact', async ( { page } ) => {
+		await setupEuroLPMCheckout(
+			page,
+			'Bancontact',
+			config.get( 'addresses.customer_belgium.billing' ),
+			'blocks'
+		);
+
+		await clickPlaceOrder( page );
+		await handleHostedTestPaymentPage( page );
+		await waitForOrderReceivedPage( page );
+	} );
+} );

--- a/tests/e2e/tests/checkout/blocks/lpms/ideal.spec.js
+++ b/tests/e2e/tests/checkout/blocks/lpms/ideal.spec.js
@@ -1,0 +1,25 @@
+import { test } from '@playwright/test';
+import config from 'config';
+import { payments } from '../../../../utils';
+
+const {
+	clickPlaceOrder,
+	setupEuroLPMCheckout,
+	handleHostedTestPaymentPage,
+	waitForOrderReceivedPage,
+} = payments;
+
+test.describe( 'iDEAL payment tests @blocks @ideal', () => {
+	test( 'customer can pay with iDEAL', async ( { page } ) => {
+		await setupEuroLPMCheckout(
+			page,
+			'iDEAL | Wero',
+			config.get( 'addresses.customer_netherlands.billing' ),
+			'blocks'
+		);
+
+		await clickPlaceOrder( page );
+		await handleHostedTestPaymentPage( page );
+		await waitForOrderReceivedPage( page );
+	} );
+} );

--- a/tests/e2e/tests/checkout/blocks/lpms/sepa.spec.js
+++ b/tests/e2e/tests/checkout/blocks/lpms/sepa.spec.js
@@ -1,0 +1,94 @@
+import { test } from '@playwright/test';
+import { randomUUID } from 'crypto';
+import config from 'config';
+import { payments, api, user } from '../../../../utils';
+
+const {
+	clickPlaceOrder,
+	emptyCart,
+	setupCart,
+	setupBlocksCheckout,
+	setupEuroLPMCheckout,
+	fillSepaDetails,
+	waitForOrderReceivedPage,
+} = payments;
+
+test.describe( 'SEPA Direct Debit payment tests @blocks @sepa', () => {
+	let username, userEmail;
+
+	test.beforeAll( async () => {
+		// Create test user.
+		const randomString = randomUUID();
+		userEmail = randomString + '+' + config.get( 'users.customer.email' );
+		username = randomString + '.' + config.get( 'users.customer.username' );
+
+		const testUser = {
+			...config.get( 'users.customer' ),
+			...config.get( 'addresses.customer_netherlands' ),
+			email: userEmail,
+			username,
+		};
+		await api.create.customer( testUser );
+	} );
+
+	test.describe.configure( { mode: 'parallel' } );
+
+	test( 'customer can pay with SEPA Direct Debit', async ( { page } ) => {
+		await setupEuroLPMCheckout(
+			page,
+			'SEPA Direct Debit',
+			config.get( 'addresses.customer_netherlands.billing' ),
+			'blocks'
+		);
+		await fillSepaDetails( page, config.get( 'sepa.iban' ), 'blocks' );
+
+		await clickPlaceOrder( page );
+		await waitForOrderReceivedPage( page );
+	} );
+
+	test( 'customer can save and reuse SEPA Direct Debit', async ( {
+		page,
+	} ) => {
+		// First order - Save the payment method.
+		await test.step( 'Save payment method during first checkout', async () => {
+			await user.login(
+				page,
+				username,
+				config.get( 'users.customer.password' )
+			);
+			await setupEuroLPMCheckout(
+				page,
+				'SEPA Direct Debit',
+				config.get( 'addresses.customer_netherlands.billing' ),
+				'blocks'
+			);
+			await fillSepaDetails( page, config.get( 'sepa.iban' ), 'blocks' );
+
+			await page
+				.locator(
+					'.wc-block-components-payment-methods__save-card-info'
+				)
+				.click();
+
+			await clickPlaceOrder( page );
+			await waitForOrderReceivedPage( page );
+		} );
+
+		// Second order - Use saved payment method.
+		await test.step( 'Use saved payment method for second checkout', async () => {
+			await emptyCart( page );
+			await setupCart( page );
+			await setupBlocksCheckout(
+				page,
+				config.get( 'addresses.customer_netherlands.billing' )
+			);
+			await page
+				.locator( 'label' )
+				.filter( { hasText: 'SEPA IBAN ending in' } )
+				.click();
+
+			await clickPlaceOrder( page );
+			await waitForOrderReceivedPage( page );
+		} );
+	} );
+} );

--- a/tests/e2e/tests/checkout/shortcode/lpms/bancontact.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/lpms/bancontact.spec.js
@@ -1,0 +1,25 @@
+import { test } from '@playwright/test';
+import config from 'config';
+import { payments } from '../../../../utils';
+
+const {
+	clickPlaceOrder,
+	setupEuroLPMCheckout,
+	handleHostedTestPaymentPage,
+	waitForOrderReceivedPage,
+} = payments;
+
+test.describe( 'Bancontact payment tests @shortcode @bancontact', () => {
+	test( 'customer can pay with Bancontact', async ( { page } ) => {
+		await setupEuroLPMCheckout(
+			page,
+			'Bancontact',
+			config.get( 'addresses.customer_belgium.billing' ),
+			'shortcode'
+		);
+
+		await clickPlaceOrder( page );
+		await handleHostedTestPaymentPage( page );
+		await waitForOrderReceivedPage( page );
+	} );
+} );

--- a/tests/e2e/tests/checkout/shortcode/lpms/ideal.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/lpms/ideal.spec.js
@@ -1,0 +1,25 @@
+import { test } from '@playwright/test';
+import config from 'config';
+import { payments } from '../../../../utils';
+
+const {
+	clickPlaceOrder,
+	setupEuroLPMCheckout,
+	handleHostedTestPaymentPage,
+	waitForOrderReceivedPage,
+} = payments;
+
+test.describe( 'iDEAL payment tests @shortcode @ideal', () => {
+	test( 'customer can pay with iDEAL', async ( { page } ) => {
+		await setupEuroLPMCheckout(
+			page,
+			'iDEAL | Wero',
+			config.get( 'addresses.customer_netherlands.billing' ),
+			'shortcode'
+		);
+
+		await clickPlaceOrder( page );
+		await handleHostedTestPaymentPage( page );
+		await waitForOrderReceivedPage( page );
+	} );
+} );

--- a/tests/e2e/tests/checkout/shortcode/lpms/sepa.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/lpms/sepa.spec.js
@@ -1,0 +1,106 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'crypto';
+import config from 'config';
+import { payments, api, user } from '../../../../utils';
+
+const {
+	clickPlaceOrder,
+	emptyCart,
+	setupCart,
+	setupShortcodeCheckout,
+	setupEuroLPMCheckout,
+	fillSepaDetails,
+	waitForOrderReceivedPage,
+} = payments;
+
+test.describe( 'SEPA Direct Debit payment tests @shortcode @sepa', () => {
+	let username, userEmail;
+
+	test.beforeAll( async () => {
+		// Create test user.
+		const randomString = randomUUID();
+		userEmail = randomString + '+' + config.get( 'users.customer.email' );
+		username = randomString + '.' + config.get( 'users.customer.username' );
+
+		const testUser = {
+			...config.get( 'users.customer' ),
+			...config.get( 'addresses.customer_netherlands' ),
+			email: userEmail,
+			username,
+		};
+		await api.create.customer( testUser );
+	} );
+
+	test.describe.configure( { mode: 'parallel' } );
+
+	test( 'customer can pay with SEPA Direct Debit', async ( { page } ) => {
+		await setupEuroLPMCheckout(
+			page,
+			'SEPA Direct Debit',
+			config.get( 'addresses.customer_netherlands.billing' ),
+			'shortcode'
+		);
+		await fillSepaDetails( page, config.get( 'sepa.iban' ), 'shortcode' );
+
+		await clickPlaceOrder( page );
+		await waitForOrderReceivedPage( page );
+	} );
+
+	test( 'customer can save and reuse SEPA Direct Debit', async ( {
+		page,
+	} ) => {
+		// First order - Save the payment method.
+		await test.step( 'Save payment method during first checkout', async () => {
+			await user.login(
+				page,
+				username,
+				config.get( 'users.customer.password' )
+			);
+			await setupEuroLPMCheckout(
+				page,
+				'SEPA Direct Debit',
+				config.get( 'addresses.customer_netherlands.billing' ),
+				'shortcode'
+			);
+			await fillSepaDetails(
+				page,
+				config.get( 'sepa.iban' ),
+				'shortcode'
+			);
+
+			await page
+				.getByRole( 'checkbox', {
+					name: 'Save payment information to',
+				} )
+				.click();
+
+			await clickPlaceOrder( page );
+			await waitForOrderReceivedPage( page );
+		} );
+
+		// Second order - Use saved payment method.
+		await test.step( 'Use saved payment method for second checkout', async () => {
+			await emptyCart( page );
+			await setupCart( page );
+			await setupShortcodeCheckout(
+				page,
+				config.get( 'addresses.customer_netherlands.billing' )
+			);
+			await page
+				.getByText( 'SEPA Direct Debit', { exact: true } )
+				.click();
+			await expect(
+				page.locator(
+					'.woocommerce-SavedPaymentMethods-token input[id^="wc-stripe_sepa_debit-payment-token-"]'
+				)
+			).toHaveCount( 1 );
+			await page
+				.locator( '.woocommerce-SavedPaymentMethods-token' )
+				.first()
+				.click();
+
+			await clickPlaceOrder( page );
+			await waitForOrderReceivedPage( page );
+		} );
+	} );
+} );

--- a/tests/e2e/tests/eur-lpms.setup.js
+++ b/tests/e2e/tests/eur-lpms.setup.js
@@ -1,0 +1,15 @@
+import { test as setup } from '@playwright/test';
+import { admin } from '../utils';
+
+setup( 'Configure store for EUR LPM tests', async ( { browser } ) => {
+	// Change store currency to EUR. SEPA, iDEAL, and Bancontact are only
+	// available for euro-denominated payments; the default Stripe account
+	// supports them, so no account/key switch is needed.
+	await admin.updateStoreCurrency( browser, 'EUR' );
+
+	// Enable the EUR payment methods in the admin. SEPA Direct Debit is
+	// listed as "Direct debit payment" in the admin methods panel.
+	await admin.togglePaymentMethod( browser, 'Direct debit payment', true );
+	await admin.togglePaymentMethod( browser, 'iDEAL | Wero', true );
+	await admin.togglePaymentMethod( browser, 'Bancontact', true );
+} );

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -1077,6 +1077,102 @@ export const fillBECSDetails = async ( page, checkoutType = 'blocks' ) => {
 };
 
 /**
+ * Set up the checkout page for a euro-denominated local payment method
+ * (SEPA Direct Debit, iDEAL, Bancontact).
+ *
+ * These methods share the same selection flow and only differ in the method
+ * label and the shopper billing country they are restricted to.
+ *
+ * @param {Page} page Playwright page fixture.
+ * @param {string} methodLabel The payment method label shown at checkout (e.g. 'SEPA Direct Debit').
+ * @param {Object} billingDetails The billing details in the format provided on the test-data.
+ * @param {string} checkoutType The type of checkout ('blocks' or 'shortcode').
+ */
+export const setupEuroLPMCheckout = async (
+	page,
+	methodLabel,
+	billingDetails,
+	checkoutType = 'blocks'
+) => {
+	await emptyCart( page );
+	await setupCart( page );
+
+	if ( checkoutType === 'blocks' ) {
+		await setupBlocksCheckout( page, billingDetails );
+
+		const methodOptionLabel = page
+			.locator( 'label' )
+			.filter( { hasText: methodLabel } );
+		await methodOptionLabel.waitFor( { state: 'visible' } );
+		await methodOptionLabel.dispatchEvent( 'click' );
+	} else {
+		await setupShortcodeCheckout( page, billingDetails );
+
+		const methodOptionLabel = page.getByText( methodLabel, {
+			exact: true,
+		} );
+		await methodOptionLabel.waitFor( { state: 'visible' } );
+		await methodOptionLabel.dispatchEvent( 'click' );
+	}
+};
+
+/**
+ * Interact with the Stripe Elements iframe to fill in the SEPA IBAN.
+ *
+ * @param {Page} page Playwright page fixture.
+ * @param {string} iban The IBAN to pay with.
+ * @param {string} checkoutType The type of checkout ('blocks' or 'shortcode').
+ */
+export const fillSepaDetails = async (
+	page,
+	iban,
+	checkoutType = 'blocks'
+) => {
+	let frameHandle;
+	if ( checkoutType === 'shortcode' ) {
+		frameHandle = await page.waitForSelector(
+			'.wc_payment_method.payment_method_stripe_sepa_debit iframe[src*="elements-inner-payment"]'
+		);
+	} else {
+		frameHandle = await page.waitForSelector(
+			'#radio-control-wc-payment-method-options-stripe_sepa_debit__content iframe[src*="elements-inner-payment"]'
+		);
+	}
+
+	const stripeFrame = await frameHandle.contentFrame();
+
+	await expect( stripeFrame.locator( '[name="iban"]' ) ).toBeVisible( {
+		timeout: 30000,
+	} );
+
+	await stripeFrame.locator( '[name="iban"]' ).fill( iban );
+};
+
+/**
+ * Complete a redirect-based payment on Stripe's hosted test page.
+ *
+ * In test mode, redirect methods (e.g. iDEAL, Bancontact) send the shopper to
+ * a Stripe-hosted page where the payment outcome is chosen manually instead of
+ * a real bank flow.
+ *
+ * @param {Page} page Playwright page fixture.
+ * @param {string} action The payment outcome to pick ('authorize' or 'fail').
+ */
+export const handleHostedTestPaymentPage = async (
+	page,
+	action = 'authorize'
+) => {
+	const linkName =
+		action === 'authorize' ? 'Authorize Test Payment' : 'Fail Test Payment';
+
+	// The hosted page is reached via a full-page redirect after placing the
+	// order, so give it the same generous timeout used for other Stripe pages.
+	const actionLink = page.getByRole( 'link', { name: linkName } );
+	await expect( actionLink ).toBeVisible( { timeout: 30000 } );
+	await actionLink.click();
+};
+
+/**
  * Set up the checkout page for Affirm payment.
  *
  * @param {Page} page Playwright page fixture.


### PR DESCRIPTION
## Description

Closes the largest gap in our in-repo Playwright coverage: none of the EUR redirect/debit payment methods had E2E tests. This PR adds coverage for **SEPA Direct Debit**, **iDEAL**, and **Bancontact** on both the classic (shortcode) and Blocks checkout surfaces.

The three methods share a new `eur-lpms` Playwright project because they all require the store currency to be EUR. Unlike `blik` (PL account) and `becs` (AU account), they are supported by the default Stripe test account, so the project only switches the store currency and enables the methods — no key swap or account teardown is needed (same pattern as `acss`).

### Coverage added

| Method | Classic | Blocks | Notes |
| --- | --- | --- | --- |
| SEPA Direct Debit | pay + save/reuse | pay + save/reuse | Fills test IBAN in the payment element; reuses the saved `stripe_sepa_debit` token |
| iDEAL | pay | pay | Redirect flow — authorizes on Stripe's hosted test page |
| Bancontact | pay | pay | Redirect flow — authorizes on Stripe's hosted test page |

New shared helpers in `tests/e2e/utils/payments.js`: `setupEuroLPMCheckout`, `fillSepaDetails`, and `handleHostedTestPaymentPage` (reusable for other redirect-based methods later).

Also:
- `eur-lpms` added to the CI matrix in `e2e-tests.yml` (uses the default `E2E_STRIPE_*` secrets).
- `npm run test:e2e-lpm-eur[-debug]` convenience scripts, matching the other LPM projects.
- NL/BE customer addresses and a SEPA test IBAN added to the E2E test data.

iDEAL and Bancontact are pay-only for now: their save/reuse (SEPA tokens for iDEAL/Bancontact) is behind a feature flag, so token coverage for those flows is left as a follow-up.

## Backward compatibility

None — test/CI-only change; no runtime code touched.

## Testing instructions

1. `npm run test:e2e-setup` (Docker path) with test-mode Stripe keys in `tests/e2e/config/local.env`.
2. `npm run test:e2e-lpm-eur`.

Verified locally against the Docker environment (WP 7.0.2 / WC 10.9.4): all 9 tests (setup + 8 specs) passed in two consecutive runs with retries disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)