### PR TITLE
Move the Agentic Commerce settings to their own tab on the Stripe settings page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -80,6 +80,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
 * Fix - Prevent fatals during internal order check
+* Tweak - Move the Agentic Commerce settings to their own tab on the Stripe settings page
 * Fix - Ensure that settings with checked, disabled checkboxes look disabled
 
 2026-07-14 - version 10.8.4

--- a/client/settings/agentic-commerce/__tests__/index.test.js
+++ b/client/settings/agentic-commerce/__tests__/index.test.js
@@ -539,7 +539,7 @@ describe( 'AgenticCommerceSection', () => {
 
 		await waitFor( () => {
 			expect(
-				screen.getByText( /Setup webhooks in/i )
+				screen.getByText( /Set up webhooks in/i )
 			).toBeInTheDocument();
 		} );
 	} );

--- a/client/settings/agentic-commerce/index.js
+++ b/client/settings/agentic-commerce/index.js
@@ -39,17 +39,17 @@ const OnboardingSteps = styled.ol`
 
 const AgenticCommerceDescription = () => (
 	<>
-		<h2>{ __( 'Agentic commerce', 'woocommerce-gateway-stripe' ) }</h2>
+		<h2>{ __( 'Agentic Commerce', 'woocommerce-gateway-stripe' ) }</h2>
 		<p>
 			{ __(
-				'Enable and configure agentic commerce for your store.',
+				'Enable and configure Agentic Commerce for your store.',
 				'woocommerce-gateway-stripe'
 			) }
 		</p>
 		<p>
 			<ExternalLink href="https://docs.stripe.com/agentic-commerce">
 				{ __(
-					'Learn more about agentic commerce',
+					'Learn more about Agentic Commerce',
 					'woocommerce-gateway-stripe'
 				) }
 			</ExternalLink>
@@ -158,7 +158,7 @@ const AgenticCommerceSection = forwardRef( ( props, ref ) => {
 							<>
 								<CheckboxControl
 									label={ __(
-										'Enable agentic commerce',
+										'Enable Agentic Commerce',
 										'woocommerce-gateway-stripe'
 									) }
 									help={ __(
@@ -253,7 +253,7 @@ const AgenticCommerceSection = forwardRef( ( props, ref ) => {
 													  } )
 													: interpolateComponents( {
 															mixedString: __(
-																'Setup webhooks in {{strong}}Account details{{/strong}} above, then set endpoint URL to your webhook URL',
+																'Set up webhooks in {{strong}}Account details{{/strong}} on the Settings tab, then set endpoint URL to your webhook URL',
 																'woocommerce-gateway-stripe'
 															),
 															components: {
@@ -278,7 +278,7 @@ const AgenticCommerceSection = forwardRef( ( props, ref ) => {
 
 										<TextControl
 											label={ __(
-												'Agentic commerce webhook secret',
+												'Agentic Commerce webhook secret',
 												'woocommerce-gateway-stripe'
 											) }
 											help={ __(

--- a/client/settings/payment-settings/index.js
+++ b/client/settings/payment-settings/index.js
@@ -2,7 +2,6 @@ import { React, useState } from 'react';
 import SettingsSection from '../settings-section';
 import PaymentsAndTransactionsSection from '../payments-and-transactions-section';
 import AdvancedSettingsSection from '../advanced-settings-section';
-import AgenticCommerceSection from '../agentic-commerce';
 import AccountDetailsSection from './account-details-section';
 import GeneralSettingsSection from './general-settings-section';
 import { AccountKeysModal } from './account-keys-modal';
@@ -72,8 +71,6 @@ const PaymentSettingsPanel = ( {
 	promotionalBannerType,
 	isOCEnabled,
 	setIsOCEnabled,
-	isAgenticCommerceEnabled,
-	agenticSaveRef,
 } ) => {
 	// @todo - deconstruct modalType and setModalType from useModalType custom hook
 	const [ modalType, setModalType ] = useState( '' );
@@ -138,9 +135,6 @@ const PaymentSettingsPanel = ( {
 					<PaymentsAndTransactionsSection />
 				</LoadableSettingsSection>
 			</SettingsSection>
-			{ isAgenticCommerceEnabled && (
-				<AgenticCommerceSection ref={ agenticSaveRef } />
-			) }
 			<AdvancedSettingsSection
 				isOCEnabled={ isOCEnabled }
 				setIsOCEnabled={ setIsOCEnabled }

--- a/client/settings/settings-manager/__tests__/index.test.js
+++ b/client/settings/settings-manager/__tests__/index.test.js
@@ -6,6 +6,8 @@ jest.mock( '../../payment-settings' );
 
 jest.mock( '../../payment-methods' );
 
+jest.mock( '../../agentic-commerce' );
+
 jest.mock( '../../save-settings-section' );
 
 jest.mock( 'wcstripe/data', () => ( {
@@ -67,7 +69,7 @@ describe( 'SettingsManager', () => {
 		} );
 	} );
 
-	it( 'should not render a third tab when agentic commerce is enabled', async () => {
+	it( 'should render an Agentic Commerce tab when the feature is enabled', async () => {
 		global.wc_stripe_settings_params = {
 			...BASE_PARAMS,
 			is_agentic_commerce_enabled: true,
@@ -77,9 +79,13 @@ describe( 'SettingsManager', () => {
 
 		await waitFor( () => {
 			expect(
-				screen.getByRole( 'tab', { name: /Payment Methods/i } )
+				screen.getByRole( 'tab', { name: /Agentic Commerce/i } )
 			).toBeInTheDocument();
 		} );
+	} );
+
+	it( 'should not render an Agentic Commerce tab when the feature is disabled', async () => {
+		render( <SettingsManager /> );
 
 		await waitFor( () => {
 			expect(
@@ -90,6 +96,24 @@ describe( 'SettingsManager', () => {
 		expect(
 			screen.queryByRole( 'tab', { name: /Agentic/i } )
 		).not.toBeInTheDocument();
+	} );
+
+	it( 'should open the Agentic Commerce tab when the URL panel matches', async () => {
+		global.wc_stripe_settings_params = {
+			...BASE_PARAMS,
+			is_agentic_commerce_enabled: true,
+		};
+		getQuery.mockReturnValue( { panel: 'agentic-commerce' } );
+
+		render( <SettingsManager /> );
+
+		await waitFor( () => {
+			expect(
+				screen.queryByTestId( 'agentic-commerce-tab' )
+			).toBeInTheDocument();
+		} );
+
+		expect( screen.queryByTestId( 'methods-tab' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should render the Stripe payment method tab content by default', async () => {

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -6,6 +6,7 @@ import { isEmpty } from 'lodash';
 import SettingsLayout from '../settings-layout';
 import PaymentSettingsPanel from '../payment-settings';
 import PaymentMethodsPanel from '../payment-methods';
+import AgenticCommerceSection from '../agentic-commerce';
 import SaveSettingsSection from '../save-settings-section';
 import { useEnabledPaymentMethodIds, useSettings } from '../../data';
 import { TabPanel } from '@wordpress/components';
@@ -25,7 +26,7 @@ const StyledTabPanel = styled( TabPanel )`
 	}
 `;
 
-const TABS = [
+const getTabs = ( isAgenticCommerceEnabled ) => [
 	{
 		name: 'methods',
 		title: __( 'Payment Methods', 'woocommerce-gateway-stripe' ),
@@ -34,6 +35,17 @@ const TABS = [
 		name: 'settings',
 		title: __( 'Settings', 'woocommerce-gateway-stripe' ),
 	},
+	...( isAgenticCommerceEnabled
+		? [
+				{
+					name: 'agentic-commerce',
+					title: __(
+						'Agentic Commerce',
+						'woocommerce-gateway-stripe'
+					),
+				},
+		  ]
+		: [] ),
 ];
 
 const SettingsManager = () => {
@@ -96,12 +108,12 @@ const SettingsManager = () => {
 		updateQueryString( { panel: tabName }, '/', getQuery() );
 	};
 
-	const getInitialTab = () => {
-		if ( panel === 'settings' ) {
-			return 'settings';
-		}
+	const tabs = getTabs( isAgenticCommerceEnabled );
 
-		return 'methods';
+	const getInitialTab = () => {
+		const requestedTab = tabs.find( ( { name } ) => name === panel );
+
+		return requestedTab ? requestedTab.name : 'methods';
 	};
 
 	return (
@@ -119,7 +131,7 @@ const SettingsManager = () => {
 			<StyledTabPanel
 				className="wc-stripe-account-settings-panel"
 				initialTabName={ getInitialTab() }
-				tabs={ TABS }
+				tabs={ tabs }
 				onSelect={ updatePanelUri }
 			>
 				{ ( tab ) => (
@@ -133,10 +145,6 @@ const SettingsManager = () => {
 								promotionalBannerType={ promotionalBannerType }
 								isOCEnabled={ isOCEnabled }
 								setIsOCEnabled={ setIsOCEnabled }
-								isAgenticCommerceEnabled={
-									isAgenticCommerceEnabled
-								}
-								agenticSaveRef={ agenticSaveRef }
 							/>
 						) }
 						{ tab.name === 'methods' && (
@@ -151,10 +159,13 @@ const SettingsManager = () => {
 								setIsOCEnabled={ setIsOCEnabled }
 							/>
 						) }
+						{ tab.name === 'agentic-commerce' && (
+							<AgenticCommerceSection ref={ agenticSaveRef } />
+						) }
 						<SaveSettingsSection
 							onSettingsSave={ onSettingsSave }
 							agenticSaveRef={
-								tab.name === 'settings'
+								tab.name === 'agentic-commerce'
 									? agenticSaveRef
 									: undefined
 							}

--- a/readme.txt
+++ b/readme.txt
@@ -237,6 +237,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
 * Fix - Prevent fatals during internal order check
+* Tweak - Move the Agentic Commerce settings to their own tab on the Stripe settings page
 * Fix - Ensure that settings with checked, disabled checkboxes look disabled
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-1307

## Changes proposed in this Pull Request:

Moves the Agentic Commerce settings out of the general Settings tab into their own "Agentic Commerce" tab on the Stripe settings page.

- The tab only renders when the agentic commerce feature is enabled (same flag that previously gated the inline section), and `panel=agentic-commerce` deep-links to it.
- The save button on the new tab triggers the agentic save ref; the Settings tab no longer knows about agentic commerce at all.
- Unknown `panel` values still fall back to the Payment Methods tab.

**BC impact:** none on public PHP surface. The section's location in the admin UI changes; no existing deep link targets it (`panel=settings` links go to the general tab, which still exists).

Preview:
<img width="1101" height="523" alt="Screenshot 2026-07-27 at 16 46 20" src="https://github.com/user-attachments/assets/72188384-7625-454d-a5b2-b1aa930b7b01" />

## Testing instructions

1. Enable the agentic commerce feature flag (`wp option update _wcstripe_feature_agentic_commerce yes`).
2. Go to WooCommerce → Settings → Payments → Stripe: an "Agentic Commerce" tab appears after Payment Methods and Settings, containing the agentic settings previously at the bottom of the Settings tab.
3. Toggle a setting there and Save changes — it persists; the Settings tab no longer shows the section.
4. Disable the flag — the tab disappears.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

Changelog entries added to `changelog.txt` and `readme.txt` under 10.9.0 (Tweak).

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

