### PR TITLE
Consolidate Stripe.js registration into a shared helper

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -83,6 +83,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Open the Stripe Dashboard links in subscription renewal failure order notes in a new tab
 * Fix - Prevent fatals during internal order check
 * Fix - Ensure that settings with checked, disabled checkboxes look disabled
+* Dev - Register Stripe.js through a single shared helper
 
 2026-07-14 - version 10.8.4
 * Fix - Improve Checkout Session amount integrity

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -2385,7 +2385,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			return;
 		}
 
-		wp_register_script( 'stripe', 'https://js.stripe.com/dahlia/stripe.js', [], null, true );
+		WC_Stripe_Helper::register_stripe_js();
 		wp_enqueue_script( 'stripe' );
 
 		if ( $this->should_skip_full_payment_scripts() ) {

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -127,7 +127,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	 * @return array
 	 */
 	public function get_payment_method_script_handles(): array {
-		// Ensure Stripe JS is enqueued
+		// Ensure Stripe JS is registered
 		WC_Stripe_Helper::register_stripe_js();
 
 		$this->register_upe_payment_method_script_handles();

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -101,13 +101,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	 */
 	public function get_payment_method_script_handles() {
 		// Ensure Stripe JS is enqueued
-		wp_register_script(
-			'stripe',
-			'https://js.stripe.com/dahlia/stripe.js',
-			[],
-			null,
-			true
-		);
+		WC_Stripe_Helper::register_stripe_js();
 
 		$this->register_upe_payment_method_script_handles();
 

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -36,11 +36,30 @@ class WC_Stripe_Helper {
 	public const OFFICIAL_PLUGIN_ID_KLARNA = 'klarna_payments';
 
 	/**
+	 * The Stripe.js SDK URL, pinned to a named major release.
+	 *
+	 * @var string
+	 */
+	protected const STRIPE_JS_URL = 'https://js.stripe.com/dahlia/stripe.js';
+
+	/**
 	 * List of legacy Stripe gateways.
 	 *
 	 * @var array
 	 */
 	public static $stripe_legacy_gateways = [];
+
+	/**
+	 * Register the shared Stripe.js SDK script under the 'stripe' handle.
+	 *
+	 * Single registration point so the handle, URL, and loading flags can't
+	 * drift between the surfaces that need the SDK.
+	 *
+	 * @return void
+	 */
+	public static function register_stripe_js() {
+		wp_register_script( 'stripe', self::STRIPE_JS_URL, [], null, true );
+	}
 
 	/**
 	 * Get the main Stripe settings option.

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -436,7 +436,7 @@ class WC_Stripe_Express_Checkout_Element {
 	private function register_express_checkout_script() {
 		$asset_data = $this->get_asset_data();
 
-		wp_register_script( 'stripe', 'https://js.stripe.com/dahlia/stripe.js', '', null, true );
+		WC_Stripe_Helper::register_stripe_js();
 		wp_register_script(
 			'wc_stripe_express_checkout',
 			WC_STRIPE_PLUGIN_URL . '/build/express-checkout.js',

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -468,7 +468,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		wp_register_script( 'stripe', 'https://js.stripe.com/dahlia/stripe.js', [], null, true );
+		WC_Stripe_Helper::register_stripe_js();
 		wp_enqueue_script( 'stripe' );
 
 		if ( $this->should_skip_full_payment_scripts() ) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3577,12 +3577,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-express-checkout-element.php
 
 		-
-			message: '#^Parameter \#3 \$deps of function wp_register_script expects array\<string\>, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-element.php
-
-		-
 			message: '#^Property WooCommerce\:\:\$session \(WC_Session\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
 			count: 1

--- a/readme.txt
+++ b/readme.txt
@@ -240,5 +240,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Open the Stripe Dashboard links in subscription renewal failure order notes in a new tab
 * Fix - Prevent fatals during internal order check
 * Fix - Ensure that settings with checked, disabled checkboxes look disabled
+* Dev - Register Stripe.js through a single shared helper
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -2673,4 +2673,20 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			],
 		];
 	}
+
+	/**
+	 * The shared helper must produce the canonical 'stripe' handle.
+	 *
+	 * @return void
+	 */
+	public function test_register_stripe_js_registers_the_stripe_handle() {
+		wp_deregister_script( 'stripe' );
+
+		WC_Stripe_Helper::register_stripe_js();
+
+		$this->assertTrue( wp_script_is( 'stripe', 'registered' ) );
+		$registered = wp_scripts()->registered['stripe'];
+		$this->assertSame( 'https://js.stripe.com/dahlia/stripe.js', $registered->src );
+		$this->assertSame( 1, wp_scripts()->get_data( 'stripe', 'group' ), 'Stripe.js must load in the footer.' );
+	}
 }


### PR DESCRIPTION
Towards STRIPE-956
Towards #1439

## Changes proposed in this Pull Request:

Four independent call sites registered the `stripe` script handle with their own copy of the Stripe.js URL and slightly different argument signatures (classic gateway, UPE gateway, express checkout element, Blocks support). This PR routes them all through a new `WC_Stripe_Helper::register_stripe_js()` helper so the handle, URL/release train, and loading flags can't drift between surfaces.

No behavior change: the handle name, URL, and footer loading are identical to before. This is groundwork for the STRIPE-956 performance series — later PRs change *how* the SDK loads, and that only has to happen in one place now.

**Backward compatibility:** none affected. The public `stripe` script handle and its URL are unchanged; the new helper is additive.

## Testing instructions

1. Enable the Stripe gateway with valid test keys.
2. Load the classic checkout, a product page with express checkout enabled, and the Blocks checkout.
3. In each case, verify the page loads a single `<script>` tag from `https://js.stripe.com/dahlia/stripe.js` and payment forms/buttons render as before.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
