### PR TITLE
Ensure disabled checked checkboxes in admin UI look disabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -80,6 +80,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
 * Fix - Prevent fatals during internal order check
+* Fix - Ensure that settings with checked, disabled checkboxes look disabled
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/client/settings/payment-settings/style.scss
+++ b/client/settings/payment-settings/style.scss
@@ -63,9 +63,3 @@
 	display: block;
 	padding-top: styles.$grid-unit-10;
 }
-
-.wcstripe-test-mode-checkbox--disabled {
-	.components-checkbox-control__input-container {
-		opacity: 0.5;
-	}
-}

--- a/client/settings/payment-settings/test-mode-checkbox.js
+++ b/client/settings/payment-settings/test-mode-checkbox.js
@@ -50,11 +50,6 @@ const TestModeCheckbox = () => {
 		<>
 			<h4>{ __( 'Test mode', 'woocommerce-gateway-stripe' ) }</h4>
 			<CheckboxControl
-				className={
-					isLocked
-						? 'wcstripe-test-mode-checkbox--disabled'
-						: undefined
-				}
 				checked={ isTestModeEnabled }
 				disabled={ isLocked }
 				onChange={ handleCheckboxChange }

--- a/client/settings/styles.scss
+++ b/client/settings/styles.scss
@@ -1,5 +1,10 @@
 #wc-stripe-account-settings-container {
 	box-sizing: border-box;
+
+	/* Ensure that disabled, checked checkboxes look disabled */
+	.components-checkbox-control__input[type='checkbox']:checked:disabled {
+		opacity: 0.5;
+	}
 }
 
 #wc-stripe-new-account-container {

--- a/readme.txt
+++ b/readme.txt
@@ -237,5 +237,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
 * Fix - Prevent fatals during internal order check
+* Fix - Ensure that settings with checked, disabled checkboxes look disabled
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Related to https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5597

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR expands the implementation from https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5597 to apply to _any_ checkbox in the settings UI that is both checked and disabled. More specifically, any checked, disabled checkbox control in the settings UI should now get `opacity: 0.5;` assigned, which makes the content look greyed out. The PR removes the CSS and additional class used for #5597 in favour of a top-level CSS rule that applies to all checkbox controls.

Prior to this change, the disabled state was only distinguishable from the active state by mousing over the checkbox and noticing that the cursor didn't change and/or that clicking on the checkbox had no effect. The most noticeable area affected by these changes is for Optimized Checkout Suite and Adaptive Pricing, which can both be disabled for various reasons.

### Screenshots

#### Before

<img width="1099" height="632" alt="Screenshot 2026-07-24 at 17 04 00" src="https://github.com/user-attachments/assets/54cf5b24-36d6-444a-8f9a-f5903d65b4cb" />

_Note the checkbox control for "Dynamically display the most relevant payment methods you've enabled" looks the same as the "Log debug messages" control._

#### After

<img width="1099" height="632" alt="Screenshot 2026-07-24 at 17 03 28" src="https://github.com/user-attachments/assets/6fe52b39-2dce-4f3e-85cd-2cc5c1df6c28" />

_Note how the checkbox after the warning message looks disabled._

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

* Run a build with the code from this branch/PR applied
* Connect to Stripe in test mode only
* Open the settings page and confirm that the "Enable test mode" checkbox has the dimmed style applied. (This is a regression test for the initial PR.)
* Enable Optimized Checkout Suite to get the setting enabled. Optionally enable Adaptive Pricing as well if it is available.
* Run the following command to disable Settings Sync: `wp option patch update woocommerce_stripe_settings pmc_enabled no`
* Reload the page.
* Confirm that the Optimized Checkout Suite checkbox is dimmed and still checked.
* If you had also enabled Adaptive Pricing, verify that the checkbox is dimmed and still checked.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
