### PR TITLE
Agentic Commerce: document the coupon limitation and reject discounted sessions explicitly

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -79,6 +79,7 @@ xxxx-xx-xx - version 10.9.0
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Update - Document that WooCommerce coupons and their usage limits do not apply to agentic checkout, and reject discounted agentic sessions with an explicit error instead of an opaque total mismatch
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/changelog.txt
+++ b/changelog.txt
@@ -79,7 +79,7 @@ xxxx-xx-xx - version 10.9.0
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
-* Update - Document that WooCommerce coupons and their usage limits do not apply to agentic checkout, and reject discounted agentic sessions with an explicit error instead of an opaque total mismatch
+* Update - Document that WooCommerce coupons do not apply to in-agent agentic purchases and reject discounted agentic sessions with an explicit error
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/client/settings/agentic-commerce/index.js
+++ b/client/settings/agentic-commerce/index.js
@@ -48,7 +48,7 @@ const AgenticCommerceDescription = () => (
 		</p>
 		<p>
 			{ __(
-				'WooCommerce coupons and their usage limits do not apply to purchases completed inside AI agents.',
+				'WooCommerce coupons and their usage limits do not apply to purchases completed inside AI agents. Purchases redirected to your store use the standard checkout, where coupons work as usual.',
 				'woocommerce-gateway-stripe'
 			) }
 		</p>

--- a/client/settings/agentic-commerce/index.js
+++ b/client/settings/agentic-commerce/index.js
@@ -47,6 +47,12 @@ const AgenticCommerceDescription = () => (
 			) }
 		</p>
 		<p>
+			{ __(
+				'WooCommerce coupons and their usage limits do not apply to purchases completed inside AI agents.',
+				'woocommerce-gateway-stripe'
+			) }
+		</p>
+		<p>
 			<ExternalLink href="https://docs.stripe.com/agentic-commerce">
 				{ __(
 					'Learn more about agentic commerce',

--- a/includes/agentic-commerce/README.md
+++ b/includes/agentic-commerce/README.md
@@ -364,3 +364,13 @@ add_filter(
 ```
 
 > The Stripe-prefixed `wc_stripe_agentic_commerce_disable_checkout` filter is **deprecated since 10.9.0** in favour of the shareable `woocommerce_agentic_commerce_disable_checkout` above (mirroring the `woocommerce_agentic_commerce_should_sync_product` migration). Existing hooks on the old name still run — they seed the new filter's default — but emit a deprecation notice.
+
+## Coupons and discounts
+
+WooCommerce coupons do not participate in delegated (in-agent) checkout. Prices come from the synced product feed and are computed by Stripe, the shopper pays inside the AI agent, and the WooCommerce order is only created afterwards from the completed session. Consequences merchants should be aware of:
+
+- No WooCommerce coupon is ever applied to an agentic order — agentic shoppers pay the feed price.
+- WooCommerce coupon **usage limits are neither enforced nor consumed** by agentic sales. A limited-use coupon promotion does not cap, count, or discount purchases completed inside an agent.
+- Stripe-side discounts are rejected at order creation: a session whose `total_details.amount_discount` is non-zero fails with an explicit error (WooCommerce recalculates full catalog prices, so such an order could never pass total verification). Because Stripe captures payment before the webhook fires, the failure surfaces in logs for manual resolution.
+
+Whether to support promotions in agentic checkout (mapping Stripe discounts to WooCommerce coupons and enforcing usage limits at `finalize_checkout`) is an open product decision, tracked in STRIPE-1257.

--- a/includes/agentic-commerce/README.md
+++ b/includes/agentic-commerce/README.md
@@ -373,4 +373,6 @@ WooCommerce coupons do not participate in delegated (in-agent) checkout. Prices 
 - WooCommerce coupon **usage limits are neither enforced nor consumed** by agentic sales. A limited-use coupon promotion does not cap, count, or discount purchases completed inside an agent.
 - Stripe-side discounts are rejected at order creation: a session whose `total_details.amount_discount` is non-zero fails with an explicit error (WooCommerce recalculates full catalog prices, so such an order could never pass total verification). Because Stripe captures payment before the webhook fires, the failure surfaces in logs for manual resolution.
 
-Whether to support promotions in agentic checkout (mapping Stripe discounts to WooCommerce coupons and enforcing usage limits at `finalize_checkout`) is an open product decision, tracked in STRIPE-1257.
+This limitation only affects delegated (in-agent) purchases. In feed-only / redirect mode (see [Checkout Mode](#checkout-mode-embedded-vs-redirect) above) the shopper completes checkout on the store, where WooCommerce coupons and their usage limits apply as usual.
+
+Whether to support promotions in delegated checkout (mapping Stripe discounts to WooCommerce coupons and enforcing usage limits at `finalize_checkout`) is an open product decision, tracked in STRIPE-1257.

--- a/includes/agentic-commerce/class-wc-stripe-agentic-checkout-session.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-checkout-session.php
@@ -94,6 +94,16 @@ class WC_Stripe_Agentic_Checkout_Session {
 	}
 
 	/**
+	 * Returns the aggregate discount amount in the smallest currency unit, or 0 when absent.
+	 *
+	 * @since 10.9.0
+	 * @return int
+	 */
+	public function get_amount_discount(): int {
+		return (int) ( $this->session->total_details->amount_discount ?? 0 );
+	}
+
+	/**
 	 * Returns the customer email, falling back from customer_details to customer_email.
 	 * Returns null when neither source is present.
 	 *

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
@@ -124,6 +124,21 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 				)
 			);
 		}
+
+		// WooCommerce coupons don't participate in delegated checkout, so a
+		// Stripe-side discount can't be represented on the order — WC
+		// recalculates full catalog prices, and the total verification would
+		// reject the order anyway after it was built. Fail fast with an
+		// explicit reason instead of an opaque total mismatch.
+		if ( $session->get_amount_discount() > 0 ) {
+			throw new Exception(
+				sprintf(
+					'Checkout session %s includes a discount (%d): discounts are not supported for agentic checkout orders.',
+					$session->get_id(),
+					$session->get_amount_discount()
+				)
+			);
+		}
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -236,5 +236,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Update - Document that WooCommerce coupons and their usage limits do not apply to agentic checkout, and reject discounted agentic sessions with an explicit error instead of an opaque total mismatch
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -236,6 +236,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
-* Update - Document that WooCommerce coupons and their usage limits do not apply to agentic checkout, and reject discounted agentic sessions with an explicit error instead of an opaque total mismatch
+* Update - Document that WooCommerce coupons do not apply to in-agent agentic purchases and reject discounted agentic sessions with an explicit error
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-checkout-session-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-checkout-session-test.php
@@ -56,15 +56,39 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 
 	/**
 	 * Test get_amount_discount reads total_details and defaults to 0 when absent.
+	 *
+	 * @dataProvider provide_amount_discount_cases
+	 *
+	 * @param object $raw      Raw session data.
+	 * @param int    $expected Expected discount amount.
 	 */
-	public function test_get_amount_discount() {
-		$with_discount = new WC_Stripe_Agentic_Checkout_Session(
-			(object) [ 'total_details' => (object) [ 'amount_discount' => 500 ] ]
-		);
-		$this->assertSame( 500, $with_discount->get_amount_discount() );
+	public function test_get_amount_discount( object $raw, int $expected ) {
+		$session = new WC_Stripe_Agentic_Checkout_Session( $raw );
+		$this->assertSame( $expected, $session->get_amount_discount() );
+	}
 
-		$without = new WC_Stripe_Agentic_Checkout_Session( (object) [] );
-		$this->assertSame( 0, $without->get_amount_discount() );
+	/**
+	 * @return array
+	 */
+	public function provide_amount_discount_cases(): array {
+		return [
+			'discount present'          => [
+				(object) [ 'total_details' => (object) [ 'amount_discount' => 500 ] ],
+				500,
+			],
+			'zero discount'             => [
+				(object) [ 'total_details' => (object) [ 'amount_discount' => 0 ] ],
+				0,
+			],
+			'total_details without key' => [
+				(object) [ 'total_details' => (object) [] ],
+				0,
+			],
+			'missing total_details'     => [
+				(object) [],
+				0,
+			],
+		];
 	}
 
 	/**

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-checkout-session-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-checkout-session-test.php
@@ -55,6 +55,19 @@ class WC_Stripe_Agentic_Checkout_Session_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_amount_discount reads total_details and defaults to 0 when absent.
+	 */
+	public function test_get_amount_discount() {
+		$with_discount = new WC_Stripe_Agentic_Checkout_Session(
+			(object) [ 'total_details' => (object) [ 'amount_discount' => 500 ] ]
+		);
+		$this->assertSame( 500, $with_discount->get_amount_discount() );
+
+		$without = new WC_Stripe_Agentic_Checkout_Session( (object) [] );
+		$this->assertSame( 0, $without->get_amount_discount() );
+	}
+
+	/**
 	 * @dataProvider provide_amount_total_cases
 	 */
 	public function test_get_amount_total( object $raw, ?int $expected ) {

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
@@ -1056,6 +1056,27 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that a session carrying a Stripe-side discount is rejected with an
+	 * explicit error before the order is built.
+	 */
+	public function test_exception_thrown_for_discounted_session() {
+		$session = $this->build_checkout_session(
+			[
+				'total_details' => (object) [
+					'amount_shipping' => 0,
+					'amount_tax'      => 0,
+					'amount_discount' => 500,
+				],
+			]
+		);
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'discounts are not supported' );
+
+		$this->mapper->create_order_from_checkout_session( $session );
+	}
+
+	/**
 	 * Test creating an order with multiple line items.
 	 *
 	 * @return void


### PR DESCRIPTION
Towards STRIPE-1257

## Changes proposed in this Pull Request:

The delegated (in-agent) checkout order path never applies WooCommerce coupons: line-item prices come from the synced feed and are computed by Stripe, and the order is created only after the shopper has paid inside the agent. (Feed-only / redirect mode is unaffected — redirected shoppers use the store's standard checkout, where coupons work as usual.) Two consequences follow: WooCommerce coupon usage limits are neither enforced nor consumed by agentic sales, and a Stripe-side discount on a session can never be represented on the order — today it fails `verify_order_total()` with an opaque "total mismatch" *after* the order was built and payment captured.

Whether promotions should be *supported* in agentic checkout (mapping Stripe discounts to WC coupons and enforcing usage limits at `finalize_checkout`) is a product decision this PR deliberately does not make. It implements the decision-neutral pieces:

- **Fail fast with a clear reason:** `validate_checkout_session()` now rejects a session whose `total_details.amount_discount` is non-zero with an explicit "discounts are not supported" error, before the order is built. This changes no outcomes — discounted sessions always failed — only where and how clearly they fail. New `get_amount_discount()` accessor on the session wrapper.
- **Document the limitation:** new "Coupons and discounts" section in `includes/agentic-commerce/README.md`, and copy in the Agentic Commerce settings panel telling merchants that WooCommerce coupons and their usage limits do not apply to purchases completed inside AI agents, while redirect-mode purchases keep normal coupon behavior. Both surfaces scope the limitation to delegated checkout.

If the eventual decision is to support promotions, the fail-fast check is the single seam to replace with discount mapping.

**BC impact:** no public signatures, hooks, or options change. The only behavior change is the earlier, clearer failure for discounted sessions (previously an unavoidable total-mismatch failure on the same sessions).

## Testing instructions

1. Load Stripe settings → Agentic commerce — the section description now states the coupon limitation.
2. Unit coverage: `npm run test:php -- --filter "WC_Stripe_Agentic_Commerce_Order_Mapper_Test|WC_Stripe_Agentic_Checkout_Session_Test"` — covers the discounted-session rejection and the new accessor; `npm run test:js -- client/settings/agentic-commerce` for the settings panel.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

Changelog entries added to `changelog.txt` and `readme.txt` under 10.9.0.

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

