### PR TITLE
Scope Agentic Commerce catalog sync state to the active Stripe mode

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -80,6 +80,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
 * Fix - Prevent fatals during internal order check
+* Fix - Resync the Agentic Commerce catalog when switching between test and live mode, and scope the sync status shown in settings to the active mode
 * Fix - Ensure that settings with checked, disabled checkboxes look disabled
 
 2026-07-14 - version 10.8.4

--- a/includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
+++ b/includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
@@ -407,7 +407,13 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 		$status_updates = [];
 		$mode_updates   = [];
 		$delivery       = null;
-		$current_mode   = WC_Stripe_Agentic_Commerce_Integration::get_current_mode();
+
+		// One settings snapshot supplies both the mode used to filter entries
+		// and the key used to poll them: separate reads could straddle a
+		// concurrent settings save and poll this mode's entries with the other
+		// mode's key, misreading the resulting 404s as cross-mode entries.
+		$context      = WC_Stripe_Agentic_Commerce_Integration::get_delivery_context();
+		$current_mode = $context['mode'];
 
 		foreach ( $history as $entry ) {
 			$current_status = $entry['status'] ?? '';
@@ -427,7 +433,7 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 			}
 
 			try {
-				$delivery   = $delivery ?? $this->create_delivery();
+				$delivery   = $delivery ?? new WC_Stripe_Agentic_Commerce_Files_Api_Delivery( $context['secret_key'] );
 				$import_set = $delivery->get_import_set( $import_set_id );
 				$new_status = $import_set['status'] ?? $current_status;
 
@@ -461,22 +467,6 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 		}
 
 		WC_Stripe_Agentic_Commerce_Integration::update_pending_statuses( $status_updates, $mode_updates );
-	}
-
-	/**
-	 * Create a Files API delivery instance using the current Stripe settings.
-	 *
-	 * @since 10.7.0
-	 * @return WC_Stripe_Agentic_Commerce_Files_Api_Delivery
-	 */
-	private function create_delivery(): WC_Stripe_Agentic_Commerce_Files_Api_Delivery {
-		$settings  = WC_Stripe_Helper::get_stripe_settings();
-		$test_mode = isset( $settings['testmode'] ) && 'yes' === $settings['testmode'];
-		$secret    = $test_mode
-			? ( $settings['test_secret_key'] ?? '' )
-			: ( $settings['secret_key'] ?? '' );
-
-		return new WC_Stripe_Agentic_Commerce_Files_Api_Delivery( $secret );
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
+++ b/includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
@@ -177,6 +177,13 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 		$last_sync   = WC_Stripe_Agentic_Commerce_Integration::get_last_sync();
 		$history_raw = WC_Stripe_Agentic_Commerce_Integration::get_sync_history();
 
+		// Syncs from the other mode describe a different Stripe environment's
+		// catalog; showing them here would report the wrong catalog as synced.
+		if ( ! $this->is_entry_for_current_mode( $last_sync ) ) {
+			$last_sync = [];
+		}
+		$history_raw = array_values( array_filter( $history_raw, [ $this, 'is_entry_for_current_mode' ] ) );
+
 		// Return the most recent history entries, newest first.
 		$history = array_map(
 			[ $this, 'format_entry' ],
@@ -393,6 +400,12 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 				continue;
 			}
 
+			// An ImportSet from the other mode can't be retrieved with the
+			// current mode's key (Stripe returns a 404).
+			if ( ! $this->is_entry_for_current_mode( $entry ) ) {
+				continue;
+			}
+
 			$import_set_id = $entry['import_set_id'] ?? '';
 			if ( '' === $import_set_id ) {
 				continue;
@@ -454,6 +467,22 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 			'file_id'       => $entry['file_id'] ?? null,
 			'error'         => $entry['error'] ?? null,
 		];
+	}
+
+	/**
+	 * Whether a persisted sync entry belongs to the currently active mode.
+	 *
+	 * Entries with no recorded mode predate mode tracking and are kept, since
+	 * their mode can no longer be determined.
+	 *
+	 * @since 10.9.0
+	 * @param array $entry Raw entry from the options table.
+	 * @return bool
+	 */
+	private function is_entry_for_current_mode( array $entry ): bool {
+		$mode = $entry['mode'] ?? '';
+
+		return '' === $mode || WC_Stripe_Agentic_Commerce_Integration::get_current_mode() === $mode;
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
+++ b/includes/admin/class-wc-rest-stripe-agentic-commerce-controller.php
@@ -174,15 +174,28 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 		// Refresh any pending entries from Stripe before reading.
 		$this->refresh_pending_sync_statuses();
 
-		$last_sync   = WC_Stripe_Agentic_Commerce_Integration::get_last_sync();
 		$history_raw = WC_Stripe_Agentic_Commerce_Integration::get_sync_history();
 
 		// Syncs from the other mode describe a different Stripe environment's
 		// catalog; showing them here would report the wrong catalog as synced.
-		if ( ! $this->is_entry_for_current_mode( $last_sync ) ) {
-			$last_sync = [];
-		}
-		$history_raw = array_values( array_filter( $history_raw, [ $this, 'is_entry_for_current_mode' ] ) );
+		$current_mode = WC_Stripe_Agentic_Commerce_Integration::get_current_mode();
+		$history_raw  = array_values(
+			array_filter(
+				$history_raw,
+				function ( $entry ) use ( $current_mode ) {
+					return $this->is_entry_for_mode( $entry, $current_mode );
+				}
+			)
+		);
+
+		// Derive the snapshot from the mode-filtered history instead of the
+		// last-sync option: that option is only rewritten when a sync
+		// completes, so after switching modes and back it can still hold the
+		// other mode's entry until the queued resync runs (minutes, or never
+		// if that mode's keys are missing) — and the card would say "No syncs
+		// yet" while this mode has history.
+		$last_sync = end( $history_raw );
+		$last_sync = is_array( $last_sync ) ? $last_sync : [];
 
 		// Return the most recent history entries, newest first.
 		$history = array_map(
@@ -392,7 +405,9 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 		}
 
 		$status_updates = [];
+		$mode_updates   = [];
 		$delivery       = null;
+		$current_mode   = WC_Stripe_Agentic_Commerce_Integration::get_current_mode();
 
 		foreach ( $history as $entry ) {
 			$current_status = $entry['status'] ?? '';
@@ -402,7 +417,7 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 
 			// An ImportSet from the other mode can't be retrieved with the
 			// current mode's key (Stripe returns a 404).
-			if ( ! $this->is_entry_for_current_mode( $entry ) ) {
+			if ( ! $this->is_entry_for_mode( $entry, $current_mode ) ) {
 				continue;
 			}
 
@@ -420,6 +435,21 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 					$status_updates[ $import_set_id ] = $new_status;
 				}
 			} catch ( Exception $e ) {
+				// A 404 under this mode's key means the ImportSet lives in the
+				// other Stripe environment — legacy entries recorded no mode,
+				// so they are polled here on the chance they belong. Stamp the
+				// other mode so the entry stops being retried with a key that
+				// can never resolve it; it becomes pollable again if that mode
+				// is activated.
+				if ( 404 === $e->getCode() && '' === ( $entry['mode'] ?? '' ) ) {
+					$mode_updates[ $import_set_id ] = 'test' === $current_mode ? 'live' : 'test';
+					WC_Stripe_Logger::info(
+						'Agentic Commerce: ImportSet not found in the active mode; attributing the legacy history entry to the other mode.',
+						[ 'import_set_id' => $import_set_id ]
+					);
+					continue;
+				}
+
 				WC_Stripe_Logger::error(
 					'Agentic Commerce: Failed to refresh ImportSet status',
 					[
@@ -430,7 +460,7 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 			}
 		}
 
-		WC_Stripe_Agentic_Commerce_Integration::update_pending_statuses( $status_updates );
+		WC_Stripe_Agentic_Commerce_Integration::update_pending_statuses( $status_updates, $mode_updates );
 	}
 
 	/**
@@ -470,19 +500,22 @@ class WC_REST_Stripe_Agentic_Commerce_Controller extends WC_Stripe_REST_Base_Con
 	}
 
 	/**
-	 * Whether a persisted sync entry belongs to the currently active mode.
+	 * Whether a persisted sync entry belongs to the given mode.
 	 *
-	 * Entries with no recorded mode predate mode tracking and are kept, since
-	 * their mode can no longer be determined.
+	 * The mode is passed in rather than re-read per entry so one resolved
+	 * value applies to a whole filtering pass. Entries with no recorded mode
+	 * predate mode tracking and are kept, since their mode can no longer be
+	 * determined.
 	 *
 	 * @since 10.9.0
-	 * @param array $entry Raw entry from the options table.
+	 * @param array  $entry Raw entry from the options table.
+	 * @param string $mode  Mode to compare against ('test' or 'live').
 	 * @return bool
 	 */
-	private function is_entry_for_current_mode( array $entry ): bool {
-		$mode = $entry['mode'] ?? '';
+	private function is_entry_for_mode( array $entry, string $mode ): bool {
+		$entry_mode = $entry['mode'] ?? '';
 
-		return '' === $mode || WC_Stripe_Agentic_Commerce_Integration::get_current_mode() === $mode;
+		return '' === $entry_mode || $mode === $entry_mode;
 	}
 
 	/**

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-files-api-delivery.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-files-api-delivery.php
@@ -397,12 +397,16 @@ class WC_Stripe_Agentic_Commerce_Files_Api_Delivery {
 		$body      = wp_remote_retrieve_body( $response );
 
 		if ( $http_code < 200 || $http_code > 299 ) {
+			// The HTTP status rides on the exception code so callers can react
+			// to specific statuses (the refresh poll treats 404 as "wrong
+			// mode's key") without parsing the message.
 			throw new Exception(
 				sprintf(
 					'Stripe ImportSet status API returned HTTP %d: %s',
 					$http_code,
 					$this->parse_stripe_error( $body )
-				)
+				),
+				(int) $http_code
 			);
 		}
 

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-integration.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-integration.php
@@ -572,14 +572,14 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 			return false;
 		}
 
-		// Capture the mode once, alongside the delivery client, and hold it for
-		// the whole run: a settings save can flip testmode while the sync is
-		// generating the feed, and every record this run persists must describe
-		// the environment it actually delivered to, not the mode at write time.
-		$mode = self::get_current_mode();
-
-		// Check delivery setup before generating the feed.
-		$delivery = $this->get_push_delivery_method();
+		// One settings snapshot supplies both the mode label and the delivery
+		// key, held for the whole run: separate reads could straddle a
+		// concurrent settings save and pair one mode's label with the other
+		// mode's key, and every record this run persists must describe the
+		// environment it actually delivered to, not the mode at write time.
+		$context  = self::get_delivery_context();
+		$mode     = $context['mode'];
+		$delivery = new WC_Stripe_Agentic_Commerce_Files_Api_Delivery( $context['secret_key'] );
 
 		if ( ! $delivery->check_setup() ) {
 			WC_Stripe_Logger::error( 'Agentic Commerce: Sync skipped - Stripe API key not configured' );
@@ -1117,19 +1117,31 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 	}
 
 	/**
+	 * Captures the Stripe mode and its matching secret key from a single settings read.
+	 *
+	 * Both values derive from one snapshot so a concurrent settings save can
+	 * never pair one mode's label with the other mode's key.
+	 *
+	 * @since 10.9.0
+	 * @return array{mode: string, secret_key: string}
+	 */
+	public static function get_delivery_context(): array {
+		$settings  = WC_Stripe_Helper::get_stripe_settings();
+		$test_mode = isset( $settings['testmode'] ) && 'yes' === $settings['testmode'];
+
+		return [
+			'mode'       => $test_mode ? 'test' : 'live',
+			'secret_key' => $test_mode ? ( $settings['test_secret_key'] ?? '' ) : ( $settings['secret_key'] ?? '' ),
+		];
+	}
+
+	/**
 	 * Get Stripe secret key from settings.
 	 *
 	 * @since 10.5.0
 	 * @return string Stripe secret key.
 	 */
 	private function get_secret_key(): string {
-		$settings  = WC_Stripe_Helper::get_stripe_settings();
-		$test_mode = isset( $settings['testmode'] ) && 'yes' === $settings['testmode'];
-
-		if ( $test_mode ) {
-			return $settings['test_secret_key'] ?? '';
-		}
-
-		return $settings['secret_key'] ?? '';
+		return self::get_delivery_context()['secret_key'];
 	}
 }

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-integration.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-integration.php
@@ -572,6 +572,12 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 			return false;
 		}
 
+		// Capture the mode once, alongside the delivery client, and hold it for
+		// the whole run: a settings save can flip testmode while the sync is
+		// generating the feed, and every record this run persists must describe
+		// the environment it actually delivered to, not the mode at write time.
+		$mode = self::get_current_mode();
+
 		// Check delivery setup before generating the feed.
 		$delivery = $this->get_push_delivery_method();
 
@@ -718,7 +724,7 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 			// can't claim "this catalog is on Stripe". Storing the hash in those
 			// cases would suppress the next upload that could have recovered.
 			if ( ! empty( $feed_hash ) && '' !== $import_set_id && 'failed' !== $status ) {
-				$this->remember_feed_upload( $feed_hash, $result );
+				$this->remember_feed_upload( $feed_hash, $result, $mode );
 			}
 
 			// Delete the file to prevent accumulation.
@@ -736,7 +742,8 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 					'import_set_id'    => $import_set_id,
 					'error'            => '',
 					'skipped_products' => $skipped_count,
-				]
+				],
+				$mode
 			);
 
 			return true;
@@ -760,7 +767,8 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 					'import_set_id'    => '',
 					'error'            => $e->getMessage(),
 					'skipped_products' => 0,
-				]
+				],
+				$mode
 			);
 
 			return false;
@@ -786,9 +794,12 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 	 *                                    to `succeeded_with_errors` once the
 	 *                                    ImportSet completes.
 	 * }
+	 * @param string|null $mode The mode ('test'/'live') the sync ran against, as
+	 *                          captured when it started; null falls back to the
+	 *                          current mode for callers outside a sync run.
 	 * @return void
 	 */
-	public function store_sync_result( array $result ): void {
+	public function store_sync_result( array $result, ?string $mode = null ): void {
 		$history = get_option( self::SYNC_HISTORY_OPTION, [] );
 
 		if ( ! is_array( $history ) ) {
@@ -803,7 +814,7 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 			'import_set_id'    => $result['import_set_id'] ?? '',
 			'error'            => $result['error'] ?? '',
 			'skipped_products' => isset( $result['skipped_products'] ) ? max( 0, (int) $result['skipped_products'] ) : 0,
-			'mode'             => self::get_current_mode(),
+			'mode'             => $mode ?? self::get_current_mode(),
 		];
 
 		$history[] = $entry;
@@ -922,10 +933,15 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 	 *
 	 * @since 10.7.0
 	 * @param array<string, string> $status_updates Map of import_set_id to new status.
+	 * @param array<string, string> $mode_updates   Map of import_set_id to a mode
+	 *                                              learned after the fact. Only
+	 *                                              stamped onto entries that have
+	 *                                              no recorded mode; a recorded
+	 *                                              mode is never overwritten.
 	 * @return void
 	 */
-	public static function update_pending_statuses( array $status_updates ): void {
-		if ( empty( $status_updates ) ) {
+	public static function update_pending_statuses( array $status_updates, array $mode_updates = [] ): void {
+		if ( empty( $status_updates ) && empty( $mode_updates ) ) {
 			return;
 		}
 
@@ -935,12 +951,25 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 		$changed = false;
 
 		foreach ( $history as &$entry ) {
+			$import_set_id = $entry['import_set_id'] ?? '';
+			if ( '' === $import_set_id ) {
+				continue;
+			}
+
+			// A mode learned after the fact (e.g. a 404 under the active key
+			// proving a legacy entry belongs to the other environment) is
+			// stamped so the entry stops being polled with a key that can
+			// never resolve it.
+			if ( isset( $mode_updates[ $import_set_id ] ) && '' === ( $entry['mode'] ?? '' ) ) {
+				$entry['mode'] = $mode_updates[ $import_set_id ];
+				$changed       = true;
+			}
+
 			if ( ! in_array( $entry['status'] ?? '', $non_terminal_statuses, true ) ) {
 				continue;
 			}
 
-			$import_set_id = $entry['import_set_id'] ?? '';
-			if ( '' === $import_set_id || ! isset( $status_updates[ $import_set_id ] ) ) {
+			if ( ! isset( $status_updates[ $import_set_id ] ) ) {
 				continue;
 			}
 
@@ -1054,11 +1083,13 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 	 * Record the hash, timestamp, and Stripe file id of a successful upload.
 	 *
 	 * @since 10.8.0
-	 * @param string $hash   SHA-256 hex digest of the uploaded feed content.
-	 * @param array  $result Delivery result array returned by the Files API delivery method.
+	 * @param string      $hash   SHA-256 hex digest of the uploaded feed content.
+	 * @param array       $result Delivery result array returned by the Files API delivery method.
+	 * @param string|null $mode   The mode captured at sync start; null falls back
+	 *                            to the current mode.
 	 * @return void
 	 */
-	protected function remember_feed_upload( string $hash, array $result ): void {
+	protected function remember_feed_upload( string $hash, array $result, ?string $mode = null ): void {
 		update_option(
 			self::LAST_UPLOAD_OPTION,
 			[
@@ -1066,7 +1097,7 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 				'uploaded_at'   => time(),
 				'file_id'       => is_string( $result['file_id'] ?? null ) ? $result['file_id'] : '',
 				'import_set_id' => is_string( $result['import_set_id'] ?? null ) ? $result['import_set_id'] : '',
-				'mode'          => self::get_current_mode(),
+				'mode'          => $mode ?? self::get_current_mode(),
 			],
 			false
 		);

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-integration.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-integration.php
@@ -195,12 +195,38 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 		// exported product that becomes excluded would only drop out of Stripe's
 		// catalog on the next scheduled full sync.
 		add_action( 'wc_stripe_agentic_commerce_schedule_full_resync', [ $this, 'schedule_full_resync_now' ] );
+		add_action( 'update_option_woocommerce_stripe_settings', [ $this, 'maybe_resync_after_mode_switch' ], 10, 2 );
 
 		// WC 10.8+ requires `created_via` to be in an allowlist for `payment_complete()` to run.
 		add_filter( 'woocommerce_payment_complete_allowed_created_via_values', [ $this, 'allow_agentic_payment_complete' ] );
 
 		$inventory_tracker = new WC_Stripe_Agentic_Commerce_Inventory_Tracker();
 		$inventory_tracker->register_hooks();
+	}
+
+	/**
+	 * Resync the catalog when the test/live mode toggles.
+	 *
+	 * The new mode's Stripe environment has its own catalog: the dedup record
+	 * belongs to the previous mode, and without a fresh upload the newly
+	 * active environment would stay empty until the feed content changes.
+	 *
+	 * @since 10.9.0
+	 * @param mixed $old_value Previous settings option value.
+	 * @param mixed $value     New settings option value.
+	 * @return void
+	 */
+	public function maybe_resync_after_mode_switch( $old_value, $value ): void {
+		$mode_of = function ( $settings ) {
+			return is_array( $settings ) && 'yes' === ( $settings['testmode'] ?? 'no' ) ? 'test' : 'live';
+		};
+
+		if ( $mode_of( $old_value ) === $mode_of( $value ) || ! self::is_merchant_enabled() ) {
+			return;
+		}
+
+		delete_option( self::LAST_UPLOAD_OPTION );
+		$this->schedule_full_resync_now();
 	}
 
 	/**
@@ -777,6 +803,7 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 			'import_set_id'    => $result['import_set_id'] ?? '',
 			'error'            => $result['error'] ?? '',
 			'skipped_products' => isset( $result['skipped_products'] ) ? max( 0, (int) $result['skipped_products'] ) : 0,
+			'mode'             => self::get_current_mode(),
 		];
 
 		$history[] = $entry;
@@ -994,6 +1021,13 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 			return false;
 		}
 
+		// A record from the other mode (or a legacy record with no mode) says
+		// nothing about the current mode's environment — its catalog may have
+		// never received this feed, so an identical hash must still upload.
+		if ( ( $last['mode'] ?? '' ) !== self::get_current_mode() ) {
+			return false;
+		}
+
 		if ( ! isset( $last['uploaded_at'] ) || ! is_numeric( $last['uploaded_at'] ) ) {
 			return false;
 		}
@@ -1032,9 +1066,23 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 				'uploaded_at'   => time(),
 				'file_id'       => is_string( $result['file_id'] ?? null ) ? $result['file_id'] : '',
 				'import_set_id' => is_string( $result['import_set_id'] ?? null ) ? $result['import_set_id'] : '',
+				'mode'          => self::get_current_mode(),
 			],
 			false
 		);
+	}
+
+	/**
+	 * Returns the Stripe mode the sync flow is currently operating in.
+	 *
+	 * Test and live are separate Stripe environments with separate catalogs,
+	 * so any persisted sync state must be attributable to one of them.
+	 *
+	 * @since 10.9.0
+	 * @return string Either 'test' or 'live'.
+	 */
+	public static function get_current_mode(): string {
+		return WC_Stripe_Mode::is_test() ? 'test' : 'live';
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -237,6 +237,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Lock the order while confirming a 3DS card payment so a concurrent webhook can't complete it twice, duplicating stock reduction, order notes, and emails
 * Fix - Store the Stripe refund ID on each WooCommerce refund record so orders with multiple partial refunds retain every refund ID
 * Fix - Prevent fatals during internal order check
+* Fix - Resync the Agentic Commerce catalog when switching between test and live mode, and scope the sync status shown in settings to the active mode
 * Fix - Ensure that settings with checked, disabled checkboxes look disabled
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/admin/class-wc-rest-stripe-agentic-commerce-controller-test.php
+++ b/tests/phpunit/admin/class-wc-rest-stripe-agentic-commerce-controller-test.php
@@ -144,19 +144,21 @@ class WC_REST_Stripe_Agentic_Commerce_Controller_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * GET returns formatted last_sync when option is set.
+	 * GET returns formatted last_sync derived from the newest history entry.
 	 */
 	public function test_get_status_returns_last_sync(): void {
 		$now = time();
 		update_option(
-			WC_Stripe_Agentic_Commerce_Integration::LAST_SYNC_OPTION,
+			WC_Stripe_Agentic_Commerce_Integration::SYNC_HISTORY_OPTION,
 			[
-				'status'        => 'succeeded',
-				'timestamp'     => $now,
-				'products'      => 42,
-				'import_set_id' => 'impset_abc',
-				'file_id'       => 'file_xyz',
-				'error'         => '',
+				[
+					'status'        => 'succeeded',
+					'timestamp'     => $now,
+					'products'      => 42,
+					'import_set_id' => 'impset_abc',
+					'file_id'       => 'file_xyz',
+					'error'         => '',
+				],
 			]
 		);
 
@@ -178,7 +180,10 @@ class WC_REST_Stripe_Agentic_Commerce_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * Entries recorded under the other mode describe a different Stripe
 	 * environment's catalog and must be hidden from status and history;
-	 * legacy entries with no recorded mode stay visible.
+	 * legacy entries with no recorded mode stay visible. The last-sync
+	 * snapshot is derived from the mode-filtered history, so a stale
+	 * other-mode snapshot option (test → live → test before the queued
+	 * resync ran) never blanks out this mode's real last sync.
 	 */
 	public function test_get_status_filters_out_other_mode_entries(): void {
 		$current_mode = WC_Stripe_Agentic_Commerce_Integration::get_current_mode();
@@ -222,11 +227,69 @@ class WC_REST_Stripe_Agentic_Commerce_Controller_Test extends WP_UnitTestCase {
 
 		$data = $response->get_data();
 
-		// The other-mode snapshot must not masquerade as the current mode's state.
-		$this->assertNull( $data['last_sync'] );
+		// The other-mode snapshot must not masquerade as the current mode's
+		// state; the newest current-mode entry takes its place.
+		$this->assertNotNull( $data['last_sync'] );
+		$this->assertSame( 'impset_current', $data['last_sync']['import_set_id'] );
 
 		$returned_ids = array_column( $data['history'], 'import_set_id' );
 		$this->assertSame( [ 'impset_current', 'impset_legacy' ], $returned_ids );
+	}
+
+	/**
+	 * A legacy mode-less entry whose ImportSet 404s under the active mode's key
+	 * is attributed to the other mode: it disappears from this mode's status
+	 * view and is not polled again on subsequent reads.
+	 */
+	public function test_get_status_reclassifies_legacy_entry_on_404(): void {
+		update_option(
+			WC_Stripe_Agentic_Commerce_Integration::SYNC_HISTORY_OPTION,
+			[
+				[
+					'status'        => 'pending',
+					'timestamp'     => 1000,
+					'products'      => 5,
+					'import_set_id' => 'impset_legacy404',
+					'file_id'       => 'file_legacy',
+					'error'         => '',
+				],
+			]
+		);
+
+		$http_calls = 0;
+		$http_stub  = function () use ( &$http_calls ) {
+			++$http_calls;
+			return [
+				'response' => [
+					'code'    => 404,
+					'message' => 'Not Found',
+				],
+				'body'     => wp_json_encode( [ 'error' => [ 'message' => 'No such import set' ] ] ),
+				'headers'  => [],
+			];
+		};
+		add_filter( 'pre_http_request', $http_stub );
+
+		try {
+			$response = rest_do_request( new WP_REST_Request( 'GET', self::STATUS_ROUTE ) );
+			$this->assertEquals( 200, $response->get_status() );
+
+			// The 404 attributed the entry to the other mode and hid it here.
+			$this->assertSame( 1, $http_calls );
+			$this->assertNull( $response->get_data()['last_sync'] );
+			$this->assertSame( [], $response->get_data()['history'] );
+
+			$current_mode = WC_Stripe_Agentic_Commerce_Integration::get_current_mode();
+			$other_mode   = 'test' === $current_mode ? 'live' : 'test';
+			$history      = get_option( WC_Stripe_Agentic_Commerce_Integration::SYNC_HISTORY_OPTION );
+			$this->assertSame( $other_mode, $history[0]['mode'] );
+
+			// A second read must not poll the reclassified entry again.
+			rest_do_request( new WP_REST_Request( 'GET', self::STATUS_ROUTE ) );
+			$this->assertSame( 1, $http_calls );
+		} finally {
+			remove_filter( 'pre_http_request', $http_stub );
+		}
 	}
 
 	/**
@@ -316,14 +379,16 @@ class WC_REST_Stripe_Agentic_Commerce_Controller_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_status_casts_numeric_fields(): void {
 		update_option(
-			WC_Stripe_Agentic_Commerce_Integration::LAST_SYNC_OPTION,
+			WC_Stripe_Agentic_Commerce_Integration::SYNC_HISTORY_OPTION,
 			[
-				'status'        => 'succeeded',
-				'timestamp'     => '1700000000', // string from old storage
-				'products'      => '99',
-				'import_set_id' => 'impset_cast',
-				'file_id'       => '',
-				'error'         => '',
+				[
+					'status'        => 'succeeded',
+					'timestamp'     => '1700000000', // string from old storage
+					'products'      => '99',
+					'import_set_id' => 'impset_cast',
+					'file_id'       => '',
+					'error'         => '',
+				],
 			]
 		);
 
@@ -342,8 +407,8 @@ class WC_REST_Stripe_Agentic_Commerce_Controller_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_status_returns_null_for_missing_optional_fields(): void {
 		update_option(
-			WC_Stripe_Agentic_Commerce_Integration::LAST_SYNC_OPTION,
-			[ 'status' => 'pending' ] // minimal entry, no other keys
+			WC_Stripe_Agentic_Commerce_Integration::SYNC_HISTORY_OPTION,
+			[ [ 'status' => 'pending' ] ] // minimal entry, no other keys
 		);
 
 		$request  = new WP_REST_Request( 'GET', self::STATUS_ROUTE );

--- a/tests/phpunit/admin/class-wc-rest-stripe-agentic-commerce-controller-test.php
+++ b/tests/phpunit/admin/class-wc-rest-stripe-agentic-commerce-controller-test.php
@@ -176,6 +176,60 @@ class WC_REST_Stripe_Agentic_Commerce_Controller_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Entries recorded under the other mode describe a different Stripe
+	 * environment's catalog and must be hidden from status and history;
+	 * legacy entries with no recorded mode stay visible.
+	 */
+	public function test_get_status_filters_out_other_mode_entries(): void {
+		$current_mode = WC_Stripe_Agentic_Commerce_Integration::get_current_mode();
+		$other_mode   = 'test' === $current_mode ? 'live' : 'test';
+
+		$current_entry = [
+			'status'        => 'succeeded',
+			'timestamp'     => 2000,
+			'products'      => 1,
+			'import_set_id' => 'impset_current',
+			'file_id'       => 'file_current',
+			'error'         => '',
+			'mode'          => $current_mode,
+		];
+		$other_entry   = array_merge(
+			$current_entry,
+			[
+				'import_set_id' => 'impset_other',
+				'timestamp'     => 3000,
+				'mode'          => $other_mode,
+			]
+		);
+		$legacy_entry  = array_diff_key(
+			array_merge(
+				$current_entry,
+				[
+					'import_set_id' => 'impset_legacy',
+					'timestamp'     => 1000,
+				]
+			),
+			[ 'mode' => '' ]
+		);
+
+		update_option( WC_Stripe_Agentic_Commerce_Integration::SYNC_HISTORY_OPTION, [ $legacy_entry, $current_entry, $other_entry ] );
+		update_option( WC_Stripe_Agentic_Commerce_Integration::LAST_SYNC_OPTION, $other_entry );
+
+		$request  = new WP_REST_Request( 'GET', self::STATUS_ROUTE );
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		// The other-mode snapshot must not masquerade as the current mode's state.
+		$this->assertNull( $data['last_sync'] );
+
+		$returned_ids = array_column( $data['history'], 'import_set_id' );
+		$this->assertSame( [ 'impset_current', 'impset_legacy' ], $returned_ids );
+	}
+
+	/**
 	 * GET returns history newest-first, capped at the 5 most recent.
 	 */
 	public function test_get_status_returns_history_newest_first_capped_at_5(): void {

--- a/tests/phpunit/admin/class-wc-rest-stripe-agentic-commerce-controller-test.php
+++ b/tests/phpunit/admin/class-wc-rest-stripe-agentic-commerce-controller-test.php
@@ -293,6 +293,75 @@ class WC_REST_Stripe_Agentic_Commerce_Controller_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A settings save landing while the refresh runs must not split the mode
+	 * used to filter entries from the key used to poll them: the current-mode
+	 * entry is polled with the matching key, refreshed, and never reclassified.
+	 */
+	public function test_refresh_polls_with_the_key_matching_the_filtering_mode(): void {
+		update_option(
+			'woocommerce_stripe_settings',
+			[
+				'testmode'        => 'yes',
+				'test_secret_key' => 'sk_test_snapshot',
+				'secret_key'      => 'sk_live_snapshot',
+			]
+		);
+		update_option(
+			WC_Stripe_Agentic_Commerce_Integration::SYNC_HISTORY_OPTION,
+			[
+				[
+					'status'        => 'pending',
+					'timestamp'     => 1000,
+					'products'      => 5,
+					'import_set_id' => 'impset_snapshot',
+					'file_id'       => 'file_snapshot',
+					'error'         => '',
+					'mode'          => 'test',
+				],
+			]
+		);
+
+		$captured_auth = [];
+		$http_stub     = function ( $preempt, $args ) use ( &$captured_auth ) {
+			$captured_auth[] = $args['headers']['Authorization'] ?? '';
+
+			// Simulate a concurrent settings save flipping the mode mid-refresh.
+			$settings             = get_option( 'woocommerce_stripe_settings', [] );
+			$settings['testmode'] = 'no';
+			update_option( 'woocommerce_stripe_settings', $settings );
+
+			return [
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'headers'  => [],
+				'body'     => wp_json_encode(
+					[
+						'id'     => 'impset_snapshot',
+						'status' => 'succeeded',
+					]
+				),
+			];
+		};
+		add_filter( 'pre_http_request', $http_stub, 10, 3 );
+
+		try {
+			$response = rest_do_request( new WP_REST_Request( 'GET', self::STATUS_ROUTE ) );
+			$this->assertEquals( 200, $response->get_status() );
+
+			$this->assertSame( [ 'Bearer sk_test_snapshot' ], $captured_auth, 'The poll must use the key from the same snapshot as the filtering mode.' );
+
+			$history = get_option( WC_Stripe_Agentic_Commerce_Integration::SYNC_HISTORY_OPTION );
+			$this->assertSame( 'succeeded', $history[0]['status'], 'The current-mode entry must be refreshed, not skipped.' );
+			$this->assertSame( 'test', $history[0]['mode'], 'The entry must never be reclassified to the other mode.' );
+		} finally {
+			remove_filter( 'pre_http_request', $http_stub, 10 );
+			delete_option( 'woocommerce_stripe_settings' );
+		}
+	}
+
+	/**
 	 * GET returns history newest-first, capped at the 5 most recent.
 	 */
 	public function test_get_status_returns_history_newest_first_capped_at_5(): void {

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-integration-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-integration-test.php
@@ -827,6 +827,68 @@ class WC_Stripe_Agentic_Commerce_Integration_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * An explicitly passed mode wins over the mode at write time, so records
+	 * from a sync that outlived a testmode flip stay attributed to the
+	 * environment the sync actually delivered to.
+	 *
+	 * @return void
+	 */
+	public function test_store_sync_result_uses_captured_mode_over_current(): void {
+		$integration  = new \WC_Stripe_Agentic_Commerce_Integration();
+		$current_mode = \WC_Stripe_Agentic_Commerce_Integration::get_current_mode();
+		$other_mode   = 'test' === $current_mode ? 'live' : 'test';
+
+		$integration->store_sync_result(
+			[
+				'products' => 1,
+				'status'   => 'succeeded',
+			],
+			$other_mode
+		);
+
+		$history = get_option( \WC_Stripe_Agentic_Commerce_Integration::SYNC_HISTORY_OPTION, [] );
+
+		$this->assertSame( $other_mode, $history[0]['mode'] );
+	}
+
+	/**
+	 * Mode updates stamp only entries with no recorded mode; a recorded mode
+	 * is never overwritten by an after-the-fact reclassification.
+	 *
+	 * @return void
+	 */
+	public function test_update_pending_statuses_stamps_mode_on_modeless_entries_only(): void {
+		update_option(
+			\WC_Stripe_Agentic_Commerce_Integration::SYNC_HISTORY_OPTION,
+			[
+				[
+					'status'        => 'pending',
+					'import_set_id' => 'impset_modeless',
+				],
+				[
+					'status'        => 'pending',
+					'import_set_id' => 'impset_recorded',
+					'mode'          => 'test',
+				],
+			],
+			false
+		);
+
+		\WC_Stripe_Agentic_Commerce_Integration::update_pending_statuses(
+			[],
+			[
+				'impset_modeless' => 'live',
+				'impset_recorded' => 'live',
+			]
+		);
+
+		$history = get_option( \WC_Stripe_Agentic_Commerce_Integration::SYNC_HISTORY_OPTION );
+
+		$this->assertSame( 'live', $history[0]['mode'] );
+		$this->assertSame( 'test', $history[1]['mode'] );
+	}
+
+	/**
 	 * A test↔live switch invalidates the dedup record and queues an immediate
 	 * resync, so the newly active mode's environment receives the feed even
 	 * when its content hash is unchanged.

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-integration-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-integration-test.php
@@ -336,6 +336,107 @@ class WC_Stripe_Agentic_Commerce_Integration_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A settings save that flips testmode while the sync is generating the
+	 * feed must not leak into the run: the upload authenticates with the key
+	 * captured at sync start and the history entry records the matching mode.
+	 *
+	 * @return void
+	 */
+	public function test_sync_feed_binds_mode_and_key_to_sync_start() {
+		if ( ! function_exists( 'as_enqueue_async_action' ) || ! class_exists( 'WC_Product_Simple' ) ) {
+			$this->markTestSkipped( 'WooCommerce product/Action Scheduler not available.' );
+		}
+
+		update_option( WC_Stripe_Feature_Flags::AGENTIC_COMMERCE_FEATURE_FLAG_NAME, 'yes' );
+		update_option(
+			'woocommerce_stripe_settings',
+			[
+				'testmode'        => 'yes',
+				'test_secret_key' => 'sk_test_snapshot',
+				'secret_key'      => 'sk_live_snapshot',
+			]
+		);
+
+		$term   = wp_insert_term( 'Stripe Snapshot Cat ' . uniqid(), 'product_cat' );
+		$cat_id = is_wp_error( $term ) ? 0 : (int) $term['term_id'];
+
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Snapshot Product' );
+		$product->set_regular_price( '10.00' );
+		$product->set_status( 'publish' );
+		if ( $cat_id ) {
+			$product->set_category_ids( [ $cat_id ] );
+		}
+		$product->save();
+
+		$product_id = $product->get_id();
+		$scope      = static function ( $args ) use ( $product_id ) {
+			$args['include'] = [ $product_id ];
+			return $args;
+		};
+		add_filter( 'wc_stripe_agentic_commerce_product_query_args', $scope );
+
+		// The should-sync filter fires per product during the walk — after the
+		// sync captured its context — so it stands in for a concurrent
+		// settings save landing mid-run.
+		$flip = static function ( $sync ) {
+			$settings             = get_option( 'woocommerce_stripe_settings', [] );
+			$settings['testmode'] = 'no';
+			update_option( 'woocommerce_stripe_settings', $settings );
+			return $sync;
+		};
+		add_filter( 'woocommerce_agentic_commerce_should_sync_product', $flip );
+
+		$files_stub = fn() => [ 'id' => 'file_stub' ];
+		add_filter( 'wc_stripe_agentic_commerce_files_api_pre_request', $files_stub, 10, 2 );
+
+		$captured_auth = [];
+		$http_stub     = function ( $preempt, $args ) use ( &$captured_auth ) {
+			$captured_auth[] = $args['headers']['Authorization'] ?? '';
+			return [
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'headers'  => [],
+				'body'     => wp_json_encode(
+					[
+						'id'     => 'impset_stub',
+						'status' => 'pending',
+					]
+				),
+			];
+		};
+		add_filter( 'pre_http_request', $http_stub, 10, 3 );
+
+		try {
+			$integration = new \WC_Stripe_Agentic_Commerce_Integration();
+			$result      = $integration->sync_feed( true );
+
+			$this->assertTrue( $result, 'Sync should succeed with the stubbed Files API.' );
+
+			$last_sync = \WC_Stripe_Agentic_Commerce_Integration::get_last_sync();
+			$this->assertSame( 'test', $last_sync['mode'], 'The record must keep the mode captured at sync start, not the flipped mode.' );
+
+			$this->assertNotEmpty( $captured_auth );
+			foreach ( $captured_auth as $auth ) {
+				$this->assertSame( 'Bearer sk_test_snapshot', $auth, 'Delivery must authenticate with the key captured alongside the recorded mode.' );
+			}
+		} finally {
+			remove_filter( 'wc_stripe_agentic_commerce_product_query_args', $scope );
+			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $flip );
+			remove_filter( 'wc_stripe_agentic_commerce_files_api_pre_request', $files_stub, 10 );
+			remove_filter( 'pre_http_request', $http_stub, 10 );
+			delete_option( WC_Stripe_Feature_Flags::AGENTIC_COMMERCE_FEATURE_FLAG_NAME );
+			delete_option( 'woocommerce_stripe_settings' );
+			$product->delete( true );
+			if ( $cat_id ) {
+				wp_delete_term( $cat_id, 'product_cat' );
+			}
+		}
+	}
+
+	/**
 	 * Test is_enabled returns false by default.
 	 *
 	 * @return void
@@ -849,6 +950,43 @@ class WC_Stripe_Agentic_Commerce_Integration_Test extends WP_UnitTestCase {
 		$history = get_option( \WC_Stripe_Agentic_Commerce_Integration::SYNC_HISTORY_OPTION, [] );
 
 		$this->assertSame( $other_mode, $history[0]['mode'] );
+	}
+
+	/**
+	 * get_delivery_context derives the mode label and the secret key from one
+	 * settings read, so even when every read observes a different testmode
+	 * (simulating a concurrent settings save), the pair is never split.
+	 *
+	 * @return void
+	 */
+	public function test_get_delivery_context_pairs_mode_and_key_from_one_read(): void {
+		// The option_{name} filter only runs when the option exists, so seed it.
+		update_option( 'woocommerce_stripe_settings', [ 'testmode' => 'yes' ] );
+
+		$read_count = 0;
+		$alternate  = function ( $value ) use ( &$read_count ) {
+			++$read_count;
+			$test_mode = 1 === $read_count % 2;
+
+			return [
+				'testmode'        => $test_mode ? 'yes' : 'no',
+				'test_secret_key' => 'sk_test_snapshot',
+				'secret_key'      => 'sk_live_snapshot',
+			];
+		};
+		add_filter( 'option_woocommerce_stripe_settings', $alternate );
+
+		try {
+			for ( $i = 0; $i < 4; $i++ ) {
+				$context = \WC_Stripe_Agentic_Commerce_Integration::get_delivery_context();
+
+				$expected_key = 'test' === $context['mode'] ? 'sk_test_snapshot' : 'sk_live_snapshot';
+				$this->assertSame( $expected_key, $context['secret_key'], 'The key must always belong to the mode captured in the same snapshot.' );
+			}
+		} finally {
+			remove_filter( 'option_woocommerce_stripe_settings', $alternate );
+			delete_option( 'woocommerce_stripe_settings' );
+		}
 	}
 
 	/**

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-integration-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-integration-test.php
@@ -692,17 +692,27 @@ class WC_Stripe_Agentic_Commerce_Integration_Test extends WP_UnitTestCase {
 			'hash'        => 'abc123',
 			'uploaded_at' => time(),
 			'file_id'     => 'file_test',
+			'mode'        => \WC_Stripe_Agentic_Commerce_Integration::get_current_mode(),
 		];
+
+		$other_mode_record         = $fresh_record;
+		$other_mode_record['mode'] = 'test' === $fresh_record['mode'] ? 'live' : 'test';
+
+		$legacy_record = $fresh_record;
+		unset( $legacy_record['mode'] );
 
 		return [
 			'no cached record falls through'              => [ null, 'abc123', true, false ],
 			'fresh hash match short-circuits'             => [ $fresh_record, 'abc123', true, true ],
+			'other-mode record forces fresh upload'       => [ $other_mode_record, 'abc123', true, false ],
+			'legacy record without mode forces upload'    => [ $legacy_record, 'abc123', true, false ],
 			'hash mismatch falls through'                 => [ $fresh_record, 'different_hash', true, false ],
 			'expired record forces fresh upload'          => [
 				[
 					'hash'        => 'abc123',
 					'uploaded_at' => time() - ( 2 * WEEK_IN_SECONDS ),
 					'file_id'     => 'file_test',
+					'mode'        => \WC_Stripe_Agentic_Commerce_Integration::get_current_mode(),
 				],
 				'abc123',
 				true,
@@ -714,6 +724,7 @@ class WC_Stripe_Agentic_Commerce_Integration_Test extends WP_UnitTestCase {
 				[
 					'hash'    => 'abc123',
 					'file_id' => 'file_test',
+					'mode'    => \WC_Stripe_Agentic_Commerce_Integration::get_current_mode(),
 				],
 				'abc123',
 				true,
@@ -724,6 +735,7 @@ class WC_Stripe_Agentic_Commerce_Integration_Test extends WP_UnitTestCase {
 					'hash'        => 'abc123',
 					'uploaded_at' => 'not-a-timestamp',
 					'file_id'     => 'file_test',
+					'mode'        => \WC_Stripe_Agentic_Commerce_Integration::get_current_mode(),
 				],
 				'abc123',
 				true,
@@ -734,6 +746,7 @@ class WC_Stripe_Agentic_Commerce_Integration_Test extends WP_UnitTestCase {
 					'hash'        => 'abc123',
 					'uploaded_at' => 0,
 					'file_id'     => 'file_test',
+					'mode'        => \WC_Stripe_Agentic_Commerce_Integration::get_current_mode(),
 				],
 				'abc123',
 				true,
@@ -769,6 +782,7 @@ class WC_Stripe_Agentic_Commerce_Integration_Test extends WP_UnitTestCase {
 		$this->assertSame( 'abc123', $record['hash'] );
 		$this->assertSame( 'file_123', $record['file_id'] );
 		$this->assertSame( 'imp_456', $record['import_set_id'] );
+		$this->assertSame( \WC_Stripe_Agentic_Commerce_Integration::get_current_mode(), $record['mode'] );
 		$this->assertIsInt( $record['uploaded_at'] );
 		$this->assertLessThanOrEqual( time(), $record['uploaded_at'] );
 
@@ -807,8 +821,107 @@ class WC_Stripe_Agentic_Commerce_Integration_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'impset_xyz', $history[0]['import_set_id'] );
 		$this->assertSame( 3, $history[0]['skipped_products'] );
 		$this->assertArrayHasKey( 'timestamp', $history[0] );
+		$this->assertSame( \WC_Stripe_Agentic_Commerce_Integration::get_current_mode(), $history[0]['mode'] );
 
 		$this->assertEquals( $history[0], $last_sync );
+	}
+
+	/**
+	 * A test↔live switch invalidates the dedup record and queues an immediate
+	 * resync, so the newly active mode's environment receives the feed even
+	 * when its content hash is unchanged.
+	 *
+	 * @return void
+	 */
+	public function test_mode_switch_clears_dedup_and_schedules_resync() {
+		if ( ! function_exists( 'as_enqueue_async_action' ) ) {
+			$this->markTestSkipped( 'Action Scheduler not available.' );
+		}
+
+		as_unschedule_all_actions( $this->immediate_sync_action, [], 'wc-stripe' );
+		update_option( \WC_Stripe_Agentic_Commerce_Integration::ENABLED_OPTION, 'yes' );
+		update_option( $this->last_upload_option, [ 'hash' => 'abc' ], false );
+
+		try {
+			$integration = new \WC_Stripe_Agentic_Commerce_Integration();
+			$integration->maybe_resync_after_mode_switch(
+				[ 'testmode' => 'yes' ],
+				[ 'testmode' => 'no' ]
+			);
+
+			$this->assertFalse( get_option( $this->last_upload_option ) );
+			$this->assertNotFalse(
+				as_has_scheduled_action( $this->immediate_sync_action )
+			);
+		} finally {
+			as_unschedule_all_actions( $this->immediate_sync_action, [], 'wc-stripe' );
+			delete_option( \WC_Stripe_Agentic_Commerce_Integration::ENABLED_OPTION );
+		}
+	}
+
+	/**
+	 * No dedup invalidation or resync when the mode did not change, or when
+	 * the merchant has not enabled the integration.
+	 *
+	 * @dataProvider provide_mode_switch_noop_scenarios
+	 *
+	 * @param array  $old_value Previous settings option value.
+	 * @param array  $new_value New settings option value.
+	 * @param string $enabled   ENABLED_OPTION value to seed.
+	 * @return void
+	 */
+	public function test_mode_switch_noops( array $old_value, array $new_value, string $enabled ) {
+		if ( ! function_exists( 'as_enqueue_async_action' ) ) {
+			$this->markTestSkipped( 'Action Scheduler not available.' );
+		}
+
+		as_unschedule_all_actions( $this->immediate_sync_action, [], 'wc-stripe' );
+		update_option( \WC_Stripe_Agentic_Commerce_Integration::ENABLED_OPTION, $enabled );
+		update_option( $this->last_upload_option, [ 'hash' => 'abc' ], false );
+
+		try {
+			$integration = new \WC_Stripe_Agentic_Commerce_Integration();
+			$integration->maybe_resync_after_mode_switch( $old_value, $new_value );
+
+			$this->assertSame( [ 'hash' => 'abc' ], get_option( $this->last_upload_option ) );
+			$this->assertFalse(
+				as_has_scheduled_action( $this->immediate_sync_action )
+			);
+		} finally {
+			as_unschedule_all_actions( $this->immediate_sync_action, [], 'wc-stripe' );
+			delete_option( \WC_Stripe_Agentic_Commerce_Integration::ENABLED_OPTION );
+		}
+	}
+
+	/**
+	 * Provider for `test_mode_switch_noops`.
+	 *
+	 * @return array
+	 */
+	public function provide_mode_switch_noop_scenarios(): array {
+		return [
+			'mode unchanged'               => [
+				[ 'testmode' => 'yes' ],
+				[ 'testmode' => 'yes' ],
+				'yes',
+			],
+			'mode changed but not enabled' => [
+				[ 'testmode' => 'yes' ],
+				[ 'testmode' => 'no' ],
+				'no',
+			],
+			'non-mode setting change only' => [
+				[
+					'testmode' => 'no',
+					'capture'  => 'yes',
+				],
+				[
+					'testmode' => 'no',
+					'capture'  => 'no',
+				],
+				'yes',
+			],
+		];
 	}
 
 	/**


### PR DESCRIPTION
Fixes STRIPE-1306

## Changes proposed in this Pull Request:

Mode *identification* in the Agentic Commerce catalog sync is correct — every entry point resolves the secret key from `testmode` at call time — but the persisted state around the sync was mode-blind, so switching test↔live silently misbehaved:

- The unchanged-feed dedup record is a single global option, so after a mode switch the first sync to the new mode's environment was skipped (same content hash) and the newly active catalog stayed empty until products changed or the cache TTL expired.
- Sync history and the settings status card reported the other mode's sync as current.
- The pending-status poll called `get_import_set()` with the current mode's key for ImportSets created under the other mode, which 404s — leaving a pending badge that could never resolve.

Fix:

- The dedup record and each sync-history entry now record their `mode` (`test`/`live`). A mode mismatch (or a legacy record with no mode) invalidates dedup, and the REST status endpoint filters history/last-sync/polling to the active mode (legacy entries stay visible).
- Toggling `testmode` in the Stripe settings clears the dedup record and schedules an immediate resync (only when the merchant has the integration enabled), so the new mode's catalog populates without waiting for the next content change.

**BC impact:** additive — new keys in existing option records, one new public static helper (`get_current_mode()`), one new hook registration on the existing `update_option_woocommerce_stripe_settings` action. Legacy records without a mode trigger one extra (idempotent) upload and remain visible in history.

## Testing instructions

1. Enable Agentic Commerce in test mode and let a sync complete; note the status in the settings.
2. Switch the plugin to live mode (with live keys configured): an immediate resync is scheduled (visible in Action Scheduler), and the sync status/history no longer shows the test-mode entries.
3. Switch back to test mode: the test-mode history reappears.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

Changelog entries added to `changelog.txt` and `readme.txt` under 10.9.0 (Fix).

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
