### PR TITLE
Show a re-authentication notice when settings sync is disabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -78,6 +78,7 @@ xxxx-xx-xx - version 10.9.0
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Add - Show a notice on the payment methods settings page asking merchants to re-authenticate their Stripe connection when payment method settings can no longer be synced with Stripe
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/client/settings/payment-methods/index.js
+++ b/client/settings/payment-methods/index.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 import AmazonPayTaxesBillingAddressNotice from 'wcstripe/components/amazon-pay-taxes-billing-address-notice';
 import PromotionalBanner from 'wcstripe/settings/payment-settings/promotional-banner';
 import OptimizedCheckoutNotice from 'wcstripe/settings/optimized-checkout-notice';
+import SettingsSyncDisabledNotice from 'wcstripe/settings/settings-sync-disabled-notice';
 
 const PaymentMethodsDescription = () => {
 	return (
@@ -82,6 +83,7 @@ const PaymentMethodsPanel = ( {
 				</SettingsSection>
 			) }
 			<SettingsSection Description={ PaymentMethodsDescription }>
+				<SettingsSyncDisabledNotice />
 				<DisplayOrderCustomizationNotice isOCEnabled={ isOCEnabled } />
 				<OptimizedCheckoutNotice isOCEnabled={ isOCEnabled } />
 				<GeneralSettingsSection onSaveChanges={ onSaveChanges } />

--- a/client/settings/settings-sync-disabled-notice/__tests__/index.test.js
+++ b/client/settings/settings-sync-disabled-notice/__tests__/index.test.js
@@ -1,0 +1,145 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SettingsSyncDisabledNotice from '..';
+import { useDispatch } from '@wordpress/data';
+import { recordEvent } from 'wcstripe/tracking';
+import { useTestMode } from 'wcstripe/data';
+
+const noticesDispatch = {
+	createErrorNotice: jest.fn(),
+};
+
+jest.mock( '@wordpress/data' );
+
+jest.mock( 'wcstripe/data', () => ( {
+	useTestMode: jest.fn(),
+} ) );
+
+jest.mock( 'wcstripe/tracking', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+describe( 'SettingsSyncDisabledNotice', () => {
+	const globalValues = global.wc_stripe_settings_params;
+
+	beforeEach( () => {
+		global.wc_stripe_settings_params = {
+			...globalValues,
+			is_pmc_sync_disabled: '1',
+			oauth_nonce: 'test-nonce',
+		};
+		global.ajaxurl = '/wp-admin/admin-ajax.php';
+		useDispatch.mockImplementation( ( storeName ) => {
+			if ( storeName === 'core/notices' ) {
+				return noticesDispatch;
+			}
+
+			return {};
+		} );
+		useTestMode.mockReturnValue( [ false, jest.fn() ] );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+		global.wc_stripe_settings_params = globalValues;
+	} );
+
+	it( 'should render the notice when settings sync is disabled', () => {
+		render( <SettingsSyncDisabledNotice /> );
+
+		expect(
+			screen.queryAllByText(
+				'Your payment method settings are no longer synced with your Stripe account. To restore syncing, please re-authenticate your Stripe account connection.'
+			)?.[ 0 ]
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'button', { name: 'Re-authenticate' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should not render the notice when settings sync is not disabled', () => {
+		global.wc_stripe_settings_params.is_pmc_sync_disabled = '';
+
+		const { container } = render( <SettingsSyncDisabledNotice /> );
+
+		expect( container.firstChild ).toBeNull();
+	} );
+
+	it( 'should fetch the OAuth URL and redirect on button click', async () => {
+		Object.defineProperty( window, 'location', {
+			value: { assign: jest.fn() },
+		} );
+
+		const oauthUrl = 'http://example.com/oauth';
+		global.jQuery = {
+			ajax: jest.fn().mockResolvedValue( {
+				success: true,
+				data: { oauth_url: oauthUrl },
+			} ),
+		};
+
+		render( <SettingsSyncDisabledNotice /> );
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'Re-authenticate' } )
+		);
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'wcstripe_reconnect_button_click',
+			{
+				source: 'settings-sync-disabled-notice',
+				mode: 'live',
+			}
+		);
+		expect( global.jQuery.ajax ).toHaveBeenCalledWith( {
+			url: '/wp-admin/admin-ajax.php',
+			method: 'POST',
+			data: {
+				action: 'wc_stripe_get_oauth_url',
+				mode: 'live',
+				nonce: 'test-nonce',
+			},
+		} );
+		await waitFor( () =>
+			expect( window.location.assign ).toHaveBeenCalledWith( oauthUrl )
+		);
+	} );
+
+	it( 'should use test mode when test mode is enabled', async () => {
+		useTestMode.mockReturnValue( [ true, jest.fn() ] );
+		global.jQuery = {
+			ajax: jest.fn().mockResolvedValue( {
+				success: true,
+				data: { oauth_url: 'http://example.com/oauth' },
+			} ),
+		};
+
+		render( <SettingsSyncDisabledNotice /> );
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'Re-authenticate' } )
+		);
+
+		expect( global.jQuery.ajax ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				data: expect.objectContaining( { mode: 'test' } ),
+			} )
+		);
+	} );
+
+	it( 'should show an error notice when fetching the OAuth URL fails', async () => {
+		global.jQuery = {
+			ajax: jest.fn().mockResolvedValue( { success: false } ),
+		};
+
+		render( <SettingsSyncDisabledNotice /> );
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'Re-authenticate' } )
+		);
+
+		await waitFor( () =>
+			expect( noticesDispatch.createErrorNotice ).toHaveBeenCalledWith(
+				'There was an error. Please reload the page and try again.'
+			)
+		);
+	} );
+} );

--- a/client/settings/settings-sync-disabled-notice/index.js
+++ b/client/settings/settings-sync-disabled-notice/index.js
@@ -1,0 +1,99 @@
+/* global wc_stripe_settings_params, ajaxurl */
+import React, { useState } from 'react';
+import styled from '@emotion/styled';
+import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { recordEvent } from 'wcstripe/tracking';
+import { useTestMode } from 'wcstripe/data';
+
+const NoticeWrapper = styled( Notice )`
+	margin: 0 0 24px 0;
+`;
+
+/**
+ * Warning shown when the account is connected but payment method settings can no longer
+ * be synced with Stripe (e.g. legacy connections without a usable Payment Method
+ * Configuration). Re-authenticating through the OAuth flow restores syncing.
+ */
+const SettingsSyncDisabledNotice = () => {
+	const [ isTestModeEnabled ] = useTestMode();
+	const { createErrorNotice } = useDispatch( 'core/notices' );
+	const [ isLoading, setIsLoading ] = useState( false );
+
+	// eslint-disable-next-line camelcase
+	if ( ! wc_stripe_settings_params?.is_pmc_sync_disabled ) {
+		return null;
+	}
+
+	const handleReauthenticate = async () => {
+		if ( isLoading ) {
+			return;
+		}
+
+		const mode = isTestModeEnabled ? 'test' : 'live';
+
+		recordEvent( 'wcstripe_reconnect_button_click', {
+			source: 'settings-sync-disabled-notice',
+			mode,
+		} );
+
+		setIsLoading( true );
+
+		try {
+			const response = await jQuery.ajax( {
+				url: ajaxurl,
+				method: 'POST',
+				data: {
+					action: 'wc_stripe_get_oauth_url',
+					mode,
+					nonce: wc_stripe_settings_params.oauth_nonce, // eslint-disable-line camelcase
+				},
+			} );
+
+			if ( response.success && response.data.oauth_url ) {
+				window.location.assign( response.data.oauth_url );
+			} else {
+				createErrorNotice(
+					__(
+						'There was an error. Please reload the page and try again.',
+						'woocommerce-gateway-stripe'
+					)
+				);
+				setIsLoading( false );
+			}
+		} catch ( err ) {
+			createErrorNotice(
+				__(
+					'There was an error. Please reload the page and try again.',
+					'woocommerce-gateway-stripe'
+				)
+			);
+			setIsLoading( false );
+		}
+	};
+
+	return (
+		<NoticeWrapper
+			status="warning"
+			isDismissible={ false }
+			actions={ [
+				{
+					label: __(
+						'Re-authenticate',
+						'woocommerce-gateway-stripe'
+					),
+					onClick: handleReauthenticate,
+					variant: 'secondary',
+				},
+			] }
+		>
+			{ __(
+				'Your payment method settings are no longer synced with your Stripe account. To restore syncing, please re-authenticate your Stripe account connection.',
+				'woocommerce-gateway-stripe'
+			) }
+		</NoticeWrapper>
+	);
+};
+
+export default SettingsSyncDisabledNotice;

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -253,6 +253,9 @@ class WC_Stripe_Settings_Controller {
 			'are_apms_deprecated'                   => false,
 			'is_oc_available'                       => WC_Stripe_Feature_Flags::is_oc_available(),
 			'is_oc_enabled'                         => $is_oc_enabled,
+			// Settings sync is only reported as disabled for connected accounts: is_enabled() is also
+			// false when there is no connection at all, but in that case the connect UI is shown instead.
+			'is_pmc_sync_disabled'                  => WC_Stripe_Helper::is_connected() && ! WC_Stripe_Payment_Method_Configurations::is_enabled(),
 			'is_cs_available'                       => $is_checkout_sessions_available,
 			'adaptive_pricing_unavailable_reason'   => $adaptive_pricing_unavailable_reason,
 			'oc_layout'                             => $this->get_gateway()->get_validated_option( 'optimized_checkout_layout' ),

--- a/readme.txt
+++ b/readme.txt
@@ -235,5 +235,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Add - Show a notice on the payment methods settings page asking merchants to re-authenticate their Stripe connection when payment method settings can no longer be synced with Stripe
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-537

## Changes proposed in this Pull Request:

When settings sync is disabled for a connected account (`pmc_enabled` set to `no` because no usable Payment Method Configuration was found — typically legacy connections not linked to the WooCommerce platform), the plugin silently falls back to locally stored payment method settings and features like the Optimized Checkout become unavailable, with no explanation to the merchant.

This PR adds a warning notice on the **Payment Methods** settings tab telling merchants their payment method settings are no longer synced with Stripe, with a **Re-authenticate** action that launches the Stripe Connect OAuth flow. Completing OAuth creates a platform-linked Payment Method Configuration, which restores sync eligibility (the `pmc_enabled` flag is also re-checked after re-connecting and on plugin upgrade).

Implementation:

- `includes/admin/class-wc-stripe-settings-controller.php`: expose an `is_pmc_sync_disabled` flag in `wc_stripe_settings_params` (true only when the account is connected and `WC_Stripe_Payment_Method_Configurations::is_enabled()` is false, so a not-yet-attempted migration or a disconnected account doesn't trigger the notice).
- `client/settings/settings-sync-disabled-notice/`: new non-dismissible warning notice; the Re-authenticate action reuses the existing `wc_stripe_get_oauth_url` AJAX flow (same as the reconnect promotional banner and connect buttons) and records a `wcstripe_reconnect_button_click` tracks event with a distinct `source`.
- Rendered at the top of the payment methods panel, above the existing display-order and Optimized Checkout notices.

**Backward compatibility impact:** none. This only adds a new key to the `wc_stripe_settings_params` localized script data and a new admin-only React component; no hooks, signatures, option keys, or checkout behavior change.

## Testing instructions

- Check out this branch (`stripe-537-linear-issue`) and run `npm run build:webpack`
- Connect your Stripe account
- Disable settings sync by running: `wp option patch update woocommerce_stripe_settings pmc_enabled 'no'`
- Go to **WooCommerce → Settings → Payments → Stripe** (Payment Methods tab)
- Confirm a warning notice appears above the payment methods list: "Your payment method settings are no longer synced with your Stripe account. To restore syncing, please re-authenticate your Stripe account connection."
- Click **Re-authenticate** and confirm you are redirected to the Stripe Connect OAuth page
- Restore sync (`wp option patch update woocommerce_stripe_settings pmc_enabled 'yes'`), reload the settings page, and confirm the notice is gone
- Also confirm the notice does not appear when no Stripe account is connected

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
