### PR TITLE
Center card field content on the Blocks checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -80,6 +80,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
 * Fix - Prevent fatals during internal order check
+* Fix - Center the card brand icons and field text vertically in the card fields on the Blocks checkout
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/changelog.txt
+++ b/changelog.txt
@@ -82,7 +82,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
 * Fix - Open the Stripe Dashboard links in subscription renewal failure order notes in a new tab
 * Fix - Prevent fatals during internal order check
-* Fix - Center the card brand icons and field text vertically in the card fields on the Blocks checkout
+* Fix - Center the text and card icons inside the payment fields on the Blocks checkout
 * Fix - Ensure that settings with checked, disabled checkboxes look disabled
 
 2026-07-14 - version 10.8.4

--- a/client/styles/upe/__tests__/utils.js
+++ b/client/styles/upe/__tests__/utils.js
@@ -111,6 +111,89 @@ describe( 'handleAppearanceForFloatingLabel', () => {
 		},
 	} );
 
+	// Values a stock Blocks checkout produces at a 16px root font size:
+	// `.wc-block-components-text-input.is-active input` resolves to
+	// `padding: 24px 9px 8px`, and its label to `line-height: 22px` with
+	// `transform: scale(0.82)`.
+	const BLOCKS_INPUT_PADDING_TOP = '24px';
+	const BLOCKS_INPUT_PADDING_BOTTOM = '8px';
+	const BLOCKS_FLOATING_LABEL = {
+		transform: 'matrix(0.82, 0, 0, 0.82, 0, 0)',
+		lineHeight: '22px',
+		color: 'rgb(100, 100, 100)',
+	};
+
+	it( 'splits the floating label compensation evenly across the input', () => {
+		const appearance = makeAppearance( {
+			paddingTop: BLOCKS_INPUT_PADDING_TOP,
+			paddingBottom: BLOCKS_INPUT_PADDING_BOTTOM,
+		} );
+
+		const result = upeUtils.handleAppearanceForFloatingLabel( appearance, {
+			...BLOCKS_FLOATING_LABEL,
+		} );
+
+		// Stripe centers field content — including the card brand icons — inside
+		// .Input, so an uneven split leaves them sitting off-center.
+		expect( result.rules[ '.Input' ].paddingTop ).toBe(
+			result.rules[ '.Input' ].paddingBottom
+		);
+
+		// floor(22 * 0.82) = 18px reserved for the label, plus Stripe's 4px and
+		// 1px of offset per side: (24 + 8 - 18 - 4 - 2) / 2 = 4px each.
+		expect( result.rules[ '.Input' ].paddingTop ).toBe( '4px' );
+		expect( result.rules[ '.Input' ].paddingBottom ).toBe( '4px' );
+	} );
+
+	it( 'preserves the total vertical padding so the field height is unchanged', () => {
+		const appearance = makeAppearance( {
+			paddingTop: BLOCKS_INPUT_PADDING_TOP,
+			paddingBottom: BLOCKS_INPUT_PADDING_BOTTOM,
+		} );
+
+		const result = upeUtils.handleAppearanceForFloatingLabel( appearance, {
+			...BLOCKS_FLOATING_LABEL,
+		} );
+
+		const total =
+			parseFloat( result.rules[ '.Input' ].paddingTop ) +
+			parseFloat( result.rules[ '.Input' ].paddingBottom );
+
+		// Same total the top-heavy split reserved: 1px + 7px.
+		expect( total ).toBe( 8 );
+	} );
+
+	it( 'leaves the resting label unnudged once padding is balanced', () => {
+		const appearance = makeAppearance( {
+			paddingTop: BLOCKS_INPUT_PADDING_TOP,
+			paddingBottom: BLOCKS_INPUT_PADDING_BOTTOM,
+		} );
+
+		const result = upeUtils.handleAppearanceForFloatingLabel( appearance, {
+			...BLOCKS_FLOATING_LABEL,
+		} );
+
+		// The margin existed only to pull the label back toward center against
+		// a top-heavy input; with even padding it would push it low instead.
+		expect( 'marginTop' in result.rules[ '.Label' ] ).toBe( false );
+	} );
+
+	it( 'clamps to zero rather than emitting negative padding', () => {
+		const appearance = makeAppearance( {
+			paddingTop: '8px',
+			paddingBottom: '8px',
+		} );
+
+		const result = upeUtils.handleAppearanceForFloatingLabel( appearance, {
+			...BLOCKS_FLOATING_LABEL,
+		} );
+
+		// 8 + 8 - 18 - 4 - 2 is negative; a negative padding would be dropped by
+		// Stripe and let the field grow taller than the theme's inputs.
+		expect( result.rules[ '.Input' ].paddingTop ).toBe( '0px' );
+		expect( result.rules[ '.Input' ].paddingBottom ).toBe( '0px' );
+	} );
+
 	it( 'adjusts padding and label styles with a valid transform matrix', () => {
 		const appearance = makeAppearance();
 		const floatingStyles = {
@@ -131,16 +214,12 @@ describe( 'handleAppearanceForFloatingLabel', () => {
 			'transform'
 		);
 
-		// paddingTop = calc(10px - 15px - 4px - 1px)
-		expect( result.rules[ '.Input' ].paddingTop ).toBe(
-			'calc(10px - 15px - 4px - 1px)'
-		);
+		// (10 + 12 - 15 - 4 - 2) / 2 = 0.5px on each side.
+		expect( result.rules[ '.Input' ].paddingTop ).toBe( '0.5px' );
+		expect( result.rules[ '.Input' ].paddingBottom ).toBe( '0.5px' );
 
-		// paddingBottom = 12 - 1 = 11px
-		expect( result.rules[ '.Input' ].paddingBottom ).toBe( '11px' );
-
-		// Label marginTop = floor((12 - 1) / 3) = 3px
-		expect( result.rules[ '.Label' ].marginTop ).toBe( '3px' );
+		// Balanced padding centers the resting label without a nudge.
+		expect( 'marginTop' in result.rules[ '.Label' ] ).toBe( false );
 
 		// Floating label marginTop set to 3px for border spacing.
 		expect( result.rules[ '.Label--floating' ].marginTop ).toBe( '3px' );
@@ -204,10 +283,9 @@ describe( 'handleAppearanceForFloatingLabel', () => {
 		expect( result.rules[ '.Label--floating' ] ).not.toHaveProperty(
 			'fontSize'
 		);
-		// Padding adjustments still run using original lineHeight.
-		expect( result.rules[ '.Input' ].paddingTop ).toBe(
-			'calc(10px - 20px - 4px - 1px)'
-		);
+		// Padding adjustments still run using the original lineHeight, and
+		// 10 + 12 - 20 - 4 - 2 is negative, so both sides clamp to zero.
+		expect( result.rules[ '.Input' ].paddingTop ).toBe( '0px' );
 	} );
 
 	it( 'skips transform processing when transform is none', () => {

--- a/client/styles/upe/__tests__/utils.js
+++ b/client/styles/upe/__tests__/utils.js
@@ -341,20 +341,22 @@ describe( 'handleAppearanceForFloatingLabel', () => {
 		);
 	} );
 
-	// When a value can't be resolved, all three overrides must come off
+	// When a value can't be resolved, both padding overrides come off
 	// together — a partial adjustment is worse than none.
 	describe( 'when an operand cannot be resolved', () => {
-		// One object, so a partial adjustment shows all three properties at once.
+		// One object, so a partial adjustment shows all properties at once.
+		// `.Label` marginTop is the legacy nudge the old fallback wrote;
+		// pinned here so no path reintroduces it.
 		const overridesOn = ( result ) => ( {
 			paddingTop: 'paddingTop' in result.rules[ '.Input' ],
 			paddingBottom: 'paddingBottom' in result.rules[ '.Input' ],
-			labelMarginTop: 'marginTop' in result.rules[ '.Label' ],
+			legacyLabelNudge: 'marginTop' in result.rules[ '.Label' ],
 		} );
 
 		const NONE = {
 			paddingTop: false,
 			paddingBottom: false,
-			labelMarginTop: false,
+			legacyLabelNudge: false,
 		};
 
 		it( 'drops the overrides when the label styles are empty', () => {
@@ -451,6 +453,8 @@ describe( 'handleAppearanceForFloatingLabel', () => {
 					paddingTop: result.rules[ '.Input' ].paddingTop,
 					paddingBottom: result.rules[ '.Input' ].paddingBottom,
 					labelMarginTop: result.rules[ '.Label' ].marginTop,
+					floatingLabelMarginTop:
+						result.rules[ '.Label--floating' ].marginTop,
 				} ).forEach( ( [ prop, value ] ) => {
 					if (
 						value !== undefined &&

--- a/client/styles/upe/__tests__/utils.js
+++ b/client/styles/upe/__tests__/utils.js
@@ -345,8 +345,7 @@ describe( 'handleAppearanceForFloatingLabel', () => {
 	// together — a partial adjustment is worse than none.
 	describe( 'when an operand cannot be resolved', () => {
 		// One object, so a partial adjustment shows all properties at once.
-		// `.Label` marginTop is the legacy nudge the old fallback wrote;
-		// pinned here so no path reintroduces it.
+		// The resting label must not receive a margin nudge on fallback paths.
 		const overridesOn = ( result ) => ( {
 			paddingTop: 'paddingTop' in result.rules[ '.Input' ],
 			paddingBottom: 'paddingBottom' in result.rules[ '.Input' ],

--- a/client/styles/upe/__tests__/utils.js
+++ b/client/styles/upe/__tests__/utils.js
@@ -282,25 +282,6 @@ describe( 'handleAppearanceForFloatingLabel', () => {
 		expect( result.rules[ '.Label--floating' ].transform ).toBe( 'none' );
 	} );
 
-	it( 'skips matrix block when transform is not a matrix', () => {
-		const appearance = makeAppearance();
-		const floatingStyles = {
-			transform: 'translateY(-10px)',
-			lineHeight: '20px',
-		};
-
-		const result = upeUtils.handleAppearanceForFloatingLabel(
-			appearance,
-			floatingStyles
-		);
-
-		// Matrix regex doesn't match — transform deleted but lineHeight unchanged.
-		expect( result.rules[ '.Label--floating' ] ).not.toHaveProperty(
-			'transform'
-		);
-		expect( result.rules[ '.Label--floating' ].lineHeight ).toBe( '20px' );
-	} );
-
 	// When a value can't be resolved, both padding overrides come off
 	// together — a partial adjustment is worse than none.
 	describe( 'when an operand cannot be resolved', () => {
@@ -394,6 +375,30 @@ describe( 'handleAppearanceForFloatingLabel', () => {
 			expect( overridesOn( result ) ).toEqual( NONE );
 			expect( result.rules[ '.Label--floating' ] ).not.toHaveProperty(
 				'transform'
+			);
+		} );
+
+		it( 'drops the overrides when the transform is not a 2d matrix', () => {
+			// Computed transforms are always none, matrix() or matrix3d(). A
+			// 3d matrix may scale the label, but this code can't read it.
+			const appearance = makeAppearance();
+
+			const result = upeUtils.handleAppearanceForFloatingLabel(
+				appearance,
+				{
+					transform:
+						'matrix3d(0.82, 0, 0, 0, 0, 0.82, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)',
+					lineHeight: '20px',
+				}
+			);
+
+			expect( overridesOn( result ) ).toEqual( NONE );
+			expect( result.rules[ '.Label--floating' ] ).not.toHaveProperty(
+				'transform'
+			);
+			// The unreadable transform is discarded, not applied unscaled.
+			expect( result.rules[ '.Label--floating' ].lineHeight ).toBe(
+				'20px'
 			);
 		} );
 

--- a/client/styles/upe/__tests__/utils.js
+++ b/client/styles/upe/__tests__/utils.js
@@ -244,27 +244,6 @@ describe( 'handleAppearanceForFloatingLabel', () => {
 		);
 	} );
 
-	it( 'returns early when matrix scale components are non-finite', () => {
-		const appearance = makeAppearance();
-		const floatingStyles = {
-			transform: 'matrix(foo, 0, 0, 0.75, 0, -10)',
-			lineHeight: '20px',
-		};
-
-		const result = upeUtils.handleAppearanceForFloatingLabel(
-			appearance,
-			floatingStyles
-		);
-
-		// Early return path: transform removed, no padding/margin adjustments applied.
-		expect( result.rules[ '.Label--floating' ] ).not.toHaveProperty(
-			'transform'
-		);
-		expect( result.rules[ '.Input' ].paddingTop ).toBe( '10px' );
-		expect( result.rules[ '.Input' ].paddingBottom ).toBe( '12px' );
-		expect( 'marginTop' in result.rules[ '.Label' ] ).toBe( false );
-	} );
-
 	it( 'skips transform processing when transform is absent', () => {
 		const appearance = makeAppearance();
 		const floatingStyles = {
@@ -320,25 +299,6 @@ describe( 'handleAppearanceForFloatingLabel', () => {
 			'transform'
 		);
 		expect( result.rules[ '.Label--floating' ].lineHeight ).toBe( '20px' );
-	} );
-
-	it( 'returns early when lineHeight is NaN', () => {
-		const appearance = makeAppearance();
-		const floatingStyles = {
-			transform: 'matrix(0.75, 0, 0, 0.75, 0, -10)',
-			lineHeight: 'normal',
-		};
-
-		const result = upeUtils.handleAppearanceForFloatingLabel(
-			appearance,
-			floatingStyles
-		);
-
-		// NaN guard triggers early return — padding unchanged.
-		expect( result.rules[ '.Input' ].paddingTop ).toBe( '10px' );
-		expect( result.rules[ '.Label--floating' ] ).not.toHaveProperty(
-			'transform'
-		);
 	} );
 
 	// When a value can't be resolved, both padding overrides come off
@@ -399,6 +359,55 @@ describe( 'handleAppearanceForFloatingLabel', () => {
 			expect( overridesOn( result ) ).toEqual( NONE );
 		} );
 
+		it( 'drops the overrides when the matrix scale is not finite', () => {
+			const appearance = makeAppearance();
+
+			const result = upeUtils.handleAppearanceForFloatingLabel(
+				appearance,
+				{
+					transform: 'matrix(foo, 0, 0, 0.75, 0, -10)',
+					lineHeight: '20px',
+				}
+			);
+
+			expect( overridesOn( result ) ).toEqual( NONE );
+			expect( result.rules[ '.Label--floating' ] ).not.toHaveProperty(
+				'transform'
+			);
+			// The label still floats, so it keeps its border offset.
+			expect( result.rules[ '.Label--floating' ].marginTop ).toBe(
+				'3px'
+			);
+		} );
+
+		it( 'drops the overrides when lineHeight is a keyword and a transform scales it', () => {
+			const appearance = makeAppearance();
+
+			const result = upeUtils.handleAppearanceForFloatingLabel(
+				appearance,
+				{
+					transform: 'matrix(0.75, 0, 0, 0.75, 0, -10)',
+					lineHeight: 'normal',
+				}
+			);
+
+			expect( overridesOn( result ) ).toEqual( NONE );
+			expect( result.rules[ '.Label--floating' ] ).not.toHaveProperty(
+				'transform'
+			);
+		} );
+
+		it( 'drops the overrides when a padding is not in px', () => {
+			const appearance = makeAppearance( { paddingTop: '1.5rem' } );
+
+			const result = upeUtils.handleAppearanceForFloatingLabel(
+				appearance,
+				{ lineHeight: '20px' }
+			);
+
+			expect( overridesOn( result ) ).toEqual( NONE );
+		} );
+
 		it( 'drops the overrides when paddingTop is absent', () => {
 			const appearance = makeAppearance();
 			delete appearance.rules[ '.Input' ].paddingTop;
@@ -437,6 +446,11 @@ describe( 'handleAppearanceForFloatingLabel', () => {
 				[
 					'var() padding',
 					{ paddingBottom: 'var(--pad)' },
+					{ lineHeight: '20px' },
+				],
+				[
+					'rem padding',
+					{ paddingTop: '1.5rem' },
 					{ lineHeight: '20px' },
 				],
 			];

--- a/client/styles/upe/__tests__/utils.js
+++ b/client/styles/upe/__tests__/utils.js
@@ -111,10 +111,8 @@ describe( 'handleAppearanceForFloatingLabel', () => {
 		},
 	} );
 
-	// Values a stock Blocks checkout produces at a 16px root font size:
-	// `.wc-block-components-text-input.is-active input` resolves to
-	// `padding: 24px 9px 8px`, and its label to `line-height: 22px` with
-	// `transform: scale(0.82)`.
+	// Real values from a stock Blocks checkout at a 16px root font size:
+	// input padding 24px top / 8px bottom, label line-height 22px, scale 0.82.
 	const BLOCKS_INPUT_PADDING_TOP = '24px';
 	const BLOCKS_INPUT_PADDING_BOTTOM = '8px';
 	const BLOCKS_FLOATING_LABEL = {
@@ -343,41 +341,127 @@ describe( 'handleAppearanceForFloatingLabel', () => {
 		);
 	} );
 
-	it( 'skips paddingTop adjustment when paddingTop is absent', () => {
-		const appearance = makeAppearance();
-		delete appearance.rules[ '.Input' ].paddingTop;
-		const floatingStyles = {
-			lineHeight: '20px',
+	// When a value can't be resolved, all three overrides must come off
+	// together — a partial adjustment is worse than none.
+	describe( 'when an operand cannot be resolved', () => {
+		// One object, so a partial adjustment shows all three properties at once.
+		const overridesOn = ( result ) => ( {
+			paddingTop: 'paddingTop' in result.rules[ '.Input' ],
+			paddingBottom: 'paddingBottom' in result.rules[ '.Input' ],
+			labelMarginTop: 'marginTop' in result.rules[ '.Label' ],
+		} );
+
+		const NONE = {
+			paddingTop: false,
+			paddingBottom: false,
+			labelMarginTop: false,
 		};
 
-		const result = upeUtils.handleAppearanceForFloatingLabel(
-			appearance,
-			floatingStyles
-		);
+		it( 'drops the overrides when the label styles are empty', () => {
+			// A missed selector gives {} label styles while the input padding
+			// is still valid. Without the guard this emits `calc(... - undefined ...)`.
+			const appearance = makeAppearance( {
+				paddingTop: BLOCKS_INPUT_PADDING_TOP,
+				paddingBottom: BLOCKS_INPUT_PADDING_BOTTOM,
+			} );
 
-		expect( 'paddingTop' in result.rules[ '.Input' ] ).toBe( false );
-		// paddingBottom adjustment still runs.
-		expect( result.rules[ '.Input' ].paddingBottom ).toBe( '11px' );
-	} );
+			const result = upeUtils.handleAppearanceForFloatingLabel(
+				appearance,
+				{}
+			);
 
-	it( 'skips paddingBottom adjustment when paddingBottom is absent', () => {
-		const appearance = makeAppearance();
-		delete appearance.rules[ '.Input' ].paddingBottom;
-		const floatingStyles = {
-			lineHeight: '20px',
-		};
+			expect( overridesOn( result ) ).toEqual( NONE );
+		} );
 
-		const result = upeUtils.handleAppearanceForFloatingLabel(
-			appearance,
-			floatingStyles
-		);
+		it( 'drops the overrides when the input styles are empty', () => {
+			const appearance = makeAppearance();
+			delete appearance.rules[ '.Input' ].paddingTop;
+			delete appearance.rules[ '.Input' ].paddingBottom;
 
-		expect( 'paddingBottom' in result.rules[ '.Input' ] ).toBe( false );
-		// paddingTop adjustment still runs.
-		expect( result.rules[ '.Input' ].paddingTop ).toBe(
-			'calc(10px - 20px - 4px - 1px)'
-		);
-		// Label marginTop not adjusted without paddingBottom.
-		expect( 'marginTop' in result.rules[ '.Label' ] ).toBe( false );
+			const result = upeUtils.handleAppearanceForFloatingLabel(
+				appearance,
+				{ ...BLOCKS_FLOATING_LABEL }
+			);
+
+			expect( overridesOn( result ) ).toEqual( NONE );
+		} );
+
+		it( 'drops the overrides when lineHeight is a keyword and no transform scales it', () => {
+			// No transform means no early return — `normal` reaches the padding math.
+			const appearance = makeAppearance();
+
+			const result = upeUtils.handleAppearanceForFloatingLabel(
+				appearance,
+				{ lineHeight: 'normal', color: 'rgb(100, 100, 100)' }
+			);
+
+			expect( overridesOn( result ) ).toEqual( NONE );
+		} );
+
+		it( 'drops the overrides when paddingTop is absent', () => {
+			const appearance = makeAppearance();
+			delete appearance.rules[ '.Input' ].paddingTop;
+
+			const result = upeUtils.handleAppearanceForFloatingLabel(
+				appearance,
+				{ lineHeight: '20px' }
+			);
+
+			expect( overridesOn( result ) ).toEqual( NONE );
+		} );
+
+		it( 'drops the overrides when paddingBottom is absent', () => {
+			const appearance = makeAppearance();
+			delete appearance.rules[ '.Input' ].paddingBottom;
+
+			const result = upeUtils.handleAppearanceForFloatingLabel(
+				appearance,
+				{ lineHeight: '20px' }
+			);
+
+			expect( overridesOn( result ) ).toEqual( NONE );
+		} );
+
+		it( 'never emits an unusable length', () => {
+			// Stripe silently drops values it can't parse, so a bad one is
+			// invisible in production. Anything emitted must be a plain px length.
+			const cases = [
+				[ 'empty label styles', { paddingTop: '24px' }, {} ],
+				[ 'keyword lineHeight', {}, { lineHeight: 'normal' } ],
+				[
+					'calc() padding',
+					{ paddingTop: 'calc(1rem + 2px)' },
+					{ lineHeight: '20px' },
+				],
+				[
+					'var() padding',
+					{ paddingBottom: 'var(--pad)' },
+					{ lineHeight: '20px' },
+				],
+			];
+
+			const violations = [];
+			cases.forEach( ( [ name, inputOverrides, floatingStyles ] ) => {
+				const result = upeUtils.handleAppearanceForFloatingLabel(
+					makeAppearance( inputOverrides ),
+					floatingStyles
+				);
+
+				Object.entries( {
+					paddingTop: result.rules[ '.Input' ].paddingTop,
+					paddingBottom: result.rules[ '.Input' ].paddingBottom,
+					labelMarginTop: result.rules[ '.Label' ].marginTop,
+				} ).forEach( ( [ prop, value ] ) => {
+					if (
+						value !== undefined &&
+						! /^\d+(\.\d+)?px$/.test( value )
+					) {
+						violations.push( `${ name } → ${ prop }: ${ value }` );
+					}
+				} );
+			} );
+
+			expect( violations ).toEqual( [] );
+		} );
 	} );
 } );

--- a/client/styles/upe/utils.js
+++ b/client/styles/upe/utils.js
@@ -186,26 +186,66 @@ export const handleAppearanceForFloatingLabel = (
 		delete appearance.rules[ '.Label--floating' ].transform;
 	}
 
-	// Subtract the label's lineHeight from padding-top to account for floating label height.
-	// Minus STRIPE_PADDING_TOP which is a constant value added by Stripe to the padding-top.
-	// Minus STRIPE_PADDING_OFFSET for each vertical padding to account for unpredictable input height.
-	if ( appearance.rules[ '.Input' ].paddingTop ) {
-		appearance.rules[
-			'.Input'
-		].paddingTop = `calc(${ appearance.rules[ '.Input' ].paddingTop } - ${ appearance.rules[ '.Label--floating' ].lineHeight } - ${ STRIPE_PADDING_TOP } - ${ STRIPE_PADDING_OFFSET })`;
-	}
-	if ( appearance.rules[ '.Input' ].paddingBottom ) {
-		const paddingOffset = parseFloat( STRIPE_PADDING_OFFSET );
-		const originalPaddingBottom = parseFloat(
-			appearance.rules[ '.Input' ].paddingBottom
-		);
-		appearance.rules[ '.Input' ].paddingBottom = `${
-			originalPaddingBottom - paddingOffset
-		}px`;
+	// Reserve room for the floating label without letting the field grow taller
+	// than the theme's own inputs. The space the label needs is its lineHeight,
+	// plus STRIPE_PADDING_TOP which Stripe adds to padding-top on its own, plus
+	// STRIPE_PADDING_OFFSET per side to absorb unpredictable input height.
+	const paddingTop = parseFloat( appearance.rules[ '.Input' ].paddingTop );
+	const paddingBottom = parseFloat(
+		appearance.rules[ '.Input' ].paddingBottom
+	);
+	const floatingLabelLineHeight = parseFloat(
+		appearance.rules[ '.Label--floating' ].lineHeight
+	);
 
-		appearance.rules[ '.Label' ].marginTop = `${ Math.floor(
-			( originalPaddingBottom - paddingOffset ) / 3
-		) }px`;
+	if (
+		Number.isFinite( paddingTop ) &&
+		Number.isFinite( paddingBottom ) &&
+		Number.isFinite( floatingLabelLineHeight )
+	) {
+		// Themes that float their labels park the extra vertical space at the
+		// top of the input, where the label sits. Stripe centers what it draws
+		// inside .Input — the value, and the card brand icons on the card
+		// number field — against the padding box, so carrying that top-heavy
+		// split across leaves them visibly high. Take the same total out of
+		// both sides instead: the field keeps its height and the contents stay
+		// centered. Clamped at zero because a negative padding is dropped, and
+		// the field would then outgrow the theme's inputs.
+		const reservedForLabel =
+			floatingLabelLineHeight +
+			parseFloat( STRIPE_PADDING_TOP ) +
+			parseFloat( STRIPE_PADDING_OFFSET ) * 2;
+		const balancedPadding = Math.max(
+			0,
+			( paddingTop + paddingBottom - reservedForLabel ) / 2
+		);
+
+		appearance.rules[ '.Input' ].paddingTop = `${ balancedPadding }px`;
+		appearance.rules[ '.Input' ].paddingBottom = `${ balancedPadding }px`;
+	} else {
+		// Fall back to adjusting each side on its own when a padding or the
+		// label's lineHeight doesn't resolve to a number (`normal`, a keyword,
+		// or absent from the sampled styles).
+		if ( appearance.rules[ '.Input' ].paddingTop ) {
+			appearance.rules[
+				'.Input'
+			].paddingTop = `calc(${ appearance.rules[ '.Input' ].paddingTop } - ${ appearance.rules[ '.Label--floating' ].lineHeight } - ${ STRIPE_PADDING_TOP } - ${ STRIPE_PADDING_OFFSET })`;
+		}
+		if ( appearance.rules[ '.Input' ].paddingBottom ) {
+			const paddingOffset = parseFloat( STRIPE_PADDING_OFFSET );
+			const originalPaddingBottom = parseFloat(
+				appearance.rules[ '.Input' ].paddingBottom
+			);
+			appearance.rules[ '.Input' ].paddingBottom = `${
+				originalPaddingBottom - paddingOffset
+			}px`;
+
+			// Pulls the resting label back toward center against the top-heavy
+			// input this branch leaves behind.
+			appearance.rules[ '.Label' ].marginTop = `${ Math.floor(
+				( originalPaddingBottom - paddingOffset ) / 3
+			) }px`;
+		}
 	}
 
 	// Add top margin so the floating label doesn't sit flush against the input border.

--- a/client/styles/upe/utils.js
+++ b/client/styles/upe/utils.js
@@ -186,10 +186,7 @@ export const handleAppearanceForFloatingLabel = (
 		delete appearance.rules[ '.Label--floating' ].transform;
 	}
 
-	// Reserve room for the floating label without letting the field grow taller
-	// than the theme's own inputs. The space the label needs is its lineHeight,
-	// plus STRIPE_PADDING_TOP which Stripe adds to padding-top on its own, plus
-	// STRIPE_PADDING_OFFSET per side to absorb unpredictable input height.
+	// Reserve room for the floating label without letting the field grow taller.
 	const paddingTop = parseFloat( appearance.rules[ '.Input' ].paddingTop );
 	const paddingBottom = parseFloat(
 		appearance.rules[ '.Input' ].paddingBottom
@@ -203,14 +200,8 @@ export const handleAppearanceForFloatingLabel = (
 		Number.isFinite( paddingBottom ) &&
 		Number.isFinite( floatingLabelLineHeight )
 	) {
-		// Themes that float their labels park the extra vertical space at the
-		// top of the input, where the label sits. Stripe centers what it draws
-		// inside .Input — the value, and the card brand icons on the card
-		// number field — against the padding box, so carrying that top-heavy
-		// split across leaves them visibly high. Take the same total out of
-		// both sides instead: the field keeps its height and the contents stay
-		// centered. Clamped at zero because a negative padding is dropped, and
-		// the field would then outgrow the theme's inputs.
+		// Split the padding evenly: content stays centered, field height unchanged.
+		// Clamp at zero — negative padding is invalid CSS.
 		const reservedForLabel =
 			floatingLabelLineHeight +
 			parseFloat( STRIPE_PADDING_TOP ) +
@@ -223,29 +214,10 @@ export const handleAppearanceForFloatingLabel = (
 		appearance.rules[ '.Input' ].paddingTop = `${ balancedPadding }px`;
 		appearance.rules[ '.Input' ].paddingBottom = `${ balancedPadding }px`;
 	} else {
-		// Fall back to adjusting each side on its own when a padding or the
-		// label's lineHeight doesn't resolve to a number (`normal`, a keyword,
-		// or absent from the sampled styles).
-		if ( appearance.rules[ '.Input' ].paddingTop ) {
-			appearance.rules[
-				'.Input'
-			].paddingTop = `calc(${ appearance.rules[ '.Input' ].paddingTop } - ${ appearance.rules[ '.Label--floating' ].lineHeight } - ${ STRIPE_PADDING_TOP } - ${ STRIPE_PADDING_OFFSET })`;
-		}
-		if ( appearance.rules[ '.Input' ].paddingBottom ) {
-			const paddingOffset = parseFloat( STRIPE_PADDING_OFFSET );
-			const originalPaddingBottom = parseFloat(
-				appearance.rules[ '.Input' ].paddingBottom
-			);
-			appearance.rules[ '.Input' ].paddingBottom = `${
-				originalPaddingBottom - paddingOffset
-			}px`;
-
-			// Pulls the resting label back toward center against the top-heavy
-			// input this branch leaves behind.
-			appearance.rules[ '.Label' ].marginTop = `${ Math.floor(
-				( originalPaddingBottom - paddingOffset ) / 3
-			) }px`;
-		}
+		// A value didn't resolve to a number, so the compensation can't be
+		// computed. Remove both overrides and let Stripe's defaults apply.
+		delete appearance.rules[ '.Input' ].paddingTop;
+		delete appearance.rules[ '.Input' ].paddingBottom;
 	}
 
 	// Add top margin so the floating label doesn't sit flush against the input border.

--- a/client/styles/upe/utils.js
+++ b/client/styles/upe/utils.js
@@ -134,6 +134,12 @@ const STRIPE_PADDING_TOP = '4px';
 const STRIPE_PADDING_OFFSET = '1px';
 const STRIPE_FLOATING_LABEL_MARGIN_TOP = '3px';
 
+// Computed styles resolve to px; anything else means the value didn't resolve.
+const parsePx = ( value ) =>
+	typeof value === 'string' && value.endsWith( 'px' )
+		? parseFloat( value )
+		: NaN;
+
 /**
  * Modifies the appearance object to include styles for floating label.
  * Adjusts input padding to prevent fields from growing taller when labels
@@ -150,7 +156,10 @@ export const handleAppearanceForFloatingLabel = (
 	// Add floating label styles.
 	appearance.rules[ '.Label--floating' ] = floatingLabelStyles;
 
-	// Update line-height for floating label to account for scaling.
+	// Update line-height for floating label to account for scaling. Cleared
+	// when the label's rendered size can't be determined, so the padding
+	// logic below stands down instead of compensating with a wrong value.
+	let compensationPossible = true;
 	if (
 		appearance.rules[ '.Label--floating' ].transform &&
 		appearance.rules[ '.Label--floating' ].transform !== 'none'
@@ -162,40 +171,38 @@ export const handleAppearanceForFloatingLabel = (
 			const splitMatrixValues = matrixValues[ 1 ].split( /\s*,\s*/ );
 			const scaleX = parseFloat( splitMatrixValues[ 0 ] );
 			const scaleY = parseFloat( splitMatrixValues[ 3 ] );
-			if ( ! Number.isFinite( scaleX ) || ! Number.isFinite( scaleY ) ) {
-				delete appearance.rules[ '.Label--floating' ].transform;
-				return appearance;
-			}
-			const scale = ( scaleX + scaleY ) / 2;
-
-			const lineHeight = parseFloat(
+			const lineHeight = parsePx(
 				appearance.rules[ '.Label--floating' ].lineHeight
 			);
-			if ( isNaN( lineHeight ) ) {
-				delete appearance.rules[ '.Label--floating' ].transform;
-				return appearance;
+			if (
+				! Number.isFinite( scaleX ) ||
+				! Number.isFinite( scaleY ) ||
+				isNaN( lineHeight )
+			) {
+				compensationPossible = false;
+			} else {
+				const scale = ( scaleX + scaleY ) / 2;
+				const newLineHeight = Math.floor( lineHeight * scale );
+				appearance.rules[
+					'.Label--floating'
+				].lineHeight = `${ newLineHeight }px`;
+				appearance.rules[
+					'.Label--floating'
+				].fontSize = `${ newLineHeight }px`;
 			}
-			const newLineHeight = Math.floor( lineHeight * scale );
-			appearance.rules[
-				'.Label--floating'
-			].lineHeight = `${ newLineHeight }px`;
-			appearance.rules[
-				'.Label--floating'
-			].fontSize = `${ newLineHeight }px`;
 		}
 		delete appearance.rules[ '.Label--floating' ].transform;
 	}
 
 	// Reserve room for the floating label without letting the field grow taller.
-	const paddingTop = parseFloat( appearance.rules[ '.Input' ].paddingTop );
-	const paddingBottom = parseFloat(
-		appearance.rules[ '.Input' ].paddingBottom
-	);
-	const floatingLabelLineHeight = parseFloat(
+	const paddingTop = parsePx( appearance.rules[ '.Input' ].paddingTop );
+	const paddingBottom = parsePx( appearance.rules[ '.Input' ].paddingBottom );
+	const floatingLabelLineHeight = parsePx(
 		appearance.rules[ '.Label--floating' ].lineHeight
 	);
 
 	if (
+		compensationPossible &&
 		Number.isFinite( paddingTop ) &&
 		Number.isFinite( paddingBottom ) &&
 		Number.isFinite( floatingLabelLineHeight )

--- a/client/styles/upe/utils.js
+++ b/client/styles/upe/utils.js
@@ -190,6 +190,10 @@ export const handleAppearanceForFloatingLabel = (
 					'.Label--floating'
 				].fontSize = `${ newLineHeight }px`;
 			}
+		} else {
+			// A transform we can't read — e.g. matrix3d() — may scale the
+			// label, so its rendered size is unknown.
+			compensationPossible = false;
 		}
 		delete appearance.rules[ '.Label--floating' ].transform;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -237,5 +237,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
 * Fix - Prevent fatals during internal order check
+* Fix - Center the card brand icons and field text vertically in the card fields on the Blocks checkout
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -239,7 +239,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
 * Fix - Open the Stripe Dashboard links in subscription renewal failure order notes in a new tab
 * Fix - Prevent fatals during internal order check
-* Fix - Center the card brand icons and field text vertically in the card fields on the Blocks checkout
+* Fix - Center the text and card icons inside the payment fields on the Blocks checkout
 * Fix - Ensure that settings with checked, disabled checkboxes look disabled
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-1276

## Changes proposed in this Pull Request:

On the Blocks checkout, the content inside the Stripe card fields sat about 3px above center — easiest to see on the card brand icons. We build Stripe's styling from the theme's own input, whose padding is top-heavy for the floating label, and we subtracted the label's room from the top only. Now the same total comes off both sides: content is centered, field height unchanged.

Review found a second problem in the same function, fixed here too. When a sampled value doesn't parse (a selector that matches nothing, a `line-height` keyword), the fallback emitted invalid CSS like `calc(24px - undefined - 4px - 1px)` and still adjusted the other side. It now removes both padding overrides together and lets Stripe's defaults apply. Checked against a live Payment Element: Stripe drops only the single invalid declaration, so this renders the same as the old invalid output did.

Applies to every Payment Element field on the Blocks checkout, OCS on or off. Classic checkout is untouched — the code only runs for Blocks. No hooks, options, or PHP changes.

### Screenshots

Same site, theme, and Stripe account; only the plugin build differs (release 10.9.x vs this PR).
All screenshots are added in the comment.

## Testing instructions

1. Connect Stripe in test mode and use the Checkout block for the checkout page (not the shortcode).
2. Add a product, go to checkout, and leave the card fields empty.
3. Check the Card number field: the brand icons and label text should sit on the field's center line, and the card fields should match the height of the address inputs above.
4. Type `4242 4242 4242 4242` with any expiry and CVC. The label floats up, the value stays centered. Place the order.
5. Go to WooCommerce → Settings → Payments → Stripe, enable **Optimized Checkout Suite**, reload the checkout, and repeat steps 3–4 on the "Payment methods" element.
6. Optional: run `npm run test:js -- client/styles/upe` — 21 tests, red on `develop`, green here.

---

-   [x] Covered with tests (10 new unit tests: balanced padding and the non-numeric fallback)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

Added to `changelog.txt` and `readme.txt`.

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

---

*Drafted with AI; reviewed by me.*
