### PR TITLE
Fix currency warnings in wp-admin when Adaptive Pricing is active

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -87,6 +87,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Center the text and card icons inside the payment fields on the Blocks checkout
 * Fix - Ensure that settings with checked, disabled checkboxes look disabled
 * Fix - Only load the Blocks checkout stylesheet on pages that render the Cart or Checkout block, instead of on every page of the store
+* Fix - Don't show currency admin notices for payment methods when Adaptive Pricing is active
 
 2026-08-05 - version 10.8.5
 * Update - Improve webhook handling

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -461,28 +461,57 @@ class WC_Stripe_Admin_Notices {
 	 * @return void
 	 */
 	public function payment_methods_check_environment() {
-		// phpcs:ignore
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$is_stripe_settings_page = isset( $_GET['page'], $_GET['section'] ) && 'wc-settings' === $_GET['page'] && 0 === strpos( $_GET['section'], 'stripe' );
-		$currency_messages       = '';
 
-		foreach ( WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS as $method_class ) {
-			if ( WC_Stripe_UPE_Payment_Method_CC::class === $method_class || WC_Stripe_UPE_Payment_Method_Link::class === $method_class ) {
-				continue;
-			}
-			$method     = $method_class::STRIPE_ID;
-			$upe_method = new $method_class();
-			if ( ! $upe_method->is_enabled() ) {
-				continue;
-			}
-
-			if ( ! $is_stripe_settings_page && ! in_array( get_woocommerce_currency(), $upe_method->get_supported_currencies(), true ) ) {
-				/* translators: %1$s Payment method, %2$s List of supported currencies */
-				$currency_messages .= sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s<br>', 'woocommerce-gateway-stripe' ), $upe_method->get_label(), implode( ', ', $upe_method->get_supported_currencies() ) );
-			}
+		if ( $is_stripe_settings_page ) {
+			return;
 		}
 
 		$show_notice = get_option( 'wc_stripe_show_upe_payment_methods_notice' );
-		if ( ! empty( $currency_messages ) && 'no' !== $show_notice ) {
+		if ( 'no' === $show_notice ) {
+			return;
+		}
+
+		// If Adaptive Pricing is enabled, we should not show currency compatibility notices.
+		$settings = WC_Stripe_Helper::get_stripe_settings();
+		if (
+			WC_Stripe_Helper::is_checkout_sessions_available() &&
+			'yes' === ( $settings['adaptive_pricing'] ?? 'no' ) &&
+			WC_Stripe_Helper::is_adaptive_pricing_available_for_account()
+		) {
+			return;
+		}
+
+		$currency_messages = '';
+
+		$gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
+		if ( ! $gateway instanceof WC_Stripe_UPE_Payment_Gateway ) {
+			return;
+		}
+
+		foreach ( $gateway->get_upe_enabled_payment_method_ids() as $payment_method_id ) {
+			if ( ! isset( $gateway->payment_methods[ $payment_method_id ] ) ) {
+				continue;
+			}
+
+			$upe_method = $gateway->payment_methods[ $payment_method_id ];
+			if ( ! $upe_method instanceof WC_Stripe_UPE_Payment_Method ) {
+				continue;
+			}
+
+			$supported_currencies = $upe_method->get_supported_currencies();
+			if ( null === $supported_currencies ) {
+				continue;
+			}
+
+			if ( ! in_array( get_woocommerce_currency(), $supported_currencies, true ) ) {
+				/* translators: %1$s Payment method, %2$s List of supported currencies */
+				$currency_messages .= sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s<br>', 'woocommerce-gateway-stripe' ), $upe_method->get_label(), implode( ', ', $supported_currencies ) );
+			}
+		}
+
+		if ( ! empty( $currency_messages ) ) {
 			$this->add_admin_notice( 'upe_payment_methods', 'notice notice-error', $currency_messages, true );
 		}
 	}

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -473,20 +473,8 @@ class WC_Stripe_Admin_Notices {
 			return;
 		}
 
-		// If Adaptive Pricing is enabled, we should not show currency compatibility notices.
-		$settings = WC_Stripe_Helper::get_stripe_settings();
-		if (
-			WC_Stripe_Helper::is_checkout_sessions_available() &&
-			'yes' === ( $settings['adaptive_pricing'] ?? 'no' ) &&
-			WC_Stripe_Helper::is_adaptive_pricing_available_for_account()
-		) {
-			return;
-		}
-
-		$currency_messages = '';
-
 		$gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
-		if ( ! $gateway instanceof WC_Stripe_UPE_Payment_Gateway ) {
+		if ( ! $gateway instanceof WC_Stripe_UPE_Payment_Gateway || ! $gateway->is_enabled() ) {
 			return;
 		}
 
@@ -494,6 +482,8 @@ class WC_Stripe_Admin_Notices {
 		if ( empty( $store_currency ) ) {
 			return;
 		}
+
+		$currency_messages = '';
 
 		foreach ( $gateway->get_upe_enabled_payment_method_ids() as $payment_method_id ) {
 			if ( ! isset( $gateway->payment_methods[ $payment_method_id ] ) ) {
@@ -517,6 +507,18 @@ class WC_Stripe_Admin_Notices {
 		}
 
 		if ( ! empty( $currency_messages ) ) {
+			// If Adaptive Pricing is enabled, we should not show currency compatibility notices.
+			// Note that we run these checks here because is_adaptive_pricing_available_for_account() can trigger API calls
+			// when checking on webhook status.
+			$settings = WC_Stripe_Helper::get_stripe_settings();
+			if (
+				WC_Stripe_Helper::is_checkout_sessions_available() &&
+				'yes' === ( $settings['adaptive_pricing'] ?? 'no' ) &&
+				WC_Stripe_Helper::is_adaptive_pricing_available_for_account()
+			) {
+				return;
+			}
+
 			$settings_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods' );
 
 			$review_action = sprintf(

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -490,6 +490,11 @@ class WC_Stripe_Admin_Notices {
 			return;
 		}
 
+		$store_currency = get_woocommerce_currency();
+		if ( empty( $store_currency ) ) {
+			return;
+		}
+
 		foreach ( $gateway->get_upe_enabled_payment_method_ids() as $payment_method_id ) {
 			if ( ! isset( $gateway->payment_methods[ $payment_method_id ] ) ) {
 				continue;
@@ -505,7 +510,7 @@ class WC_Stripe_Admin_Notices {
 				continue;
 			}
 
-			if ( ! in_array( get_woocommerce_currency(), $supported_currencies, true ) ) {
+			if ( ! in_array( $store_currency, $supported_currencies, true ) ) {
 				/* translators: %1$s Payment method, %2$s List of supported currencies */
 				$currency_messages .= sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s<br>', 'woocommerce-gateway-stripe' ), $upe_method->get_label(), implode( ', ', $supported_currencies ) );
 			}

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -462,7 +462,7 @@ class WC_Stripe_Admin_Notices {
 	 */
 	public function payment_methods_check_environment() {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$is_stripe_settings_page = isset( $_GET['page'], $_GET['section'] ) && 'wc-settings' === $_GET['page'] && 0 === strpos( $_GET['section'], 'stripe' );
+		$is_stripe_settings_page = isset( $_GET['page'], $_GET['section'] ) && 'wc-settings' === $_GET['page'] && 'stripe' === $_GET['section'];
 
 		if ( $is_stripe_settings_page ) {
 			return;

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -512,7 +512,15 @@ class WC_Stripe_Admin_Notices {
 		}
 
 		if ( ! empty( $currency_messages ) ) {
-			$this->add_admin_notice( 'upe_payment_methods', 'notice notice-error', $currency_messages, true );
+			$settings_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods' );
+
+			$review_action = sprintf(
+				'<a href="%s" class="button button-secondary" style="margin:1em 2em 0.5em 0;">%s</a>',
+				esc_url( $settings_url ),
+				__( 'Review Stripe payment method settings', 'woocommerce-gateway-stripe' )
+			);
+
+			$this->add_admin_notice( 'upe_payment_methods', 'notice notice-error', $currency_messages, true, [ $review_action ] );
 		}
 	}
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1207,18 +1207,6 @@ parameters:
 			path: includes/admin/class-wc-stripe-admin-notices.php
 
 		-
-			message: '#^Parameter \#2 \$haystack of function in_array expects array, array\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/admin/class-wc-stripe-admin-notices.php
-
-		-
-			message: '#^Parameter \#2 \$pieces of function implode expects array, array\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/admin/class-wc-stripe-admin-notices.php
-
-		-
 			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
 			identifier: method.notFound
 			count: 3

--- a/readme.txt
+++ b/readme.txt
@@ -244,5 +244,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Center the text and card icons inside the payment fields on the Blocks checkout
 * Fix - Ensure that settings with checked, disabled checkboxes look disabled
 * Fix - Only load the Blocks checkout stylesheet on pages that render the Cart or Checkout block
+* Fix - Don't show currency admin notices for payment methods when Adaptive Pricing is active
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/admin/class-wc-stripe-admin-notices-test.php
+++ b/tests/phpunit/admin/class-wc-stripe-admin-notices-test.php
@@ -571,21 +571,34 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that the currency notice is shown when UPE methods are enabled.
+	 * The currency notice lists every enabled UPE payment method whose supported
+	 * currencies don't include the store currency, and is suppressed on the Stripe
+	 * settings page, once dismissed, or when Adaptive Pricing is active.
+	 *
+	 * @param bool        $is_stripe_settings_page                Whether the request is for the Stripe settings page.
+	 * @param string|null $dismiss_option                         Value for `wc_stripe_show_upe_payment_methods_notice`; null deletes the option.
+	 * @param bool        $checkout_sessions_available            Whether the Stripe Checkout Sessions feature is available.
+	 * @param string      $adaptive_pricing                       Value for the `adaptive_pricing` setting.
+	 * @param string      $account_country                        The country of the connected account.
+	 * @param string      $store_currency                         The store currency.
+	 * @param string[]    $enabled_payment_method_ids             The IDs of the enabled payment methods.
+	 * @param string[]    $expected_payment_method_ids_in_notice  The IDs of the payment methods that are expected in the notice.
+	 *
+	 * @dataProvider provide_test_currency_notices_scenarios
 	 *
 	 * @return void
 	 */
-	public function test_currency_notice_is_shown_for_upe_methods(): void {
-		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
-
-		$this->mock_payment_method_configurations(
-			[
-				WC_Stripe_Payment_Methods::CARD,
-				WC_Stripe_Payment_Methods::GIROPAY,
-				WC_Stripe_Payment_Methods::BANCONTACT,
-				WC_Stripe_Payment_Methods::EPS,
-			]
-		);
+	public function test_currency_notices(
+		bool $is_stripe_settings_page,
+		?string $dismiss_option,
+		bool $checkout_sessions_available,
+		string $adaptive_pricing,
+		string $account_country,
+		string $store_currency,
+		array $enabled_payment_method_ids,
+		array $expected_payment_method_ids_in_notice
+	): void {
+		$this->mock_payment_method_configurations( $enabled_payment_method_ids );
 
 		WC_Stripe_Helper::update_main_stripe_settings(
 			[
@@ -595,24 +608,319 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'test_secret_key'                 => 'sk_test_valid_test_key',
 				'upe_checkout_experience_enabled' => 'yes',
 				'connection_type'                 => 'connect',
+				'pmc_enabled'                     => 'yes',
+				'optimized_checkout_element'      => $checkout_sessions_available ? 'yes' : 'no',
+				'capture'                         => 'yes',
+				'adaptive_pricing'                => $adaptive_pricing,
 			]
 		);
 
-		update_option( 'wc_stripe_show_style_notice', 'no' );
-		update_option( 'home', 'https://...' );
-		update_option( 'wc_stripe_show_sca_notice', 'no' );
+		// Clear the cache while we are still in test mode to ensure the right values are cleared.
+		WC_Stripe_Payment_Method_Configurations::clear_payment_method_configuration_cache();
 
-		$notices = new WC_Stripe_Admin_Notices();
-		ob_start();
-		$notices->admin_notices();
-		ob_end_clean();
-		if ( WC_Stripe_Helper::is_wc_lt( WC_STRIPE_FUTURE_MIN_WC_VER ) ) {
-			$this->assertCount( 2, $notices->notices );
-			$this->assertArrayHasKey( 'wcver', $notices->notices );
+		if ( null === $dismiss_option ) {
+			delete_option( 'wc_stripe_show_upe_payment_methods_notice' );
 		} else {
-			$this->assertCount( 1, $notices->notices );
+			update_option( 'wc_stripe_show_upe_payment_methods_notice', $dismiss_option );
 		}
-		$this->assertArrayHasKey( 'upe_payment_methods', $notices->notices );
+
+		$original_get = $_GET;
+		if ( $is_stripe_settings_page ) {
+			$_GET['page']    = 'wc-settings';
+			$_GET['section'] = 'stripe';
+		}
+
+		$account_backup = WC_Stripe::get_instance()->account;
+		$account        = $this->getMockBuilder( WC_Stripe_Account::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_account_country', 'is_webhook_enabled', 'get_cached_account_data' ] )
+			->getMock();
+		$account->method( 'get_account_country' )->willReturn( $account_country );
+		$account->method( 'is_webhook_enabled' )->willReturn( true );
+		$account->method( 'get_cached_account_data' )->willReturn( [ 'country' => $account_country ] );
+		WC_Stripe::get_instance()->account = $account;
+
+		$currency_filter = static function () use ( $store_currency ) {
+			return $store_currency;
+		};
+		add_filter( 'woocommerce_currency', $currency_filter );
+
+		// Force a fresh gateway so it picks up the mocked payment method configuration.
+		$this->set_main_stripe_gateway( null );
+
+		try {
+			$notices = new WC_Stripe_Admin_Notices();
+			$notices->payment_methods_check_environment();
+
+			$expected_message = $this->build_expected_currency_notice_message( $expected_payment_method_ids_in_notice );
+
+			if ( '' === $expected_message ) {
+				$this->assertArrayNotHasKey( 'upe_payment_methods', $notices->notices );
+			} else {
+				$this->assertArrayHasKey( 'upe_payment_methods', $notices->notices );
+				$this->assertSame( $expected_message, $notices->notices['upe_payment_methods']['message'] );
+				$this->assertSame( 'notice notice-error', $notices->notices['upe_payment_methods']['class'] );
+				$this->assertTrue( $notices->notices['upe_payment_methods']['dismissible'] );
+			}
+		} finally {
+			$this->set_main_stripe_gateway( null );
+			remove_filter( 'woocommerce_currency', $currency_filter );
+			WC_Stripe::get_instance()->account = $account_backup;
+			$_GET                              = $original_get;
+			delete_option( 'wc_stripe_show_upe_payment_methods_notice' );
+			WC_Stripe_Payment_Method_Configurations::clear_payment_method_configuration_cache();
+			WC_Stripe_Helper::delete_main_stripe_settings();
+		}
+	}
+
+	/**
+	 * Builds the currency notice message expected for a set of payment method IDs.
+	 *
+	 * @param string[] $expected_payment_method_ids_in_notice The IDs of the payment methods that are expected in the notice.
+	 *
+	 * @return string The expected message, or an empty string when no notice is expected.
+	 */
+	private function build_expected_currency_notice_message( array $expected_payment_method_ids_in_notice ): string {
+		if ( [] === $expected_payment_method_ids_in_notice ) {
+			return '';
+		}
+
+		$gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
+		$message = '';
+
+		foreach ( $expected_payment_method_ids_in_notice as $payment_method_id ) {
+			$payment_method = $gateway->payment_methods[ $payment_method_id ];
+			$message       .= sprintf(
+				'%1$s is enabled - it requires store currency to be set to %2$s<br>',
+				$payment_method->get_label(),
+				implode( ', ', $payment_method->get_supported_currencies() )
+			);
+		}
+
+		return $message;
+	}
+
+	/**
+	 * Data provider for {@see test_currency_notices()}.
+	 *
+	 * @return array
+	 */
+	public function provide_test_currency_notices_scenarios(): array {
+		return [
+			'methods that do not support the store currency are listed'                    => [
+				'is stripe settings page'               => false,
+				'dismiss option'                        => null,
+				'checkout sessions available'           => true,
+				'adaptive pricing'                      => 'no',
+				'account country'                       => 'US',
+				'store currency'                        => 'USD',
+				'enabled payment method IDs'            => [
+					WC_Stripe_Payment_Methods::CARD,
+					WC_Stripe_Payment_Methods::EPS,
+					WC_Stripe_Payment_Methods::ALIPAY,
+					WC_Stripe_Payment_Methods::IDEAL,
+					WC_Stripe_Payment_Methods::BANCONTACT,
+					WC_Stripe_Payment_Methods::KLARNA,
+				],
+				'expected payment method IDs in notice' => [
+					WC_Stripe_Payment_Methods::EPS,
+					WC_Stripe_Payment_Methods::IDEAL,
+					WC_Stripe_Payment_Methods::BANCONTACT,
+					WC_Stripe_Payment_Methods::KLARNA,
+				],
+			],
+			'no notice when every method supports the store currency'                      => [
+				'is stripe settings page'               => false,
+				'dismiss option'                        => null,
+				'checkout sessions available'           => true,
+				'adaptive pricing'                      => 'no',
+				'account country'                       => 'FR',
+				'store currency'                        => 'EUR',
+				'enabled payment method IDs'            => [
+					WC_Stripe_Payment_Methods::CARD,
+					WC_Stripe_Payment_Methods::EPS,
+					WC_Stripe_Payment_Methods::BANCONTACT,
+					WC_Stripe_Payment_Methods::IDEAL,
+					WC_Stripe_Payment_Methods::KLARNA,
+				],
+				'expected payment method IDs in notice' => [],
+			],
+			'notice when a the store currency is not supported for the account country'    => [
+				'is stripe settings page'               => false,
+				'dismiss option'                        => null,
+				'checkout sessions available'           => true,
+				'adaptive pricing'                      => 'no',
+				'account country'                       => 'US',
+				'store currency'                        => 'EUR',
+				'enabled payment method IDs'            => [
+					WC_Stripe_Payment_Methods::CARD,
+					WC_Stripe_Payment_Methods::EPS,
+					WC_Stripe_Payment_Methods::BANCONTACT,
+					WC_Stripe_Payment_Methods::IDEAL,
+					WC_Stripe_Payment_Methods::KLARNA,
+				],
+				'expected payment method IDs in notice' => [
+					WC_Stripe_Payment_Methods::KLARNA, // US merchants can only offer Klarna for USD purchases.
+				],
+			],
+			'card and Link are never flagged'                                              => [
+				'is stripe settings page'               => false,
+				'dismiss option'                        => null,
+				'checkout sessions available'           => true,
+				'adaptive pricing'                      => 'no',
+				'account country'                       => 'US',
+				'store currency'                        => 'AAA', // Invalid currency.
+				'enabled payment method IDs'            => [
+					WC_Stripe_Payment_Methods::CARD,
+					WC_Stripe_Payment_Methods::LINK,
+					WC_Stripe_Payment_Methods::BOLETO,
+					WC_Stripe_Payment_Methods::OXXO,
+				],
+				'expected payment method IDs in notice' => [
+					WC_Stripe_Payment_Methods::BOLETO,
+					WC_Stripe_Payment_Methods::OXXO,
+				],
+			],
+			'methods the gateway does not expose are skipped'                              => [
+				// Giropay is only instantiated on order details/refund requests, so it is
+				// enabled in the configuration but absent from the gateway's methods.
+				'is stripe settings page'               => false,
+				'dismiss option'                        => null,
+				'checkout sessions available'           => true,
+				'adaptive pricing'                      => 'no',
+				'account country'                       => 'US',
+				'store currency'                        => 'USD',
+				'enabled payment method IDs'            => [
+					WC_Stripe_Payment_Methods::EPS,
+					WC_Stripe_Payment_Methods::GIROPAY,
+					WC_Stripe_Payment_Methods::IDEAL,
+					WC_Stripe_Payment_Methods::KLARNA,
+				],
+				'expected payment method IDs in notice' => [
+					WC_Stripe_Payment_Methods::EPS,
+					WC_Stripe_Payment_Methods::IDEAL,
+					WC_Stripe_Payment_Methods::KLARNA,
+				],
+			],
+			'no notice when no restricted method is enabled'                               => [
+				'is stripe settings page'               => false,
+				'dismiss option'                        => null,
+				'checkout sessions available'           => true,
+				'adaptive pricing'                      => 'no',
+				'account country'                       => 'US',
+				'store currency'                        => 'USD',
+				'enabled payment method IDs'            => [
+					WC_Stripe_Payment_Methods::CARD,
+					WC_Stripe_Payment_Methods::LINK,
+				],
+				'expected payment method IDs in notice' => [],
+			],
+			'suppressed on the Stripe settings page'                                       => [
+				'is stripe settings page'               => true,
+				'dismiss option'                        => null,
+				'checkout sessions available'           => true,
+				'adaptive pricing'                      => 'no',
+				'account country'                       => 'US',
+				'store currency'                        => 'USD',
+				'enabled payment method IDs'            => [
+					WC_Stripe_Payment_Methods::EPS,
+					WC_Stripe_Payment_Methods::BANCONTACT,
+					WC_Stripe_Payment_Methods::IDEAL,
+					WC_Stripe_Payment_Methods::KLARNA,
+				],
+				'expected payment method IDs in notice' => [],
+			],
+			'suppressed once dismissed'                                                    => [
+				'is stripe settings page'               => false,
+				'dismiss option'                        => 'no',
+				'checkout sessions available'           => true,
+				'adaptive pricing'                      => 'no',
+				'account country'                       => 'US',
+				'store currency'                        => 'USD',
+				'enabled payment method IDs'            => [
+					WC_Stripe_Payment_Methods::EPS,
+					WC_Stripe_Payment_Methods::BANCONTACT,
+					WC_Stripe_Payment_Methods::IDEAL,
+					WC_Stripe_Payment_Methods::KLARNA,
+				],
+				'expected payment method IDs in notice' => [],
+			],
+			'shown while the dismiss option is yes'                                        => [
+				'is stripe settings page'               => false,
+				'dismiss option'                        => 'yes',
+				'checkout sessions available'           => true,
+				'adaptive pricing'                      => 'no',
+				'account country'                       => 'US',
+				'store currency'                        => 'USD',
+				'enabled payment method IDs'            => [
+					WC_Stripe_Payment_Methods::EPS,
+					WC_Stripe_Payment_Methods::BANCONTACT,
+					WC_Stripe_Payment_Methods::IDEAL,
+					WC_Stripe_Payment_Methods::KLARNA,
+				],
+				'expected payment method IDs in notice' => [
+					WC_Stripe_Payment_Methods::EPS,
+					WC_Stripe_Payment_Methods::BANCONTACT,
+					WC_Stripe_Payment_Methods::IDEAL,
+					WC_Stripe_Payment_Methods::KLARNA,
+				],
+			],
+			'suppressed when Adaptive Pricing is enabled'                                  => [
+				'is stripe settings page'               => false,
+				'dismiss option'                        => '',
+				'checkout sessions available'           => true,
+				'adaptive pricing'                      => 'yes',
+				'account country'                       => 'US',
+				'store currency'                        => 'USD',
+				'enabled payment method IDs'            => [
+					WC_Stripe_Payment_Methods::EPS,
+					WC_Stripe_Payment_Methods::BANCONTACT,
+					WC_Stripe_Payment_Methods::IDEAL,
+					WC_Stripe_Payment_Methods::KLARNA,
+				],
+				'expected payment method IDs in notice' => [],
+			],
+			'shown when Adaptive Pricing is enabled but Checkout Sessions are unavailable' => [
+				'is stripe settings page'               => false,
+				'dismiss option'                        => '',
+				'checkout sessions available'           => false,
+				'adaptive pricing'                      => 'yes',
+				'account country'                       => 'US',
+				'store currency'                        => 'USD',
+				'enabled payment method IDs'            => [
+					WC_Stripe_Payment_Methods::EPS,
+					WC_Stripe_Payment_Methods::BANCONTACT,
+					WC_Stripe_Payment_Methods::IDEAL,
+					WC_Stripe_Payment_Methods::KLARNA,
+				],
+				'expected payment method IDs in notice' => [
+					WC_Stripe_Payment_Methods::EPS,
+					WC_Stripe_Payment_Methods::BANCONTACT,
+					WC_Stripe_Payment_Methods::IDEAL,
+					WC_Stripe_Payment_Methods::KLARNA,
+				],
+			],
+			'shown when Adaptive Pricing is enabled but unavailable for the account'       => [
+				'is stripe settings page'                => false,
+				'dismiss option'                         => '',
+				'checkout sessions available'            => true,
+				'adaptive pricing'                       => 'yes',
+				'adaptive pricing available for account' => 'IN',
+				'store currency'                         => 'USD',
+				'enabled payment method IDs'             => [
+					WC_Stripe_Payment_Methods::EPS,
+					WC_Stripe_Payment_Methods::BANCONTACT,
+					WC_Stripe_Payment_Methods::IDEAL,
+					WC_Stripe_Payment_Methods::KLARNA,
+				],
+				'expected payment method IDs in notice'  => [
+					WC_Stripe_Payment_Methods::EPS,
+					WC_Stripe_Payment_Methods::BANCONTACT,
+					WC_Stripe_Payment_Methods::IDEAL,
+					WC_Stripe_Payment_Methods::KLARNA,
+				],
+			],
+		];
 	}
 
 	/**

--- a/tests/phpunit/admin/class-wc-stripe-admin-notices-test.php
+++ b/tests/phpunit/admin/class-wc-stripe-admin-notices-test.php
@@ -735,6 +735,22 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 					WC_Stripe_Payment_Methods::KLARNA,
 				],
 			],
+			'no notice when the store currency is empty'                                   => [
+				'is stripe settings page'               => false,
+				'dismiss option'                        => null,
+				'checkout sessions available'           => true,
+				'adaptive pricing'                      => 'no',
+				'account country'                       => 'FR',
+				'store currency'                        => '',
+				'enabled payment method IDs'            => [
+					WC_Stripe_Payment_Methods::CARD,
+					WC_Stripe_Payment_Methods::EPS,
+					WC_Stripe_Payment_Methods::BANCONTACT,
+					WC_Stripe_Payment_Methods::IDEAL,
+					WC_Stripe_Payment_Methods::KLARNA,
+				],
+				'expected payment method IDs in notice' => [],
+			],
 			'no notice when every method supports the store currency'                      => [
 				'is stripe settings page'               => false,
 				'dismiss option'                        => null,

--- a/tests/phpunit/admin/class-wc-stripe-admin-notices-test.php
+++ b/tests/phpunit/admin/class-wc-stripe-admin-notices-test.php
@@ -191,7 +191,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 */
 	public function options_to_notices_map(): array {
 		return [
-			[
+			'style notice is shown when the Stripe gateway is enabled'              => [
 				[
 					'woocommerce_stripe_settings' => [ 'enabled' => 'yes' ],
 				],
@@ -502,7 +502,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 					'changed_keys',
 				],
 			],
-			[
+			'changed key notice is shown when option is set and OAuth is connected' => [
 				[
 					'woocommerce_stripe_settings'        => [
 						'enabled'         => 'yes',
@@ -533,25 +533,8 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 					'wc_stripe_show_sca_notice'   => 'no',
 				],
 			],
-			[
-				[
-					'woocommerce_stripe_settings' => [
-						'enabled'                                   => 'yes',
-						'testmode'                                  => 'no',
-						'publishable_key'                           => 'pk_live_valid_test_key',
-						'secret_key'                                => 'sk_live_valid_test_key',
-						'upe_checkout_experience_accepted_payments' => [ 'card', 'eps' ],
-					],
-					'wc_stripe_show_style_notice' => 'no',
-					'home'                        => 'https://...',
-					'wc_stripe_show_sca_notice'   => 'no',
-				],
-				'is oauth connected' => true,
-				[
-					'upe_payment_methods',
-				],
-			],
-			'OAuth required notice' => [
+			/* Note that currency notices are handled via test_currency_notices(). */
+			'OAuth required notice'                                                 => [
 				[
 					'woocommerce_stripe_settings' => [
 						'enabled'         => 'yes',
@@ -576,6 +559,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 * settings page, once dismissed, or when Adaptive Pricing is active.
 	 *
 	 * @param bool        $is_stripe_settings_page                Whether the request is for the Stripe settings page.
+	 * @param bool        $is_gateway_enabled                     Whether the Stripe gateway is enabled.
 	 * @param string|null $dismiss_option                         Value for `wc_stripe_show_upe_payment_methods_notice`; null deletes the option.
 	 * @param bool        $checkout_sessions_available            Whether the Stripe Checkout Sessions feature is available.
 	 * @param string      $adaptive_pricing                       Value for the `adaptive_pricing` setting.
@@ -590,6 +574,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 */
 	public function test_currency_notices(
 		bool $is_stripe_settings_page,
+		bool $is_gateway_enabled,
 		?string $dismiss_option,
 		bool $checkout_sessions_available,
 		string $adaptive_pricing,
@@ -602,7 +587,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 
 		WC_Stripe_Helper::update_main_stripe_settings(
 			[
-				'enabled'                         => 'yes',
+				'enabled'                         => $is_gateway_enabled ? 'yes' : 'no',
 				'testmode'                        => 'yes',
 				'test_publishable_key'            => 'pk_test_valid_test_key',
 				'test_secret_key'                 => 'sk_test_valid_test_key',
@@ -713,8 +698,26 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 */
 	public function provide_test_currency_notices_scenarios(): array {
 		return [
+			'no notice when the Stripe gateway is disabled'                                => [
+				'is stripe settings page'               => false,
+				'is gateway enabled'                    => false,
+				'dismiss option'                        => null,
+				'checkout sessions available'           => true,
+				'adaptive pricing'                      => 'no',
+				'account country'                       => 'FR',
+				'store currency'                        => '',
+				'enabled payment method IDs'            => [
+					WC_Stripe_Payment_Methods::CARD,
+					WC_Stripe_Payment_Methods::EPS,
+					WC_Stripe_Payment_Methods::BANCONTACT,
+					WC_Stripe_Payment_Methods::IDEAL,
+					WC_Stripe_Payment_Methods::KLARNA,
+				],
+				'expected payment method IDs in notice' => [],
+			],
 			'methods that do not support the store currency are listed'                    => [
 				'is stripe settings page'               => false,
+				'is gateway enabled'                    => true,
 				'dismiss option'                        => null,
 				'checkout sessions available'           => true,
 				'adaptive pricing'                      => 'no',
@@ -737,6 +740,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			],
 			'no notice when the store currency is empty'                                   => [
 				'is stripe settings page'               => false,
+				'is gateway enabled'                    => true,
 				'dismiss option'                        => null,
 				'checkout sessions available'           => true,
 				'adaptive pricing'                      => 'no',
@@ -753,6 +757,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			],
 			'no notice when every method supports the store currency'                      => [
 				'is stripe settings page'               => false,
+				'is gateway enabled'                    => true,
 				'dismiss option'                        => null,
 				'checkout sessions available'           => true,
 				'adaptive pricing'                      => 'no',
@@ -769,6 +774,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			],
 			'notice when a the store currency is not supported for the account country'    => [
 				'is stripe settings page'               => false,
+				'is gateway enabled'                    => true,
 				'dismiss option'                        => null,
 				'checkout sessions available'           => true,
 				'adaptive pricing'                      => 'no',
@@ -787,6 +793,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			],
 			'card and Link are never flagged'                                              => [
 				'is stripe settings page'               => false,
+				'is gateway enabled'                    => true,
 				'dismiss option'                        => null,
 				'checkout sessions available'           => true,
 				'adaptive pricing'                      => 'no',
@@ -807,6 +814,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				// Giropay is only instantiated on order details/refund requests, so it is
 				// enabled in the configuration but absent from the gateway's methods.
 				'is stripe settings page'               => false,
+				'is gateway enabled'                    => true,
 				'dismiss option'                        => null,
 				'checkout sessions available'           => true,
 				'adaptive pricing'                      => 'no',
@@ -826,6 +834,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			],
 			'no notice when no restricted method is enabled'                               => [
 				'is stripe settings page'               => false,
+				'is gateway enabled'                    => true,
 				'dismiss option'                        => null,
 				'checkout sessions available'           => true,
 				'adaptive pricing'                      => 'no',
@@ -839,6 +848,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			],
 			'suppressed on the Stripe settings page'                                       => [
 				'is stripe settings page'               => true,
+				'is gateway enabled'                    => true,
 				'dismiss option'                        => null,
 				'checkout sessions available'           => true,
 				'adaptive pricing'                      => 'no',
@@ -854,6 +864,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			],
 			'suppressed once dismissed'                                                    => [
 				'is stripe settings page'               => false,
+				'is gateway enabled'                    => true,
 				'dismiss option'                        => 'no',
 				'checkout sessions available'           => true,
 				'adaptive pricing'                      => 'no',
@@ -869,6 +880,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			],
 			'shown while the dismiss option is yes'                                        => [
 				'is stripe settings page'               => false,
+				'is gateway enabled'                    => true,
 				'dismiss option'                        => 'yes',
 				'checkout sessions available'           => true,
 				'adaptive pricing'                      => 'no',
@@ -889,6 +901,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			],
 			'suppressed when Adaptive Pricing is enabled'                                  => [
 				'is stripe settings page'               => false,
+				'is gateway enabled'                    => true,
 				'dismiss option'                        => '',
 				'checkout sessions available'           => true,
 				'adaptive pricing'                      => 'yes',
@@ -904,6 +917,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			],
 			'shown when Adaptive Pricing is enabled but Checkout Sessions are unavailable' => [
 				'is stripe settings page'               => false,
+				'is gateway enabled'                    => true,
 				'dismiss option'                        => '',
 				'checkout sessions available'           => false,
 				'adaptive pricing'                      => 'yes',
@@ -923,19 +937,20 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				],
 			],
 			'shown when Adaptive Pricing is enabled but unavailable for the account'       => [
-				'is stripe settings page'                => false,
-				'dismiss option'                         => '',
-				'checkout sessions available'            => true,
-				'adaptive pricing'                       => 'yes',
-				'adaptive pricing available for account' => 'IN',
-				'store currency'                         => 'USD',
-				'enabled payment method IDs'             => [
+				'is stripe settings page'               => false,
+				'is gateway enabled'                    => true,
+				'dismiss option'                        => '',
+				'checkout sessions available'           => true,
+				'adaptive pricing'                      => 'yes',
+				'account country'                       => 'IN',
+				'store currency'                        => 'USD',
+				'enabled payment method IDs'            => [
 					WC_Stripe_Payment_Methods::EPS,
 					WC_Stripe_Payment_Methods::BANCONTACT,
 					WC_Stripe_Payment_Methods::IDEAL,
 					WC_Stripe_Payment_Methods::KLARNA,
 				],
-				'expected payment method IDs in notice'  => [
+				'expected payment method IDs in notice' => [
 					WC_Stripe_Payment_Methods::EPS,
 					WC_Stripe_Payment_Methods::BANCONTACT,
 					WC_Stripe_Payment_Methods::IDEAL,

--- a/tests/phpunit/admin/class-wc-stripe-admin-notices-test.php
+++ b/tests/phpunit/admin/class-wc-stripe-admin-notices-test.php
@@ -661,6 +661,12 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				$this->assertSame( $expected_message, $notices->notices['upe_payment_methods']['message'] );
 				$this->assertSame( 'notice notice-error', $notices->notices['upe_payment_methods']['class'] );
 				$this->assertTrue( $notices->notices['upe_payment_methods']['dismissible'] );
+
+				$this->assertNotEmpty( $notices->notices['upe_payment_methods']['actions'] );
+				$this->assertCount( 1, $notices->notices['upe_payment_methods']['actions'] );
+				$action                      = reset( $notices->notices['upe_payment_methods']['actions'] );
+				$payment_method_settings_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods' );
+				$this->assertStringContainsString( '<a href="' . esc_url( $payment_method_settings_url ) . '" class="button button-secondary" style="margin:1em 2em 0.5em 0;">Review Stripe payment method settings</a>', $action );
 			}
 		} finally {
 			$this->set_main_stripe_gateway( null );

--- a/tests/phpunit/admin/class-wc-stripe-admin-notices-test.php
+++ b/tests/phpunit/admin/class-wc-stripe-admin-notices-test.php
@@ -704,8 +704,8 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'dismiss option'                        => null,
 				'checkout sessions available'           => true,
 				'adaptive pricing'                      => 'no',
-				'account country'                       => 'FR',
-				'store currency'                        => '',
+				'account country'                       => 'US',
+				'store currency'                        => 'USD',
 				'enabled payment method IDs'            => [
 					WC_Stripe_Payment_Methods::CARD,
 					WC_Stripe_Payment_Methods::EPS,


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
The primary purpose of this PR is to prevent Stripe currency mismatch notices from displaying in wp-admin when Adaptive Pricing is enabled, but the PR also refactors the code and takes on some related cleanup. The key changes are as follows:
 * Add a secondary CTA when the message does show so a merchant can take action -- it links to the payment method settings UI
 * Implement all exit conditions as early returns, including being in the Stripe settings UI, the dismiss option being set, and adding a check for Adaptive Pricing being active
 * Change the logic to treat only the `stripe` section as part of the settings UI -- previously any section starting with `stripe` would hide the notice
 * Drive the main loop based on the result of `WC_Stripe_UPE_Payment_Gateway->get_upe_enabled_payment_method_ids()` instead of looping over all possible payment methods
 * Access the payment method instances via the `WC_Stripe_UPE_Payment_Gateway->payment_methods[ $payment_method_id ]` instead of constructing a new instance for every payment method, which has some complex side-effects
 * Update the logic to fully rely on the return value from `$payment_method->get_supported_currencies()`, especially `null` returns for payment methods without currency restrictions, especially card and Link, which previously had special checks

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
### Screenshots

#### Before

Shown in all admin pages that show notices and are not the Stripe settings pages, regardless of whether Adaptive Pricing is enabled.

<img width="865" height="165" alt="Screenshot 2026-08-06 at 14 40 22" src="https://github.com/user-attachments/assets/c26638c4-cf1e-4654-af51-335304974426" />

#### After

When Adaptive Pricing is disabled and one or more payment methods don't support the store currency, and the page is not the Stripe settings UI.

<img width="865" height="223" alt="Screenshot 2026-08-06 at 14 39 51" src="https://github.com/user-attachments/assets/f2b62d3a-4850-43c9-b4be-a2e687a910ee" />

_When Adaptive Pricing is active, no notice is shown._

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->
 - Run a build from develop or some other branch
 - Ensure that you are connected to Stripe and have Adaptive Pricing enabled
 - Ensure that one or more payment methods do not support your current store currency
 - Run `wp option delete wc_stripe_show_upe_payment_methods_notice` to ensure the notice is not dismissed
 - Navigate to a wp-admin page that shows notices, such as WooCommerce -> Settings or event Appearance -> Themes
 - Confirm that you see the currency notice, and that there is no action you can take in response
 - Now switch to this build, and reload the relevant admin pages
 - Verify that Adaptive Pricing is still enabled and active
 - Confirm that you no longer see the currency notice
 - Now disable Optimized Checkout, and reload your original test page (this keeps the Adaptive Pricing option enabled, but the feature is off)
 - Verify that you now see the notice, and that the CTA is present
 - Click on the CTA, and confirm that you're taken to the Stripe payment methods settings UI
 - Re-enable Optimized Checkout and disable Adaptive Pricing
 - Reload your test page, and confirm that you still see the notice with the CTA
---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
