### PR TITLE
Fix potential fatal in level3 checks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -79,6 +79,7 @@ xxxx-xx-xx - version 10.9.0
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Fix - Prevent fatals during internal order check
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1612,6 +1612,10 @@ class WC_Stripe_Helper {
 	 * @return bool Whether Level 3 data applies to the order's payment method.
 	 */
 	public static function order_supports_level3_data( $order ) {
+		if ( ! $order instanceof WC_Order ) {
+			return false;
+		}
+
 		$payment_method_type = WC_Stripe_Order_Helper::get_instance()->get_stripe_upe_payment_type( $order );
 
 		// Legacy WC_Gateway_Stripe orders and the charge-based capture fallback never write the

--- a/readme.txt
+++ b/readme.txt
@@ -236,5 +236,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Show a clear message when manual capture is blocking Adaptive Pricing from being enabled
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
+* Fix - Prevent fatals during internal order check
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -886,6 +886,37 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
+	 * Test for `order_supports_level3_data` with invalid order data.
+	 *
+	 * @dataProvider provide_invalid_order_for_order_supports_level3_data
+	 * @param mixed $order The invalid order data.
+	 * @return void
+	 */
+	public function test_order_supports_level3_data_with_invalid_order( $order ): void {
+		$this->assertFalse( WC_Stripe_Helper::order_supports_level3_data( $order ) );
+	}
+
+	/**
+	 * Data provider for {@see test_order_supports_level3_data_with_invalid_order()}.
+	 *
+	 * @return array
+	 */
+	public function provide_invalid_order_for_order_supports_level3_data(): array {
+		return [
+			'null'            => [ null ],
+			'false'           => [ false ],
+			'string'          => [ 'invalid' ],
+			'int'             => [ 123 ],
+			'float'           => [ 123.45 ],
+			'true'            => [ true ],
+			'array'           => [ [ 'invalid' ] ],
+			'object'          => [ new stdClass() ],
+			'WP_Error'        => [ new WP_Error( 'invalid', 'Invalid order data' ) ],
+			'WC_Order_Refund' => [ $this->getMockBuilder( WC_Order_Refund::class )->disableOriginalConstructor()->getMock() ],
+		];
+	}
+
+	/**
 	 * Provider for `test_payment_method_allows_manual_capture`
 	 *
 	 * @return array


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-1294
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/5735

Related to https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5681

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR adds a guard against a non-`WC_Order` argument to `WC_Stripe_Helper->order_supports_level3_data()` to prevent runtime fatals for incorrect calls. The guard is needed as the code calls `WC_Stripe_Order_Helper->get_stripe_upe_payment_type()` which accepts a more strictly typed `?WC_Order` argument.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
Code inspection should be sufficient.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
