### PR TITLE
Update webhook status cache to use database cache

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -91,6 +91,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Prevent dismissed admin banner notices from reappearing after navigating between Settings and Payment Methods tabs
 * Fix - Only load the Blocks checkout stylesheet on pages that render the Cart or Checkout block, instead of on every page of the store
 * Fix - Reserve stock when completing agentic checkout orders so concurrent sessions cannot oversell; orders losing the race are set on-hold instead of driving stock negative
+* Tweak - Use database cache for webhook status tracking
 
 2026-08-05 - version 10.8.5
 * Update - Improve webhook handling

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -74,6 +74,15 @@ class WC_Stripe_Account {
 	];
 
 	/**
+	 * The webhook status cache key.
+	 *
+	 * @internal
+	 *
+	 * @var string
+	 */
+	protected const WEBHOOK_STATUS_CACHE_KEY = 'webhook_status';
+
+	/**
 	 * The Stripe connect instance.
 	 *
 	 * @var WC_Stripe_Connect
@@ -190,8 +199,8 @@ class WC_Stripe_Account {
 	 * Wipes the cached webhook status for both modes.
 	 */
 	private function clear_webhook_status_cache(): void {
-		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'live' );
-		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'test' );
+		WC_Stripe_Database_Cache::delete_with_mode( self::WEBHOOK_STATUS_CACHE_KEY, 'live' );
+		WC_Stripe_Database_Cache::delete_with_mode( self::WEBHOOK_STATUS_CACHE_KEY, 'test' );
 	}
 
 	/**
@@ -461,8 +470,7 @@ class WC_Stripe_Account {
 		}
 
 		// Check if we have a cached status.
-		$cache_key     = 'webhook_status';
-		$cached_status = WC_Stripe_Database_Cache::get( $cache_key );
+		$cached_status = WC_Stripe_Database_Cache::get( self::WEBHOOK_STATUS_CACHE_KEY );
 		if ( null !== $cached_status ) {
 			return 'enabled' === $cached_status;
 		}
@@ -477,7 +485,7 @@ class WC_Stripe_Account {
 			$webhook_status = ! empty( $webhook->status ) && 'enabled' === $webhook->status ?
 				'enabled' :
 				'disabled';
-			WC_Stripe_Database_Cache::set( $cache_key, $webhook_status, 2 * HOUR_IN_SECONDS );
+			WC_Stripe_Database_Cache::set( self::WEBHOOK_STATUS_CACHE_KEY, $webhook_status, 2 * HOUR_IN_SECONDS );
 
 			return 'enabled' === $webhook_status;
 		} catch ( Exception $e ) {

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -24,7 +24,18 @@ class WC_Stripe_Account {
 	 */
 	public const ACCOUNT_CACHE_EXPIRATION = 2 * HOUR_IN_SECONDS;
 
+	/**
+	 * The transient key that was previously used to cache the live mode webhook status.
+	 *
+	 * @deprecated 11.0.0
+	 */
 	public const LIVE_WEBHOOK_STATUS_OPTION = 'wcstripe_webhook_status_live';
+
+	/**
+	 * The transient key that was previously used to cache the test mode webhook status.
+	 *
+	 * @deprecated 11.0.0
+	 */
 	public const TEST_WEBHOOK_STATUS_OPTION = 'wcstripe_webhook_status_test';
 
 	public const STATUS_COMPLETE        = 'complete';
@@ -179,8 +190,8 @@ class WC_Stripe_Account {
 	 * Wipes the cached webhook status for both modes.
 	 */
 	private function clear_webhook_status_cache(): void {
-		delete_transient( self::LIVE_WEBHOOK_STATUS_OPTION );
-		delete_transient( self::TEST_WEBHOOK_STATUS_OPTION );
+		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'live' );
+		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'test' );
 	}
 
 	/**
@@ -450,9 +461,9 @@ class WC_Stripe_Account {
 		}
 
 		// Check if we have a cached status.
-		$cache_key     = $is_testmode ? self::TEST_WEBHOOK_STATUS_OPTION : self::LIVE_WEBHOOK_STATUS_OPTION;
-		$cached_status = get_transient( $cache_key );
-		if ( false !== $cached_status ) {
+		$cache_key     = 'webhook_status';
+		$cached_status = WC_Stripe_Database_Cache::get( $cache_key );
+		if ( null !== $cached_status ) {
 			return 'enabled' === $cached_status;
 		}
 
@@ -466,7 +477,7 @@ class WC_Stripe_Account {
 			$webhook_status = ! empty( $webhook->status ) && 'enabled' === $webhook->status ?
 				'enabled' :
 				'disabled';
-			set_transient( $cache_key, $webhook_status, 2 * HOUR_IN_SECONDS );
+			WC_Stripe_Database_Cache::set( $cache_key, $webhook_status, 2 * HOUR_IN_SECONDS );
 
 			return 'enabled' === $webhook_status;
 		} catch ( Exception $e ) {

--- a/readme.txt
+++ b/readme.txt
@@ -248,5 +248,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Prevent dismissed admin banner notices from reappearing after navigating between Settings and Payment Methods tabs
 * Fix - Only load the Blocks checkout stylesheet on pages that render the Cart or Checkout block
 * Fix - Reserve stock when completing agentic checkout orders so concurrent sessions cannot oversell; orders losing the race are set on-hold instead of driving stock negative
+* Tweak - Use database cache for webhook status tracking
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/e2e/bin/run-tests.sh
+++ b/tests/e2e/bin/run-tests.sh
@@ -46,11 +46,9 @@ if [[ "adaptive-pricing" == "$project" ]]; then
 	echo "Seeding Adaptive Pricing prerequisites"
 	cli wp option patch insert woocommerce_stripe_settings pmc_enabled 'yes'
 	cli wp option patch insert woocommerce_stripe_settings test_webhook_data --format=json '{"id":"we_e2e_placeholder","secret":"whsec_e2e_placeholder"}'
-	# Delete first: `wp transient set` exits non-zero when the value is unchanged, which under
-	# `set -e` would abort seeding on any re-run inside the TTL. Deleting a missing transient is a
-	# no-op, so this stays correct on a fresh site and refreshes the TTL on a repeat run.
-	cli wp transient delete wcstripe_webhook_status_test
-	cli wp transient set wcstripe_webhook_status_test enabled 7200
+	# Mark test webhooks as enabled to allow Adaptive Pricing to be enabled.
+	# Note that we use wp shell so we run after plugins are loaded.
+	cli wp shell <<< "WC_Stripe_Database_Cache::set_with_mode( 'webhook_status', 'enabled', 7200, 'test' ); echo WC_Stripe_Database_Cache::get_with_mode( 'webhook_status', 'test' ); exit";
 	# Cookie-gated mu-plugin that simulates the shopper's country for
 	# conversion tests (Stripe's "+location_XX" customer_email test hook).
 	cli sh -c "mkdir -p /var/www/html/wp-content/mu-plugins && cp /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/tests/e2e/env/mu-plugins/wc-stripe-e2e-location-simulation.php /var/www/html/wp-content/mu-plugins/"

--- a/tests/e2e/bin/run-tests.sh
+++ b/tests/e2e/bin/run-tests.sh
@@ -48,7 +48,7 @@ if [[ "adaptive-pricing" == "$project" ]]; then
 	cli wp option patch insert woocommerce_stripe_settings test_webhook_data --format=json '{"id":"we_e2e_placeholder","secret":"whsec_e2e_placeholder"}'
 	# Mark test webhooks as enabled to allow Adaptive Pricing to be enabled.
 	# Note that we use wp shell so we run after plugins are loaded.
-	cli wp shell <<< "WC_Stripe_Database_Cache::set_with_mode( 'webhook_status', 'enabled', 7200, 'test' ); echo WC_Stripe_Database_Cache::get_with_mode( 'webhook_status', 'test' ); exit";
+	cli wp shell <<< "WC_Stripe_Database_Cache::set_with_mode( 'webhook_status', 'enabled', 7200, 'test' ); exit";
 	# Cookie-gated mu-plugin that simulates the shopper's country for
 	# conversion tests (Stripe's "+location_XX" customer_email test hook).
 	cli sh -c "mkdir -p /var/www/html/wp-content/mu-plugins && cp /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/tests/e2e/env/mu-plugins/wc-stripe-e2e-location-simulation.php /var/www/html/wp-content/mu-plugins/"

--- a/tests/phpunit/admin/class-wc-rest-stripe-account-controller-test.php
+++ b/tests/phpunit/admin/class-wc-rest-stripe-account-controller-test.php
@@ -59,8 +59,9 @@ class WC_REST_Stripe_Account_Controller_Test extends WP_UnitTestCase {
 		WC_Stripe_Database_Cache::delete( WC_Stripe_Account::ACCOUNT_CACHE_KEY );
 		WC_Stripe_Helper::delete_main_stripe_settings();
 
-		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'live' );
-		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'test' );
+		$webhook_status_cache_key = WC_Stripe_Test_Helper::get_class_const_value( WC_Stripe_Account::class, 'WEBHOOK_STATUS_CACHE_KEY', 'string' );
+		WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'live' );
+		WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'test' );
 
 		WC_Helper_Stripe_Api::reset();
 
@@ -68,13 +69,14 @@ class WC_REST_Stripe_Account_Controller_Test extends WP_UnitTestCase {
 	}
 
 	public function test_refresh_account_clears_the_cached_webhook_status() {
-		WC_Stripe_Database_Cache::set_with_mode( 'webhook_status', 'enabled', HOUR_IN_SECONDS, 'live' );
-		WC_Stripe_Database_Cache::set_with_mode( 'webhook_status', 'enabled', HOUR_IN_SECONDS, 'test' );
+		$webhook_status_cache_key = WC_Stripe_Test_Helper::get_class_const_value( WC_Stripe_Account::class, 'WEBHOOK_STATUS_CACHE_KEY', 'string' );
+		WC_Stripe_Database_Cache::set_with_mode( $webhook_status_cache_key, 'enabled', HOUR_IN_SECONDS, 'live' );
+		WC_Stripe_Database_Cache::set_with_mode( $webhook_status_cache_key, 'enabled', HOUR_IN_SECONDS, 'test' );
 
 		$this->controller->refresh_account();
 
-		$this->assertNull( WC_Stripe_Database_Cache::get_with_mode( 'webhook_status', 'live' ) );
-		$this->assertNull( WC_Stripe_Database_Cache::get_with_mode( 'webhook_status', 'test' ) );
+		$this->assertNull( WC_Stripe_Database_Cache::get_with_mode( $webhook_status_cache_key, 'live' ) );
+		$this->assertNull( WC_Stripe_Database_Cache::get_with_mode( $webhook_status_cache_key, 'test' ) );
 	}
 
 	public function test_refresh_account_stores_the_freshly_fetched_account_data() {

--- a/tests/phpunit/admin/class-wc-rest-stripe-account-controller-test.php
+++ b/tests/phpunit/admin/class-wc-rest-stripe-account-controller-test.php
@@ -59,8 +59,8 @@ class WC_REST_Stripe_Account_Controller_Test extends WP_UnitTestCase {
 		WC_Stripe_Database_Cache::delete( WC_Stripe_Account::ACCOUNT_CACHE_KEY );
 		WC_Stripe_Helper::delete_main_stripe_settings();
 
-		delete_transient( WC_Stripe_Account::LIVE_WEBHOOK_STATUS_OPTION );
-		delete_transient( WC_Stripe_Account::TEST_WEBHOOK_STATUS_OPTION );
+		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'live' );
+		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'test' );
 
 		WC_Helper_Stripe_Api::reset();
 
@@ -68,13 +68,13 @@ class WC_REST_Stripe_Account_Controller_Test extends WP_UnitTestCase {
 	}
 
 	public function test_refresh_account_clears_the_cached_webhook_status() {
-		set_transient( WC_Stripe_Account::LIVE_WEBHOOK_STATUS_OPTION, 'enabled', HOUR_IN_SECONDS );
-		set_transient( WC_Stripe_Account::TEST_WEBHOOK_STATUS_OPTION, 'enabled', HOUR_IN_SECONDS );
+		WC_Stripe_Database_Cache::set_with_mode( 'webhook_status', 'enabled', HOUR_IN_SECONDS, 'live' );
+		WC_Stripe_Database_Cache::set_with_mode( 'webhook_status', 'enabled', HOUR_IN_SECONDS, 'test' );
 
 		$this->controller->refresh_account();
 
-		$this->assertFalse( get_transient( WC_Stripe_Account::LIVE_WEBHOOK_STATUS_OPTION ) );
-		$this->assertFalse( get_transient( WC_Stripe_Account::TEST_WEBHOOK_STATUS_OPTION ) );
+		$this->assertNull( WC_Stripe_Database_Cache::get_with_mode( 'webhook_status', 'live' ) );
+		$this->assertNull( WC_Stripe_Database_Cache::get_with_mode( 'webhook_status', 'test' ) );
 	}
 
 	public function test_refresh_account_stores_the_freshly_fetched_account_data() {

--- a/tests/phpunit/class-wc-stripe-account-test.php
+++ b/tests/phpunit/class-wc-stripe-account-test.php
@@ -46,6 +46,7 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 
 	public function tear_down() {
 		WC_Stripe_Database_Cache::delete( WC_Stripe_Account::ACCOUNT_CACHE_KEY );
+		$this->clear_webhook_status_cache();
 		WC_Stripe_Helper::delete_main_stripe_settings();
 
 		WC_Helper_Stripe_Api::reset();
@@ -485,8 +486,9 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 	}
 
 	private function clear_webhook_status_cache() {
-		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'test' );
-		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'live' );
+		$webhook_status_cache_key = WC_Stripe_Test_Helper::get_class_const_value( WC_Stripe_Account::class, 'WEBHOOK_STATUS_CACHE_KEY', 'string' );
+		WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'test' );
+		WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'live' );
 	}
 
 	/**

--- a/tests/phpunit/class-wc-stripe-account-test.php
+++ b/tests/phpunit/class-wc-stripe-account-test.php
@@ -485,8 +485,8 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 	}
 
 	private function clear_webhook_status_cache() {
-		delete_transient( WC_Stripe_Account::TEST_WEBHOOK_STATUS_OPTION );
-		delete_transient( WC_Stripe_Account::LIVE_WEBHOOK_STATUS_OPTION );
+		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'test' );
+		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'live' );
 	}
 
 	/**

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -1949,13 +1949,15 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		}
 		WC_Stripe_Helper::update_main_stripe_settings( $new_stripe_settings );
 
+		$webhook_status_cache_key = WC_Stripe_Test_Helper::get_class_const_value( WC_Stripe_Account::class, 'WEBHOOK_STATUS_CACHE_KEY', 'string' );
+
 		// is_webhook_enabled() short-circuits on a cached status, so we don't hit the Stripe API here.
 		if ( $webhook_enabled ) {
-			WC_Stripe_Database_Cache::set_with_mode( 'webhook_status', 'enabled', HOUR_IN_SECONDS, 'live' );
-			WC_Stripe_Database_Cache::set_with_mode( 'webhook_status', 'enabled', HOUR_IN_SECONDS, 'test' );
+			WC_Stripe_Database_Cache::set_with_mode( $webhook_status_cache_key, 'enabled', HOUR_IN_SECONDS, 'live' );
+			WC_Stripe_Database_Cache::set_with_mode( $webhook_status_cache_key, 'enabled', HOUR_IN_SECONDS, 'test' );
 		} else {
-			WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'live' );
-			WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'test' );
+			WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'live' );
+			WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'test' );
 		}
 
 		$is_checkout_filter = function () use ( $is_checkout ) {
@@ -2015,8 +2017,9 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 
 		remove_filter( 'woocommerce_is_checkout', $is_checkout_filter );
 		WC_Stripe_Helper::update_main_stripe_settings( $original_stripe_settings );
-		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'live' );
-		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'test' );
+		$webhook_status_cache_key = WC_Stripe_Test_Helper::get_class_const_value( WC_Stripe_Account::class, 'WEBHOOK_STATUS_CACHE_KEY', 'string' );
+		WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'live' );
+		WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'test' );
 		\WC_Subscriptions_Product::set_is_subscription( false );
 		\WC_Subscriptions_Product::set_subscription_product_ids( [] );
 		\WC_Pre_Orders_Product::set_is_pre_order_charged_upon_release( false );
@@ -2221,13 +2224,15 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		}
 		WC_Stripe_Helper::update_main_stripe_settings( $settings );
 
+		$webhook_status_cache_key = WC_Stripe_Test_Helper::get_class_const_value( WC_Stripe_Account::class, 'WEBHOOK_STATUS_CACHE_KEY', 'string' );
+
 		// is_webhook_enabled() short-circuits on a cached status, so we don't hit the Stripe API here.
 		if ( $webhook_enabled ) {
-			WC_Stripe_Database_Cache::set_with_mode( 'webhook_status', 'enabled', HOUR_IN_SECONDS, 'live' );
-			WC_Stripe_Database_Cache::set_with_mode( 'webhook_status', 'enabled', HOUR_IN_SECONDS, 'test' );
+			WC_Stripe_Database_Cache::set_with_mode( $webhook_status_cache_key, 'enabled', HOUR_IN_SECONDS, 'live' );
+			WC_Stripe_Database_Cache::set_with_mode( $webhook_status_cache_key, 'enabled', HOUR_IN_SECONDS, 'test' );
 		} else {
-			WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'live' );
-			WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'test' );
+			WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'live' );
+			WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'test' );
 		}
 
 		if ( $amount_mismatch_detected ) {
@@ -2247,8 +2252,10 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		update_option( 'woocommerce_currency', $original_currency );
 		delete_option( 'wc_stripe_adaptive_pricing_session_amount_mismatch_detected' );
 		WC_Stripe_Helper::update_main_stripe_settings( $original_settings );
-		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'live' );
-		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'test' );
+
+		$webhook_status_cache_key = WC_Stripe_Test_Helper::get_class_const_value( WC_Stripe_Account::class, 'WEBHOOK_STATUS_CACHE_KEY', 'string' );
+		WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'live' );
+		WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'test' );
 
 		$this->assertSame( $expected, $actual );
 	}

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -1951,11 +1951,11 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 
 		// is_webhook_enabled() short-circuits on a cached status, so we don't hit the Stripe API here.
 		if ( $webhook_enabled ) {
-			set_transient( WC_Stripe_Account::LIVE_WEBHOOK_STATUS_OPTION, 'enabled', HOUR_IN_SECONDS );
-			set_transient( WC_Stripe_Account::TEST_WEBHOOK_STATUS_OPTION, 'enabled', HOUR_IN_SECONDS );
+			WC_Stripe_Database_Cache::set_with_mode( 'webhook_status', 'enabled', HOUR_IN_SECONDS, 'live' );
+			WC_Stripe_Database_Cache::set_with_mode( 'webhook_status', 'enabled', HOUR_IN_SECONDS, 'test' );
 		} else {
-			delete_transient( WC_Stripe_Account::LIVE_WEBHOOK_STATUS_OPTION );
-			delete_transient( WC_Stripe_Account::TEST_WEBHOOK_STATUS_OPTION );
+			WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'live' );
+			WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'test' );
 		}
 
 		$is_checkout_filter = function () use ( $is_checkout ) {
@@ -2015,8 +2015,8 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 
 		remove_filter( 'woocommerce_is_checkout', $is_checkout_filter );
 		WC_Stripe_Helper::update_main_stripe_settings( $original_stripe_settings );
-		delete_transient( WC_Stripe_Account::LIVE_WEBHOOK_STATUS_OPTION );
-		delete_transient( WC_Stripe_Account::TEST_WEBHOOK_STATUS_OPTION );
+		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'live' );
+		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'test' );
 		\WC_Subscriptions_Product::set_is_subscription( false );
 		\WC_Subscriptions_Product::set_subscription_product_ids( [] );
 		\WC_Pre_Orders_Product::set_is_pre_order_charged_upon_release( false );
@@ -2223,11 +2223,11 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 
 		// is_webhook_enabled() short-circuits on a cached status, so we don't hit the Stripe API here.
 		if ( $webhook_enabled ) {
-			set_transient( WC_Stripe_Account::LIVE_WEBHOOK_STATUS_OPTION, 'enabled', HOUR_IN_SECONDS );
-			set_transient( WC_Stripe_Account::TEST_WEBHOOK_STATUS_OPTION, 'enabled', HOUR_IN_SECONDS );
+			WC_Stripe_Database_Cache::set_with_mode( 'webhook_status', 'enabled', HOUR_IN_SECONDS, 'live' );
+			WC_Stripe_Database_Cache::set_with_mode( 'webhook_status', 'enabled', HOUR_IN_SECONDS, 'test' );
 		} else {
-			delete_transient( WC_Stripe_Account::LIVE_WEBHOOK_STATUS_OPTION );
-			delete_transient( WC_Stripe_Account::TEST_WEBHOOK_STATUS_OPTION );
+			WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'live' );
+			WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'test' );
 		}
 
 		if ( $amount_mismatch_detected ) {
@@ -2247,8 +2247,8 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		update_option( 'woocommerce_currency', $original_currency );
 		delete_option( 'wc_stripe_adaptive_pricing_session_amount_mismatch_detected' );
 		WC_Stripe_Helper::update_main_stripe_settings( $original_settings );
-		delete_transient( WC_Stripe_Account::LIVE_WEBHOOK_STATUS_OPTION );
-		delete_transient( WC_Stripe_Account::TEST_WEBHOOK_STATUS_OPTION );
+		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'live' );
+		WC_Stripe_Database_Cache::delete_with_mode( 'webhook_status', 'test' );
 
 		$this->assertSame( $expected, $actual );
 	}


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Related to https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5788

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR updates our caching for webhook status to use our database cache instead of transients. The main driver for this change is to ensure that we have a reliable cache for that data, otherwise we may unintentionally be adding unnecessary Stripe API calls to determine webhook status in checkout and in wp-admin as part of determining whether we can support Adaptive Pricing. By using our database cache, we can be confident that we have a more durable cache.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
Verify that all tests continue to pass. This is a tricky one to test directly, as the two implementations are meant to be very similar and low-level.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
