### PR TITLE
ci: add concurrency to PHP tests, drop unused xdebug

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -3,6 +3,10 @@ name: PHP tests
 on:
   pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     name: Check for code changes
@@ -110,7 +114,10 @@ jobs:
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: ${{ matrix.php }}
-          coverage:    xdebug
+          # Tests run with --no-coverage (bin/phpunit.sh); coverage reports come from
+          # the dedicated php-code-coverage workflow. Loading xdebug here only slows
+          # the matrix down.
+          coverage:    none
 
       - name: Run CI checks
         run: bash bin/run-ci-tests.bash


### PR DESCRIPTION
### What

Two changes to `php-tests.yml`, both aimed at cutting wasted CI work:

1. **Add a `concurrency` group with `cancel-in-progress: true`.** The ~10-job PHP × WP × WC matrix had no cancellation, so every rapid push to a PR stacked a full duplicate matrix on top of the still-running one. Superseded runs are now cancelled, matching what `e2e-tests.yml` already does.
2. **`coverage: xdebug` → `coverage: none`.** `bin/phpunit.sh` passes `--no-coverage`, and coverage reporting lives in the dedicated `php-code-coverage.yml` workflow — so loading xdebug here only slows every matrix job down. `coverage: none` matches this repo's own pattern in `compatibility.yml`, `linting.yml`, and `phpstan.yml`.

### Why

Part of the org-wide effort to reduce GitHub Actions usage. These changes were first proposed against the internal mirror; per review feedback there, they're being made upstream instead so the two repos stay in sync.

### Testing

- `actionlint` passes (only pre-existing warnings about local action metadata).
- After merge: push twice in quick succession to a PR → the first `PHP tests` run shows as *cancelled*; the coverage comment on PRs still comes from the `PHP code coverage` workflow, unaffected.
### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This PR only affects GitHub CI workflows and usage. No merchant-facing impact.
</details>
