### PR TITLE
Add e2e coverage for Adaptive Pricing

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        project: ['default', 'isk', 'acss', 'optimized-checkout', 'blik', 'becs']
+        project: ['default', 'isk', 'acss', 'optimized-checkout', 'adaptive-pricing', 'blik', 'becs']
 
     name: E2E - ${{ matrix.project }} WP=latest, WC=latest, PHP=7.4
     steps:

--- a/changelog.txt
+++ b/changelog.txt
@@ -79,7 +79,7 @@ xxxx-xx-xx - version 10.9.0
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
-* Dev - Add e2e coverage for Adaptive Pricing: shortcode and blocks purchases, the "Paid by customer" order row, address-less logged-in buyers, and the manual-capture settings gate
+* Dev - Add e2e coverage for Adaptive Pricing: shortcode and blocks purchases, address-less logged-in buyers, and the manual-capture settings gate
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/changelog.txt
+++ b/changelog.txt
@@ -79,6 +79,7 @@ xxxx-xx-xx - version 10.9.0
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Dev - Add e2e coverage for Adaptive Pricing: shortcode and blocks purchases, the "Paid by customer" order row, address-less logged-in buyers, and the manual-capture settings gate
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/package.json
+++ b/package.json
@@ -185,6 +185,8 @@
     "test:e2e-lpm-becs-debug": "npm run test:e2e-lpm-becs -- --debug",
     "test:e2e-isk": "./tests/e2e/bin/run-tests.sh --project=isk",
     "test:e2e-isk-debug": "npm run test:e2e-isk -- --debug",
+    "test:e2e-adaptive-pricing": "./tests/e2e/bin/run-tests.sh --project=adaptive-pricing",
+    "test:e2e-adaptive-pricing-debug": "npm run test:e2e-adaptive-pricing -- --debug",
     "changelog": "node bin/changelog.js",
     "doc:hooks": "cd tasks/hooks && composer install --quiet && composer run-script generate"
   },

--- a/readme.txt
+++ b/readme.txt
@@ -236,6 +236,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
-* Dev - Add e2e coverage for Adaptive Pricing: shortcode and blocks purchases, the "Paid by customer" order row, address-less logged-in buyers, and the manual-capture settings gate
+* Dev - Add e2e coverage for Adaptive Pricing: shortcode and blocks purchases, address-less logged-in buyers, and the manual-capture settings gate
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -236,5 +236,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Dev - Add e2e coverage for Adaptive Pricing: shortcode and blocks purchases, the "Paid by customer" order row, address-less logged-in buyers, and the manual-capture settings gate
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/e2e/bin/run-tests.sh
+++ b/tests/e2e/bin/run-tests.sh
@@ -39,4 +39,16 @@ fi
 TEST_ENV="$TEST_ENV DOCKER=true E2E_ROOT=${E2E_ROOT} BASE_URL='http://localhost:8088'"
 TEST_ENV="$TEST_ENV ADMIN_USER='admin' ADMIN_PASSWORD='admin'"
 
+# Adaptive Pricing is only offered while the plugin believes webhooks work and
+# the payment method configurations API is on. The docker site cannot receive
+# real webhooks (no tunnel), so seed exactly what the availability checks read:
+# webhook data plus the cached status transient — which is_webhook_enabled()
+# trusts without calling Stripe — and the PMC flag.
+if [[ "adaptive-pricing" == "$project" ]]; then
+	echo "Seeding Adaptive Pricing prerequisites"
+	cli wp option patch insert woocommerce_stripe_settings pmc_enabled 'yes'
+	cli wp option patch insert woocommerce_stripe_settings test_webhook_data --format=json '{"id":"we_e2e_placeholder","secret":"whsec_e2e_placeholder"}'
+	cli wp transient set wcstripe_webhook_status_test enabled 7200
+fi
+
 cross-env $TEST_ENV playwright test --config=tests/e2e/config/playwright.config.js $TEST_ARGS ${project:+--project=$project}

--- a/tests/e2e/bin/run-tests.sh
+++ b/tests/e2e/bin/run-tests.sh
@@ -39,11 +39,9 @@ fi
 TEST_ENV="$TEST_ENV DOCKER=true E2E_ROOT=${E2E_ROOT} BASE_URL='http://localhost:8088'"
 TEST_ENV="$TEST_ENV ADMIN_USER='admin' ADMIN_PASSWORD='admin'"
 
-# Adaptive Pricing is only offered while the plugin believes webhooks work and
-# the payment method configurations API is on. The docker site cannot receive
-# real webhooks (no tunnel), so seed exactly what the availability checks read:
-# webhook data plus the cached status transient — which is_webhook_enabled()
-# trusts without calling Stripe — and the PMC flag.
+# The docker site can't receive real webhooks (no tunnel), so seed what the
+# Adaptive Pricing availability checks read: webhook data, the cached status
+# transient is_webhook_enabled() trusts without calling Stripe, and PMC.
 if [[ "adaptive-pricing" == "$project" ]]; then
 	echo "Seeding Adaptive Pricing prerequisites"
 	cli wp option patch insert woocommerce_stripe_settings pmc_enabled 'yes'

--- a/tests/e2e/config/playwright.config.js
+++ b/tests/e2e/config/playwright.config.js
@@ -88,6 +88,7 @@ const config = {
 			testIgnore: [
 				'**/acss.spec.js',
 				'**/*optimized-checkout.spec.js',
+				'**/adaptive-pricing.spec.js',
 				'**/blik.spec.js',
 				'**/becs.spec.js',
 				'**/isk.spec.js',
@@ -133,6 +134,23 @@ const config = {
 			name: 'optimized-checkout',
 			testMatch: '**/*optimized-checkout.spec.js',
 			dependencies: [ 'oc-setup' ],
+			use: { ...devices[ 'Desktop Chrome' ] },
+		},
+		{
+			name: 'adaptive-pricing-setup',
+			testMatch: '/adaptive-pricing.setup.js',
+			teardown: 'adaptive-pricing-teardown',
+			use: { ...devices[ 'Desktop Chrome' ] },
+		},
+		{
+			name: 'adaptive-pricing',
+			testMatch: '**/adaptive-pricing.spec.js',
+			dependencies: [ 'adaptive-pricing-setup' ],
+			use: { ...devices[ 'Desktop Chrome' ] },
+		},
+		{
+			name: 'adaptive-pricing-teardown',
+			testMatch: '/adaptive-pricing.teardown.js',
 			use: { ...devices[ 'Desktop Chrome' ] },
 		},
 		{

--- a/tests/e2e/tests/adaptive-pricing.setup.js
+++ b/tests/e2e/tests/adaptive-pricing.setup.js
@@ -1,0 +1,6 @@
+import { test as setup } from '@playwright/test';
+import { initializeAdaptivePricing } from '../utils/admin';
+
+setup( 'Configure store for Adaptive Pricing tests', async ( { browser } ) => {
+	await initializeAdaptivePricing( browser, true );
+} );

--- a/tests/e2e/tests/adaptive-pricing.teardown.js
+++ b/tests/e2e/tests/adaptive-pricing.teardown.js
@@ -1,0 +1,14 @@
+import { test as teardown } from '@playwright/test';
+import {
+	initializeAdaptivePricing,
+	initializeOptimizedCheckout,
+} from '../utils/admin';
+
+teardown(
+	'Restore store after Adaptive Pricing tests',
+	async ( { browser } ) => {
+		// AP first: its checkbox is only interactable while OC is still on.
+		await initializeAdaptivePricing( browser, false );
+		await initializeOptimizedCheckout( browser, false );
+	}
+);

--- a/tests/e2e/tests/checkout/adaptive-pricing.spec.js
+++ b/tests/e2e/tests/checkout/adaptive-pricing.spec.js
@@ -15,7 +15,7 @@ const {
 	clickPlaceOrder,
 	getCartTotal,
 	getOrderIdFromOrderReceivedUrl,
-	waitForOrderReceivedPageAndConfirmExpectedTotal,
+	waitForOrderReceivedPage,
 } = payments;
 
 const SETTINGS_URL =
@@ -29,12 +29,11 @@ const MANUAL_CAPTURE_LABEL =
 /**
  * Completes an Adaptive Pricing card purchase and returns the order ID.
  *
- * @param {Page}    page         Playwright page fixture.
- * @param {Browser} browser      Playwright browser fixture.
- * @param {string}  checkoutType 'shortcode' or 'blocks'.
+ * @param {Page}   page         Playwright page fixture.
+ * @param {string} checkoutType 'shortcode' or 'blocks'.
  * @return {Promise<string>} The WooCommerce order ID.
  */
-const payWithAdaptivePricing = async ( page, browser, checkoutType ) => {
+const payWithAdaptivePricing = async ( page, checkoutType ) => {
 	await setupOptimizedCheckout( page, checkoutType );
 	await fillOCDetails( page, config.get( 'cards.basic' ), checkoutType );
 
@@ -42,11 +41,14 @@ const payWithAdaptivePricing = async ( page, browser, checkoutType ) => {
 
 	await clickPlaceOrder( page );
 
-	await waitForOrderReceivedPageAndConfirmExpectedTotal(
-		browser,
-		page,
-		expectedTotal
-	);
+	// Adaptive Pricing orders are only marked paid by the checkout session
+	// webhooks, which cannot reach the tunnel-less CI site — so assert the
+	// order-received page (the redirect handler verifies the live session)
+	// and its total instead of the admin "Paid" row.
+	await waitForOrderReceivedPage( page );
+	await expect(
+		page.locator( '.woocommerce-order-overview__total' )
+	).toContainText( expectedTotal );
 
 	return getOrderIdFromOrderReceivedUrl( page.url() );
 };
@@ -58,11 +60,7 @@ test.describe( 'Adaptive Pricing checkout', () => {
 		page,
 		browser,
 	} ) => {
-		const orderId = await payWithAdaptivePricing(
-			page,
-			browser,
-			'shortcode'
-		);
+		const orderId = await payWithAdaptivePricing( page, 'shortcode' );
 
 		// The order edit page shows the "Paid by customer" row with the
 		// presentment amount reported by the checkout session.
@@ -86,14 +84,12 @@ test.describe( 'Adaptive Pricing checkout', () => {
 
 	test( 'customer can pay through Adaptive Pricing on blocks checkout @smoke', async ( {
 		page,
-		browser,
 	} ) => {
-		await payWithAdaptivePricing( page, browser, 'blocks' );
+		await payWithAdaptivePricing( page, 'blocks' );
 	} );
 
 	test( 'logged-in customer without a saved billing address can pay through Adaptive Pricing', async ( {
 		page,
-		browser,
 	} ) => {
 		// A bare customer: no billing/shipping address saved on the account.
 		const randomString = randomUUID();
@@ -113,7 +109,7 @@ test.describe( 'Adaptive Pricing checkout', () => {
 
 		// Creating the checkout session for this buyer must not fail on the
 		// missing address; the payment element renders and the purchase works.
-		await payWithAdaptivePricing( page, browser, 'shortcode' );
+		await payWithAdaptivePricing( page, 'shortcode' );
 	} );
 
 	test( 'manual capture blocks Adaptive Pricing in the settings with a clear reason', async ( {

--- a/tests/e2e/tests/checkout/adaptive-pricing.spec.js
+++ b/tests/e2e/tests/checkout/adaptive-pricing.spec.js
@@ -32,7 +32,11 @@ const MANUAL_CAPTURE_LABEL =
  * @param {string} checkoutType 'shortcode' or 'blocks'.
  */
 const payWithAdaptivePricing = async ( page, checkoutType ) => {
-	await setupOptimizedCheckout( page, checkoutType );
+	await setupOptimizedCheckout( page, checkoutType, {
+		timeout: 10000,
+		skipCartSetup: false,
+		cardSelectionOptional: true,
+	} );
 	await fillOCDetails( page, config.get( 'cards.basic' ), checkoutType );
 
 	const expectedTotal = await getCartTotal( page );

--- a/tests/e2e/tests/checkout/adaptive-pricing.spec.js
+++ b/tests/e2e/tests/checkout/adaptive-pricing.spec.js
@@ -14,7 +14,6 @@ const {
 	fillOCDetails,
 	clickPlaceOrder,
 	getCartTotal,
-	getOrderIdFromOrderReceivedUrl,
 	waitForOrderReceivedPage,
 } = payments;
 
@@ -27,11 +26,10 @@ const MANUAL_CAPTURE_LABEL =
 	'Issue an authorization on checkout, and capture later';
 
 /**
- * Completes an Adaptive Pricing card purchase and returns the order ID.
+ * Completes an Adaptive Pricing card purchase through to the received page.
  *
  * @param {Page}   page         Playwright page fixture.
  * @param {string} checkoutType 'shortcode' or 'blocks'.
- * @return {Promise<string>} The WooCommerce order ID.
  */
 const payWithAdaptivePricing = async ( page, checkoutType ) => {
 	await setupOptimizedCheckout( page, checkoutType );
@@ -49,37 +47,19 @@ const payWithAdaptivePricing = async ( page, checkoutType ) => {
 	await expect(
 		page.locator( '.woocommerce-order-overview__total' )
 	).toContainText( expectedTotal );
-
-	return getOrderIdFromOrderReceivedUrl( page.url() );
 };
 
 test.describe( 'Adaptive Pricing checkout', () => {
 	test.describe.configure( { mode: 'serial' } );
 
-	test( 'customer can pay through Adaptive Pricing on shortcode checkout, and the order records the presentment amount @smoke', async ( {
+	test( 'customer can pay through Adaptive Pricing on shortcode checkout @smoke', async ( {
 		page,
-		browser,
 	} ) => {
-		const orderId = await payWithAdaptivePricing( page, 'shortcode' );
-
-		// The order edit page shows the "Paid by customer" row with the
-		// presentment amount reported by the checkout session.
-		const { context, page: adminPage } =
-			await admin.getAdminPage( browser );
-		try {
-			await adminPage.goto(
-				`/wp-admin/post.php?post=${ orderId }&action=edit`
-			);
-			const paidByCustomerRow = adminPage
-				.locator( '.wc-order-totals tr' )
-				.filter( { hasText: 'Paid by customer' } );
-			await expect( paidByCustomerRow ).toBeVisible();
-			// Same-currency purchase: the symbol clashes with the store's, so
-			// the currency code is spelled out.
-			await expect( paidByCustomerRow ).toContainText( 'USD' );
-		} finally {
-			await context.close();
-		}
+		// The "Paid by customer" presentment row is NOT asserted here: Stripe
+		// only reports presentment details when a currency conversion actually
+		// happened, which a same-currency CI shopper cannot produce. Its
+		// rendering is covered by unit tests.
+		await payWithAdaptivePricing( page, 'shortcode' );
 	} );
 
 	test( 'customer can pay through Adaptive Pricing on blocks checkout @smoke', async ( {

--- a/tests/e2e/tests/checkout/adaptive-pricing.spec.js
+++ b/tests/e2e/tests/checkout/adaptive-pricing.spec.js
@@ -1,0 +1,163 @@
+/**
+ * Adaptive Pricing flows. On a test-mode US account with working webhooks the
+ * feature is available, and a same-currency shopper still checks out through
+ * the Adaptive Pricing (checkout sessions) path — Stripe just presents the
+ * store currency — so these flows exercise the real session code end-to-end.
+ */
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'crypto';
+import config from 'config';
+import { payments, api, user, admin } from '../../utils';
+
+const {
+	setupOptimizedCheckout,
+	fillOCDetails,
+	clickPlaceOrder,
+	getCartTotal,
+	getOrderIdFromOrderReceivedUrl,
+	waitForOrderReceivedPageAndConfirmExpectedTotal,
+} = payments;
+
+const SETTINGS_URL =
+	'/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings';
+
+const AP_CHECKBOX_LABEL =
+	'Let customers pay in their local currency with Adaptive Pricing';
+const MANUAL_CAPTURE_LABEL =
+	'Issue an authorization on checkout, and capture later';
+
+/**
+ * Completes an Adaptive Pricing card purchase and returns the order ID.
+ *
+ * @param {Page}    page         Playwright page fixture.
+ * @param {Browser} browser      Playwright browser fixture.
+ * @param {string}  checkoutType 'shortcode' or 'blocks'.
+ * @return {Promise<string>} The WooCommerce order ID.
+ */
+const payWithAdaptivePricing = async ( page, browser, checkoutType ) => {
+	await setupOptimizedCheckout( page, checkoutType );
+	await fillOCDetails( page, config.get( 'cards.basic' ), checkoutType );
+
+	const expectedTotal = await getCartTotal( page );
+
+	await clickPlaceOrder( page );
+
+	await waitForOrderReceivedPageAndConfirmExpectedTotal(
+		browser,
+		page,
+		expectedTotal
+	);
+
+	return getOrderIdFromOrderReceivedUrl( page.url() );
+};
+
+test.describe( 'Adaptive Pricing checkout', () => {
+	test.describe.configure( { mode: 'serial' } );
+
+	test( 'customer can pay through Adaptive Pricing on shortcode checkout, and the order records the presentment amount @smoke', async ( {
+		page,
+		browser,
+	} ) => {
+		const orderId = await payWithAdaptivePricing(
+			page,
+			browser,
+			'shortcode'
+		);
+
+		// The order edit page shows the "Paid by customer" row with the
+		// presentment amount reported by the checkout session.
+		const { context, page: adminPage } =
+			await admin.getAdminPage( browser );
+		try {
+			await adminPage.goto(
+				`/wp-admin/post.php?post=${ orderId }&action=edit`
+			);
+			const paidByCustomerRow = adminPage
+				.locator( '.wc-order-totals tr' )
+				.filter( { hasText: 'Paid by customer' } );
+			await expect( paidByCustomerRow ).toBeVisible();
+			// Same-currency purchase: the symbol clashes with the store's, so
+			// the currency code is spelled out.
+			await expect( paidByCustomerRow ).toContainText( 'USD' );
+		} finally {
+			await context.close();
+		}
+	} );
+
+	test( 'customer can pay through Adaptive Pricing on blocks checkout @smoke', async ( {
+		page,
+		browser,
+	} ) => {
+		await payWithAdaptivePricing( page, browser, 'blocks' );
+	} );
+
+	test( 'logged-in customer without a saved billing address can pay through Adaptive Pricing', async ( {
+		page,
+		browser,
+	} ) => {
+		// A bare customer: no billing/shipping address saved on the account.
+		const randomString = randomUUID();
+		const username =
+			randomString + '.' + config.get( 'users.customer.username' );
+		await api.create.customer( {
+			...config.get( 'users.customer' ),
+			email: randomString + '+' + config.get( 'users.customer.email' ),
+			username,
+		} );
+
+		await user.login(
+			page,
+			username,
+			config.get( 'users.customer.password' )
+		);
+
+		// Creating the checkout session for this buyer must not fail on the
+		// missing address; the payment element renders and the purchase works.
+		await payWithAdaptivePricing( page, browser, 'shortcode' );
+	} );
+
+	test( 'manual capture blocks Adaptive Pricing in the settings with a clear reason', async ( {
+		browser,
+	} ) => {
+		const { context, page } = await admin.getAdminPage( browser );
+
+		const saveSettings = async () => {
+			await page.click( 'text=Save changes' );
+			await expect(
+				page.locator(
+					'.components-snackbar__content:has-text("Settings saved.")'
+				)
+			).toBeVisible();
+		};
+
+		try {
+			await page.goto( SETTINGS_URL );
+
+			// Enabling manual capture requires confirming a modal.
+			await page.getByLabel( MANUAL_CAPTURE_LABEL ).click();
+			await page
+				.getByRole( 'button', { name: 'Enable', exact: true } )
+				.click();
+			await saveSettings();
+
+			await page.goto( SETTINGS_URL );
+			await expect( page.getByLabel( AP_CHECKBOX_LABEL ) ).toBeDisabled();
+			await expect(
+				page.locator( '.wc-stripe-adaptive-pricing-unavailable-reason' )
+			).toContainText( 'Adaptive Pricing requires automatic capture' );
+		} finally {
+			// Restore automatic capture (unchecking shows no modal) and
+			// confirm Adaptive Pricing becomes selectable again.
+			await page.goto( SETTINGS_URL );
+			const manualCapture = page.getByLabel( MANUAL_CAPTURE_LABEL );
+			if ( await manualCapture.isChecked() ) {
+				await manualCapture.click();
+				await saveSettings();
+			}
+
+			await page.goto( SETTINGS_URL );
+			await expect( page.getByLabel( AP_CHECKBOX_LABEL ) ).toBeEnabled();
+			await context.close();
+		}
+	} );
+} );

--- a/tests/e2e/tests/checkout/adaptive-pricing.spec.js
+++ b/tests/e2e/tests/checkout/adaptive-pricing.spec.js
@@ -79,10 +79,15 @@ test.describe( 'Adaptive Pricing checkout', () => {
 		const randomString = randomUUID();
 		const username =
 			randomString + '.' + config.get( 'users.customer.username' );
+		// Empty billing/shipping: the helper maps their fields, and the
+		// undefined values are dropped from the request, creating the
+		// customer with no saved address.
 		await api.create.customer( {
 			...config.get( 'users.customer' ),
 			email: randomString + '+' + config.get( 'users.customer.email' ),
 			username,
+			billing: {},
+			shipping: {},
 		} );
 
 		await user.login(

--- a/tests/e2e/tests/checkout/adaptive-pricing.spec.js
+++ b/tests/e2e/tests/checkout/adaptive-pricing.spec.js
@@ -1,8 +1,7 @@
 /**
- * Adaptive Pricing flows. On a test-mode US account with working webhooks the
- * feature is available, and a same-currency shopper still checks out through
- * the Adaptive Pricing (checkout sessions) path — Stripe just presents the
- * store currency — so these flows exercise the real session code end-to-end.
+ * Adaptive Pricing flows. A same-currency shopper still checks out through
+ * the checkout-sessions path (Stripe just presents the store currency), so
+ * these exercise the real session code end-to-end.
  */
 import { test, expect } from '@playwright/test';
 import { randomUUID } from 'crypto';
@@ -43,10 +42,8 @@ const payWithAdaptivePricing = async ( page, checkoutType ) => {
 
 	await clickPlaceOrder( page );
 
-	// Adaptive Pricing orders are only marked paid by the checkout session
-	// webhooks, which cannot reach the tunnel-less CI site — so assert the
-	// order-received page (the redirect handler verifies the live session)
-	// and its total instead of the admin "Paid" row.
+	// AP orders are only marked paid by webhooks, which can't reach the
+	// tunnel-less CI site — assert the received page, not the "Paid" row.
 	await waitForOrderReceivedPage( page );
 	await expect(
 		page.locator( '.woocommerce-order-overview__total' )
@@ -59,10 +56,9 @@ test.describe( 'Adaptive Pricing checkout', () => {
 	test( 'customer can pay through Adaptive Pricing on shortcode checkout @smoke', async ( {
 		page,
 	} ) => {
-		// The "Paid by customer" presentment row is NOT asserted here: Stripe
-		// only reports presentment details when a currency conversion actually
-		// happened, which a same-currency CI shopper cannot produce. Its
-		// rendering is covered by unit tests.
+		// No "Paid by customer" assertion: Stripe only reports presentment
+		// details on real conversions, impossible for a same-currency CI
+		// shopper. Unit tests cover the row.
 		await payWithAdaptivePricing( page, 'shortcode' );
 	} );
 
@@ -75,13 +71,11 @@ test.describe( 'Adaptive Pricing checkout', () => {
 	test( 'logged-in customer without a saved billing address can pay through Adaptive Pricing', async ( {
 		page,
 	} ) => {
-		// A bare customer: no billing/shipping address saved on the account.
+		// Empty addresses: the helper's mapped fields come out undefined and
+		// are dropped, creating the customer with no saved address.
 		const randomString = randomUUID();
 		const username =
 			randomString + '.' + config.get( 'users.customer.username' );
-		// Empty billing/shipping: the helper maps their fields, and the
-		// undefined values are dropped from the request, creating the
-		// customer with no saved address.
 		await api.create.customer( {
 			...config.get( 'users.customer' ),
 			email: randomString + '+' + config.get( 'users.customer.email' ),
@@ -96,8 +90,7 @@ test.describe( 'Adaptive Pricing checkout', () => {
 			config.get( 'users.customer.password' )
 		);
 
-		// Creating the checkout session for this buyer must not fail on the
-		// missing address; the payment element renders and the purchase works.
+		// Session creation must not fail on the missing address.
 		await payWithAdaptivePricing( page, 'shortcode' );
 	} );
 
@@ -131,8 +124,7 @@ test.describe( 'Adaptive Pricing checkout', () => {
 				page.locator( '.wc-stripe-adaptive-pricing-unavailable-reason' )
 			).toContainText( 'Adaptive Pricing requires automatic capture' );
 		} finally {
-			// Restore automatic capture (unchecking shows no modal) and
-			// confirm Adaptive Pricing becomes selectable again.
+			// Restore automatic capture (no modal on uncheck).
 			await page.goto( SETTINGS_URL );
 			const manualCapture = page.getByLabel( MANUAL_CAPTURE_LABEL );
 			if ( await manualCapture.isChecked() ) {

--- a/tests/e2e/utils/admin.js
+++ b/tests/e2e/utils/admin.js
@@ -192,6 +192,14 @@ export const initializeAdaptivePricing = async (
 				'.components-snackbar__content:has-text("Settings saved.")'
 			)
 		).toBeVisible();
+
+		// A save that silently didn't take would fail every dependent test
+		// deep in checkout; assert the resulting state here instead.
+		if ( shouldEnable ) {
+			await expect( checkbox ).toBeChecked();
+		} else {
+			await expect( checkbox ).not.toBeChecked();
+		}
 	}
 
 	await adminContext.close();

--- a/tests/e2e/utils/admin.js
+++ b/tests/e2e/utils/admin.js
@@ -147,6 +147,56 @@ export const initializeOptimizedCheckout = async (
 };
 
 /**
+ * Enables or disables Adaptive Pricing in the Stripe settings.
+ *
+ * Adaptive Pricing is only offered while the Optimized Checkout Suite is
+ * enabled, so enabling it enables OC first. Disabling only unchecks Adaptive
+ * Pricing; callers that also want OC off should call
+ * initializeOptimizedCheckout( browser, false ) afterwards.
+ *
+ * @param {Browser} browser      Playwright browser fixture.
+ * @param {boolean} shouldEnable Whether to enable or disable Adaptive Pricing.
+ */
+export const initializeAdaptivePricing = async (
+	browser,
+	shouldEnable = true
+) => {
+	if ( shouldEnable ) {
+		await initializeOptimizedCheckout( browser, true );
+	}
+
+	const adminContext = await browser.newContext( {
+		storageState: process.env.ADMINSTATE,
+	} );
+
+	const page = await adminContext.newPage();
+
+	await page.goto(
+		'/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings'
+	);
+
+	const checkbox = page.getByLabel(
+		'Let customers pay in their local currency with Adaptive Pricing'
+	);
+	const isChecked = await checkbox.isChecked();
+
+	const updateNeeded =
+		( shouldEnable && ! isChecked ) || ( ! shouldEnable && isChecked );
+
+	if ( updateNeeded ) {
+		await checkbox.click();
+		await page.click( 'text=Save changes' );
+		await expect(
+			page.locator(
+				'.components-snackbar__content:has-text("Settings saved.")'
+			)
+		).toBeVisible();
+	}
+
+	await adminContext.close();
+};
+
+/**
  * Open the admin order edit page for an order and confirm the expected amount
  * was charged.
  *

--- a/tests/e2e/utils/admin.js
+++ b/tests/e2e/utils/admin.js
@@ -149,10 +149,8 @@ export const initializeOptimizedCheckout = async (
 /**
  * Enables or disables Adaptive Pricing in the Stripe settings.
  *
- * Adaptive Pricing is only offered while the Optimized Checkout Suite is
- * enabled, so enabling it enables OC first. Disabling only unchecks Adaptive
- * Pricing; callers that also want OC off should call
- * initializeOptimizedCheckout( browser, false ) afterwards.
+ * Enabling turns on the Optimized Checkout Suite first (AP requires it);
+ * disabling leaves OC on.
  *
  * @param {Browser} browser      Playwright browser fixture.
  * @param {boolean} shouldEnable Whether to enable or disable Adaptive Pricing.
@@ -184,8 +182,8 @@ export const initializeAdaptivePricing = async (
 		( shouldEnable && ! isChecked ) || ( ! shouldEnable && isChecked );
 
 	if ( updateNeeded ) {
-		// Fail fast with a readable reason when an availability gate (webhooks,
-		// PMC, capture, OC) is unmet, instead of timing out on the click.
+		// Fail fast when an availability gate (webhooks, PMC, capture, OC)
+		// is unmet, instead of timing out on the click.
 		await expect( checkbox ).toBeEnabled();
 		await checkbox.click();
 		await page.click( 'text=Save changes' );

--- a/tests/e2e/utils/admin.js
+++ b/tests/e2e/utils/admin.js
@@ -184,6 +184,9 @@ export const initializeAdaptivePricing = async (
 		( shouldEnable && ! isChecked ) || ( ! shouldEnable && isChecked );
 
 	if ( updateNeeded ) {
+		// Fail fast with a readable reason when an availability gate (webhooks,
+		// PMC, capture, OC) is unmet, instead of timing out on the click.
+		await expect( checkbox ).toBeEnabled();
 		await checkbox.click();
 		await page.click( 'text=Save changes' );
 		await expect(

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -795,8 +795,17 @@ export const setupOptimizedCheckout = async (
 
 		const paymentFrame = paymentIframe.contentFrame();
 
-		// Select the card payment method
-		await paymentFrame.getByRole( 'button', { name: 'Card' } ).click();
+		// Select the card payment method. Optional because the Adaptive
+		// Pricing (checkout sessions) element on blocks renders card
+		// preselected with no method selector.
+		const cardButton = paymentFrame.getByRole( 'button', {
+			name: 'Card',
+		} );
+		if ( options.cardSelectionOptional ) {
+			await cardButton.click( { timeout: 5000 } ).catch( () => {} );
+		} else {
+			await cardButton.click();
+		}
 	} catch ( error ) {
 		throw new Error(
 			`Failed to set up Optimized Checkout: ${ error.message }`

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -788,9 +788,8 @@ export const setupOptimizedCheckout = async (
 			options.timeout
 		);
 
-		// Select the card payment method. Optional because the Adaptive
-		// Pricing (checkout sessions) element renders differently across
-		// flows; fillOCDetails() expands the Card accordion row when needed.
+		// Optional for Adaptive Pricing, whose element renders differently
+		// across flows; fillOCDetails() expands the Card row when needed.
 		if ( options.cardSelectionOptional ) {
 			await paymentFrame
 				.locator(
@@ -959,10 +958,8 @@ export async function handleCheckoutCashAppPay(
 /**
  * Resolves the visible Stripe iframe that renders the payment UI.
  *
- * Multiple visible Stripe frames can match the container selector — e.g. the
- * Adaptive Pricing element adds a test-mode banner frame ("Use card 4242…")
- * before the payment frame — so pick the frame that actually contains the
- * method selector or card fields instead of blindly taking the first.
+ * Multiple visible frames can match the selector (e.g. Adaptive Pricing adds
+ * a test-mode banner frame first), so pick by content, not position.
  *
  * @param {Page}   page           Playwright page fixture.
  * @param {string} iframeSelector Selector matching the container's Stripe iframes.
@@ -994,8 +991,7 @@ const getOCPaymentFrame = async ( page, iframeSelector, timeout = 10000 ) => {
 		await page.waitForTimeout( 250 );
 	} while ( Date.now() < deadline );
 
-	// Fall back to the first visible frame so the caller's own failure
-	// message points at the missing field.
+	// Fall back so the caller's own failure message names the missing field.
 	return candidates.first().contentFrame();
 };
 
@@ -1015,8 +1011,7 @@ export const fillOCDetails = async ( page, card, checkoutType = 'blocks' ) => {
 
 	const paymentFrame = await getOCPaymentFrame( page, iframeSelector );
 
-	// The Adaptive Pricing blocks element renders the methods as a collapsed
-	// accordion; expand Card if its fields are not showing yet.
+	// Expand the Card accordion row if its fields are not showing yet.
 	if ( ! ( await paymentFrame.locator( '[name="number"]' ).isVisible() ) ) {
 		await paymentFrame
 			.locator(

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -1030,14 +1030,17 @@ export const fillOCDetails = async ( page, card, checkoutType = 'blocks' ) => {
 
 	// For emails Link doesn't recognize, it offers signup with "Save my
 	// information" pre-checked, which requires a mobile number the tests
-	// don't fill and blocks the payment; opt out instead.
+	// don't fill and blocks the payment; opt out instead. Best-effort:
+	// mandatory-save flows (e.g. subscriptions) render the checkbox only
+	// transiently before re-rendering without it, so it can disappear
+	// between the check and the uncheck.
 	const linkSaveInfo = paymentFrame.getByRole( 'checkbox', {
 		name: 'Save my information for faster checkout',
 	} );
 	if (
 		await linkSaveInfo.isChecked( { timeout: 5000 } ).catch( () => false )
 	) {
-		await linkSaveInfo.uncheck();
+		await linkSaveInfo.uncheck( { timeout: 5000 } ).catch( () => {} );
 	}
 };
 

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -782,29 +782,25 @@ export const setupOptimizedCheckout = async (
 			);
 		}
 
-		// Stripe may inject a secondary hidden iframe that matches the selector.
-		// Ensure we're looking for the visible frame.
-		const paymentIframe = page
-			.locator( currentSelectors.iframe )
-			.filter( { visible: true } )
-			.first();
-		await paymentIframe.waitFor( {
-			state: 'visible',
-			timeout: options.timeout,
-		} );
-
-		const paymentFrame = paymentIframe.contentFrame();
+		const paymentFrame = await getOCPaymentFrame(
+			page,
+			currentSelectors.iframe,
+			options.timeout
+		);
 
 		// Select the card payment method. Optional because the Adaptive
-		// Pricing (checkout sessions) element on blocks renders card
-		// preselected with no method selector.
-		const cardButton = paymentFrame.getByRole( 'button', {
-			name: 'Card',
-		} );
+		// Pricing (checkout sessions) element renders differently across
+		// flows; fillOCDetails() expands the Card accordion row when needed.
 		if ( options.cardSelectionOptional ) {
-			await cardButton.click( { timeout: 5000 } ).catch( () => {} );
+			await paymentFrame
+				.locator(
+					'[role="button"]:has-text("Card"), button:has-text("Card")'
+				)
+				.first()
+				.click( { timeout: 5000 } )
+				.catch( () => {} );
 		} else {
-			await cardButton.click();
+			await paymentFrame.getByRole( 'button', { name: 'Card' } ).click();
 		}
 	} catch ( error ) {
 		throw new Error(
@@ -961,6 +957,49 @@ export async function handleCheckoutCashAppPay(
 }
 
 /**
+ * Resolves the visible Stripe iframe that renders the payment UI.
+ *
+ * Multiple visible Stripe frames can match the container selector — e.g. the
+ * Adaptive Pricing element adds a test-mode banner frame ("Use card 4242…")
+ * before the payment frame — so pick the frame that actually contains the
+ * method selector or card fields instead of blindly taking the first.
+ *
+ * @param {Page}   page           Playwright page fixture.
+ * @param {string} iframeSelector Selector matching the container's Stripe iframes.
+ * @param {number} timeout        How long to wait for the payment frame, in ms.
+ * @return {FrameLocator} The payment frame.
+ */
+const getOCPaymentFrame = async ( page, iframeSelector, timeout = 10000 ) => {
+	const candidates = page
+		.locator( iframeSelector )
+		.filter( { visible: true } );
+	await candidates.first().waitFor( { state: 'visible', timeout } );
+
+	const deadline = Date.now() + timeout;
+	do {
+		const count = await candidates.count();
+		for ( let i = 0; i < count; i++ ) {
+			const frame = candidates.nth( i ).contentFrame();
+			const isPaymentUI = await frame
+				.locator(
+					'[name="number"], [role="button"]:has-text("Card"), button:has-text("Card")'
+				)
+				.first()
+				.isVisible()
+				.catch( () => false );
+			if ( isPaymentUI ) {
+				return frame;
+			}
+		}
+		await page.waitForTimeout( 250 );
+	} while ( Date.now() < deadline );
+
+	// Fall back to the first visible frame so the caller's own failure
+	// message points at the missing field.
+	return candidates.first().contentFrame();
+};
+
+/**
  * Fill in the payment details for Optimized Checkout (OC).
  *
  * @param {Page} page Playwright page fixture.
@@ -974,16 +1013,18 @@ export const fillOCDetails = async ( page, card, checkoutType = 'blocks' ) => {
 			? '#radio-control-wc-payment-method-options-stripe__content iframe[name^="__privateStripeFrame"]'
 			: '#wc-stripe-upe-form .StripeElement iframe[name^="__privateStripeFrame"]';
 
-	// Stripe injects a hidden "accessory-target" iframe alongside the real
-	// payment input frame; both match the selector. Target the visible one to
-	// avoid latching onto the hidden frame.
-	const paymentIframe = page
-		.locator( iframeSelector )
-		.filter( { visible: true } )
-		.first();
-	await paymentIframe.waitFor( { state: 'visible', timeout: 10000 } );
+	const paymentFrame = await getOCPaymentFrame( page, iframeSelector );
 
-	const paymentFrame = paymentIframe.contentFrame();
+	// The Adaptive Pricing blocks element renders the methods as a collapsed
+	// accordion; expand Card if its fields are not showing yet.
+	if ( ! ( await paymentFrame.locator( '[name="number"]' ).isVisible() ) ) {
+		await paymentFrame
+			.locator(
+				'[role="button"]:has-text("Card"), button:has-text("Card")'
+			)
+			.first()
+			.click();
+	}
 
 	// Fill in test card details
 	await paymentFrame.locator( '[name="number"]' ).fill( card.number );

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -1027,6 +1027,18 @@ export const fillOCDetails = async ( page, card, checkoutType = 'blocks' ) => {
 		.locator( '[name="expiry"]' )
 		.fill( card.expires.month + card.expires.year );
 	await paymentFrame.locator( '[name="cvc"]' ).fill( card.cvc );
+
+	// For emails Link doesn't recognize, it offers signup with "Save my
+	// information" pre-checked, which requires a mobile number the tests
+	// don't fill and blocks the payment; opt out instead.
+	const linkSaveInfo = paymentFrame.getByRole( 'checkbox', {
+		name: 'Save my information for faster checkout',
+	} );
+	if (
+		await linkSaveInfo.isChecked( { timeout: 5000 } ).catch( () => false )
+	) {
+		await linkSaveInfo.uncheck();
+	}
 };
 
 /**


### PR DESCRIPTION
Part of STRIPE-1289

## Changes proposed in this Pull Request:

Adds e2e coverage for Adaptive Pricing — the feature has none today despite a run of recent fixes. A same-currency test-mode shopper still checks out through the real checkout-sessions path, so these flows exercise the session code end-to-end on the CI account.

New `adaptive-pricing` Playwright project (own project + CI matrix job because setup mutates store-wide settings; a teardown restores them):

| Test | Recent fix it guards |
|---|---|
| Shortcode purchase through the sessions path | #5618, #5695, #5672 |
| Blocks purchase | same path on the Blocks `CheckoutForm` branch |
| Logged-in buyer with no saved billing address | #5654 |
| Manual capture disables the AP setting with the "requires automatic capture" reason | #5684 |

Not covered in this PR: the "Paid by customer" row and conversion notice (#5671 — need a real conversion; e2e-covered in follow-up #5739 via a simulated shopper location), the total-sync error/resync notice (#5682/#5694 — need injected API failures), and the payment-intent metadata (#5676 — Stripe-side).

Shared OC helper changes (also on the OC suite's path): the payment frame is resolved by content instead of first-visible (the AP element adds a visible test-mode banner frame), `fillOCDetails()` expands the Card accordion row when needed and unchecks Link's pre-checked "Save my information" checkbox for unrecognized emails (its signup pane demands a mobile number and blocks payment; best-effort, since mandatory-save subscription flows render it only transiently), and `setupOptimizedCheckout()` gains an opt-in `cardSelectionOptional`.

CI note: the tunnel-less docker site can't receive webhooks, which both gates the AP setting off (`is_webhook_enabled()`) and prevents settlement. `run-tests.sh` seeds what the availability checks read (webhook data + status transient + `pmc_enabled`) for this project only, and the purchase tests assert the order-received page rather than the webhook-dependent "Paid" row.

## Testing instructions

1. CI: the new `E2E - adaptive-pricing` matrix job.
2. Locally: `npm run test:e2e-adaptive-pricing -- --base_url=<staging-url>` after the usual e2e setup.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

Changelog entries added to `changelog.txt` and `readme.txt` under 10.9.0 (Dev).

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



