### PR TITLE
Ensure that block styles are only enqueued when needed

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -83,6 +83,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Open the Stripe Dashboard links in subscription renewal failure order notes in a new tab
 * Fix - Prevent fatals during internal order check
 * Fix - Ensure that settings with checked, disabled checkboxes look disabled
+* Fix - Only load the Blocks checkout stylesheet on pages that render the Cart or Checkout block, instead of on every page of the store
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -206,7 +206,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 
 			if ( is_array( $asset ) ) {
 				$version      = $asset['version'] ?? $version;
-				$dependencies = $asset['dependencies'] ?? $dependencies;
+				$dependencies = is_array( $asset['dependencies'] ?? null ) ? $asset['dependencies'] : $dependencies;
 			}
 		}
 

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -39,6 +39,13 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	private $express_checkout_configuration;
 
 	/**
+	 * Local cache for the UPE blocks asset metadata. Used to avoid multiple file reads.
+	 *
+	 * @var array{version: string, dependencies: array}|null
+	 */
+	private $blocks_asset = null;
+
+	/**
 	 * Constructor
 	 *
 	 * @param mixed                                   $payment_request_configuration The Stripe Payment Request configuration used for Payment Request buttons (removed).
@@ -186,6 +193,10 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	 * @return array{version: string, dependencies: array} The build version and script dependencies.
 	 */
 	private function get_upe_blocks_asset(): array {
+		if ( null !== $this->blocks_asset ) {
+			return $this->blocks_asset;
+		}
+
 		$asset_path   = WC_STRIPE_PLUGIN_PATH . '/build/upe-blocks.asset.php';
 		$version      = WC_STRIPE_VERSION;
 		$dependencies = [];
@@ -199,10 +210,12 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 			}
 		}
 
-		return [
+		$this->blocks_asset = [
 			'version'      => $version,
 			'dependencies' => $dependencies,
 		];
+
+		return $this->blocks_asset;
 	}
 
 	/**

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -10,6 +10,20 @@ defined( 'ABSPATH' ) || exit;
  */
 final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	/**
+	 * Handle for our integration script for block cart and checkout.
+	 *
+	 * @var string
+	 */
+	private const BLOCKS_SCRIPT_HANDLE = 'wc-stripe-blocks-integration';
+
+	/**
+	 * Handle for our stylesheet for block cart and checkout.
+	 *
+	 * @var string
+	 */
+	private const BLOCKS_STYLE_HANDLE = 'wc-stripe-blocks-checkout-style';
+
+	/**
 	 * Payment method name defined by payment methods extending this class.
 	 *
 	 * @var string
@@ -58,6 +72,12 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	 */
 	public function initialize() {
 		$this->settings = WC_Stripe_Helper::get_stripe_settings();
+
+		// Hooks to manually enqueue the block CSS, as WooCommerce doesn't have an API for styles.
+		add_filter( 'render_block_woocommerce/checkout', [ $this, 'maybe_enqueue_blocks_style' ] );
+		add_filter( 'render_block_woocommerce/cart', [ $this, 'maybe_enqueue_blocks_style' ] );
+		// Note that this is hooked at priority 20 so we run after WooCommerce has registered and enqueued the Cart and Checkout editor scripts.
+		add_action( 'enqueue_block_editor_assets', [ $this, 'maybe_enqueue_blocks_style_for_editor' ], 20 );
 	}
 
 	/**
@@ -99,7 +119,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	 *
 	 * @return array
 	 */
-	public function get_payment_method_script_handles() {
+	public function get_payment_method_script_handles(): array {
 		// Ensure Stripe JS is enqueued
 		wp_register_script(
 			'stripe',
@@ -111,7 +131,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 
 		$this->register_upe_payment_method_script_handles();
 
-		return [ 'wc-stripe-blocks-integration' ];
+		return [ self::BLOCKS_SCRIPT_HANDLE ];
 	}
 
 	/**
@@ -119,38 +139,119 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	 *
 	 * @return void
 	 */
-	private function register_upe_payment_method_script_handles() {
-		$asset_path   = WC_STRIPE_PLUGIN_PATH . '/build/upe-blocks.asset.php';
-		$version      = WC_STRIPE_VERSION;
-		$dependencies = [];
-		if ( file_exists( $asset_path ) ) {
-			$asset        = require $asset_path;
-			$version      = is_array( $asset ) && isset( $asset['version'] )
-				? $asset['version']
-				: $version;
-			$dependencies = is_array( $asset ) && isset( $asset['dependencies'] )
-				? $asset['dependencies']
-				: $dependencies;
-		}
+	private function register_upe_payment_method_script_handles(): void {
+		$this->register_upe_payment_method_style_handle();
 
-		wp_enqueue_style(
-			'wc-stripe-blocks-checkout-style',
-			WC_STRIPE_PLUGIN_URL . '/build/upe-blocks.css',
-			[],
-			$version
-		);
+		$asset = $this->get_upe_blocks_asset();
 
 		wp_register_script(
-			'wc-stripe-blocks-integration',
+			self::BLOCKS_SCRIPT_HANDLE,
 			WC_STRIPE_PLUGIN_URL . '/build/upe-blocks.js',
-			array_merge( [ 'stripe' ], $dependencies ),
-			$version,
+			array_merge( [ 'stripe' ], $asset['dependencies'] ),
+			$asset['version'],
 			true
 		);
 		wp_set_script_translations(
-			'wc-stripe-blocks-integration',
+			self::BLOCKS_SCRIPT_HANDLE,
 			'woocommerce-gateway-stripe'
 		);
+	}
+
+	/**
+	 * Registers our stylesheet for block cart and checkout.
+	 *
+	 * @return void
+	 */
+	private function register_upe_payment_method_style_handle(): void {
+		if ( wp_style_is( self::BLOCKS_STYLE_HANDLE, 'registered' ) ) {
+			return;
+		}
+
+		$asset = $this->get_upe_blocks_asset();
+
+		wp_register_style(
+			self::BLOCKS_STYLE_HANDLE,
+			WC_STRIPE_PLUGIN_URL . '/build/upe-blocks.css',
+			[],
+			$asset['version']
+		);
+
+		// Register RTL support.
+		wp_style_add_data( self::BLOCKS_STYLE_HANDLE, 'rtl', 'replace' );
+	}
+
+	/**
+	 * Get the build metadata for the UPE blocks bundle, with fallback logic when the file doesn't exist.
+	 *
+	 * @return array{version: string, dependencies: array} The build version and script dependencies.
+	 */
+	private function get_upe_blocks_asset(): array {
+		$asset_path   = WC_STRIPE_PLUGIN_PATH . '/build/upe-blocks.asset.php';
+		$version      = WC_STRIPE_VERSION;
+		$dependencies = [];
+
+		if ( file_exists( $asset_path ) ) {
+			$asset = require $asset_path;
+
+			if ( is_array( $asset ) ) {
+				$version      = $asset['version'] ?? $version;
+				$dependencies = $asset['dependencies'] ?? $dependencies;
+			}
+		}
+
+		return [
+			'version'      => $version,
+			'dependencies' => $dependencies,
+		];
+	}
+
+	/**
+	 * Enqueue the block stylesheet when the Cart or Checkout block renders AND
+	 * our blocks script has also been enqueued.
+	 *
+	 * Implemented to run as a filter callback for `render_block_woocommerce/cart`
+	 * and `render_block_woocommerce/checkout`, so the content MUST be returned as-is.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @param string $content The rendered block content.
+	 *
+	 * @return string The unmodified block content.
+	 */
+	public function maybe_enqueue_blocks_style( $content ) {
+		$this->enqueue_blocks_style_if_script_enqueued();
+
+		return $content;
+	}
+
+	/**
+	 * Block editor counterpart to {@see maybe_enqueue_blocks_style()},
+	 * which enqueues our block stylesheet when the block script has been enqueued.
+	 *
+	 * @since 10.9.0
+	 *
+	 * @return void
+	 */
+	public function maybe_enqueue_blocks_style_for_editor(): void {
+		$this->enqueue_blocks_style_if_script_enqueued();
+	}
+
+	/**
+	 * Enqueues the blocks stylesheet if the block script has been enqueued.
+	 *
+	 * @return void
+	 */
+	private function enqueue_blocks_style_if_script_enqueued(): void {
+		// Check if our script handle has been enqueued. Note that wp_script_is()
+		// also checks dependencies and catches cases where the script will be
+		// enqueued as a dependency of another script.
+		if ( ! wp_script_is( self::BLOCKS_SCRIPT_HANDLE, 'enqueued' ) ) {
+			return;
+		}
+
+		$this->register_upe_payment_method_style_handle();
+
+		wp_enqueue_style( self::BLOCKS_STYLE_HANDLE );
 	}
 
 	/**

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -281,7 +281,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 			$version      = is_array( $asset ) && isset( $asset['version'] )
 				? $asset['version']
 				: $version;
-			$dependencies = is_array( $asset ) && isset( $asset['dependencies'] )
+			$dependencies = is_array( $asset ) && isset( $asset['dependencies'] ) && is_array( $asset['dependencies'] )
 				? $asset['dependencies']
 				: $dependencies;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -240,5 +240,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Open the Stripe Dashboard links in subscription renewal failure order notes in a new tab
 * Fix - Prevent fatals during internal order check
 * Fix - Ensure that settings with checked, disabled checkboxes look disabled
+* Fix - Only load the Blocks checkout stylesheet on pages that render the Cart or Checkout block
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-blocks-support-test.php
+++ b/tests/phpunit/class-wc-stripe-blocks-support-test.php
@@ -5,11 +5,39 @@
  */
 class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 	/**
+	 * Handle of the blocks integration script, mirroring the private constant on the class under test.
+	 *
+	 * @var string
+	 */
+	private const BLOCK_SCRIPT_HANDLE = 'wc-stripe-blocks-integration';
+
+	/**
+	 * Handle of the blocks checkout stylesheet, mirroring the private constant on the class under test.
+	 *
+	 * @var string
+	 */
+	private const BLOCK_STYLE_HANDLE = 'wc-stripe-blocks-checkout-style';
+
+	/**
 	 * The gateway instance cached on the WC_Stripe singleton before a test swaps it out.
 	 *
 	 * @var WC_Stripe_UPE_Payment_Gateway|null
 	 */
 	private $original_main_gateway;
+
+	/**
+	 * Script handles registered by a test, deregistered in tearDown.
+	 *
+	 * @var string[]
+	 */
+	private $registered_test_scripts = [];
+
+	/**
+	 * Blocks-support instances that registered hooks via initialize(), unhooked in tearDown.
+	 *
+	 * @var WC_Stripe_Blocks_Support[]
+	 */
+	private $initialized_blocks_support = [];
 
 	/**
 	 * Replaces the gateway returned by WC_Stripe::get_main_stripe_gateway() with the given instance.
@@ -45,7 +73,52 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 
 		remove_filter( 'woocommerce_available_payment_gateways', '__return_empty_array', 100 );
 
+		// WP_Scripts and WP_Styles are globals shared across the suite.
+		// Ensure that we clean up after each test.
+		wp_dequeue_style( self::BLOCK_STYLE_HANDLE );
+		wp_deregister_style( self::BLOCK_STYLE_HANDLE );
+
+		foreach ( array_merge( [ self::BLOCK_SCRIPT_HANDLE, 'stripe' ], $this->registered_test_scripts ) as $handle ) {
+			wp_dequeue_script( $handle );
+			wp_deregister_script( $handle );
+		}
+		$this->registered_test_scripts = [];
+
+		foreach ( $this->initialized_blocks_support as $blocks_support ) {
+			remove_filter( 'render_block_woocommerce/checkout', [ $blocks_support, 'maybe_enqueue_blocks_style' ] );
+			remove_filter( 'render_block_woocommerce/cart', [ $blocks_support, 'maybe_enqueue_blocks_style' ] );
+			remove_action( 'enqueue_block_editor_assets', [ $blocks_support, 'maybe_enqueue_blocks_style_for_editor' ], 20 );
+		}
+		$this->initialized_blocks_support = [];
+
 		parent::tearDown();
+	}
+
+	/**
+	 * Registers a stub script and records it for teardown.
+	 *
+	 * @param string   $handle Script handle.
+	 * @param string[] $deps   Script dependencies.
+	 *
+	 * @return void
+	 */
+	private function register_test_script( string $handle, array $deps = [] ): void {
+		$this->registered_test_scripts[] = $handle;
+		wp_register_script( $handle, 'https://example.org/' . $handle . '.js', $deps, '1.0.0', true );
+	}
+
+	/**
+	 * Returns a blocks-support instance with its hooks registered, tracked for teardown.
+	 *
+	 * @return WC_Stripe_Blocks_Support
+	 */
+	private function get_initialized_blocks_support(): WC_Stripe_Blocks_Support {
+		$blocks_support = new WC_Stripe_Blocks_Support();
+		$blocks_support->initialize();
+
+		$this->initialized_blocks_support[] = $blocks_support;
+
+		return $blocks_support;
 	}
 
 	/**
@@ -106,5 +179,154 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 		add_filter( 'woocommerce_available_payment_gateways', '__return_empty_array', 100 );
 
 		$this->assertSame( [], $this->invoke_get_gateway_javascript_params() );
+	}
+
+	/**
+	 * WooCommerce resolves payment method script dependencies on every request, so enqueuing the
+	 * stylesheet from the script registration callback loaded it store-wide. It must only register.
+	 *
+	 * @return void
+	 */
+	public function test_get_payment_method_script_handles_registers_style_without_enqueuing_it(): void {
+		$blocks_support = new WC_Stripe_Blocks_Support();
+
+		$handles = $blocks_support->get_payment_method_script_handles();
+
+		$this->assertSame( [ self::BLOCK_SCRIPT_HANDLE ], $handles );
+		$this->assertTrue( wp_style_is( self::BLOCK_STYLE_HANDLE, 'registered' ) );
+		$this->assertFalse( wp_style_is( self::BLOCK_STYLE_HANDLE, 'enqueued' ) );
+	}
+
+	/**
+	 * Ensure RTL support is registered.
+	 *
+	 * @return void
+	 */
+	public function test_registered_style_is_flagged_for_rtl_replacement(): void {
+		( new WC_Stripe_Blocks_Support() )->get_payment_method_script_handles();
+
+		$this->assertSame( 'replace', wp_styles()->get_data( self::BLOCK_STYLE_HANDLE, 'rtl' ) );
+	}
+
+	/**
+	 * The enqueue hangs off a render_block filter, so it must pass the rendered markup straight back.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_enqueue_blocks_style_returns_content_unchanged(): void {
+		$blocks_support = new WC_Stripe_Blocks_Support();
+		$content        = '<div class="wp-block-woocommerce-checkout"></div>';
+
+		$this->assertSame( $content, $blocks_support->maybe_enqueue_blocks_style( $content ) );
+	}
+
+	/**
+	 * Our script handle is never enqueued directly - WooCommerce adds it as a dependency of
+	 * the Cart and Checkout block scripts. These cases test various dependency shapes
+	 * to make sure our logic handles all cases correctly.
+	 *
+	 * @dataProvider provider_blocks_script_dependency_shapes
+	 *
+	 * @param array  $scripts_to_register Handle => dependencies map of stub scripts to register.
+	 * @param string $handle_to_enqueue   The handle the page enqueues.
+	 * @param bool   $expected_enqueued   Whether the block stylesheet should end up enqueued.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_enqueue_blocks_style_follows_script_dependency_graph( array $scripts_to_register, string $handle_to_enqueue, bool $expected_enqueued ): void {
+		$blocks_support = new WC_Stripe_Blocks_Support();
+		$blocks_support->get_payment_method_script_handles();
+
+		foreach ( $scripts_to_register as $handle => $deps ) {
+			$this->register_test_script( $handle, $deps );
+		}
+		wp_enqueue_script( $handle_to_enqueue );
+
+		$blocks_support->maybe_enqueue_blocks_style( '' );
+
+		$this->assertSame( $expected_enqueued, wp_style_is( self::BLOCK_STYLE_HANDLE, 'enqueued' ) );
+	}
+
+	/**
+	 * @return array[]
+	 */
+	public function provider_blocks_script_dependency_shapes(): array {
+		return [
+			'directly enqueued'                => [
+				[],
+				self::BLOCK_SCRIPT_HANDLE,
+				true,
+			],
+			'dependency of the checkout block' => [
+				[ 'wc-checkout-block-frontend' => [ self::BLOCK_SCRIPT_HANDLE ] ],
+				'wc-checkout-block-frontend',
+				true,
+			],
+			'dependency of the cart block'     => [
+				[ 'wc-cart-block-frontend' => [ self::BLOCK_SCRIPT_HANDLE ] ],
+				'wc-cart-block-frontend',
+				true,
+			],
+			'transitive dependency'            => [
+				[
+					'wc-checkout-block-frontend' => [ self::BLOCK_SCRIPT_HANDLE ],
+					'theme-checkout-extras'      => [ 'wc-checkout-block-frontend' ],
+				],
+				'theme-checkout-extras',
+				true,
+			],
+			'unrelated script only'            => [
+				[ 'theme-scripts' => [] ],
+				'theme-scripts',
+				false,
+			],
+		];
+	}
+
+	public function test_maybe_enqueue_blocks_style_does_nothing_without_an_enqueued_script(): void {
+		$blocks_support = new WC_Stripe_Blocks_Support();
+		$blocks_support->get_payment_method_script_handles();
+
+		$blocks_support->maybe_enqueue_blocks_style( '' );
+
+		$this->assertFalse( wp_style_is( self::BLOCK_STYLE_HANDLE, 'enqueued' ) );
+	}
+
+	public function test_maybe_enqueue_blocks_style_for_editor_enqueues_when_editor_script_is_enqueued(): void {
+		$blocks_support = new WC_Stripe_Blocks_Support();
+		$blocks_support->get_payment_method_script_handles();
+
+		$this->register_test_script( 'wc-checkout-block', [ self::BLOCK_SCRIPT_HANDLE ] );
+		wp_enqueue_script( 'wc-checkout-block' );
+
+		$blocks_support->maybe_enqueue_blocks_style_for_editor();
+
+		$this->assertTrue( wp_style_is( self::BLOCK_STYLE_HANDLE, 'enqueued' ) );
+	}
+
+	/**
+	 * @dataProvider provider_render_time_hooks
+	 *
+	 * @param string $hook              Hook name.
+	 * @param string $method            Callback method on the blocks-support instance.
+	 * @param int    $expected_priority Expected registration priority.
+	 *
+	 * @return void
+	 */
+	public function test_initialize_registers_render_time_hooks( string $hook, string $method, int $expected_priority ): void {
+		$blocks_support = $this->get_initialized_blocks_support();
+
+		$this->assertSame( $expected_priority, has_filter( $hook, [ $blocks_support, $method ] ) );
+	}
+
+	/**
+	 * @return array[]
+	 */
+	public function provider_render_time_hooks(): array {
+		return [
+			'checkout block render' => [ 'render_block_woocommerce/checkout', 'maybe_enqueue_blocks_style', 10 ],
+			'cart block render'     => [ 'render_block_woocommerce/cart', 'maybe_enqueue_blocks_style', 10 ],
+			'block editor assets'   => [ 'enqueue_block_editor_assets', 'maybe_enqueue_blocks_style_for_editor', 20 ],
+		];
 	}
 }

--- a/tests/phpunit/class-wc-stripe-blocks-support-test.php
+++ b/tests/phpunit/class-wc-stripe-blocks-support-test.php
@@ -10,7 +10,7 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 	 *
 	 * @var WC_Stripe_UPE_Payment_Gateway|null
 	 */
-	private $original_main_gateway;
+	private $original_main_gateway = null;
 
 	/**
 	 * Script handles registered by a test, deregistered in tearDown.

--- a/tests/phpunit/class-wc-stripe-blocks-support-test.php
+++ b/tests/phpunit/class-wc-stripe-blocks-support-test.php
@@ -4,19 +4,6 @@
  * Unit tests for WC_Stripe_Blocks_Support.
  */
 class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
-	/**
-	 * Handle of the blocks integration script, mirroring the private constant on the class under test.
-	 *
-	 * @var string
-	 */
-	private const BLOCK_SCRIPT_HANDLE = 'wc-stripe-blocks-integration';
-
-	/**
-	 * Handle of the blocks checkout stylesheet, mirroring the private constant on the class under test.
-	 *
-	 * @var string
-	 */
-	private const BLOCK_STYLE_HANDLE = 'wc-stripe-blocks-checkout-style';
 
 	/**
 	 * The gateway instance cached on the WC_Stripe singleton before a test swaps it out.
@@ -75,10 +62,10 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 
 		// WP_Scripts and WP_Styles are globals shared across the suite.
 		// Ensure that we clean up after each test.
-		wp_dequeue_style( self::BLOCK_STYLE_HANDLE );
-		wp_deregister_style( self::BLOCK_STYLE_HANDLE );
+		wp_dequeue_style( $this->get_block_style_handle() );
+		wp_deregister_style( $this->get_block_style_handle() );
 
-		foreach ( array_merge( [ self::BLOCK_SCRIPT_HANDLE, 'stripe' ], $this->registered_test_scripts ) as $handle ) {
+		foreach ( array_merge( [ $this->get_block_script_handle(), 'stripe' ], $this->registered_test_scripts ) as $handle ) {
 			wp_dequeue_script( $handle );
 			wp_deregister_script( $handle );
 		}
@@ -192,9 +179,9 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 
 		$handles = $blocks_support->get_payment_method_script_handles();
 
-		$this->assertSame( [ self::BLOCK_SCRIPT_HANDLE ], $handles );
-		$this->assertTrue( wp_style_is( self::BLOCK_STYLE_HANDLE, 'registered' ) );
-		$this->assertFalse( wp_style_is( self::BLOCK_STYLE_HANDLE, 'enqueued' ) );
+		$this->assertSame( [ $this->get_block_script_handle() ], $handles );
+		$this->assertTrue( wp_style_is( $this->get_block_style_handle(), 'registered' ) );
+		$this->assertFalse( wp_style_is( $this->get_block_style_handle(), 'enqueued' ) );
 	}
 
 	/**
@@ -205,7 +192,7 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 	public function test_registered_style_is_flagged_for_rtl_replacement(): void {
 		( new WC_Stripe_Blocks_Support() )->get_payment_method_script_handles();
 
-		$this->assertSame( 'replace', wp_styles()->get_data( self::BLOCK_STYLE_HANDLE, 'rtl' ) );
+		$this->assertSame( 'replace', wp_styles()->get_data( $this->get_block_style_handle(), 'rtl' ) );
 	}
 
 	/**
@@ -244,7 +231,7 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 
 		$blocks_support->maybe_enqueue_blocks_style( '' );
 
-		$this->assertSame( $expected_enqueued, wp_style_is( self::BLOCK_STYLE_HANDLE, 'enqueued' ) );
+		$this->assertSame( $expected_enqueued, wp_style_is( $this->get_block_style_handle(), 'enqueued' ) );
 	}
 
 	/**
@@ -254,22 +241,22 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 		return [
 			'directly enqueued'                => [
 				[],
-				self::BLOCK_SCRIPT_HANDLE,
+				$this->get_block_script_handle(),
 				true,
 			],
 			'dependency of the checkout block' => [
-				[ 'wc-checkout-block-frontend' => [ self::BLOCK_SCRIPT_HANDLE ] ],
+				[ 'wc-checkout-block-frontend' => [ $this->get_block_script_handle() ] ],
 				'wc-checkout-block-frontend',
 				true,
 			],
 			'dependency of the cart block'     => [
-				[ 'wc-cart-block-frontend' => [ self::BLOCK_SCRIPT_HANDLE ] ],
+				[ 'wc-cart-block-frontend' => [ $this->get_block_script_handle() ] ],
 				'wc-cart-block-frontend',
 				true,
 			],
 			'transitive dependency'            => [
 				[
-					'wc-checkout-block-frontend' => [ self::BLOCK_SCRIPT_HANDLE ],
+					'wc-checkout-block-frontend' => [ $this->get_block_script_handle() ],
 					'theme-checkout-extras'      => [ 'wc-checkout-block-frontend' ],
 				],
 				'theme-checkout-extras',
@@ -289,19 +276,19 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 
 		$blocks_support->maybe_enqueue_blocks_style( '' );
 
-		$this->assertFalse( wp_style_is( self::BLOCK_STYLE_HANDLE, 'enqueued' ) );
+		$this->assertFalse( wp_style_is( $this->get_block_style_handle(), 'enqueued' ) );
 	}
 
 	public function test_maybe_enqueue_blocks_style_for_editor_enqueues_when_editor_script_is_enqueued(): void {
 		$blocks_support = new WC_Stripe_Blocks_Support();
 		$blocks_support->get_payment_method_script_handles();
 
-		$this->register_test_script( 'wc-checkout-block', [ self::BLOCK_SCRIPT_HANDLE ] );
+		$this->register_test_script( 'wc-checkout-block', [ $this->get_block_script_handle() ] );
 		wp_enqueue_script( 'wc-checkout-block' );
 
 		$blocks_support->maybe_enqueue_blocks_style_for_editor();
 
-		$this->assertTrue( wp_style_is( self::BLOCK_STYLE_HANDLE, 'enqueued' ) );
+		$this->assertTrue( wp_style_is( $this->get_block_style_handle(), 'enqueued' ) );
 	}
 
 	/**
@@ -328,5 +315,13 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 			'cart block render'     => [ 'render_block_woocommerce/cart', 'maybe_enqueue_blocks_style', 10 ],
 			'block editor assets'   => [ 'enqueue_block_editor_assets', 'maybe_enqueue_blocks_style_for_editor', 20 ],
 		];
+	}
+
+	private function get_block_script_handle(): string {
+		return WC_Stripe_Test_Helper::get_class_const_value( WC_Stripe_Blocks_Support::class, 'BLOCKS_SCRIPT_HANDLE', 'string' );
+	}
+
+	private function get_block_style_handle(): string {
+		return WC_Stripe_Test_Helper::get_class_const_value( WC_Stripe_Blocks_Support::class, 'BLOCKS_STYLE_HANDLE', 'string' );
 	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-1300
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/5742

Related to https://github.com/woocommerce/woocommerce/pull/67029

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR updates our logic for registering and enqueuing the `upe-blocks.css` styles to prevent those styles from incorrectly being enqueued on all pages.

The core issue, as discussed in https://github.com/woocommerce/woocommerce-gateway-stripe/issues/5742 and the related upstream WooCommerce PR in https://github.com/woocommerce/woocommerce/pull/67029, is that the WooCommerce block integration APIs for payment methods only support scripts, and not styles. As a result, our code has been unconditionally enqueuing the styles regardless of whether the scripts will be loaded.

This PR changes the approach as follows:
 * When we register our payment method scripts, we will only now register our `upe-blocks.css` stylesheet
 * We then hook into the `render_block_woocommerce/checkout`, `render_block_woocommerce/cart`, and `enqueue_block_editor_assets` actions, and will also enqueue our style in any situation where the `upe-blocks.js` script has been enqueued.
   - This ensures that we enqueue the relevant styles in multiple situations where we have the JS scripts enqueued, without adding any overly complex logic.

I have found that `upe-blocks.js` is getting enqueued in the post editor for other pages (i.e. not the block cart or block checkout), but that is not something I am trying to address in this PR.
<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

 * On an existing site _without_ this code applied, ensure that you have Stripe set up as a valid, active payment method.
 * Navigate to various pages in the UI, and verify that `upe-blocks.css` is getting loaded, regardless of whether you're viewing a cart or checkout page.
 * Repeat the steps when editing various pages and posts in the editor.
 * Now run the code from this branch.
 * Navigate to various pages in the site _except_ for the block cart and block checkout.
 * Verify that `upe-blocks.css` is NOT sent back to the UI.
 * Navigate to the block cart.
 * Verify that `upe-blocks.css` and `upe-blocks.js` are both sent back to the UI.
 * Navigate to the block checkout.
 * Verify that `upe-blocks.css` and `upe-blocks.js` are both sent back to the UI.

At this time, both `upe-blocks.js` and `upe-blocks.css` are being returned in the post editor, so there is some other upstream issue that's resulting in the block script being enqueued.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
