### PR TITLE
Gitignore local agent tooling directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ phpstan-tmp/
 
 # Temp files for doc generator
 tasks/hooks/tmp/*.json
+
+# Local agent tooling (personal, never committed)
+/.agents/
+/apm_modules/


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Adds `.agents/` and `apm_modules/` to `.gitignore`. These are personal local tooling paths that were accidentally committed once (since purged from history via a coordinated rewrite); ignoring them ensures they can never be staged again.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Tooling ignore rule only; no user-facing change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)