### PR TITLE
Open Stripe Dashboard links in the order notes in new tab

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -79,6 +79,7 @@ xxxx-xx-xx - version 10.9.0
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Fix - Open the Stripe Dashboard links in order notes in a new tab
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -595,7 +595,7 @@ trait WC_Stripe_Subscriptions_Trait {
 							/* translators: 1) error message from Stripe; 2) request log URL */
 							__( 'Sorry, we are unable to process the payment at this time. Reason: %1$s %2$s', 'woocommerce-gateway-stripe' ),
 							$response->error->message,
-							isset( $response->error->request_log_url ) ? make_clickable( $response->error->request_log_url ) : ''
+							isset( $response->error->request_log_url ) ? '<a href="' . esc_url( $response->error->request_log_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $response->error->request_log_url ) . '</a>' : ''
 						);
 						$renewal_order->add_order_note( $localized_message );
 						throw new WC_Stripe_Exception( print_r( $response, true ), $localized_message );
@@ -612,7 +612,7 @@ trait WC_Stripe_Subscriptions_Trait {
 				}
 
 				if ( isset( $response->error->request_log_url ) ) {
-					$localized_message .= ' ' . make_clickable( $response->error->request_log_url );
+					$localized_message .= ' <a href="' . esc_url( $response->error->request_log_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $response->error->request_log_url ) . '</a>';
 				}
 
 				$renewal_order->add_order_note( $localized_message );

--- a/readme.txt
+++ b/readme.txt
@@ -236,5 +236,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Fix - Open the Stripe Dashboard links in order notes in a new tab
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/compat/class-wc-stripe-subscription-renewal-test.php
+++ b/tests/phpunit/compat/class-wc-stripe-subscription-renewal-test.php
@@ -791,7 +791,7 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 	 */
 	public function test_failed_renewal_note_links_request_log_url_in_new_tab( $mock_error_data, $expected_note_template ) {
 		$renewal_order   = WC_Helper_Order::create_order();
-		$request_log_url = 'https://dashboard.stripe.com/acct_123abc/test/logs/req_123abc';
+		$request_log_url = 'https://dashboard.stripe.com/acct_123abc/test/logs/req_123abc?t=123&span=456';
 
 		// Mock prepare_order_source() to return a valid customer.
 		$this->wc_gateway_stripe
@@ -833,15 +833,25 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 
 		\remove_filter( 'pre_http_request', $pre_http_request_response_callback, 10 );
 
+		// The fixture URL's "&" locks in the escaping: esc_url() encodes it as "&#038;"
+		// in the href, esc_html() as "&amp;" in the link text.
+		$expected_href = 'https://dashboard.stripe.com/acct_123abc/test/logs/req_123abc?t=123&#038;span=456';
+		$expected_text = 'https://dashboard.stripe.com/acct_123abc/test/logs/req_123abc?t=123&amp;span=456';
+
 		$expected_note = sprintf(
 			$expected_note_template,
-			'<a href="' . $request_log_url . '" target="_blank" rel="noopener noreferrer">' . $request_log_url . '</a>'
+			'<a href="' . $expected_href . '" target="_blank" rel="noopener noreferrer">' . $expected_text . '</a>'
 		);
 		$note_contents = wp_list_pluck( wc_get_order_notes( [ 'order_id' => $renewal_order->get_id() ] ), 'content' );
 
 		$this->assertContains( $expected_note, $note_contents );
 	}
 
+	/**
+	 * Data provider for `test_failed_renewal_note_links_request_log_url_in_new_tab`.
+	 *
+	 * @return array
+	 */
 	public function provide_test_failed_renewal_note_links_request_log_url_in_new_tab() {
 		return [
 			'non-retryable card decline'             => [

--- a/tests/phpunit/compat/class-wc-stripe-subscription-renewal-test.php
+++ b/tests/phpunit/compat/class-wc-stripe-subscription-renewal-test.php
@@ -782,4 +782,83 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected_raw_error, $thrown_exception->getMessage() );
 		$this->assertEquals( $expected_localized_error, $thrown_exception->getLocalizedMessage() );
 	}
+
+	/**
+	 * The failure order note links the Stripe request log URL with target="_blank" so the
+	 * merchant does not navigate away from the order screen when opening it.
+	 *
+	 * @dataProvider provide_test_failed_renewal_note_links_request_log_url_in_new_tab
+	 */
+	public function test_failed_renewal_note_links_request_log_url_in_new_tab( $mock_error_data, $expected_note_template ) {
+		$renewal_order   = WC_Helper_Order::create_order();
+		$request_log_url = 'https://dashboard.stripe.com/acct_123abc/test/logs/req_123abc';
+
+		// Mock prepare_order_source() to return a valid customer.
+		$this->wc_gateway_stripe
+			->method( 'prepare_order_source' )
+			->willReturn(
+				(object) [
+					'token_id'       => false,
+					'customer'       => 'cus_123abc',
+					'source'         => 'src_123abc',
+					'source_object'  => (object) [
+						'type' => WC_Stripe_Payment_Methods::CARD,
+					],
+					'payment_method' => null,
+				]
+			);
+
+		$mock_error = (object) [
+			'error' => (object) array_merge( $mock_error_data, [ 'request_log_url' => $request_log_url ] ),
+		];
+
+		// Arrange: Add filter that will return a mocked HTTP response for the payment_intent call.
+		$pre_http_request_response_callback = function ( $preempt, $request_args, $url ) use ( $mock_error ) {
+			if ( 'https://api.stripe.com/v1/payment_intents' !== $url ) {
+				return $preempt;
+			}
+
+			return [
+				'headers'  => [],
+				'body'     => json_encode( $mock_error ),
+				'response' => [
+					'code'    => 400,
+					'message' => 'Bad Request',
+				],
+			];
+		};
+		\add_filter( 'pre_http_request', $pre_http_request_response_callback, 10, 3 );
+
+		$this->wc_gateway_stripe->process_subscription_payment( $renewal_order->get_total(), $renewal_order, false, false );
+
+		\remove_filter( 'pre_http_request', $pre_http_request_response_callback, 10 );
+
+		$expected_note = sprintf(
+			$expected_note_template,
+			'<a href="' . $request_log_url . '" target="_blank" rel="noopener noreferrer">' . $request_log_url . '</a>'
+		);
+		$note_contents = wp_list_pluck( wc_get_order_notes( [ 'order_id' => $renewal_order->get_id() ] ), 'content' );
+
+		$this->assertContains( $expected_note, $note_contents );
+	}
+
+	public function provide_test_failed_renewal_note_links_request_log_url_in_new_tab() {
+		return [
+			'non-retryable card decline'             => [
+				[
+					'type'    => 'card_error',
+					'code'    => 'card_declined',
+					'message' => 'Mock card declined error',
+				],
+				'The card was declined. %s',
+			],
+			'retryable error with retries exhausted' => [
+				[
+					'type'    => 'api_error',
+					'message' => 'Mock API error',
+				],
+				'Sorry, we are unable to process the payment at this time. Reason: Mock API error %s',
+			],
+		];
+	}
 }


### PR DESCRIPTION
Fixes STRIPE-1281
Fixes #5707

## Changes proposed in this Pull Request:

This PR replaces `make_clickable()` with an explicit anchor carrying `target="_blank" rel="noopener noreferrer"` to match the other order note links in the plugin (e.g. the webhook handler's dispute and refund notes)

## Testing instructions

1. Go to he Store, and place an order for a subscription and pay with the `4242 4242 4242 4242` test card.
2. Add this snippet to simulate a card decline on renewal:
      ```php
      add_filter( 'pre_http_request', function ( $pre, $args, $url ) {
          if ( false !== strpos( $url, 'api.stripe.com/v1/payment_intents' ) ) {
              return [
                  'headers'  => [],
                  'body'     => wp_json_encode( [
                      'error' => [
                          'type'            => 'card_error',
                          'code'            => 'card_declined',
                          'message'         => 'Your card was declined.',
                          'request_log_url' => 'https://dashboard.stripe.com/test/logs/req_test123',
                      ],
                  ] ),
                  'response' => [ 'code' => 400, 'message' => 'Bad Request' ],
              ];
          }
          return $pre;
      }, 10, 3 );
      ```
3. Go to `WP-Admin > WooCommerce > Subscriptions`, open the subscription, and run the **Process renewal** subscription action.
4. Open the newly created (failed) renewal order and find the order note reading `The card was declined.
  https://dashboard.stripe.com/test/logs/req_test123`.
5. Click the link and verify it opens in a **new tab**.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
