### PR TITLE
Use WooCommerce Core hooks for Checkout Session management

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -100,6 +100,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Reserve stock when completing agentic checkout orders so concurrent sessions cannot oversell; orders losing the race are set on-hold instead of driving stock negative
 * Tweak - Use database cache for webhook status tracking
 * Dev - Add WC_Stripe::get_settings()/update_settings() as the canonical accessors for the main Stripe settings, with the WC_Stripe_Helper shims delegating to them
+* Update - Use WooCommerce Core hooks for Adaptive Pricing session management
 
 2026-08-05 - version 10.8.5
 * Update - Improve webhook handling

--- a/client/blocks/checkout-sessions/__tests__/checkout-container.test.js
+++ b/client/blocks/checkout-sessions/__tests__/checkout-container.test.js
@@ -1,15 +1,9 @@
 import { extensionCartUpdate } from '@woocommerce/blocks-checkout';
-import { useState } from 'react';
 import { render } from '@testing-library/react';
 import { CheckoutElementsProvider } from '@stripe/react-stripe-js/checkout';
 import { CheckoutContainer } from 'wcstripe/blocks/checkout-sessions/checkout-container';
 import { initializeUPEAppearance } from 'wcstripe/stripe-utils/upe-appearance';
 import { getFontRulesFromPage } from 'wcstripe/styles/upe';
-
-jest.mock( 'react', () => ( {
-	...jest.requireActual( 'react' ),
-	useState: jest.fn(),
-} ) );
 
 jest.mock(
 	'@woocommerce/blocks-checkout',
@@ -64,7 +58,6 @@ describe( 'CheckoutSessionsContainer', () => {
 			.mockImplementation( () => {} );
 		initializeUPEAppearance.mockReturnValue( {} );
 		getFontRulesFromPage.mockReturnValue( [] );
-		useState.mockReturnValue( [ null, jest.fn() ] );
 		extensionCartUpdate.mockClear();
 		CheckoutElementsProvider.mockClear();
 		setShouldLoadStripeElements.mockClear();
@@ -151,5 +144,30 @@ describe( 'CheckoutSessionsContainer', () => {
 			),
 			requestError
 		);
+	} );
+
+	it( 'ignores a sync failure that completes after unmount', async () => {
+		let rejectUpdate;
+		extensionCartUpdate.mockImplementationOnce(
+			() =>
+				new Promise( ( resolve, reject ) => {
+					rejectUpdate = reject;
+				} )
+		);
+
+		const { unmount } = render(
+			<CheckoutContainer
+				api={ api }
+				setShouldLoadStripeElements={ setShouldLoadStripeElements }
+			/>
+		);
+
+		unmount();
+		rejectUpdate( new Error( 'Network request failed' ) );
+		// Give the in-flight synchronization a chance to observe the rejection.
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+		expect( setShouldLoadStripeElements ).not.toHaveBeenCalled();
+		expect( consoleErrorSpy ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/blocks/checkout-sessions/__tests__/checkout-container.test.js
+++ b/client/blocks/checkout-sessions/__tests__/checkout-container.test.js
@@ -129,4 +129,27 @@ describe( 'CheckoutSessionsContainer', () => {
 		expect( setShouldLoadStripeElements ).toHaveBeenCalledWith( true );
 		expect( consoleErrorSpy ).toHaveBeenCalled();
 	} );
+
+	it( 'falls back when the Store API request rejects', async () => {
+		const requestError = new Error( 'Network request failed' );
+		extensionCartUpdate.mockRejectedValueOnce( requestError );
+
+		render(
+			<CheckoutContainer
+				api={ api }
+				setShouldLoadStripeElements={ setShouldLoadStripeElements }
+			/>
+		);
+
+		await expect(
+			CheckoutElementsProvider.mock.calls[ 0 ][ 0 ].options.clientSecret
+		).resolves.toBeNull();
+		expect( setShouldLoadStripeElements ).toHaveBeenCalledWith( true );
+		expect( consoleErrorSpy ).toHaveBeenCalledWith(
+			expect.stringContaining(
+				'Unable to initialize a checkout session'
+			),
+			requestError
+		);
+	} );
 } );

--- a/client/blocks/checkout-sessions/__tests__/checkout-container.test.js
+++ b/client/blocks/checkout-sessions/__tests__/checkout-container.test.js
@@ -1,3 +1,4 @@
+import { extensionCartUpdate } from '@woocommerce/blocks-checkout';
 import { useState } from 'react';
 import { render } from '@testing-library/react';
 import { CheckoutElementsProvider } from '@stripe/react-stripe-js/checkout';
@@ -14,6 +15,14 @@ jest.mock(
 	'@woocommerce/blocks-checkout',
 	() => ( {
 		StoreNotice: jest.fn( ( { children } ) => <div>{ children }</div> ),
+		extensionCartUpdate: jest.fn().mockResolvedValue( {
+			extensions: {
+				'wc-stripe/checkout-session': {
+					client_secret: 'test_secret',
+					status: 'success',
+				},
+			},
+		} ),
 	} ),
 	{ virtual: true }
 );
@@ -47,14 +56,25 @@ describe( 'CheckoutSessionsContainer', () => {
 		} ),
 	};
 	const setShouldLoadStripeElements = jest.fn();
+	let consoleErrorSpy;
 
 	beforeEach( () => {
+		consoleErrorSpy = jest
+			.spyOn( console, 'error' )
+			.mockImplementation( () => {} );
 		initializeUPEAppearance.mockReturnValue( {} );
 		getFontRulesFromPage.mockReturnValue( [] );
 		useState.mockReturnValue( [ null, jest.fn() ] );
+		extensionCartUpdate.mockClear();
+		CheckoutElementsProvider.mockClear();
+		setShouldLoadStripeElements.mockClear();
 	} );
 
-	it( 'should render the container', () => {
+	afterEach( () => {
+		consoleErrorSpy.mockRestore();
+	} );
+
+	it( 'initializes from the Checkout Session embedded in the Store API response', async () => {
 		render(
 			<CheckoutContainer
 				api={ api }
@@ -76,5 +96,37 @@ describe( 'CheckoutSessionsContainer', () => {
 			} ),
 			{}
 		);
+		expect( extensionCartUpdate ).toHaveBeenCalledWith( {
+			namespace: 'wc-stripe/checkout-session',
+			data: { action: 'sync' },
+		} );
+		expect( api.checkoutSessionsCreateSession ).not.toHaveBeenCalled();
+		await expect(
+			CheckoutElementsProvider.mock.calls[ 0 ][ 0 ].options.clientSecret
+		).resolves.toBe( 'test_secret' );
+	} );
+
+	it( 'falls back when the Store API reports a synchronization error', async () => {
+		extensionCartUpdate.mockResolvedValueOnce( {
+			extensions: {
+				'wc-stripe/checkout-session': {
+					client_secret: 'stale_secret',
+					status: 'error',
+				},
+			},
+		} );
+
+		render(
+			<CheckoutContainer
+				api={ api }
+				setShouldLoadStripeElements={ setShouldLoadStripeElements }
+			/>
+		);
+
+		await expect(
+			CheckoutElementsProvider.mock.calls[ 0 ][ 0 ].options.clientSecret
+		).resolves.toBeNull();
+		expect( setShouldLoadStripeElements ).toHaveBeenCalledWith( true );
+		expect( consoleErrorSpy ).toHaveBeenCalled();
 	} );
 } );

--- a/client/blocks/checkout-sessions/__tests__/hooks.test.js
+++ b/client/blocks/checkout-sessions/__tests__/hooks.test.js
@@ -760,7 +760,69 @@ describe( 'CheckoutSessions hook tests', () => {
 			).not.toHaveBeenCalled();
 		} );
 
-		it( 'notifies Stripe.js about a revision that landed before Checkout was ready', async () => {
+		it( 'reports a sync failure when the first embedded session state has an error', async () => {
+			const createErrorNotice = dispatch().createErrorNotice;
+			createErrorNotice.mockClear();
+			const syncFailedRef = { current: false };
+			const checkoutState = {
+				type: 'success',
+				checkout: {
+					id: 'cs_test',
+					runServerUpdate: jest.fn(),
+				},
+			};
+
+			renderHook( () =>
+				useCheckoutSessionTotalsSync(
+					'cs_test',
+					checkoutState,
+					syncFailedRef,
+					{ revision: 1, status: 'error' }
+				)
+			);
+
+			await waitFor( () => {
+				expect( syncFailedRef.current ).toBe( true );
+			} );
+			expect( createErrorNotice ).toHaveBeenCalledWith(
+				STALE_TOTAL_MESSAGE,
+				{
+					id: 'wc-stripe-stale-checkout-total',
+					context: 'wc/checkout/payments',
+				}
+			);
+			expect(
+				checkoutState.checkout.runServerUpdate
+			).not.toHaveBeenCalled();
+		} );
+
+		it( 'reports a sync failure for a failed initial state when Checkout is not ready yet', async () => {
+			const createErrorNotice = dispatch().createErrorNotice;
+			createErrorNotice.mockClear();
+			const syncFailedRef = { current: false };
+
+			renderHook( () =>
+				useCheckoutSessionTotalsSync(
+					'cs_test',
+					{ type: 'loading' },
+					syncFailedRef,
+					{ revision: 1, status: 'error' }
+				)
+			);
+
+			await waitFor( () => {
+				expect( syncFailedRef.current ).toBe( true );
+			} );
+			expect( createErrorNotice ).toHaveBeenCalledWith(
+				STALE_TOTAL_MESSAGE,
+				{
+					id: 'wc-stripe-stale-checkout-total',
+					context: 'wc/checkout/payments',
+				}
+			);
+		} );
+
+		it( 'runs the server update for a revision that landed before Checkout was ready', async () => {
 			const runServerUpdate = jest.fn( async ( fn ) => {
 				await fn();
 				return { type: 'success' };
@@ -795,7 +857,7 @@ describe( 'CheckoutSessions hook tests', () => {
 			} );
 		} );
 
-		it( 'clears the stale flag after Stripe.js accepts a newer revision', async () => {
+		it( 'clears the sync failure flag after a newer revision is received', async () => {
 			const syncFailedRef = { current: true };
 			let sessionData = { revision: 1, status: 'error' };
 			const checkoutState = {

--- a/client/blocks/checkout-sessions/__tests__/hooks.test.js
+++ b/client/blocks/checkout-sessions/__tests__/hooks.test.js
@@ -6,7 +6,7 @@ import {
 	useCheckoutSessionTotalsSync,
 } from 'wcstripe/blocks/checkout-sessions/hooks';
 import { useEffect } from '@wordpress/element';
-import { dispatch, select, useSelect } from '@wordpress/data';
+import { dispatch, select } from '@wordpress/data';
 import { waitForPaymentElementCompletion } from 'wcstripe/blocks/wait-for-payment-element-completion';
 
 jest.mock( '@wordpress/element', () => ( {
@@ -19,7 +19,6 @@ jest.mock( '@wordpress/data', () => {
 	const removeNotice = jest.fn();
 	return {
 		select: jest.fn(),
-		useSelect: jest.fn( () => '' ),
 		dispatch: jest.fn( () => ( { createErrorNotice, removeNotice } ) ),
 	};
 } );
@@ -661,36 +660,11 @@ describe( 'CheckoutSessions hook tests', () => {
 	} );
 
 	describe( 'useCheckoutSessionTotalsSync hook', () => {
-		let cartPrice;
-
-		beforeEach( () => {
-			cartPrice = '1000';
-			window.wc = {
-				wcBlocksData: { cartStore: 'wc/store/cart' },
-			};
-			useSelect.mockImplementation( ( mapSelect ) => {
-				const mockSelect = ( storeKey ) =>
-					storeKey === window.wc.wcBlocksData.cartStore
-						? {
-								getCartTotals: () => ( {
-									total_price: cartPrice,
-								} ),
-						  }
-						: {};
-				return mapSelect( mockSelect );
-			} );
-		} );
-
 		afterEach( () => {
 			useEffect.mockImplementation( ( fn ) => fn() );
 		} );
 
-		it( 'does not call update on the first totals snapshot', () => {
-			const api = {
-				checkoutSessionsUpdateSession: jest.fn( () =>
-					Promise.resolve( {} )
-				),
-			};
+		it( 'does not notify Stripe.js for the first embedded revision', () => {
 			const checkoutState = {
 				type: 'success',
 				checkout: {
@@ -703,18 +677,19 @@ describe( 'CheckoutSessions hook tests', () => {
 			};
 
 			renderHook( () =>
-				useCheckoutSessionTotalsSync( api, 'cs_test', checkoutState )
+				useCheckoutSessionTotalsSync( 'cs_test', checkoutState, null, {
+					revision: 1,
+					status: 'success',
+				} )
 			);
 
-			expect( api.checkoutSessionsUpdateSession ).not.toHaveBeenCalled();
+			expect(
+				checkoutState.checkout.runServerUpdate
+			).not.toHaveBeenCalled();
 		} );
 
-		it( 'calls checkoutSessionsUpdateSession when cart totals change', async () => {
-			const api = {
-				checkoutSessionsUpdateSession: jest.fn( () =>
-					Promise.resolve( {} )
-				),
-			};
+		it( 'notifies Stripe.js when the Store API embeds a newer revision', async () => {
+			let sessionData = { revision: 1, status: 'success' };
 			const checkoutState = {
 				type: 'success',
 				checkout: {
@@ -727,50 +702,47 @@ describe( 'CheckoutSessions hook tests', () => {
 			};
 
 			const { rerender } = renderHook( () =>
-				useCheckoutSessionTotalsSync( api, 'cs_test', checkoutState )
+				useCheckoutSessionTotalsSync(
+					'cs_test',
+					checkoutState,
+					null,
+					sessionData
+				)
 			);
 
-			cartPrice = '2000';
+			sessionData = { revision: 2, status: 'success' };
 			rerender();
 
 			await waitFor( () => {
 				expect(
-					api.checkoutSessionsUpdateSession
-				).toHaveBeenCalledWith( 'cs_test' );
+					checkoutState.checkout.runServerUpdate
+				).toHaveBeenCalled();
 			} );
-			expect( checkoutState.checkout.runServerUpdate ).toHaveBeenCalled();
 		} );
 
-		it( 'flags the ref and shows a notice when the resync fails', async () => {
+		it( 'flags the ref when the embedded Store API sync failed', async () => {
 			const createErrorNotice = dispatch().createErrorNotice;
 			createErrorNotice.mockClear();
 			const syncFailedRef = { current: false };
-			const api = {
-				checkoutSessionsUpdateSession: jest.fn( () =>
-					Promise.resolve( {} )
-				),
-			};
+			let sessionData = { revision: 1, status: 'success' };
 			const checkoutState = {
 				type: 'success',
 				checkout: {
 					id: 'cs_test',
-					runServerUpdate: jest.fn( async ( fn ) => {
-						await fn();
-						return { type: 'error', error: { message: 'boom' } };
-					} ),
+					runServerUpdate: jest.fn(),
 				},
 			};
 
 			const { rerender } = renderHook( () =>
 				useCheckoutSessionTotalsSync(
-					api,
 					'cs_test',
 					checkoutState,
-					syncFailedRef
+					syncFailedRef,
+					sessionData
 				)
 			);
 
-			cartPrice = '2000';
+			sessionData = { revision: 1, status: 'error' };
 			rerender();
 
 			await waitFor( () => {
@@ -783,15 +755,14 @@ describe( 'CheckoutSessions hook tests', () => {
 					context: 'wc/checkout/payments',
 				}
 			);
+			expect(
+				checkoutState.checkout.runServerUpdate
+			).not.toHaveBeenCalled();
 		} );
 
-		it( 'clears the stale flag after a successful resync', async () => {
+		it( 'clears the stale flag after Stripe.js accepts a newer revision', async () => {
 			const syncFailedRef = { current: true };
-			const api = {
-				checkoutSessionsUpdateSession: jest.fn( () =>
-					Promise.resolve( {} )
-				),
-			};
+			let sessionData = { revision: 1, status: 'error' };
 			const checkoutState = {
 				type: 'success',
 				checkout: {
@@ -805,14 +776,14 @@ describe( 'CheckoutSessions hook tests', () => {
 
 			const { rerender } = renderHook( () =>
 				useCheckoutSessionTotalsSync(
-					api,
 					'cs_test',
 					checkoutState,
-					syncFailedRef
+					syncFailedRef,
+					sessionData
 				)
 			);
 
-			cartPrice = '2000';
+			sessionData = { revision: 2, status: 'success' };
 			rerender();
 
 			await waitFor( () => {

--- a/client/blocks/checkout-sessions/__tests__/hooks.test.js
+++ b/client/blocks/checkout-sessions/__tests__/hooks.test.js
@@ -760,6 +760,41 @@ describe( 'CheckoutSessions hook tests', () => {
 			).not.toHaveBeenCalled();
 		} );
 
+		it( 'notifies Stripe.js about a revision that landed before Checkout was ready', async () => {
+			const runServerUpdate = jest.fn( async ( fn ) => {
+				await fn();
+				return { type: 'success' };
+			} );
+			let sessionData = { revision: 1, status: 'success' };
+			let checkoutState = { type: 'loading' };
+
+			const { rerender } = renderHook( () =>
+				useCheckoutSessionTotalsSync(
+					'cs_test',
+					checkoutState,
+					null,
+					sessionData
+				)
+			);
+
+			// A newer revision lands while the Checkout instance is still initializing.
+			sessionData = { revision: 2, status: 'success' };
+			rerender();
+
+			expect( runServerUpdate ).not.toHaveBeenCalled();
+
+			// Once Checkout is ready the revision must still be treated as pending.
+			checkoutState = {
+				type: 'success',
+				checkout: { id: 'cs_test', runServerUpdate },
+			};
+			rerender();
+
+			await waitFor( () => {
+				expect( runServerUpdate ).toHaveBeenCalled();
+			} );
+		} );
+
 		it( 'clears the stale flag after Stripe.js accepts a newer revision', async () => {
 			const syncFailedRef = { current: true };
 			let sessionData = { revision: 1, status: 'error' };

--- a/client/blocks/checkout-sessions/__tests__/hooks.test.js
+++ b/client/blocks/checkout-sessions/__tests__/hooks.test.js
@@ -1,4 +1,5 @@
 import { renderHook, waitFor } from '@testing-library/react';
+import jQuery from 'jquery';
 import {
 	usePaymentSetupHandler,
 	useCheckoutSuccessHandler,
@@ -892,6 +893,125 @@ describe( 'CheckoutSessions hook tests', () => {
 				'wc-stripe-stale-checkout-total',
 				'wc/checkout/payments'
 			);
+		} );
+
+		// The jQuery mock returns a fresh chain per call, so block/unblock
+		// invocations are summed across every chain it handed out.
+		const countJQueryCalls = ( method ) =>
+			jQuery.mock.results.reduce(
+				( count, result ) =>
+					count +
+					( result.value?.[ method ]?.mock?.calls?.length ?? 0 ),
+				0
+			);
+
+		// Allow the cancellation tests that need real effects to get that behaviour.
+		const useRealEffects = () => {
+			const { useEffect: actualUseEffect } =
+				jest.requireActual( '@wordpress/element' );
+			useEffect.mockImplementation( actualUseEffect );
+		};
+
+		it( 'retries a resync cancelled by a checkout state change and lifts the UI block', async () => {
+			useRealEffects();
+			jQuery.mockClear();
+			const createErrorNotice = dispatch().createErrorNotice;
+			createErrorNotice.mockClear();
+
+			const resolvers = [];
+			const runServerUpdate = jest.fn(
+				() => new Promise( ( resolve ) => resolvers.push( resolve ) )
+			);
+			const syncFailedRef = { current: false };
+			let sessionData = { revision: 1, status: 'success' };
+			let checkoutState = {
+				type: 'success',
+				checkout: { id: 'cs_test', runServerUpdate },
+			};
+
+			const { rerender } = renderHook( () =>
+				useCheckoutSessionTotalsSync(
+					'cs_test',
+					checkoutState,
+					syncFailedRef,
+					sessionData
+				)
+			);
+
+			expect( countJQueryCalls( 'block' ) ).toBe( 0 );
+			expect( countJQueryCalls( 'unblock' ) ).toBe( 0 );
+
+			// A newer revision starts a resync that blocks the payment UI.
+			sessionData = { revision: 2, status: 'success' };
+			rerender();
+			await waitFor( () => {
+				expect( runServerUpdate ).toHaveBeenCalledTimes( 1 );
+			} );
+			expect( countJQueryCalls( 'block' ) ).toBe( 1 );
+			expect( countJQueryCalls( 'unblock' ) ).toBe( 0 );
+
+			// Checkout state changes while the resync is in flight.
+			checkoutState = { type: 'loading' };
+			rerender();
+
+			// The cancelled run must unblock the UI immediately and must not
+			// show a failure notice to the shopper.
+			expect( countJQueryCalls( 'block' ) ).toBe( 1 );
+			expect( countJQueryCalls( 'unblock' ) ).toBe( 1 );
+			expect( createErrorNotice ).not.toHaveBeenCalled();
+
+			// Once checkout recovers, the pending revision must be retried.
+			checkoutState = {
+				type: 'success',
+				checkout: { id: 'cs_test', runServerUpdate },
+			};
+			rerender();
+			await waitFor( () => {
+				expect( runServerUpdate ).toHaveBeenCalledTimes( 2 );
+			} );
+
+			resolvers[ 1 ]( { type: 'success' } );
+			await waitFor( () => {
+				expect( countJQueryCalls( 'block' ) ).toBe( 2 );
+			} );
+			expect( countJQueryCalls( 'unblock' ) ).toBe( 2 );
+			expect( syncFailedRef.current ).toBe( false );
+		} );
+
+		it( 'lifts the UI block when unmounted during an in-flight resync', async () => {
+			useRealEffects();
+			jQuery.mockClear();
+
+			const runServerUpdate = jest.fn( () => new Promise( () => {} ) );
+			let sessionData = { revision: 1, status: 'success' };
+			const checkoutState = {
+				type: 'success',
+				checkout: { id: 'cs_test', runServerUpdate },
+			};
+
+			const { rerender, unmount } = renderHook( () =>
+				useCheckoutSessionTotalsSync(
+					'cs_test',
+					checkoutState,
+					null,
+					sessionData
+				)
+			);
+
+			expect( countJQueryCalls( 'block' ) ).toBe( 0 );
+			expect( countJQueryCalls( 'unblock' ) ).toBe( 0 );
+
+			sessionData = { revision: 2, status: 'success' };
+			rerender();
+			await waitFor( () => {
+				expect( runServerUpdate ).toHaveBeenCalledTimes( 1 );
+			} );
+			expect( countJQueryCalls( 'block' ) ).toBe( 1 );
+			expect( countJQueryCalls( 'unblock' ) ).toBe( 0 );
+
+			unmount();
+			expect( countJQueryCalls( 'unblock' ) ).toBe( 1 );
+			expect( countJQueryCalls( 'block' ) ).toBe( 1 );
 		} );
 	} );
 } );

--- a/client/blocks/checkout-sessions/__tests__/hooks.test.js
+++ b/client/blocks/checkout-sessions/__tests__/hooks.test.js
@@ -679,7 +679,7 @@ describe( 'CheckoutSessions hook tests', () => {
 
 			renderHook( () =>
 				useCheckoutSessionTotalsSync( 'cs_test', checkoutState, null, {
-					revision: 1,
+					revision: 'rev_1',
 					status: 'success',
 				} )
 			);
@@ -690,7 +690,7 @@ describe( 'CheckoutSessions hook tests', () => {
 		} );
 
 		it( 'notifies Stripe.js when the Store API embeds a newer revision', async () => {
-			let sessionData = { revision: 1, status: 'success' };
+			let sessionData = { revision: 'rev_1', status: 'success' };
 			const checkoutState = {
 				type: 'success',
 				checkout: {
@@ -711,7 +711,7 @@ describe( 'CheckoutSessions hook tests', () => {
 				)
 			);
 
-			sessionData = { revision: 2, status: 'success' };
+			sessionData = { revision: 'rev_2', status: 'success' };
 			rerender();
 
 			await waitFor( () => {
@@ -725,7 +725,7 @@ describe( 'CheckoutSessions hook tests', () => {
 			const createErrorNotice = dispatch().createErrorNotice;
 			createErrorNotice.mockClear();
 			const syncFailedRef = { current: false };
-			let sessionData = { revision: 1, status: 'success' };
+			let sessionData = { revision: 'rev_1', status: 'success' };
 			const checkoutState = {
 				type: 'success',
 				checkout: {
@@ -743,7 +743,7 @@ describe( 'CheckoutSessions hook tests', () => {
 				)
 			);
 
-			sessionData = { revision: 1, status: 'error' };
+			sessionData = { revision: 'rev_1', status: 'error' };
 			rerender();
 
 			await waitFor( () => {
@@ -778,7 +778,7 @@ describe( 'CheckoutSessions hook tests', () => {
 					'cs_test',
 					checkoutState,
 					syncFailedRef,
-					{ revision: 1, status: 'error' }
+					{ revision: 'rev_1', status: 'error' }
 				)
 			);
 
@@ -807,7 +807,7 @@ describe( 'CheckoutSessions hook tests', () => {
 					'cs_test',
 					{ type: 'loading' },
 					syncFailedRef,
-					{ revision: 1, status: 'error' }
+					{ revision: 'rev_1', status: 'error' }
 				)
 			);
 
@@ -828,7 +828,7 @@ describe( 'CheckoutSessions hook tests', () => {
 				await fn();
 				return { type: 'success' };
 			} );
-			let sessionData = { revision: 1, status: 'success' };
+			let sessionData = { revision: 'rev_1', status: 'success' };
 			let checkoutState = { type: 'loading' };
 
 			const { rerender } = renderHook( () =>
@@ -841,7 +841,7 @@ describe( 'CheckoutSessions hook tests', () => {
 			);
 
 			// A newer revision lands while the Checkout instance is still initializing.
-			sessionData = { revision: 2, status: 'success' };
+			sessionData = { revision: 'rev_2', status: 'success' };
 			rerender();
 
 			expect( runServerUpdate ).not.toHaveBeenCalled();
@@ -860,7 +860,7 @@ describe( 'CheckoutSessions hook tests', () => {
 
 		it( 'clears the sync failure flag after a newer revision is received', async () => {
 			const syncFailedRef = { current: true };
-			let sessionData = { revision: 1, status: 'error' };
+			let sessionData = { revision: 'rev_1', status: 'error' };
 			const checkoutState = {
 				type: 'success',
 				checkout: {
@@ -881,7 +881,7 @@ describe( 'CheckoutSessions hook tests', () => {
 				)
 			);
 
-			sessionData = { revision: 2, status: 'success' };
+			sessionData = { revision: 'rev_2', status: 'success' };
 			rerender();
 
 			await waitFor( () => {
@@ -923,7 +923,7 @@ describe( 'CheckoutSessions hook tests', () => {
 				() => new Promise( ( resolve ) => resolvers.push( resolve ) )
 			);
 			const syncFailedRef = { current: false };
-			let sessionData = { revision: 1, status: 'success' };
+			let sessionData = { revision: 'rev_1', status: 'success' };
 			let checkoutState = {
 				type: 'success',
 				checkout: { id: 'cs_test', runServerUpdate },
@@ -942,7 +942,7 @@ describe( 'CheckoutSessions hook tests', () => {
 			expect( countJQueryCalls( 'unblock' ) ).toBe( 0 );
 
 			// A newer revision starts a resync that blocks the payment UI.
-			sessionData = { revision: 2, status: 'success' };
+			sessionData = { revision: 'rev_2', status: 'success' };
 			rerender();
 			await waitFor( () => {
 				expect( runServerUpdate ).toHaveBeenCalledTimes( 1 );
@@ -983,7 +983,7 @@ describe( 'CheckoutSessions hook tests', () => {
 			jQuery.mockClear();
 
 			const runServerUpdate = jest.fn( () => new Promise( () => {} ) );
-			let sessionData = { revision: 1, status: 'success' };
+			let sessionData = { revision: 'rev_1', status: 'success' };
 			const checkoutState = {
 				type: 'success',
 				checkout: { id: 'cs_test', runServerUpdate },
@@ -1001,7 +1001,7 @@ describe( 'CheckoutSessions hook tests', () => {
 			expect( countJQueryCalls( 'block' ) ).toBe( 0 );
 			expect( countJQueryCalls( 'unblock' ) ).toBe( 0 );
 
-			sessionData = { revision: 2, status: 'success' };
+			sessionData = { revision: 'rev_2', status: 'success' };
 			rerender();
 			await waitFor( () => {
 				expect( runServerUpdate ).toHaveBeenCalledTimes( 1 );

--- a/client/blocks/checkout-sessions/checkout-container.js
+++ b/client/blocks/checkout-sessions/checkout-container.js
@@ -1,3 +1,4 @@
+import { extensionCartUpdate } from '@woocommerce/blocks-checkout';
 import { CheckoutElementsProvider } from '@stripe/react-stripe-js/checkout';
 import React, { useMemo } from 'react';
 import CheckoutForm from 'wcstripe/blocks/checkout-sessions/checkout-form';
@@ -15,15 +16,20 @@ const stripePromise = loadStripe();
  * @return {JSX.Element} The Checkout Sessions Container component.
  */
 export const CheckoutContainer = ( props ) => {
-	const {
-		api,
-		setPaymentProcessorLoadErrorMessage,
-		setShouldLoadStripeElements,
-	} = props;
+	const { setPaymentProcessorLoadErrorMessage, setShouldLoadStripeElements } =
+		props;
 
 	const checkoutSessionPromise = useMemo( async () => {
-		const response = await api.checkoutSessionsCreateSession();
-		const clientSecret = response?.data?.client_secret;
+		const response = await extensionCartUpdate( {
+			namespace: 'wc-stripe/checkout-session',
+			data: { action: 'sync' },
+		} );
+		const sessionData =
+			response?.extensions?.[ 'wc-stripe/checkout-session' ];
+		const clientSecret =
+			sessionData?.status === 'success'
+				? sessionData?.client_secret
+				: null;
 		if ( ! clientSecret ) {
 			setShouldLoadStripeElements( true );
 			// eslint-disable-next-line no-console
@@ -32,7 +38,7 @@ export const CheckoutContainer = ( props ) => {
 			);
 		}
 		return clientSecret;
-	}, [ api, setShouldLoadStripeElements ] );
+	}, [ setShouldLoadStripeElements ] );
 
 	// Render an editor-safe appearance in the block editor preview, where the
 	// checkout DOM does not reflect the live storefront. See STRIPE-1061.

--- a/client/blocks/checkout-sessions/checkout-container.js
+++ b/client/blocks/checkout-sessions/checkout-container.js
@@ -1,6 +1,6 @@
 import { extensionCartUpdate } from '@woocommerce/blocks-checkout';
 import { CheckoutElementsProvider } from '@stripe/react-stripe-js/checkout';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import CheckoutForm from 'wcstripe/blocks/checkout-sessions/checkout-form';
 import { loadStripe } from 'wcstripe/blocks/load-stripe';
 import { initializeUPEAppearance } from 'wcstripe/stripe-utils/upe-appearance';
@@ -19,35 +19,62 @@ export const CheckoutContainer = ( props ) => {
 	const { setPaymentProcessorLoadErrorMessage, setShouldLoadStripeElements } =
 		props;
 
-	const checkoutSessionPromise = useMemo( async () => {
-		let clientSecret = null;
-		let error = null;
+	// Create a promise wrapper for the client secret during render,
+	// but use an effect to ensure that we correctly make API calls
+	// and clean up state for the component.
+	const [ checkoutSessionDeferred ] = useState( () => {
+		let resolve;
+		const promise = new Promise( ( res ) => {
+			resolve = res;
+		} );
+		return { promise, resolve };
+	} );
 
-		try {
-			const response = await extensionCartUpdate( {
-				namespace: 'wc-stripe/checkout-session',
-				data: { action: 'sync' },
-			} );
-			const sessionData =
-				response?.extensions?.[ 'wc-stripe/checkout-session' ];
-			clientSecret =
-				sessionData?.status === 'success'
-					? sessionData?.client_secret
-					: null;
-		} catch ( e ) {
-			error = e;
-		}
+	useEffect( () => {
+		let cancelled = false;
 
-		if ( ! clientSecret ) {
-			setShouldLoadStripeElements( true );
-			// eslint-disable-next-line no-console
-			console.error(
-				'Unable to initialize a checkout session. Please refresh the page and try again.',
-				...( error ? [ error ] : [] )
-			);
-		}
-		return clientSecret;
-	}, [ setShouldLoadStripeElements ] );
+		const synchronize = async () => {
+			let clientSecret = null;
+			let error = null;
+
+			try {
+				const response = await extensionCartUpdate( {
+					namespace: 'wc-stripe/checkout-session',
+					data: { action: 'sync' },
+				} );
+				const sessionData =
+					response?.extensions?.[ 'wc-stripe/checkout-session' ];
+				clientSecret =
+					sessionData?.status === 'success'
+						? sessionData?.client_secret
+						: null;
+			} catch ( e ) {
+				error = e;
+			}
+
+			// If the component has been unmounted, cancelled will be true,
+			// and we should stop processing the response.
+			if ( cancelled ) {
+				return;
+			}
+
+			if ( ! clientSecret ) {
+				setShouldLoadStripeElements( true );
+				// eslint-disable-next-line no-console
+				console.error(
+					'Unable to initialize a checkout session. Please refresh the page and try again.',
+					...( error ? [ error ] : [] )
+				);
+			}
+			checkoutSessionDeferred.resolve( clientSecret );
+		};
+
+		synchronize();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ checkoutSessionDeferred, setShouldLoadStripeElements ] );
 
 	// Render an editor-safe appearance in the block editor preview, where the
 	// checkout DOM does not reflect the live storefront. See STRIPE-1061.
@@ -55,7 +82,7 @@ export const CheckoutContainer = ( props ) => {
 
 	const providerOptions = useMemo(
 		() => ( {
-			clientSecret: checkoutSessionPromise,
+			clientSecret: checkoutSessionDeferred.promise,
 			adaptivePricing: { allowed: true },
 			elementsOptions: {
 				appearance: initializeUPEAppearance( 'true', false, isEditor ),
@@ -68,7 +95,7 @@ export const CheckoutContainer = ( props ) => {
 				},
 			},
 		} ),
-		[ checkoutSessionPromise, isEditor ]
+		[ checkoutSessionDeferred, isEditor ]
 	);
 
 	return (

--- a/client/blocks/checkout-sessions/checkout-container.js
+++ b/client/blocks/checkout-sessions/checkout-container.js
@@ -20,21 +20,30 @@ export const CheckoutContainer = ( props ) => {
 		props;
 
 	const checkoutSessionPromise = useMemo( async () => {
-		const response = await extensionCartUpdate( {
-			namespace: 'wc-stripe/checkout-session',
-			data: { action: 'sync' },
-		} );
-		const sessionData =
-			response?.extensions?.[ 'wc-stripe/checkout-session' ];
-		const clientSecret =
-			sessionData?.status === 'success'
-				? sessionData?.client_secret
-				: null;
+		let clientSecret = null;
+		let error = null;
+
+		try {
+			const response = await extensionCartUpdate( {
+				namespace: 'wc-stripe/checkout-session',
+				data: { action: 'sync' },
+			} );
+			const sessionData =
+				response?.extensions?.[ 'wc-stripe/checkout-session' ];
+			clientSecret =
+				sessionData?.status === 'success'
+					? sessionData?.client_secret
+					: null;
+		} catch ( e ) {
+			error = e;
+		}
+
 		if ( ! clientSecret ) {
 			setShouldLoadStripeElements( true );
 			// eslint-disable-next-line no-console
 			console.error(
-				'Unable to initialize a checkout session. Please refresh the page and try again.'
+				'Unable to initialize a checkout session. Please refresh the page and try again.',
+				...( error ? [ error ] : [] )
 			);
 		}
 		return clientSecret;

--- a/client/blocks/checkout-sessions/checkout-form.js
+++ b/client/blocks/checkout-sessions/checkout-form.js
@@ -28,7 +28,6 @@ import {
  * Checkout Form component.
  *
  * @param {Object}                 props                             Component props.
- * @param {Object}                 props.api                         WCStripeAPI instance (checkout session AJAX).
  * @param {EmitResponseProps}      props.emitResponse                Function to emit response back to the parent component.
  * @param {string}                 props.errorMessage                Error message to display if loading the checkout session fails.
  * @param {EventRegistrationProps} props.eventRegistration           Object containing event registration functions for payment setup, checkout success, and checkout failure.
@@ -36,6 +35,7 @@ import {
  * @param {boolean}                props.isLoggedIn                  Whether the customer is logged-in.
  * @param {boolean}                props.isPayerPhoneRequired        Whether the payer phone information is required.
  * @param {Object}                 props.shippingData                Shipping information for the checkout session.
+ * @param {Object}                 props.cartData                    Cart data containing Store API extensions.
  * @param {JSX.Element}            props.LoadingMask                 LoadingMask component to display while loading.
  * @param {Function}               props.onLoadError                 Callback function to handle load errors.
  * @param {Function}               props.setShouldLoadStripeElements Callback function to set whether Stripe Elements should be loaded instead.
@@ -43,7 +43,6 @@ import {
  * @return {JSX.Element} The Checkout Form component.
  */
 const CheckoutForm = ( {
-	api,
 	emitResponse,
 	errorMessage,
 	eventRegistration: { onPaymentSetup, onCheckoutSuccess, onCheckoutFail },
@@ -51,6 +50,7 @@ const CheckoutForm = ( {
 	isLoggedIn,
 	isPayerPhoneRequired,
 	shippingData,
+	cartData,
 	LoadingMask,
 	onLoadError,
 	setShouldLoadStripeElements,
@@ -68,6 +68,8 @@ const CheckoutForm = ( {
 	// Set when a totals resync leaves the session stale; blocks payment setup so
 	// the buyer isn't charged an out-of-date total.
 	const syncFailedRef = useRef( false );
+	const checkoutSessionData =
+		cartData?.extensions?.[ 'wc-stripe/checkout-session' ] ?? {};
 	const setHasLoadError = ( event ) => {
 		hasLoadErrorRef.current = true;
 		onLoadError( event );
@@ -93,10 +95,10 @@ const CheckoutForm = ( {
 	);
 	usePaymentFailHandler( onCheckoutFail, emitResponse );
 	useCheckoutSessionTotalsSync(
-		api,
 		checkoutSessionId,
 		checkoutState,
-		syncFailedRef
+		syncFailedRef,
+		checkoutSessionData
 	);
 
 	const paymentMethodsConfig = getBlocksConfiguration()?.paymentMethodsConfig;

--- a/client/blocks/checkout-sessions/hooks.js
+++ b/client/blocks/checkout-sessions/hooks.js
@@ -1,7 +1,7 @@
 import jQuery from 'jquery';
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { dispatch, select, useSelect } from '@wordpress/data';
+import { dispatch, select } from '@wordpress/data';
 import { isSavePaymentMethodCheckboxChecked } from 'wcstripe/blocks/utils';
 import { normalizeReturnUrl } from 'wcstripe/stripe-utils/normalize-return-url';
 import { getStaleCheckoutTotalMessage } from 'wcstripe/stripe-utils/utils';
@@ -315,64 +315,52 @@ export const usePaymentFailHandler = ( onCheckoutFail, emitResponse ) => {
 };
 
 /**
- * Keeps the Stripe Checkout Session in sync with WooCommerce cart totals (price, tax, shipping) on block checkout.
- * Uses Custom Checkout `runServerUpdate` when available (same pattern as classic checkout).
+ * Notifies Stripe.js after a native Store API cart response embeds a newer Checkout Session revision.
+ * The Store API extension synchronizes Stripe while WooCommerce serializes its fully calculated cart.
  *
- * @param {Object|null} api               WCStripeAPI instance (with checkoutSessionsUpdateSession).
  * @param {string|null} checkoutSessionId Stripe Checkout Session id once the session is ready.
  * @param {Object}      checkoutState     Result of useCheckout() from @stripe/react-stripe-js/checkout.
  * @param {Object}      [syncFailedRef]   Optional ref flagged true when a resync fails (stale session) and false once it succeeds.
+ * @param {Object}      [sessionData]     Session data embedded in cartData.extensions.
  */
 export const useCheckoutSessionTotalsSync = (
-	api,
 	checkoutSessionId,
 	checkoutState,
-	syncFailedRef = null
+	syncFailedRef = null,
+	sessionData = {}
 ) => {
-	const cartTotals = useSelect( ( selectCart ) => {
-		const cartStoreKey = window.wc?.wcBlocksData?.cartStore;
-		if ( ! cartStoreKey ) {
-			return '';
-		}
-
-		const cartStore = selectCart( cartStoreKey );
-		if ( typeof cartStore?.getCartTotals !== 'function' ) {
-			return '';
-		}
-		const totals = cartStore.getCartTotals();
-
-		return totals?.total_price;
-	}, [] );
-
 	const checkoutStateRef = useRef( checkoutState );
 	checkoutStateRef.current = checkoutState;
 
 	const prevSessionIdRef = useRef( null );
-	const prevCartTotalsRef = useRef( null );
+	const prevSessionStateRef = useRef( null );
+	const sessionState = `${ sessionData?.revision ?? 0 }:${
+		sessionData?.status ?? 'uninitialized'
+	}`;
 
-	// Update the previous session ID and totals signature when the checkout session ID changes.
+	// A replacement session has its own revision sequence, so do not compare it with the previous one.
 	useEffect( () => {
 		if ( prevSessionIdRef.current !== checkoutSessionId ) {
 			prevSessionIdRef.current = checkoutSessionId;
-			prevCartTotalsRef.current = null;
+			prevSessionStateRef.current = null;
 		}
 	}, [ checkoutSessionId ] );
 
 	useEffect( () => {
-		if ( ! checkoutSessionId || cartTotals === '' ) {
+		if ( ! checkoutSessionId ) {
 			return;
 		}
 
-		if ( prevCartTotalsRef.current === null ) {
-			prevCartTotalsRef.current = cartTotals;
+		if ( prevSessionStateRef.current === null ) {
+			prevSessionStateRef.current = sessionState;
 			return;
 		}
 
-		if ( prevCartTotalsRef.current === cartTotals ) {
+		if ( prevSessionStateRef.current === sessionState ) {
 			return;
 		}
 
-		prevCartTotalsRef.current = cartTotals;
+		prevSessionStateRef.current = sessionState;
 
 		const state = checkoutStateRef.current;
 		if ( state?.type !== 'success' ) {
@@ -412,24 +400,23 @@ export const useCheckoutSessionTotalsSync = (
 
 		const run = async () => {
 			try {
+				if ( sessionData?.status === 'error' ) {
+					markSyncFailed();
+					return;
+				}
+
 				blockUI(
 					jQuery(
 						'.wc-block-checkout__payment-method, .wc-block-components-checkout-place-order-button'
 					)
 				);
 				const { checkout } = state;
-				if (
-					typeof api?.checkoutSessionsUpdateSession !== 'function' ||
-					typeof checkout?.runServerUpdate !== 'function'
-				) {
+				if ( typeof checkout?.runServerUpdate !== 'function' ) {
+					markSyncFailed();
 					return;
 				}
 
-				const result = await checkout.runServerUpdate( async () => {
-					await api.checkoutSessionsUpdateSession(
-						checkoutSessionId
-					);
-				} );
+				const result = await checkout.runServerUpdate( async () => {} );
 				if ( ! cancelled && result && result.type === 'error' ) {
 					markSyncFailed();
 					// eslint-disable-next-line no-console
@@ -462,7 +449,12 @@ export const useCheckoutSessionTotalsSync = (
 		return () => {
 			cancelled = true;
 		};
-	}, [ api, cartTotals, checkoutSessionId, syncFailedRef ] );
+	}, [
+		checkoutSessionId,
+		sessionData?.status,
+		sessionState,
+		syncFailedRef,
+	] );
 };
 
 /**

--- a/client/blocks/checkout-sessions/hooks.js
+++ b/client/blocks/checkout-sessions/hooks.js
@@ -336,6 +336,7 @@ export const useCheckoutSessionTotalsSync = (
 	const sessionState = `${ sessionData?.revision ?? 0 }:${
 		sessionData?.status ?? 'uninitialized'
 	}`;
+	const isCheckoutReady = checkoutState?.type === 'success';
 
 	useEffect( () => {
 		if ( checkoutStateRef.current !== checkoutState ) {
@@ -365,12 +366,13 @@ export const useCheckoutSessionTotalsSync = (
 			return;
 		}
 
-		prevSessionStateRef.current = sessionState;
-
+		// If the checkout is not ready, do not proceed with the resync.
 		const state = checkoutStateRef.current;
 		if ( state?.type !== 'success' ) {
 			return;
 		}
+
+		prevSessionStateRef.current = sessionState;
 
 		let cancelled = false;
 
@@ -456,6 +458,7 @@ export const useCheckoutSessionTotalsSync = (
 		};
 	}, [
 		checkoutSessionId,
+		isCheckoutReady,
 		sessionData?.status,
 		sessionState,
 		syncFailedRef,

--- a/client/blocks/checkout-sessions/hooks.js
+++ b/client/blocks/checkout-sessions/hooks.js
@@ -357,23 +357,6 @@ export const useCheckoutSessionTotalsSync = (
 			return;
 		}
 
-		if ( prevSessionStateRef.current === null ) {
-			prevSessionStateRef.current = sessionState;
-			return;
-		}
-
-		if ( prevSessionStateRef.current === sessionState ) {
-			return;
-		}
-
-		// If the checkout is not ready, do not proceed with the resync.
-		const state = checkoutStateRef.current;
-		if ( state?.type !== 'success' ) {
-			return;
-		}
-
-		prevSessionStateRef.current = sessionState;
-
 		let cancelled = false;
 
 		// Stable id so a later successful resync can retract the notice a failed one showed.
@@ -404,6 +387,28 @@ export const useCheckoutSessionTotalsSync = (
 				'wc/checkout/payments'
 			);
 		};
+
+		if ( prevSessionStateRef.current === null ) {
+			prevSessionStateRef.current = sessionState;
+			// If the session has an error, ensure we mark the sync as failed, as errors
+			// may not bump the revision, and may not be distinguishable from each other.
+			if ( sessionData?.status === 'error' ) {
+				markSyncFailed();
+			}
+			return;
+		}
+
+		if ( prevSessionStateRef.current === sessionState ) {
+			return;
+		}
+
+		// If the checkout is not ready, do not trigger the (re)sync.
+		const state = checkoutStateRef.current;
+		if ( state?.type !== 'success' ) {
+			return;
+		}
+
+		prevSessionStateRef.current = sessionState;
 
 		const run = async () => {
 			try {

--- a/client/blocks/checkout-sessions/hooks.js
+++ b/client/blocks/checkout-sessions/hooks.js
@@ -333,7 +333,7 @@ export const useCheckoutSessionTotalsSync = (
 
 	const prevSessionIdRef = useRef( null );
 	const prevSessionStateRef = useRef( null );
-	const sessionState = `${ sessionData?.revision ?? 0 }:${
+	const sessionState = `${ sessionData?.revision ?? '' }:${
 		sessionData?.status ?? 'uninitialized'
 	}`;
 	const isCheckoutReady = checkoutState?.type === 'success';

--- a/client/blocks/checkout-sessions/hooks.js
+++ b/client/blocks/checkout-sessions/hooks.js
@@ -330,13 +330,18 @@ export const useCheckoutSessionTotalsSync = (
 	sessionData = {}
 ) => {
 	const checkoutStateRef = useRef( checkoutState );
-	checkoutStateRef.current = checkoutState;
 
 	const prevSessionIdRef = useRef( null );
 	const prevSessionStateRef = useRef( null );
 	const sessionState = `${ sessionData?.revision ?? 0 }:${
 		sessionData?.status ?? 'uninitialized'
 	}`;
+
+	useEffect( () => {
+		if ( checkoutStateRef.current !== checkoutState ) {
+			checkoutStateRef.current = checkoutState;
+		}
+	}, [ checkoutState, checkoutStateRef ] );
 
 	// A replacement session has its own revision sequence, so do not compare it with the previous one.
 	useEffect( () => {

--- a/client/blocks/checkout-sessions/hooks.js
+++ b/client/blocks/checkout-sessions/hooks.js
@@ -408,7 +408,15 @@ export const useCheckoutSessionTotalsSync = (
 			return;
 		}
 
+		const uiBlockSelector =
+			'.wc-block-checkout__payment-method, .wc-block-components-checkout-place-order-button';
+
+		// Keep a reference to the previous session state so we can restore it
+		// if we cancel the current resync before it completes.
+		const prevSessionState = prevSessionStateRef.current;
 		prevSessionStateRef.current = sessionState;
+
+		let syncCompleted = false;
 
 		const run = async () => {
 			try {
@@ -417,11 +425,7 @@ export const useCheckoutSessionTotalsSync = (
 					return;
 				}
 
-				blockUI(
-					jQuery(
-						'.wc-block-checkout__payment-method, .wc-block-components-checkout-place-order-button'
-					)
-				);
+				blockUI( jQuery( uiBlockSelector ) );
 				const { checkout } = state;
 				if ( typeof checkout?.runServerUpdate !== 'function' ) {
 					markSyncFailed();
@@ -444,14 +448,11 @@ export const useCheckoutSessionTotalsSync = (
 					console.error( error );
 				}
 			} finally {
-				// A superseded resync must not lift the block a newer, still
-				// in-flight resync is holding on the payment area.
+				syncCompleted = true;
+				// Only unblock the UI if we don't have a newer resync in flight,
+				// which is indicated by the cancelled flag remaining false.
 				if ( ! cancelled ) {
-					unblockUI(
-						jQuery(
-							'.wc-block-checkout__payment-method, .wc-block-components-checkout-place-order-button'
-						)
-					);
+					unblockUI( jQuery( uiBlockSelector ) );
 				}
 			}
 		};
@@ -460,6 +461,12 @@ export const useCheckoutSessionTotalsSync = (
 
 		return () => {
 			cancelled = true;
+			// If the run was cancelled mid-flight and the sync has not completed yet,
+			// we need to restore the previous session state and unblock the UI.
+			if ( ! syncCompleted ) {
+				prevSessionStateRef.current = prevSessionState;
+				unblockUI( jQuery( uiBlockSelector ) );
+			}
 		};
 	}, [
 		checkoutSessionId,

--- a/client/classic/upe/__tests__/payment-processing.test.js
+++ b/client/classic/upe/__tests__/payment-processing.test.js
@@ -170,7 +170,7 @@ const setNativeCheckoutSessionData = ( overrides = {} ) => {
 	dataElement.dataset.checkoutSession = JSON.stringify( {
 		session_id: MOCK_AP_CHECKOUT_SESSION_ID,
 		client_secret: MOCK_AP_CHECKOUT_CLIENT_SECRET,
-		revision: 1,
+		revision: 'rev_1',
 		status: 'success',
 		message: '',
 		...overrides,
@@ -1299,7 +1299,7 @@ describe( 'payment-processing', () => {
 				setNativeCheckoutSessionData( {
 					session_id: '',
 					client_secret: '',
-					revision: 0,
+					revision: '',
 					status: 'uninitialized',
 				} );
 				stripeUtils.showErrorCheckout.mockClear();

--- a/client/classic/upe/__tests__/payment-processing.test.js
+++ b/client/classic/upe/__tests__/payment-processing.test.js
@@ -157,6 +157,26 @@ const createMockPaymentElement = () => ( {
 const MOCK_AP_CHECKOUT_CLIENT_SECRET = 'cs_test_ap_client_secret';
 const MOCK_AP_CHECKOUT_SESSION_ID = 'cs_test_abc';
 
+const setNativeCheckoutSessionData = ( overrides = {} ) => {
+	let dataElement = document.getElementById(
+		'wc-stripe-checkout-session-data'
+	);
+	if ( ! dataElement ) {
+		dataElement = document.createElement( 'div' );
+		dataElement.id = 'wc-stripe-checkout-session-data';
+		document.body.appendChild( dataElement );
+	}
+
+	dataElement.dataset.checkoutSession = JSON.stringify( {
+		session_id: MOCK_AP_CHECKOUT_SESSION_ID,
+		client_secret: MOCK_AP_CHECKOUT_CLIENT_SECRET,
+		revision: 1,
+		status: 'success',
+		message: '',
+		...overrides,
+	} );
+};
+
 const createMockElements = () => {
 	const checkoutActions = {
 		runServerUpdate: jest.fn( async ( userFunction ) => {
@@ -518,6 +538,7 @@ describe( 'payment-processing', () => {
 
 	describe( 'adaptive pricing enabled (isAdaptivePricingEnabled = true)', () => {
 		beforeEach( () => {
+			setNativeCheckoutSessionData();
 			stripeUtils.getStripeServerData.mockReturnValue( {
 				...BASE_SERVER_DATA,
 				isAdaptivePricingEnabled: true,
@@ -526,6 +547,9 @@ describe( 'payment-processing', () => {
 		} );
 
 		afterEach( () => {
+			document
+				.getElementById( 'wc-stripe-checkout-session-data' )
+				?.remove();
 			jest.clearAllMocks();
 		} );
 
@@ -544,7 +568,9 @@ describe( 'payment-processing', () => {
 
 				await paymentProcessing.mountStripePaymentElement( api, dom );
 
-				expect( api.checkoutSessionsCreateSession ).toHaveBeenCalled();
+				expect(
+					api.checkoutSessionsCreateSession
+				).not.toHaveBeenCalled();
 				expect(
 					api._stripe.initCheckoutElementsSdk
 				).toHaveBeenCalledWith(
@@ -636,9 +662,10 @@ describe( 'payment-processing', () => {
 			it( 'falls back to standard elements when session creation fails', async () => {
 				const checkoutElements = createMockElements();
 				const api = createMockApi( checkoutElements );
-				api.checkoutSessionsCreateSession.mockRejectedValue(
-					new Error( 'Network error' )
-				);
+				setNativeCheckoutSessionData( {
+					client_secret: '',
+					status: 'error',
+				} );
 				const dom = document.createElement( 'div' );
 				dom.dataset.paymentMethodType = 'card';
 
@@ -653,8 +680,9 @@ describe( 'payment-processing', () => {
 			it( 'falls back to standard elements when client_secret or session_id is absent', async () => {
 				const checkoutElements = createMockElements();
 				const api = createMockApi( checkoutElements );
-				api.checkoutSessionsCreateSession.mockResolvedValue( {
-					data: {},
+				setNativeCheckoutSessionData( {
+					client_secret: '',
+					session_id: '',
 				} );
 				const dom = document.createElement( 'div' );
 				dom.dataset.paymentMethodType = 'card';
@@ -670,8 +698,8 @@ describe( 'payment-processing', () => {
 			it( 'falls back to standard elements when session_id is absent', async () => {
 				const checkoutElements = createMockElements();
 				const api = createMockApi( checkoutElements );
-				api.checkoutSessionsCreateSession.mockResolvedValue( {
-					data: { client_secret: MOCK_AP_CHECKOUT_CLIENT_SECRET },
+				setNativeCheckoutSessionData( {
+					session_id: '',
 				} );
 				const dom = document.createElement( 'div' );
 				dom.dataset.paymentMethodType = 'card';
@@ -684,7 +712,7 @@ describe( 'payment-processing', () => {
 				).not.toHaveBeenCalled();
 			} );
 
-			it( 'uses runServerUpdate to call checkoutSessionsUpdateSession after maybeUpdateAdaptivePricingCheckoutSession', async () => {
+			it( 'uses runServerUpdate without calling the custom update endpoint', async () => {
 				const checkoutElements = createMockElements();
 				const api = createMockApi( checkoutElements );
 				const dom = document.createElement( 'div' );
@@ -700,7 +728,7 @@ describe( 'payment-processing', () => {
 				).toHaveBeenCalled();
 				expect(
 					api.checkoutSessionsUpdateSession
-				).toHaveBeenCalledWith( MOCK_AP_CHECKOUT_SESSION_ID );
+				).not.toHaveBeenCalled();
 			} );
 
 			it( 'does not call checkoutSessionsUpdateSession when adaptive pricing is disabled', async () => {
@@ -1074,10 +1102,7 @@ describe( 'payment-processing', () => {
 			it( 'falls back to standard payment flow when session ID is missing from mount', async () => {
 				const checkoutElements = createMockElements();
 				const api = createMockApi( checkoutElements );
-				// Override to not return a session_id — triggers fallback to stripe.elements().
-				api.checkoutSessionsCreateSession.mockResolvedValue( {
-					data: { client_secret: 'cs_test_abc' },
-				} );
+				setNativeCheckoutSessionData( { session_id: '' } );
 				// Fallback elements should NOT have loadActions (like real stripe.elements()).
 				const bareElements = createMockElements();
 				delete bareElements.loadActions;
@@ -1105,10 +1130,7 @@ describe( 'payment-processing', () => {
 			it( 'shows error if checkoutSessionId is null but loadActions exists (defensive)', async () => {
 				const checkoutElements = createMockElements();
 				const api = createMockApi( checkoutElements );
-				// Override to not return a session_id.
-				api.checkoutSessionsCreateSession.mockResolvedValue( {
-					data: { client_secret: 'cs_test_abc' },
-				} );
+				setNativeCheckoutSessionData( { session_id: '' } );
 
 				await mountAndConfigureForProcess( api, checkoutElements, {
 					type: 'success',
@@ -1246,12 +1268,9 @@ describe( 'payment-processing', () => {
 					},
 				],
 				[
-					'the direct session update rejects',
-					( checkoutElements, api ) => {
+					'the element cannot expose runServerUpdate',
+					( checkoutElements ) => {
 						delete checkoutElements.loadActions;
-						api.checkoutSessionsUpdateSession.mockRejectedValueOnce(
-							new Error( 'boom' )
-						);
 					},
 				],
 			] )(
@@ -1273,6 +1292,60 @@ describe( 'payment-processing', () => {
 					).toHaveBeenCalledWith( STALE_TOTAL_MESSAGE );
 				}
 			);
+
+			it( 'stays silent when no element holds a checkout session', async () => {
+				// Nothing mounted through initCheckoutElementsSdk, so the store is on standard
+				// elements and has no session that could go stale.
+				setNativeCheckoutSessionData( {
+					session_id: '',
+					client_secret: '',
+					revision: 0,
+					status: 'uninitialized',
+				} );
+				stripeUtils.showErrorCheckout.mockClear();
+
+				await paymentProcessing.maybeUpdateAdaptivePricingCheckoutSession();
+
+				expect( stripeUtils.showErrorCheckout ).not.toHaveBeenCalled();
+			} );
+
+			it( 'shows a notice when the server reports a failed synchronization', async () => {
+				const checkoutElements = createMockElements();
+				const api = createMockApi( checkoutElements );
+				await mountElement( api, checkoutElements );
+
+				setNativeCheckoutSessionData( { status: 'error' } );
+				stripeUtils.showErrorCheckout.mockClear();
+
+				await paymentProcessing.maybeUpdateAdaptivePricingCheckoutSession();
+
+				expect( stripeUtils.showErrorCheckout ).toHaveBeenCalledWith(
+					STALE_TOTAL_MESSAGE
+				);
+				expect(
+					checkoutElements.checkoutActions.runServerUpdate
+				).not.toHaveBeenCalled();
+			} );
+
+			it( 'shows a notice when the server replaced the session the element is bound to', async () => {
+				const checkoutElements = createMockElements();
+				const api = createMockApi( checkoutElements );
+				await mountElement( api, checkoutElements );
+
+				setNativeCheckoutSessionData( {
+					session_id: 'cs_test_replacement',
+				} );
+				stripeUtils.showErrorCheckout.mockClear();
+
+				await paymentProcessing.maybeUpdateAdaptivePricingCheckoutSession();
+
+				expect( stripeUtils.showErrorCheckout ).toHaveBeenCalledWith(
+					STALE_TOTAL_MESSAGE
+				);
+				expect(
+					checkoutElements.checkoutActions.runServerUpdate
+				).not.toHaveBeenCalled();
+			} );
 
 			it( 'ignores a stale failing resync that settles after a newer successful one', async () => {
 				const checkoutElements = createMockElements();
@@ -1467,6 +1540,10 @@ describe( 'payment-processing', () => {
 				expect( mockJQueryAjax ).not.toHaveBeenCalled();
 
 				// A clean resync lifts the block and the order is created.
+				checkoutElements.loadActions.mockResolvedValue( {
+					type: 'success',
+					actions: checkoutElements.checkoutActions,
+				} );
 				await paymentProcessing.maybeUpdateAdaptivePricingCheckoutSession(
 					api
 				);

--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -91,7 +91,7 @@ jQuery( function ( $ ) {
 	$( document.body ).on( 'updated_checkout', () => {
 		// Track the re-render → re-mount chain so a mid-update submission waits.
 		const updateChain = ( async () => {
-			await maybeUpdateAdaptivePricingCheckoutSession( api );
+			await maybeUpdateAdaptivePricingCheckoutSession();
 			await maybeMountStripePaymentElement();
 			// Remounting skips an already-mounted OC element; refresh its exclusions.
 			maybeUpdateOptimizedCheckoutExclusions();

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -45,16 +45,17 @@ import { handleDisplayOfSavingCheckbox } from 'wcstripe/optimized-checkout/handl
 
 /**
  * @typedef {Object} UPEComponent
- * @property {string|null}          intentId          The ID of the intent.
- * @property {string|null}          checkoutSessionId Stripe Checkout Session id (cs_…) from create session; same value passed to initCheckoutElementsSdk as clientSecret.
- * @property {Object|null}          elements          The Stripe elements object.
- * @property {Object|null}          upeElement        The Stripe payment element.
- * @property {boolean}              hasLoadError      Whether the payment element has a load error.
- * @property {Promise<Object|null>} upeElementPromise Promise that resolves to the Stripe payment element.
- * @property {Promise<Object>|null} mountPromise      Promise that resolves once the element is fully (re)mounted, or null when no mount is in flight.
- * @property {Object|null}          mountTarget       The DOM node the in-flight mount targets, used to dedupe concurrent mounts of the same element.
- * @property {number}               mountToken        Monotonic id of the latest mount; an older mount whose token no longer matches skips its side-effects.
- * @property {boolean}              listenersAttached Whether the one-time element listeners (loaderror/change) have been wired, so remounts don't stack duplicates on the cached element.
+ * @property {string|null}          intentId                The ID of the intent.
+ * @property {string|null}          checkoutSessionId       Stripe Checkout Session id (cs_…) embedded by WooCommerce.
+ * @property {number}               checkoutSessionRevision Revision embedded by the native WooCommerce checkout response.
+ * @property {Object|null}          elements                The Stripe elements object.
+ * @property {Object|null}          upeElement              The Stripe payment element.
+ * @property {boolean}              hasLoadError            Whether the payment element has a load error.
+ * @property {Promise<Object|null>} upeElementPromise       Promise that resolves to the Stripe payment element.
+ * @property {Promise<Object>|null} mountPromise            Promise that resolves once the element is fully (re)mounted, or null when no mount is in flight.
+ * @property {Object|null}          mountTarget             The DOM node the in-flight mount targets, used to dedupe concurrent mounts of the same element.
+ * @property {number}               mountToken              Monotonic id of the latest mount; an older mount whose token no longer matches skips its side-effects.
+ * @property {boolean}              listenersAttached       Whether the one-time element listeners (loaderror/change) have been wired, so remounts don't stack duplicates on the cached element.
  */
 
 /**
@@ -132,6 +133,7 @@ export function initializeUPEComponents() {
 		gatewayUPEComponents[ paymentMethodType ] = {
 			intentId: null,
 			checkoutSessionId: null,
+			checkoutSessionRevision: 0,
 			elements: null,
 			upeElement: null,
 			hasLoadError: false,
@@ -150,21 +152,23 @@ export function initializeUPEComponents() {
 }
 
 /**
- * After classic checkout AJAX refresh (e.g. shipping or coupon), sync line items on the Stripe Checkout Session
- * so the Payment Element amount matches the cart. Uses checkoutSessionId from the create-session response.
+ * After WooCommerce refreshes classic checkout, notify Stripe.js that the native response finished synchronizing
+ * the Checkout Session. The PHP lifecycle hook has already applied WooCommerce's current cart to Stripe.
  *
  * Wraps the server request in Stripe Custom Checkout {@link https://docs.stripe.com/js/custom_checkout/run_server_update runServerUpdate}
  * when available so the embedded session state stays consistent after the update.
  *
- * @param {Object} api WCStripeAPI instance.
  * @return {Promise<void>}
  */
-export async function maybeUpdateAdaptivePricingCheckoutSession( api ) {
+export async function maybeUpdateAdaptivePricingCheckoutSession() {
 	if ( ! getStripeServerData()?.isAdaptivePricingEnabled ) {
 		return;
 	}
 
 	const generation = ++adaptivePricingSyncGeneration;
+	const nativeSession = getNativeCheckoutSessionData();
+	// Only an element that actually holds a session can go stale. A store that fell back to
+	// standard elements has nothing to resync, so it must not be warned about a stale total.
 	let resyncFailed = false;
 
 	const seen = new Set();
@@ -175,6 +179,16 @@ export async function maybeUpdateAdaptivePricingCheckoutSession( api ) {
 			continue;
 		}
 		seen.add( sessionId );
+
+		// The mounted element cannot update the checkout session ID once it has been set.
+		// So we show an error when we failed to get a session OR we got a new session.
+		if (
+			nativeSession?.status !== 'success' ||
+			nativeSession?.session_id !== sessionId
+		) {
+			resyncFailed = true;
+			continue;
+		}
 
 		const checkout = component?.elements;
 
@@ -189,16 +203,15 @@ export async function maybeUpdateAdaptivePricingCheckoutSession( api ) {
 						blockUI( jQuery( 'form.checkout #payment' ) );
 						const updateResult =
 							await loadResult.actions.runServerUpdate(
-								async () => {
-									await api.checkoutSessionsUpdateSession(
-										sessionId
-									);
-								}
+								async () => {}
 							);
 						if ( updateResult.type === 'error' ) {
 							resyncFailed = true;
 							// eslint-disable-next-line no-console
 							console.error( updateResult.error );
+						} else {
+							component.checkoutSessionRevision =
+								nativeSession.revision;
 						}
 					} catch ( error ) {
 						resyncFailed = true;
@@ -220,13 +233,9 @@ export async function maybeUpdateAdaptivePricingCheckoutSession( api ) {
 			}
 		}
 
-		try {
-			await api.checkoutSessionsUpdateSession( sessionId );
-		} catch ( error ) {
-			resyncFailed = true;
-			// eslint-disable-next-line no-console
-			console.error( error );
-		}
+		// initCheckoutElementsSdk exposes runServerUpdate; without it Stripe.js cannot be told
+		// to fetch the session revision that WooCommerce just synchronized.
+		resyncFailed = true;
 	}
 
 	// A newer resync started while we were awaiting; let it own the result.
@@ -245,6 +254,29 @@ export async function maybeUpdateAdaptivePricingCheckoutSession( api ) {
 	} else {
 		// Retract the notice a prior failed resync left behind now that totals sync.
 		clearStaleCheckoutTotalNotice();
+	}
+}
+
+/**
+ * Read Checkout Session data embedded in the latest native checkout fragment.
+ *
+ * @return {Object|null} Parsed session data.
+ */
+function getNativeCheckoutSessionData() {
+	const dataElement = document.getElementById(
+		'wc-stripe-checkout-session-data'
+	);
+	const serializedData = dataElement?.dataset?.checkoutSession;
+	if ( ! serializedData ) {
+		return null;
+	}
+
+	try {
+		return JSON.parse( serializedData );
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error( error );
+		return null;
 	}
 }
 
@@ -427,11 +459,15 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 		typeof stripe?.initCheckoutElementsSdk === 'function'
 	) {
 		try {
-			const response = await api.checkoutSessionsCreateSession();
-			const clientSecret = response?.data?.client_secret;
-			const sessionId = response?.data?.session_id;
+			const nativeSession = getNativeCheckoutSessionData();
+			const clientSecret = nativeSession?.client_secret;
+			const sessionId = nativeSession?.session_id;
 
-			if ( ! clientSecret || ! sessionId ) {
+			if (
+				! clientSecret ||
+				! sessionId ||
+				nativeSession?.status !== 'success'
+			) {
 				throw new Error(
 					__(
 						'Failed to load payment method due to missing client secret or session id.',
@@ -442,6 +478,8 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 
 			gatewayUPEComponents[ paymentMethodType ].checkoutSessionId =
 				sessionId;
+			gatewayUPEComponents[ paymentMethodType ].checkoutSessionRevision =
+				nativeSession.revision;
 
 			elements = await stripe.initCheckoutElementsSdk( {
 				clientSecret,
@@ -463,6 +501,9 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 			shouldLoadStripeElements = false;
 		} catch ( error ) {
 			gatewayUPEComponents[ paymentMethodType ].checkoutSessionId = null;
+			gatewayUPEComponents[
+				paymentMethodType
+			].checkoutSessionRevision = 0;
 			// eslint-disable-next-line no-console
 			console.error( error );
 			shouldLoadStripeElements = true;
@@ -473,6 +514,7 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 	// load the Stripe elements as fallback.
 	if ( shouldLoadStripeElements ) {
 		gatewayUPEComponents[ paymentMethodType ].checkoutSessionId = null;
+		gatewayUPEComponents[ paymentMethodType ].checkoutSessionRevision = 0;
 		elements = stripe.elements( options );
 
 		// Creation already applied these exclusions; seed the memo so the first

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -47,7 +47,7 @@ import { handleDisplayOfSavingCheckbox } from 'wcstripe/optimized-checkout/handl
  * @typedef {Object} UPEComponent
  * @property {string|null}          intentId                The ID of the intent.
  * @property {string|null}          checkoutSessionId       Stripe Checkout Session id (cs_…) embedded by WooCommerce.
- * @property {number}               checkoutSessionRevision Revision embedded by the native WooCommerce checkout response.
+ * @property {string}               checkoutSessionRevision Revision token embedded by the native WooCommerce checkout response.
  * @property {Object|null}          elements                The Stripe elements object.
  * @property {Object|null}          upeElement              The Stripe payment element.
  * @property {boolean}              hasLoadError            Whether the payment element has a load error.
@@ -133,7 +133,7 @@ export function initializeUPEComponents() {
 		gatewayUPEComponents[ paymentMethodType ] = {
 			intentId: null,
 			checkoutSessionId: null,
-			checkoutSessionRevision: 0,
+			checkoutSessionRevision: '',
 			elements: null,
 			upeElement: null,
 			hasLoadError: false,
@@ -501,9 +501,8 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 			shouldLoadStripeElements = false;
 		} catch ( error ) {
 			gatewayUPEComponents[ paymentMethodType ].checkoutSessionId = null;
-			gatewayUPEComponents[
-				paymentMethodType
-			].checkoutSessionRevision = 0;
+			gatewayUPEComponents[ paymentMethodType ].checkoutSessionRevision =
+				'';
 			// eslint-disable-next-line no-console
 			console.error( error );
 			shouldLoadStripeElements = true;
@@ -514,7 +513,7 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 	// load the Stripe elements as fallback.
 	if ( shouldLoadStripeElements ) {
 		gatewayUPEComponents[ paymentMethodType ].checkoutSessionId = null;
-		gatewayUPEComponents[ paymentMethodType ].checkoutSessionRevision = 0;
+		gatewayUPEComponents[ paymentMethodType ].checkoutSessionRevision = '';
 		elements = stripe.elements( options );
 
 		// Creation already applied these exclusions; seed the memo so the first

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,8 @@
         "includes/admin/class-wc-stripe-upe-compatibility-controller.php",
         "includes/class-wc-stripe-action-scheduler-service.php",
         "includes/class-wc-stripe-api-outage-status.php",
+        "includes/class-wc-stripe-checkout-session-lifecycle.php",
+        "includes/class-wc-stripe-checkout-session-manager.php",
         "includes/class-wc-stripe-co-branded-cc-compatibility.php",
         "includes/class-wc-stripe-exception.php",
         "includes/class-wc-stripe-hook-manager.php",

--- a/includes/class-wc-stripe-checkout-session-lifecycle.php
+++ b/includes/class-wc-stripe-checkout-session-lifecycle.php
@@ -111,7 +111,10 @@ class WC_Stripe_Checkout_Session_Lifecycle {
 			$data = $this->manager->synchronize();
 		} catch ( Throwable $e ) {
 			WC_Stripe_Logger::error( 'Native classic checkout session synchronization failed.', [ 'error_message' => $e->getMessage() ] );
-			$data = $this->manager->mark_failed( $e->getMessage() );
+
+			$message = ( $e instanceof WC_Stripe_Exception ) ? $e->getLocalizedMessage() : WC_Stripe_Checkout_Session_Manager::get_runtime_error_message();
+
+			$data = $this->manager->mark_failed( $message );
 		}
 
 		$fragments[ self::CLASSIC_FRAGMENT_SELECTOR ] = $this->get_classic_fragment_html( $data );
@@ -170,14 +173,17 @@ class WC_Stripe_Checkout_Session_Lifecycle {
 		}
 
 		if ( ! self::is_adaptive_pricing_enabled() ) {
-			return $manager->mark_failed( WC_Stripe_Checkout_Session_Context::get_unavailable_message() );
+			return $manager->mark_failed( WC_Stripe_Checkout_Session_Manager::get_runtime_error_message() );
 		}
 
 		try {
 			return $manager->synchronize();
 		} catch ( Throwable $e ) {
 			WC_Stripe_Logger::error( 'Native Store API checkout session synchronization failed.', [ 'error_message' => $e->getMessage() ] );
-			return $manager->mark_failed( $e->getMessage() );
+
+			$message = ( $e instanceof WC_Stripe_Exception ) ? $e->getLocalizedMessage() : WC_Stripe_Checkout_Session_Manager::get_runtime_error_message();
+
+			return $manager->mark_failed( $message );
 		}
 	}
 

--- a/includes/class-wc-stripe-checkout-session-lifecycle.php
+++ b/includes/class-wc-stripe-checkout-session-lifecycle.php
@@ -109,7 +109,7 @@ class WC_Stripe_Checkout_Session_Lifecycle {
 
 		try {
 			$data = $this->manager->synchronize();
-		} catch ( Exception $e ) {
+		} catch ( Throwable $e ) {
 			WC_Stripe_Logger::error( 'Native classic checkout session synchronization failed.', [ 'error_message' => $e->getMessage() ] );
 			$data = $this->manager->mark_failed( $e->getMessage() );
 		}

--- a/includes/class-wc-stripe-checkout-session-lifecycle.php
+++ b/includes/class-wc-stripe-checkout-session-lifecycle.php
@@ -175,7 +175,7 @@ class WC_Stripe_Checkout_Session_Lifecycle {
 
 		try {
 			return $manager->synchronize();
-		} catch ( Exception $e ) {
+		} catch ( Throwable $e ) {
 			WC_Stripe_Logger::error( 'Native Store API checkout session synchronization failed.', [ 'error_message' => $e->getMessage() ] );
 			return $manager->mark_failed( $e->getMessage() );
 		}

--- a/includes/class-wc-stripe-checkout-session-lifecycle.php
+++ b/includes/class-wc-stripe-checkout-session-lifecycle.php
@@ -1,0 +1,244 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use Automattic\WooCommerce\StoreApi\Schemas\V1\CartSchema;
+
+/**
+ * Connects Checkout Session synchronization to native WooCommerce checkout responses.
+ */
+class WC_Stripe_Checkout_Session_Lifecycle {
+	/**
+	 * Store API extension namespace.
+	 *
+	 * @var string
+	 */
+	private const EXTENSION_NAMESPACE = 'wc-stripe/checkout-session';
+
+	/**
+	 * Classic checkout fragment selector.
+	 *
+	 * @var string
+	 */
+	private const CLASSIC_FRAGMENT_SELECTOR = '#wc-stripe-checkout-session-data';
+
+	/**
+	 * Whether this Store API request explicitly requested initial session creation.
+	 *
+	 * @var bool
+	 */
+	private static $store_api_sync_requested = false;
+
+	/**
+	 * Checkout Session manager.
+	 *
+	 * @var WC_Stripe_Checkout_Session_Manager
+	 */
+	private $manager;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WC_Stripe_Checkout_Session_Manager|null $manager Checkout Session manager.
+	 */
+	public function __construct( ?WC_Stripe_Checkout_Session_Manager $manager = null ) {
+		$this->manager = $manager ?? WC_Stripe_Checkout_Session_Manager::get_instance();
+	}
+
+	/**
+	 * Register hooks used by classic checkout.
+	 *
+	 * @return void
+	 */
+	public function init_classic_hooks(): void {
+		add_action( 'woocommerce_review_order_after_payment', [ $this, 'render_classic_placeholder' ] );
+		add_filter( 'woocommerce_update_order_review_fragments', [ $this, 'add_classic_fragment' ], 20 );
+	}
+
+	/**
+	 * Register Checkout Session data and synchronization with the Store API.
+	 *
+	 * This must run on woocommerce_blocks_loaded, before the plugin's regular initialization.
+	 *
+	 * @return void
+	 */
+	public static function init_store_api(): void {
+		if ( ! function_exists( 'woocommerce_store_api_register_endpoint_data' ) || ! function_exists( 'woocommerce_store_api_register_update_callback' ) ) {
+			return;
+		}
+
+		woocommerce_store_api_register_endpoint_data(
+			[
+				'endpoint'        => CartSchema::IDENTIFIER,
+				'namespace'       => self::EXTENSION_NAMESPACE,
+				'schema_callback' => [ self::class, 'get_store_api_schema' ],
+				'data_callback'   => [ self::class, 'get_store_api_data' ],
+				'schema_type'     => ARRAY_A,
+			]
+		);
+
+		woocommerce_store_api_register_update_callback(
+			[
+				'namespace' => self::EXTENSION_NAMESPACE,
+				'callback'  => [ self::class, 'request_store_api_sync' ],
+			]
+		);
+	}
+
+	/**
+	 * Render the stable DOM target replaced by classic update-order-review responses.
+	 *
+	 * @return void
+	 */
+	public function render_classic_placeholder(): void {
+		echo $this->get_classic_fragment_html( $this->manager->get_current_data() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped by get_classic_fragment_html().
+	}
+
+	/**
+	 * Synchronize after WooCommerce has updated customer, shipping, and totals, then embed the result.
+	 *
+	 * @param array $fragments Checkout fragments.
+	 * @return array
+	 */
+	public function add_classic_fragment( array $fragments ): array {
+		if ( ! self::is_adaptive_pricing_enabled() ) {
+			return $fragments;
+		}
+
+		try {
+			$data = $this->manager->synchronize();
+		} catch ( Exception $e ) {
+			WC_Stripe_Logger::error( 'Native classic checkout session synchronization failed.', [ 'error_message' => $e->getMessage() ] );
+			$data = $this->manager->mark_failed( $e->getMessage() );
+		}
+
+		$fragments[ self::CLASSIC_FRAGMENT_SELECTOR ] = $this->get_classic_fragment_html( $data );
+		return $fragments;
+	}
+
+	/**
+	 * Store API schema for the embedded Checkout Session data.
+	 *
+	 * @return array
+	 */
+	public static function get_store_api_schema(): array {
+		return [
+			'session_id'    => [
+				'description' => __( 'Stripe Checkout Session ID.', 'woocommerce-gateway-stripe' ),
+				'type'        => 'string',
+				'readonly'    => true,
+			],
+			'client_secret' => [
+				'description' => __( 'Stripe Checkout Session client secret.', 'woocommerce-gateway-stripe' ),
+				'type'        => 'string',
+				'readonly'    => true,
+			],
+			'revision'      => [
+				'description' => __( 'Checkout Session revision.', 'woocommerce-gateway-stripe' ),
+				'type'        => 'integer',
+				'readonly'    => true,
+			],
+			'status'        => [
+				'description' => __( 'Checkout Session synchronization status.', 'woocommerce-gateway-stripe' ),
+				'type'        => 'string',
+				'readonly'    => true,
+			],
+			'message'       => [
+				'description' => __( 'Checkout Session synchronization message.', 'woocommerce-gateway-stripe' ),
+				'type'        => 'string',
+				'readonly'    => true,
+			],
+		];
+	}
+
+	/**
+	 * Synchronize while WooCommerce is serializing its fully calculated Cart response.
+	 *
+	 * Once initialized, every native Cart response can update the Stripe session. This covers
+	 * address, shipping, coupon, and quantity changes without guessing which client event caused it.
+	 *
+	 * @return array
+	 */
+	public static function get_store_api_data(): array {
+		$manager = WC_Stripe_Checkout_Session_Manager::get_instance();
+		$current = $manager->get_current_data();
+
+		if ( ! self::$store_api_sync_requested && empty( $current['session_id'] ) ) {
+			return $current;
+		}
+
+		if ( ! self::is_adaptive_pricing_enabled() ) {
+			return $manager->mark_failed( WC_Stripe_Checkout_Session_Context::get_unavailable_message() );
+		}
+
+		try {
+			return $manager->synchronize();
+		} catch ( Exception $e ) {
+			WC_Stripe_Logger::error( 'Native Store API checkout session synchronization failed.', [ 'error_message' => $e->getMessage() ] );
+			return $manager->mark_failed( $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Mark this Cart Extensions request as the checkout initialization request.
+	 *
+	 * Synchronization is deferred to the CartSchema data callback because WooCommerce calculates
+	 * totals after update callbacks and before serializing the response.
+	 *
+	 * @param array $data Extension request data.
+	 * @return void
+	 */
+	public static function request_store_api_sync( array $data ): void {
+		if ( 'sync' === ( $data['action'] ?? '' ) && self::is_adaptive_pricing_enabled() ) {
+			self::$store_api_sync_requested = true;
+		}
+	}
+
+	/**
+	 * Build the classic checkout fragment with safely encoded session data.
+	 *
+	 * @param array $data Public session data.
+	 * @return string
+	 */
+	private function get_classic_fragment_html( array $data ): string {
+		$encoded_data = wp_json_encode( $data );
+		if ( false === $encoded_data ) {
+			$encoded_data = '{}';
+		}
+
+		return sprintf(
+			'<div id="wc-stripe-checkout-session-data" data-checkout-session="%s" hidden></div>',
+			esc_attr( $encoded_data )
+		);
+	}
+
+	/**
+	 * Validate the same checkout/cart eligibility used to render Adaptive Pricing on the page.
+	 *
+	 * Every caller runs without WordPress's page query: classic checkout refreshes arrive as
+	 * wc-ajax requests against the home URL, and Store API cart requests are REST requests. In both
+	 * is_checkout() is false even though we are serving checkout, so it has to be forced here. The
+	 * temporary conditional is limited to eligibility checks; WooCommerce has already calculated
+	 * the cart natively.
+	 *
+	 * @return bool
+	 */
+	private static function is_adaptive_pricing_enabled(): bool {
+		$force_checkout_context = static function (): bool {
+			return true;
+		};
+
+		add_filter( 'woocommerce_is_checkout', $force_checkout_context );
+		try {
+			$gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
+
+			return $gateway instanceof WC_Stripe_UPE_Payment_Gateway
+				&& $gateway->should_render_optimized_checkout()
+				&& WC_Stripe_Helper::is_adaptive_pricing_supported();
+		} finally {
+			remove_filter( 'woocommerce_is_checkout', $force_checkout_context );
+		}
+	}
+}

--- a/includes/class-wc-stripe-checkout-session-lifecycle.php
+++ b/includes/class-wc-stripe-checkout-session-lifecycle.php
@@ -139,8 +139,8 @@ class WC_Stripe_Checkout_Session_Lifecycle {
 				'readonly'    => true,
 			],
 			'revision'      => [
-				'description' => __( 'Checkout Session revision.', 'woocommerce-gateway-stripe' ),
-				'type'        => 'integer',
+				'description' => __( 'Checkout Session revision token.', 'woocommerce-gateway-stripe' ),
+				'type'        => 'string',
 				'readonly'    => true,
 			],
 			'status'        => [

--- a/includes/class-wc-stripe-checkout-session-lifecycle.php
+++ b/includes/class-wc-stripe-checkout-session-lifecycle.php
@@ -209,7 +209,8 @@ class WC_Stripe_Checkout_Session_Lifecycle {
 		}
 
 		return sprintf(
-			'<div id="wc-stripe-checkout-session-data" data-checkout-session="%s" hidden></div>',
+			'<div id="%s" data-checkout-session="%s" hidden></div>',
+			esc_attr( ltrim( self::CLASSIC_FRAGMENT_SELECTOR, '#' ) ),
 			esc_attr( $encoded_data )
 		);
 	}

--- a/includes/class-wc-stripe-checkout-session-manager.php
+++ b/includes/class-wc-stripe-checkout-session-manager.php
@@ -135,8 +135,6 @@ class WC_Stripe_Checkout_Session_Manager {
 			throw new Exception( __( 'Checkout session ID is required.', 'woocommerce-gateway-stripe' ) );
 		}
 
-		$record = $this->get_record();
-
 		WC_Stripe_Checkout_Session_Context::with_mutation_lock(
 			$session_id,
 			function () use ( $session_id ): void {
@@ -158,17 +156,21 @@ class WC_Stripe_Checkout_Session_Manager {
 				}
 
 				WC_Stripe_Checkout_Session_Context::store_for_cart( $session_id, $cart_context );
+
+				// Make sure we read the record while we have the lock.
+				$record = $this->get_record();
+
+				if ( is_array( $record ) && (string) ( $record['session_id'] ?? '' ) === $session_id ) {
+					$record['revision'] = (int) ( $record['revision'] ?? 0 ) + 1;
+					$record['status']   = 'success';
+					$record['message']  = '';
+					$this->set_record( $record );
+				}
 			}
 		);
 
-		if ( is_array( $record ) && (string) ( $record['session_id'] ?? '' ) === $session_id ) {
-			$record['revision'] = (int) ( $record['revision'] ?? 0 ) + 1;
-			$record['status']   = 'success';
-			$record['message']  = '';
-			$this->set_record( $record );
-		}
-
-		return $this->get_public_data( $record );
+		// Ensure we (re)fetch the current data.
+		return $this->get_current_data();
 	}
 
 	/**

--- a/includes/class-wc-stripe-checkout-session-manager.php
+++ b/includes/class-wc-stripe-checkout-session-manager.php
@@ -1,0 +1,341 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Creates and synchronizes the Stripe Checkout Session owned by a WooCommerce session.
+ */
+class WC_Stripe_Checkout_Session_Manager {
+	/**
+	 * Checkout session metadata value identifying an Adaptive Pricing checkout.
+	 *
+	 * @var string
+	 */
+	public const ADAPTIVE_PRICING_CHECKOUT_TYPE = 'adaptive_pricing_checkout';
+
+	/**
+	 * WooCommerce session key containing the active Stripe Checkout Session.
+	 *
+	 * @var string
+	 */
+	private const WC_SESSION_KEY = 'wc_stripe_checkout_session';
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var self|null
+	 */
+	private static $instance;
+
+	/**
+	 * Return the shared manager instance.
+	 *
+	 * @return self
+	 */
+	public static function get_instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Create a new Stripe Checkout Session for the current WooCommerce cart.
+	 *
+	 * @return array Public session data.
+	 * @throws Exception When the cart or Stripe response is invalid.
+	 */
+	public function create_session(): array {
+		$this->validate_cart();
+
+		$cart_context = $this->build_cart_context();
+		$request      = [
+			'ui_mode'                       => 'elements',
+			'line_items'                    => $this->build_line_items( $cart_context ),
+			'excluded_payment_method_types' => WC_Stripe::get_instance()->get_main_stripe_gateway()->get_excluded_payment_method_types(),
+			'payment_intent_data'           => $this->build_payment_intent_data(),
+			'mode'                          => 'payment',
+			'adaptive_pricing'              => [
+				'enabled' => 'true',
+			],
+			'metadata'                      => [
+				'checkout_type' => self::ADAPTIVE_PRICING_CHECKOUT_TYPE,
+			],
+		];
+
+		if ( 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' ) ) {
+			$request['phone_number_collection'] = [ 'enabled' => 'true' ];
+		}
+
+		if ( is_user_logged_in() && WC()->customer instanceof WC_Customer ) {
+			try {
+				// Creation happens before checkout fields are complete, so only the saved account identity can be used here.
+				$stripe_customer = new WC_Stripe_Customer( WC()->customer->get_id() );
+				$stripe_customer->maybe_create_customer( WC_Stripe_Customer::CUSTOMER_CONTEXT_CHECKOUT_SESSION );
+			} catch ( Exception $e ) {
+				throw new Exception( __( 'Unable to create or retrieve Stripe customer.', 'woocommerce-gateway-stripe' ) );
+			}
+
+			$request['customer']                     = $stripe_customer->get_id();
+			$request['saved_payment_method_options'] = [
+				'payment_method_save' => 'enabled',
+			];
+
+			// Stripe must collect and backfill an address when the saved customer was created without one.
+			$has_billing_address = '' !== trim( (string) get_user_meta( WC()->customer->get_id(), 'billing_address_1', true ) );
+			if ( ! $has_billing_address ) {
+				$request['customer_update'] = [
+					'address' => 'auto',
+					'name'    => 'auto',
+				];
+			}
+		}
+
+		$checkout_session = WC_Stripe_API::request( $request, 'checkout/sessions' );
+		if ( ! empty( $checkout_session->error ) ) {
+			$message = empty( $checkout_session->error->message ) ? __( 'Checkout Sessions API returned an error', 'woocommerce-gateway-stripe' ) : $checkout_session->error->message;
+			throw new Exception( $message );
+		}
+
+		if ( empty( $checkout_session->client_secret ) || empty( $checkout_session->id ) ) {
+			throw new Exception( __( 'Unable to create Stripe Checkout Session.', 'woocommerce-gateway-stripe' ) );
+		}
+
+		WC_Stripe_Checkout_Session_Context::store_for_cart( $checkout_session->id, $cart_context );
+
+		// Note: we don't store the amount or currency here, as the Checkout Session context is
+		// the source of truth for the amount and currency. That code controls the data sent
+		// to Stripe and is used to validate amounts later.
+		$record = [
+			'session_id'    => (string) $checkout_session->id,
+			'client_secret' => (string) $checkout_session->client_secret,
+			'revision'      => 1,
+			'status'        => 'success',
+			'message'       => '',
+		];
+		$this->set_record( $record );
+
+		return $this->get_public_data( $record );
+	}
+
+	/**
+	 * Update an existing Stripe Checkout Session from the current cart.
+	 *
+	 * @param string $session_id Stripe Checkout Session ID.
+	 * @return array Public session data.
+	 * @throws Exception When the session cannot be updated.
+	 */
+	public function update_session( string $session_id ): array {
+		$this->validate_cart();
+
+		if ( '' === $session_id ) {
+			throw new Exception( __( 'Checkout session ID is required.', 'woocommerce-gateway-stripe' ) );
+		}
+
+		$record = $this->get_record();
+
+		WC_Stripe_Checkout_Session_Context::with_mutation_lock(
+			$session_id,
+			function () use ( $session_id ): void {
+				WC_Stripe_Checkout_Session_Context::validate_update_request( $session_id );
+
+				// Read the cart only once the lock is held and the session is known not to be
+				// linked to an order, so a concurrent request cannot push a snapshot taken
+				// against cart state that validation has already moved past.
+				$cart_context = $this->build_cart_context();
+
+				$checkout_session = WC_Stripe_API::request(
+					[ 'line_items' => $this->build_line_items( $cart_context ) ],
+					"checkout/sessions/$session_id"
+				);
+
+				if ( ! empty( $checkout_session->error ) ) {
+					$message = empty( $checkout_session->error->message ) ? __( 'Checkout Sessions update API returned an error', 'woocommerce-gateway-stripe' ) : $checkout_session->error->message;
+					throw new Exception( $message );
+				}
+
+				WC_Stripe_Checkout_Session_Context::store_for_cart( $session_id, $cart_context );
+			}
+		);
+
+		if ( is_array( $record ) && (string) ( $record['session_id'] ?? '' ) === $session_id ) {
+			$record['revision'] = (int) ( $record['revision'] ?? 0 ) + 1;
+			$record['status']   = 'success';
+			$record['message']  = '';
+			$this->set_record( $record );
+		}
+
+		return $this->get_public_data( $record );
+	}
+
+	/**
+	 * Create or update the session only when the native WooCommerce cart has changed.
+	 *
+	 * @return array Public session data.
+	 * @throws Exception When synchronization fails.
+	 */
+	public function synchronize(): array {
+		$this->validate_cart();
+
+		$record       = $this->get_record();
+		$cart_context = $this->build_cart_context();
+
+		if ( ! is_array( $record ) || empty( $record['session_id'] ) || empty( $record['client_secret'] ) ) {
+			return $this->create_session();
+		}
+
+		$context = WC_Stripe_Checkout_Session_Context::get_context( (string) $record['session_id'] );
+		if ( empty( $context ) || ! empty( $context['order_id'] ) ) {
+			return $this->create_session();
+		}
+
+		// The context is the source of truth for amount and currency, so we need to compare
+		// against the data that was pushed to Stripe.
+		if (
+			(int) ( $context['amount'] ?? 0 ) === $cart_context['amount']
+			&& (string) ( $context['currency'] ?? '' ) === $cart_context['currency']
+			&& 'success' === ( $record['status'] ?? '' )
+		) {
+			return $this->get_public_data( $record );
+		}
+
+		return $this->update_session( (string) $record['session_id'] );
+	}
+
+	/**
+	 * Return the current session data without causing a Stripe API request.
+	 *
+	 * @return array
+	 */
+	public function get_current_data(): array {
+		return $this->get_public_data( $this->get_record() );
+	}
+
+	/**
+	 * Record a synchronization failure while retaining the last usable session identifiers.
+	 *
+	 * @param string $message Failure message.
+	 * @return array
+	 */
+	public function mark_failed( string $message ): array {
+		$record            = $this->get_record() ?? [];
+		$record['status']  = 'error';
+		$record['message'] = $message;
+		$this->set_record( $record );
+
+		return $this->get_public_data( $record );
+	}
+
+	/**
+	 * Build the current cart amount and currency after WooCommerce has applied checkout integrations.
+	 *
+	 * @return array
+	 */
+	private function build_cart_context(): array {
+		$currency = get_woocommerce_currency();
+
+		return [
+			'amount'   => WC_Stripe_Helper::get_stripe_amount( (float) WC()->cart->get_total( 'edit' ), $currency ),
+			'currency' => strtolower( $currency ),
+		];
+	}
+
+	/**
+	 * Build the aggregate line item expected by Stripe Custom Checkout.
+	 *
+	 * @param array $cart_context Current cart context.
+	 * @return array
+	 */
+	private function build_line_items( array $cart_context ): array {
+		return [
+			[
+				'price_data' => [
+					'currency'     => $cart_context['currency'],
+					'product_data' => [
+						'name' => __( 'Cart total', 'woocommerce-gateway-stripe' ),
+					],
+					'unit_amount'  => $cart_context['amount'],
+				],
+				// The payable total is already aggregated into unit_amount, so quantity must remain one.
+				'quantity'   => 1,
+			],
+		];
+	}
+
+	/**
+	 * Build PaymentIntent metadata for a Checkout Session.
+	 *
+	 * @return array
+	 */
+	private function build_payment_intent_data(): array {
+		$metadata = [
+			'site_url'      => esc_url_raw( get_site_url() ),
+			'payment_type'  => 'single',
+			'checkout_type' => self::ADAPTIVE_PRICING_CHECKOUT_TYPE,
+		];
+
+		/** Documented in includes/abstracts/abstract-wc-stripe-payment-gateway.php */
+		return [ 'metadata' => apply_filters( 'wc_stripe_payment_metadata', $metadata, null, null ) ];
+	}
+
+	/**
+	 * Ensure checkout services needed by the manager exist in this request context.
+	 *
+	 * @return void
+	 * @throws Exception When the cart or WooCommerce session is unavailable.
+	 */
+	private function validate_cart(): void {
+		if ( ! WC()->session ) {
+			throw new Exception( WC_Stripe_Checkout_Session_Context::get_unavailable_message() );
+		}
+
+		if ( ! WC()->cart || WC()->cart->is_empty() ) {
+			throw new Exception( __( 'Your cart is currently empty.', 'woocommerce-gateway-stripe' ) );
+		}
+	}
+
+	/**
+	 * Get the active record from the WooCommerce session.
+	 *
+	 * @return array|null
+	 */
+	private function get_record(): ?array {
+		if ( ! WC()->session || ! is_callable( [ WC()->session, 'get' ] ) ) {
+			return null;
+		}
+
+		$record = WC()->session->get( self::WC_SESSION_KEY );
+		return is_array( $record ) ? $record : null;
+	}
+
+	/**
+	 * Store the active record in the WooCommerce session.
+	 *
+	 * @param array $record Session record.
+	 * @return void
+	 */
+	private function set_record( array $record ): void {
+		if ( WC()->session && is_callable( [ WC()->session, 'set' ] ) ) {
+			WC()->session->set( self::WC_SESSION_KEY, $record );
+		}
+	}
+
+	/**
+	 * Limit session data exposed to checkout clients.
+	 *
+	 * @param array|null $record Stored session record.
+	 * @return array
+	 */
+	private function get_public_data( ?array $record ): array {
+		return [
+			'session_id'    => (string) ( $record['session_id'] ?? '' ),
+			'client_secret' => (string) ( $record['client_secret'] ?? '' ),
+			'revision'      => (int) ( $record['revision'] ?? 0 ),
+			'status'        => (string) ( $record['status'] ?? 'uninitialized' ),
+			'message'       => (string) ( $record['message'] ?? '' ),
+		];
+	}
+}

--- a/includes/class-wc-stripe-checkout-session-manager.php
+++ b/includes/class-wc-stripe-checkout-session-manager.php
@@ -43,6 +43,15 @@ class WC_Stripe_Checkout_Session_Manager {
 	}
 
 	/**
+	 * Return a runtime error message when we cannot create, initialize, or update a Stripe Checkout Session.
+	 *
+	 * @return string
+	 */
+	public static function get_runtime_error_message(): string {
+		return __( 'Unable to enable Adaptive Pricing.', 'woocommerce-gateway-stripe' );
+	}
+
+	/**
 	 * Create a new Stripe Checkout Session for the current WooCommerce cart.
 	 *
 	 * @return array Public session data.
@@ -76,7 +85,7 @@ class WC_Stripe_Checkout_Session_Manager {
 				$stripe_customer = new WC_Stripe_Customer( WC()->customer->get_id() );
 				$stripe_customer->maybe_create_customer( WC_Stripe_Customer::CUSTOMER_CONTEXT_CHECKOUT_SESSION );
 			} catch ( Exception $e ) {
-				throw new Exception( __( 'Unable to create or retrieve Stripe customer.', 'woocommerce-gateway-stripe' ) );
+				throw new WC_Stripe_Exception( $e->getMessage(), __( 'Unable to create or retrieve Stripe customer.', 'woocommerce-gateway-stripe' ) );
 			}
 
 			$request['customer']                     = $stripe_customer->get_id();
@@ -96,12 +105,12 @@ class WC_Stripe_Checkout_Session_Manager {
 
 		$checkout_session = WC_Stripe_API::request( $request, 'checkout/sessions' );
 		if ( ! empty( $checkout_session->error ) ) {
-			$message = empty( $checkout_session->error->message ) ? __( 'Checkout Sessions API returned an error', 'woocommerce-gateway-stripe' ) : $checkout_session->error->message;
-			throw new Exception( $message );
+			$message = empty( $checkout_session->error->message ) ? '(No error message returned from Stripe)' : $checkout_session->error->message;
+			throw new WC_Stripe_Exception( $message, self::get_runtime_error_message() );
 		}
 
 		if ( empty( $checkout_session->client_secret ) || empty( $checkout_session->id ) ) {
-			throw new Exception( __( 'Unable to create Stripe Checkout Session.', 'woocommerce-gateway-stripe' ) );
+			throw new WC_Stripe_Exception( 'Failed to create Stripe Checkout Session.', self::get_runtime_error_message() );
 		}
 
 		WC_Stripe_Checkout_Session_Context::store_for_cart( $checkout_session->id, $cart_context );
@@ -132,7 +141,7 @@ class WC_Stripe_Checkout_Session_Manager {
 		$this->validate_cart();
 
 		if ( '' === $session_id ) {
-			throw new Exception( __( 'Checkout session ID is required.', 'woocommerce-gateway-stripe' ) );
+			throw new WC_Stripe_Exception( 'Checkout session ID is required.', self::get_runtime_error_message() );
 		}
 
 		WC_Stripe_Checkout_Session_Context::with_mutation_lock(
@@ -151,8 +160,8 @@ class WC_Stripe_Checkout_Session_Manager {
 				);
 
 				if ( ! empty( $checkout_session->error ) ) {
-					$message = empty( $checkout_session->error->message ) ? __( 'Checkout Sessions update API returned an error', 'woocommerce-gateway-stripe' ) : $checkout_session->error->message;
-					throw new Exception( $message );
+					$message = empty( $checkout_session->error->message ) ? '(No error message returned from Stripe)' : $checkout_session->error->message;
+					throw new WC_Stripe_Exception( $message, self::get_runtime_error_message() );
 				}
 
 				WC_Stripe_Checkout_Session_Context::store_for_cart( $session_id, $cart_context );
@@ -287,15 +296,15 @@ class WC_Stripe_Checkout_Session_Manager {
 	 * Ensure checkout services needed by the manager exist in this request context.
 	 *
 	 * @return void
-	 * @throws Exception When the cart or WooCommerce session is unavailable.
+	 * @throws WC_Stripe_Exception When the cart or WooCommerce session is unavailable.
 	 */
 	private function validate_cart(): void {
 		if ( ! WC()->session ) {
-			throw new Exception( WC_Stripe_Checkout_Session_Context::get_unavailable_message() );
+			throw new WC_Stripe_Exception( 'No WooCommerce session found.', self::get_runtime_error_message() );
 		}
 
 		if ( ! WC()->cart || WC()->cart->is_empty() ) {
-			throw new Exception( __( 'Your cart is currently empty.', 'woocommerce-gateway-stripe' ) );
+			throw new WC_Stripe_Exception( 'Cart is empty.', __( 'Your cart is currently empty.', 'woocommerce-gateway-stripe' ) );
 		}
 	}
 

--- a/includes/class-wc-stripe-checkout-session-manager.php
+++ b/includes/class-wc-stripe-checkout-session-manager.php
@@ -121,7 +121,7 @@ class WC_Stripe_Checkout_Session_Manager {
 		$record = [
 			'session_id'    => (string) $checkout_session->id,
 			'client_secret' => (string) $checkout_session->client_secret,
-			'revision'      => 1,
+			'revision'      => $this->generate_revision_token(),
 			'status'        => 'success',
 			'message'       => '',
 		];
@@ -166,11 +166,11 @@ class WC_Stripe_Checkout_Session_Manager {
 
 				WC_Stripe_Checkout_Session_Context::store_for_cart( $session_id, $cart_context );
 
-				// Make sure we read the record while we have the lock.
 				$record = $this->get_record();
 
 				if ( is_array( $record ) && (string) ( $record['session_id'] ?? '' ) === $session_id ) {
-					$record['revision'] = (int) ( $record['revision'] ?? 0 ) + 1;
+					// Generate a new revision token.
+					$record['revision'] = $this->generate_revision_token();
 					$record['status']   = 'success';
 					$record['message']  = '';
 					$this->set_record( $record );
@@ -293,6 +293,18 @@ class WC_Stripe_Checkout_Session_Manager {
 	}
 
 	/**
+	 * Generate an opaque revision token for the session record.
+	 * The token is a unique string to ensure that concurrent writes
+	 * always result in a new revision value, and clients will need to
+	 * update in response, regardless of which write is persisted.
+	 *
+	 * @return string
+	 */
+	private function generate_revision_token(): string {
+		return wp_generate_uuid4();
+	}
+
+	/**
 	 * Ensure checkout services needed by the manager exist in this request context.
 	 *
 	 * @return void
@@ -344,7 +356,7 @@ class WC_Stripe_Checkout_Session_Manager {
 		return [
 			'session_id'    => (string) ( $record['session_id'] ?? '' ),
 			'client_secret' => (string) ( $record['client_secret'] ?? '' ),
-			'revision'      => (int) ( $record['revision'] ?? 0 ),
+			'revision'      => (string) ( $record['revision'] ?? '' ),
 			'status'        => (string) ( $record['status'] ?? 'uninitialized' ),
 			'message'       => (string) ( $record['message'] ?? '' ),
 		];

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -253,6 +253,9 @@ class WC_Stripe {
 
 			$checkout_sessions_ajax_handler = new WC_Stripe_Checkout_Sessions_Ajax_Handler();
 			$checkout_sessions_ajax_handler->init_hooks();
+
+			$checkout_session_lifecycle = new WC_Stripe_Checkout_Session_Lifecycle();
+			$checkout_session_lifecycle->init_classic_hooks();
 			WC_Stripe_Checkout_Session_Context::init_hooks();
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -257,5 +257,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Reserve stock when completing agentic checkout orders so concurrent sessions cannot oversell; orders losing the race are set on-hold instead of driving stock negative
 * Tweak - Use database cache for webhook status tracking
 * Dev - Add WC_Stripe::get_settings()/update_settings() as the canonical accessors for the main Stripe settings, with the WC_Stripe_Helper shims delegating to them
+* Update - Use WooCommerce Core hooks for Adaptive Pricing session management
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
+++ b/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
@@ -12,6 +12,7 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 		WC()->session->init();
 		WC()->session->set( 'wc_stripe_checkout_session', null );
 		WC()->cart->empty_cart();
+		$this->set_store_api_sync_requested( false );
 	}
 
 	/**
@@ -25,7 +26,39 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 
 		WC()->session->set( 'wc_stripe_checkout_session', null );
 		WC()->cart->empty_cart();
+		$this->set_store_api_sync_requested( false );
 		parent::tear_down();
+	}
+
+	/**
+	 * Get a reflection for the store_api_sync_requested property.
+	 *
+	 * @return ReflectionProperty
+	 */
+	private function get_store_api_sync_requested_reflection(): ReflectionProperty {
+		$property = new ReflectionProperty( WC_Stripe_Checkout_Session_Lifecycle::class, 'store_api_sync_requested' );
+		$property->setAccessible( true );
+
+		return $property;
+	}
+
+	/**
+	 * Set the store_api_sync_requested property value.
+	 *
+	 * @param bool $requested The value to set for the flag.
+	 * @return void
+	 */
+	private function set_store_api_sync_requested( bool $requested ): void {
+		$this->get_store_api_sync_requested_reflection()->setValue( null, $requested );
+	}
+
+	/**
+	 * Read the value of the store_api_sync_requested property.
+	 *
+	 * @return bool
+	 */
+	private function is_store_api_sync_requested(): bool {
+		return (bool) $this->get_store_api_sync_requested_reflection()->getValue();
 	}
 
 	/**
@@ -138,7 +171,7 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 			$created = $manager->synchronize();
 			$reused  = $manager->synchronize();
 		} finally {
-			remove_filter( 'pre_http_request', $mock_request, 10, 3 );
+			remove_filter( 'pre_http_request', $mock_request, 10 );
 		}
 
 		$this->assertSame( 1, $request_count );
@@ -173,7 +206,7 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 			return $request;
 		};
 		$mock_request     = static function ( $return_value, $parsed_args, $url ) use ( &$requested_urls, $session_id ) {
-			if ( false === strpos( $url, '/v1/checkout/sessions' ) ) {
+			if ( ! str_starts_with( $url, 'https://api.stripe.com/v1/checkout/sessions' ) ) {
 				return $return_value;
 			}
 
@@ -200,8 +233,8 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 			WC()->cart->calculate_totals();
 			$updated = $manager->synchronize();
 		} finally {
-			remove_filter( 'wc_stripe_request_body', $capture_body, 10, 2 );
-			remove_filter( 'pre_http_request', $mock_request, 10, 3 );
+			remove_filter( 'wc_stripe_request_body', $capture_body, 10 );
+			remove_filter( 'pre_http_request', $mock_request, 10 );
 		}
 
 		$this->assertCount( 2, $requested_urls );
@@ -227,7 +260,7 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 		$session_id     = 'cs_test_drifted_context';
 		$requested_urls = [];
 		$mock_request   = static function ( $return_value, $parsed_args, $url ) use ( &$requested_urls, $session_id ) {
-			if ( false === strpos( $url, '/v1/checkout/sessions' ) ) {
+			if ( ! str_starts_with( $url, 'https://api.stripe.com/v1/checkout/sessions' ) ) {
 				return $return_value;
 			}
 
@@ -257,7 +290,7 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 
 			$manager->synchronize();
 		} finally {
-			remove_filter( 'pre_http_request', $mock_request, 10, 3 );
+			remove_filter( 'pre_http_request', $mock_request, 10 );
 		}
 
 		$this->assertCount( 2, $requested_urls, 'A drifted context must trigger a Stripe update.' );
@@ -304,7 +337,7 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 			$lifecycle = new WC_Stripe_Checkout_Session_Lifecycle();
 			$fragments = $lifecycle->add_classic_fragment( [] );
 		} finally {
-			remove_filter( 'pre_http_request', $mock_request, 10, 3 );
+			remove_filter( 'pre_http_request', $mock_request, 10 );
 			$restore();
 		}
 
@@ -352,5 +385,332 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 
 		remove_action( 'woocommerce_review_order_after_payment', [ $lifecycle, 'render_classic_placeholder' ] );
 		remove_filter( 'woocommerce_update_order_review_fragments', [ $lifecycle, 'add_classic_fragment' ], 20 );
+	}
+
+	public function test_classic_fragment_reports_stripe_api_error(): void {
+		$product = WC_Helper_Product::create_simple_product( true, [ 'regular_price' => 25 ] );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		$restore = $this->enable_adaptive_pricing();
+
+		$mock_request = static function ( $return_value, $parsed_args, $url ) {
+			if ( ! str_starts_with( $url, 'https://api.stripe.com/v1/checkout/sessions' ) ) {
+				return $return_value;
+			}
+
+			return [
+				'response' => [
+					'code'    => 402,
+					'message' => 'Payment Required',
+				],
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => wp_json_encode(
+					(object) [
+						'error' => (object) [
+							'type'    => 'card_error',
+							'message' => 'Checkout Session creation was declined.',
+						],
+					]
+				),
+			];
+		};
+		add_filter( 'pre_http_request', $mock_request, 10, 3 );
+
+		$original_logger = WC_Stripe_Logger::$logger;
+		$mock_logger     = $this->createMock( WC_Logger::class );
+		$mock_logger->expects( $this->once() )
+			->method( 'error' )
+			->with(
+				'Native classic checkout session synchronization failed.',
+				$this->callback(
+					static function ( $context ): bool {
+						return 'Checkout Session creation was declined.' === ( $context['error_message'] ?? '' );
+					}
+				)
+			);
+		WC_Stripe_Logger::$logger = $mock_logger;
+
+		try {
+			$lifecycle = new WC_Stripe_Checkout_Session_Lifecycle();
+			$fragments = $lifecycle->add_classic_fragment( [] );
+		} finally {
+			WC_Stripe_Logger::$logger = $original_logger;
+			remove_filter( 'pre_http_request', $mock_request, 10 );
+			$restore();
+		}
+
+		$this->assertArrayHasKey( '#wc-stripe-checkout-session-data', $fragments );
+		$data = json_decode( $this->get_fragment_session_data( $fragments['#wc-stripe-checkout-session-data'] ), true );
+		$this->assertSame( 'error', $data['status'] );
+		$this->assertSame( 'Checkout Session creation was declined.', $data['message'] );
+		$this->assertSame( '', $data['session_id'] );
+		$this->assertSame( '', $data['client_secret'] );
+
+		// Confirm that the error was written to the session data.
+		$record = WC()->session->get( 'wc_stripe_checkout_session' );
+		$this->assertSame( 'error', $record['status'] );
+	}
+
+	public function test_classic_fragment_reports_an_empty_cart_before_calling_stripe(): void {
+		$product = WC_Helper_Product::create_simple_product( true, [ 'regular_price' => 25 ] );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		$restore       = $this->enable_adaptive_pricing();
+		$session_id    = 'cs_test_emptied_cart';
+		$request_count = 0;
+		$mock_request  = static function ( $return_value, $parsed_args, $url ) use ( &$request_count, $session_id ) {
+			if ( ! str_starts_with( $url, 'https://api.stripe.com/v1/checkout/sessions' ) ) {
+				return $return_value;
+			}
+
+			++$request_count;
+			return [
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => wp_json_encode(
+					(object) [
+						'id'            => $session_id,
+						'client_secret' => 'cs_test_emptied_cart_secret',
+					]
+				),
+			];
+		};
+		add_filter( 'pre_http_request', $mock_request, 10, 3 );
+
+		try {
+			$lifecycle = new WC_Stripe_Checkout_Session_Lifecycle();
+			$lifecycle->add_classic_fragment( [] );
+
+			WC()->cart->empty_cart();
+			$fragments = $lifecycle->add_classic_fragment( [] );
+		} finally {
+			remove_filter( 'pre_http_request', $mock_request, 10 );
+			$restore();
+		}
+
+		$this->assertSame( 1, $request_count, 'Only initial call should call Stripe; an empty cart should not call Stripe.' );
+
+		$data = json_decode( $this->get_fragment_session_data( $fragments['#wc-stripe-checkout-session-data'] ), true );
+		$this->assertSame( 'error', $data['status'] );
+		$this->assertSame( 'Your cart is currently empty.', $data['message'] );
+
+		$this->assertSame( $session_id, $data['session_id'] );
+	}
+
+	public function test_store_api_data_stays_uninitialized_until_sync_is_requested(): void {
+		$product = WC_Helper_Product::create_simple_product( true, [ 'regular_price' => 25 ] );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		$restore       = $this->enable_adaptive_pricing();
+		$request_count = 0;
+		$mock_request  = static function ( $return_value, $parsed_args, $url ) use ( &$request_count ) {
+			if ( ! str_starts_with( $url, 'https://api.stripe.com/v1/checkout/sessions' ) ) {
+				return $return_value;
+			}
+
+			++$request_count;
+			return $return_value;
+		};
+		add_filter( 'pre_http_request', $mock_request, 10, 3 );
+
+		try {
+			$data = WC_Stripe_Checkout_Session_Lifecycle::get_store_api_data();
+		} finally {
+			remove_filter( 'pre_http_request', $mock_request, 10 );
+			$restore();
+		}
+
+		$this->assertSame( 0, $request_count );
+		$this->assertSame( 'uninitialized', $data['status'] );
+		$this->assertSame( '', $data['session_id'] );
+		$this->assertSame( '', $data['client_secret'] );
+		$this->assertSame( 0, $data['revision'] );
+	}
+
+	public function test_store_api_data_creates_the_session_when_sync_is_requested(): void {
+		$product = WC_Helper_Product::create_simple_product( true, [ 'regular_price' => 25 ] );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		$restore       = $this->enable_adaptive_pricing();
+		$session_id    = 'cs_test_store_api_sync';
+		$request_count = 0;
+		$mock_request  = static function ( $return_value, $parsed_args, $url ) use ( &$request_count, $session_id ) {
+			if ( 'https://api.stripe.com/v1/checkout/sessions' !== $url ) {
+				return $return_value;
+			}
+
+			++$request_count;
+			return [
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => wp_json_encode(
+					(object) [
+						'id'            => $session_id,
+						'client_secret' => 'cs_test_store_api_secret',
+					]
+				),
+			];
+		};
+		add_filter( 'pre_http_request', $mock_request, 10, 3 );
+
+		try {
+			$initial_data = WC_Stripe_Checkout_Session_Lifecycle::get_store_api_data();
+
+			WC_Stripe_Checkout_Session_Lifecycle::request_store_api_sync( [ 'action' => 'sync' ] );
+			$this->assertTrue( $this->is_store_api_sync_requested() );
+
+			$data = WC_Stripe_Checkout_Session_Lifecycle::get_store_api_data();
+		} finally {
+			remove_filter( 'pre_http_request', $mock_request, 10 );
+			$restore();
+		}
+
+		$this->assertSame( 1, $request_count );
+		$this->assertSame( 'uninitialized', $initial_data['status'] );
+		$this->assertSame( '', $initial_data['session_id'] );
+		$this->assertSame( '', $initial_data['client_secret'] );
+		$this->assertSame( 0, $initial_data['revision'] );
+
+		$this->assertSame( 'success', $data['status'] );
+		$this->assertSame( $session_id, $data['session_id'] );
+		$this->assertSame( 'cs_test_store_api_secret', $data['client_secret'] );
+		$this->assertSame( 1, $data['revision'] );
+	}
+
+	/**
+	 * Only valid sync requests should trigger synchronization.
+	 *
+	 * @dataProvider provide_store_api_sync_requests
+	 *
+	 * @param array $request_data             Extension request data.
+	 * @param bool  $adaptive_pricing_enabled Whether Adaptive Pricing is enabled.
+	 * @param bool  $expected_flag_value      The expected value of the store_api_sync_requested property.
+	 */
+	public function test_request_store_api_sync_only_handles_valid_sync_requests( array $request_data, bool $adaptive_pricing_enabled, bool $expected_flag_value ): void {
+		$restore = null;
+		if ( $adaptive_pricing_enabled ) {
+			$restore = $this->enable_adaptive_pricing();
+		}
+
+		try {
+			WC_Stripe_Checkout_Session_Lifecycle::request_store_api_sync( $request_data );
+		} finally {
+			if ( null !== $restore ) {
+				$restore();
+			}
+		}
+
+		$this->assertSame( $expected_flag_value, $this->is_store_api_sync_requested() );
+	}
+
+	/**
+	 * Data provider for {@see test_request_store_api_sync_only_handles_valid_sync_requests()}.
+	 *
+	 * @return array[]
+	 */
+	public function provide_store_api_sync_requests(): array {
+		return [
+			'sync request on an eligible store'   => [ [ 'action' => 'sync' ], true, true ],
+			'sync request on an ineligible store' => [ [ 'action' => 'sync' ], false, false ],
+			'unrelated action'                    => [ [ 'action' => 'refresh' ], true, false ],
+			'no action'                           => [ [], true, false ],
+		];
+	}
+
+	public function test_store_api_data_reports_failure_when_adaptive_pricing_gets_disabled(): void {
+		$product = WC_Helper_Product::create_simple_product( true, [ 'regular_price' => 25 ] );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		$request_count = 0;
+		$mock_request  = static function ( $return_value, $parsed_args, $url ) use ( &$request_count ) {
+			if ( ! str_starts_with( $url, 'https://api.stripe.com/v1/checkout/sessions' ) ) {
+				return $return_value;
+			}
+
+			++$request_count;
+			return $return_value;
+		};
+		add_filter( 'pre_http_request', $mock_request, 10, 3 );
+
+		try {
+			// Set flag to true to mock the session having been set up previously.
+			$this->set_store_api_sync_requested( true );
+			$data = WC_Stripe_Checkout_Session_Lifecycle::get_store_api_data();
+		} finally {
+			remove_filter( 'pre_http_request', $mock_request, 10 );
+		}
+
+		$this->assertSame( 0, $request_count );
+		$this->assertSame( 'error', $data['status'] );
+		$this->assertSame( WC_Stripe_Checkout_Session_Context::get_unavailable_message(), $data['message'] );
+	}
+
+	public function test_store_api_data_reports_stripe_api_error(): void {
+		$product = WC_Helper_Product::create_simple_product( true, [ 'regular_price' => 25 ] );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		$restore = $this->enable_adaptive_pricing();
+
+		$mock_request = static function ( $return_value, $parsed_args, $url ) {
+			if ( ! str_starts_with( $url, 'https://api.stripe.com/v1/checkout/sessions' ) ) {
+				return $return_value;
+			}
+
+			return [
+				'response' => [
+					'code'    => 402,
+					'message' => 'Payment Required',
+				],
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => wp_json_encode(
+					(object) [
+						'error' => (object) [
+							'type'    => 'invalid_request_error',
+							'message' => 'Checkout Session creation was rejected.',
+						],
+					]
+				),
+			];
+		};
+		add_filter( 'pre_http_request', $mock_request, 10, 3 );
+
+		$original_logger = WC_Stripe_Logger::$logger;
+		$mock_logger     = $this->createMock( WC_Logger::class );
+		$mock_logger->expects( $this->once() )
+			->method( 'error' )
+			->with(
+				'Native Store API checkout session synchronization failed.',
+				$this->callback(
+					static function ( $context ): bool {
+						return 'Checkout Session creation was rejected.' === ( $context['error_message'] ?? '' );
+					}
+				)
+			);
+		WC_Stripe_Logger::$logger = $mock_logger;
+
+		try {
+			WC_Stripe_Checkout_Session_Lifecycle::request_store_api_sync( [ 'action' => 'sync' ] );
+			$data = WC_Stripe_Checkout_Session_Lifecycle::get_store_api_data();
+		} finally {
+			WC_Stripe_Logger::$logger = $original_logger;
+			remove_filter( 'pre_http_request', $mock_request, 10 );
+			$restore();
+		}
+
+		$this->assertSame( 'error', $data['status'] );
+		$this->assertSame( 'Checkout Session creation was rejected.', $data['message'] );
+		$this->assertSame( '', $data['client_secret'] );
 	}
 }

--- a/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
+++ b/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
@@ -1,0 +1,356 @@
+<?php
+
+/**
+ * Tests for native WooCommerce Checkout Session synchronization.
+ */
+class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
+	/**
+	 * Reset cart and session state used by the manager.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		WC()->session->init();
+		WC()->session->set( 'wc_stripe_checkout_session', null );
+		WC()->cart->empty_cart();
+	}
+
+	/**
+	 * Clean up the active Checkout Session context between tests.
+	 */
+	public function tear_down(): void {
+		$record = WC()->session->get( 'wc_stripe_checkout_session' );
+		if ( is_array( $record ) && ! empty( $record['session_id'] ) ) {
+			WC_Stripe_Checkout_Session_Context::delete_context( $record['session_id'] );
+		}
+
+		WC()->session->set( 'wc_stripe_checkout_session', null );
+		WC()->cart->empty_cart();
+		parent::tear_down();
+	}
+
+	/**
+	 * Make the store eligible for Adaptive Pricing.
+	 *
+	 * @return callable Restores the settings, transients, and services this changed.
+	 */
+	private function enable_adaptive_pricing(): callable {
+		$original_settings = WC_Stripe_Helper::get_stripe_settings();
+		$original_account  = WC_Stripe::get_instance()->account;
+
+		WC_Stripe_Helper::update_main_stripe_settings(
+			array_merge(
+				$original_settings,
+				[
+					'adaptive_pricing'           => 'yes',
+					'optimized_checkout_element' => 'yes',
+					'pmc_enabled'                => 'yes',
+					'capture'                    => 'yes',
+					'webhook_data'               => [
+						'id'     => 'we_live',
+						'secret' => 'whsec_live',
+					],
+					'test_webhook_data'          => [
+						'id'     => 'we_test',
+						'secret' => 'whsec_test',
+					],
+				]
+			)
+		);
+
+		$reflection = new ReflectionProperty( WC_Stripe::class, 'stripe_gateway' );
+		$reflection->setAccessible( true );
+		$reflection->setValue( WC_Stripe::get_instance(), null );
+
+		$webhook_status_cache_key = WC_Stripe_Test_Helper::get_class_const_value( WC_Stripe_Account::class, 'WEBHOOK_STATUS_CACHE_KEY', 'string' );
+		// is_webhook_enabled() short-circuits on a cached status, so we don't hit the Stripe API here.
+		WC_Stripe_Database_Cache::set_with_mode( $webhook_status_cache_key, 'enabled', HOUR_IN_SECONDS, 'live' );
+		WC_Stripe_Database_Cache::set_with_mode( $webhook_status_cache_key, 'enabled', HOUR_IN_SECONDS, 'test' );
+
+		$account = $this->getMockBuilder( WC_Stripe_Account::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_cached_account_data' ] )
+			->getMock();
+		$account->method( 'get_cached_account_data' )->willReturn( [ 'country' => 'US' ] );
+		WC_Stripe::get_instance()->account = $account;
+
+		// The cart-eligibility loop reads these doubles, which have no default value.
+		WC_Subscriptions_Product::set_is_subscription( false );
+		WC_Subscriptions_Product::set_subscription_product_ids( [] );
+		WC_Pre_Orders_Product::set_is_pre_order_charged_upon_release( false );
+		WC_Deposits_Product_Manager::set_deposits_enabled( false );
+
+		return function () use ( $original_settings, $original_account, $reflection, $webhook_status_cache_key ): void {
+			WC_Stripe_Helper::update_main_stripe_settings( $original_settings );
+			WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'live' );
+			WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'test' );
+			WC_Stripe::get_instance()->account = $original_account;
+			WC_Subscriptions_Product::set_is_subscription( false );
+			WC_Subscriptions_Product::set_subscription_product_ids( [] );
+			WC_Pre_Orders_Product::set_is_pre_order_charged_upon_release( false );
+			WC_Deposits_Product_Manager::set_deposits_enabled( false );
+			$reflection->setValue( WC_Stripe::get_instance(), null );
+		};
+	}
+
+	/**
+	 * Extract the JSON payload the classic fragment carries.
+	 *
+	 * @param string $fragment_html Classic fragment markup.
+	 * @return string
+	 */
+	private function get_fragment_session_data( string $fragment_html ): string {
+		preg_match( '/data-checkout-session="([^"]*)"/', $fragment_html, $matches );
+
+		return html_entity_decode( $matches[1] ?? '', ENT_QUOTES );
+	}
+
+	/**
+	 * Creation stores identifiers in the WooCommerce session and reuses them while totals are unchanged.
+	 */
+	public function test_synchronize_creates_and_reuses_session_for_unchanged_cart(): void {
+		$product = WC_Helper_Product::create_simple_product( true, [ 'regular_price' => 12.34 ] );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		$request_count = 0;
+		$session_id    = 'cs_test_native_create';
+		$mock_request  = static function ( $return_value, $parsed_args, $url ) use ( &$request_count, $session_id ) {
+			if ( 'https://api.stripe.com/v1/checkout/sessions' !== $url ) {
+				return $return_value;
+			}
+
+			++$request_count;
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => wp_json_encode(
+					(object) [
+						'id'            => $session_id,
+						'client_secret' => 'cs_test_native_secret',
+					]
+				),
+			];
+		};
+		add_filter( 'pre_http_request', $mock_request, 10, 3 );
+
+		try {
+			$manager = new WC_Stripe_Checkout_Session_Manager();
+			$created = $manager->synchronize();
+			$reused  = $manager->synchronize();
+		} finally {
+			remove_filter( 'pre_http_request', $mock_request, 10, 3 );
+		}
+
+		$this->assertSame( 1, $request_count );
+		$this->assertSame( $session_id, $created['session_id'] );
+		$this->assertSame( 'cs_test_native_secret', $created['client_secret'] );
+		$this->assertSame( 1, $created['revision'] );
+		$this->assertSame( $created, $reused );
+
+		$context = WC_Stripe_Checkout_Session_Context::get_context( $session_id );
+		$this->assertIsArray( $context );
+		$this->assertSame(
+			WC_Stripe_Helper::get_stripe_amount( (float) WC()->cart->get_total( 'edit' ), get_woocommerce_currency() ),
+			$context['amount']
+		);
+	}
+
+	/**
+	 * A later native cart total updates the server-owned session and increments its embedded revision.
+	 */
+	public function test_synchronize_updates_existing_session_after_cart_total_changes(): void {
+		$product       = WC_Helper_Product::create_simple_product( true, [ 'regular_price' => 10 ] );
+		$cart_item_key = WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		$session_id       = 'cs_test_native_update';
+		$requested_urls   = [];
+		$captured_updates = [];
+		$capture_body     = static function ( $request, $api ) use ( &$captured_updates, $session_id ) {
+			if ( "checkout/sessions/$session_id" === $api ) {
+				$captured_updates[] = $request;
+			}
+			return $request;
+		};
+		$mock_request     = static function ( $return_value, $parsed_args, $url ) use ( &$requested_urls, $session_id ) {
+			if ( false === strpos( $url, '/v1/checkout/sessions' ) ) {
+				return $return_value;
+			}
+
+			$requested_urls[] = $url;
+			$body             = [ 'id' => $session_id ];
+			if ( 'https://api.stripe.com/v1/checkout/sessions' === $url ) {
+				$body['client_secret'] = 'cs_test_native_secret';
+			}
+
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => wp_json_encode( (object) $body ),
+			];
+		};
+		add_filter( 'wc_stripe_request_body', $capture_body, 10, 2 );
+		add_filter( 'pre_http_request', $mock_request, 10, 3 );
+
+		try {
+			$manager = new WC_Stripe_Checkout_Session_Manager();
+			$manager->synchronize();
+
+			WC()->cart->set_quantity( $cart_item_key, 2 );
+			WC()->cart->calculate_totals();
+			$updated = $manager->synchronize();
+		} finally {
+			remove_filter( 'wc_stripe_request_body', $capture_body, 10, 2 );
+			remove_filter( 'pre_http_request', $mock_request, 10, 3 );
+		}
+
+		$this->assertCount( 2, $requested_urls );
+		$this->assertStringEndsWith( "/v1/checkout/sessions/$session_id", $requested_urls[1] );
+		$this->assertSame( 2, $updated['revision'] );
+		$this->assertSame( $session_id, $updated['session_id'] );
+		$this->assertCount( 1, $captured_updates );
+
+		$expected_amount = WC_Stripe_Helper::get_stripe_amount( (float) WC()->cart->get_total( 'edit' ), get_woocommerce_currency() );
+		$this->assertSame( $expected_amount, $captured_updates[0]['line_items'][0]['price_data']['unit_amount'] );
+		$this->assertSame( 1, $captured_updates[0]['line_items'][0]['quantity'] );
+	}
+
+	/**
+	 * A context that no longer matches the cart must be repaired, whatever left it behind. It is the
+	 * value validate_for_order() enforces, so a stale one fails the order with an amount mismatch.
+	 */
+	public function test_synchronize_repairs_a_context_that_drifted_from_the_cart(): void {
+		$product = WC_Helper_Product::create_simple_product( true, [ 'regular_price' => 23.04 ] );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		$session_id     = 'cs_test_drifted_context';
+		$requested_urls = [];
+		$mock_request   = static function ( $return_value, $parsed_args, $url ) use ( &$requested_urls, $session_id ) {
+			if ( false === strpos( $url, '/v1/checkout/sessions' ) ) {
+				return $return_value;
+			}
+
+			$requested_urls[] = $url;
+			$body             = [ 'id' => $session_id ];
+			if ( 'https://api.stripe.com/v1/checkout/sessions' === $url ) {
+				$body['client_secret'] = 'cs_test_drifted_secret';
+			}
+
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => wp_json_encode( (object) $body ),
+			];
+		};
+		add_filter( 'pre_http_request', $mock_request, 10, 3 );
+
+		try {
+			$manager = new WC_Stripe_Checkout_Session_Manager();
+			$manager->synchronize();
+
+			// Reproduce the drift seen in production: the context holds an amount the cart no
+			// longer has, while the cart itself is unchanged and the session looks healthy.
+			$context           = WC_Stripe_Checkout_Session_Context::get_context( $session_id );
+			$context['amount'] = 5020;
+			WC_Stripe_Checkout_Session_Context::set_context( $session_id, $context );
+
+			$manager->synchronize();
+		} finally {
+			remove_filter( 'pre_http_request', $mock_request, 10, 3 );
+		}
+
+		$this->assertCount( 2, $requested_urls, 'A drifted context must trigger a Stripe update.' );
+		$this->assertStringEndsWith( "/v1/checkout/sessions/$session_id", $requested_urls[1] );
+
+		$expected_amount = WC_Stripe_Helper::get_stripe_amount( (float) WC()->cart->get_total( 'edit' ), get_woocommerce_currency() );
+		$repaired        = WC_Stripe_Checkout_Session_Context::get_context( $session_id );
+		$this->assertSame( $expected_amount, $repaired['amount'] );
+	}
+
+	/**
+	 * Classic checkout refreshes arrive as wc-ajax requests against the home URL, so is_checkout()
+	 * is false. Eligibility must still resolve or the fragment never carries a usable session.
+	 */
+	public function test_classic_fragment_synchronizes_without_page_context(): void {
+		$this->assertFalse( is_checkout(), 'This test is only meaningful without checkout page context.' );
+
+		$product = WC_Helper_Product::create_simple_product( true, [ 'regular_price' => 25 ] );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		$session_id = 'cs_test_classic_fragment';
+		$restore    = $this->enable_adaptive_pricing();
+
+		$mock_request = static function ( $return_value, $parsed_args, $url ) use ( $session_id ) {
+			if ( 'https://api.stripe.com/v1/checkout/sessions' !== $url ) {
+				return $return_value;
+			}
+
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => wp_json_encode(
+					(object) [
+						'id'            => $session_id,
+						'client_secret' => 'cs_test_classic_secret',
+					]
+				),
+			];
+		};
+		add_filter( 'pre_http_request', $mock_request, 10, 3 );
+
+		try {
+			$lifecycle = new WC_Stripe_Checkout_Session_Lifecycle();
+			$fragments = $lifecycle->add_classic_fragment( [] );
+		} finally {
+			remove_filter( 'pre_http_request', $mock_request, 10, 3 );
+			$restore();
+		}
+
+		$this->assertArrayHasKey( '#wc-stripe-checkout-session-data', $fragments );
+
+		$data = json_decode( $this->get_fragment_session_data( $fragments['#wc-stripe-checkout-session-data'] ), true );
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'session_id', $data );
+		$this->assertSame( $session_id, $data['session_id'] );
+		$this->assertArrayHasKey( 'client_secret', $data );
+		$this->assertSame( 'cs_test_classic_secret', $data['client_secret'] );
+		$this->assertSame( 'success', $data['status'] );
+	}
+
+	/**
+	 * Lifecycle hooks expose a stable classic fragment and Store API contract.
+	 */
+	public function test_lifecycle_registers_native_checkout_contracts(): void {
+		$manager = $this->getMockBuilder( WC_Stripe_Checkout_Session_Manager::class )
+			->onlyMethods( [ 'get_current_data' ] )
+			->getMock();
+		$manager->method( 'get_current_data' )->willReturn(
+			[
+				'session_id'    => 'cs_test_embedded',
+				'client_secret' => 'cs_test_embedded_secret',
+				'revision'      => 3,
+				'status'        => 'success',
+				'message'       => '',
+			]
+		);
+
+		$lifecycle = new WC_Stripe_Checkout_Session_Lifecycle( $manager );
+		$lifecycle->init_classic_hooks();
+
+		ob_start();
+		$lifecycle->render_classic_placeholder();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'id="wc-stripe-checkout-session-data"', $html );
+		$this->assertStringContainsString( 'cs_test_embedded_secret', html_entity_decode( $html ) );
+		$this->assertNotFalse( has_filter( 'woocommerce_update_order_review_fragments', [ $lifecycle, 'add_classic_fragment' ] ) );
+
+		$schema = WC_Stripe_Checkout_Session_Lifecycle::get_store_api_schema();
+		$this->assertSame( [ 'session_id', 'client_secret', 'revision', 'status', 'message' ], array_keys( $schema ) );
+
+		remove_action( 'woocommerce_review_order_after_payment', [ $lifecycle, 'render_classic_placeholder' ] );
+		remove_filter( 'woocommerce_update_order_review_fragments', [ $lifecycle, 'add_classic_fragment' ], 20 );
+	}
+}

--- a/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
+++ b/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
@@ -177,7 +177,8 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 		$this->assertSame( 1, $request_count );
 		$this->assertSame( $session_id, $created['session_id'] );
 		$this->assertSame( 'cs_test_native_secret', $created['client_secret'] );
-		$this->assertSame( 1, $created['revision'] );
+		$this->assertIsString( $created['revision'] );
+		$this->assertNotSame( '', $created['revision'] );
 		$this->assertSame( $created, $reused );
 
 		$context = WC_Stripe_Checkout_Session_Context::get_context( $session_id );
@@ -227,7 +228,7 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 
 		try {
 			$manager = new WC_Stripe_Checkout_Session_Manager();
-			$manager->synchronize();
+			$created = $manager->synchronize();
 
 			WC()->cart->set_quantity( $cart_item_key, 2 );
 			WC()->cart->calculate_totals();
@@ -239,7 +240,8 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 
 		$this->assertCount( 2, $requested_urls );
 		$this->assertStringEndsWith( "/v1/checkout/sessions/$session_id", $requested_urls[1] );
-		$this->assertSame( 2, $updated['revision'] );
+		$this->assertNotSame( '', $updated['revision'] );
+		$this->assertNotSame( $created['revision'], $updated['revision'], 'An update must issue a new revision token.' );
 		$this->assertSame( $session_id, $updated['session_id'] );
 		$this->assertCount( 1, $captured_updates );
 
@@ -363,7 +365,7 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 			[
 				'session_id'    => 'cs_test_embedded',
 				'client_secret' => 'cs_test_embedded_secret',
-				'revision'      => 3,
+				'revision'      => 'rev_embedded',
 				'status'        => 'success',
 				'message'       => '',
 			]
@@ -531,7 +533,7 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 		$this->assertSame( 'uninitialized', $data['status'] );
 		$this->assertSame( '', $data['session_id'] );
 		$this->assertSame( '', $data['client_secret'] );
-		$this->assertSame( 0, $data['revision'] );
+		$this->assertSame( '', $data['revision'] );
 	}
 
 	public function test_store_api_data_creates_the_session_when_sync_is_requested(): void {
@@ -580,12 +582,13 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 		$this->assertSame( 'uninitialized', $initial_data['status'] );
 		$this->assertSame( '', $initial_data['session_id'] );
 		$this->assertSame( '', $initial_data['client_secret'] );
-		$this->assertSame( 0, $initial_data['revision'] );
+		$this->assertSame( '', $initial_data['revision'] );
 
 		$this->assertSame( 'success', $data['status'] );
 		$this->assertSame( $session_id, $data['session_id'] );
 		$this->assertSame( 'cs_test_store_api_secret', $data['client_secret'] );
-		$this->assertSame( 1, $data['revision'] );
+		$this->assertIsString( $data['revision'] );
+		$this->assertNotSame( '', $data['revision'] );
 	}
 
 	/**

--- a/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
+++ b/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
@@ -443,7 +443,8 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( '#wc-stripe-checkout-session-data', $fragments );
 		$data = json_decode( $this->get_fragment_session_data( $fragments['#wc-stripe-checkout-session-data'] ), true );
 		$this->assertSame( 'error', $data['status'] );
-		$this->assertSame( 'Checkout Session creation was declined.', $data['message'] );
+		// The raw Stripe message is log-only; shoppers get the curated message.
+		$this->assertSame( WC_Stripe_Checkout_Session_Manager::get_runtime_error_message(), $data['message'] );
 		$this->assertSame( '', $data['session_id'] );
 		$this->assertSame( '', $data['client_secret'] );
 
@@ -653,7 +654,7 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 
 		$this->assertSame( 0, $request_count );
 		$this->assertSame( 'error', $data['status'] );
-		$this->assertSame( WC_Stripe_Checkout_Session_Context::get_unavailable_message(), $data['message'] );
+		$this->assertSame( WC_Stripe_Checkout_Session_Manager::get_runtime_error_message(), $data['message'] );
 	}
 
 	public function test_store_api_data_reports_stripe_api_error(): void {
@@ -710,7 +711,156 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 		}
 
 		$this->assertSame( 'error', $data['status'] );
-		$this->assertSame( 'Checkout Session creation was rejected.', $data['message'] );
+		$this->assertSame( WC_Stripe_Checkout_Session_Manager::get_runtime_error_message(), $data['message'] );
 		$this->assertSame( '', $data['client_secret'] );
+	}
+
+	/**
+	 * Replace the manager singleton instance for testing purposes.
+	 *
+	 * @param WC_Stripe_Checkout_Session_Manager|null $manager Manager to install, or null so get_instance() rebuilds a real one.
+	 * @return void
+	 */
+	private function set_manager_instance( ?WC_Stripe_Checkout_Session_Manager $manager ): void {
+		$property = new ReflectionProperty( WC_Stripe_Checkout_Session_Manager::class, 'instance' );
+		$property->setAccessible( true );
+		$property->setValue( null, $manager );
+	}
+
+	/**
+	 * Build a manager instance where synchronize() will fail with the given throwable,
+	 * while mark_failed() should still be run.
+	 *
+	 * @param Throwable $error Error synchronize() should throw.
+	 * @return WC_Stripe_Checkout_Session_Manager
+	 */
+	private function get_manager_with_failing_synchronize( Throwable $error ): WC_Stripe_Checkout_Session_Manager {
+		$manager = $this->getMockBuilder( WC_Stripe_Checkout_Session_Manager::class )
+			->onlyMethods( [ 'synchronize' ] )
+			->getMock();
+		$manager->method( 'synchronize' )->willReturnCallback(
+			static function () use ( $error ): void {
+				throw $error;
+			}
+		);
+
+		return $manager;
+	}
+
+	/**
+	 * Build a logger double that requires the expected log message to be logged.
+	 *
+	 * @param string    $expected_log_message Log entry that should be logged.
+	 * @param Throwable $error                Error whose raw message content must appear in the log context.
+	 * @return WC_Logger
+	 */
+	private function get_logger_expecting_error( string $expected_log_message, Throwable $error ): WC_Logger {
+		$mock_logger = $this->createMock( WC_Logger::class );
+		$mock_logger->expects( $this->once() )
+			->method( 'error' )
+			->with(
+				$expected_log_message,
+				$this->callback(
+					static function ( $context ) use ( $error ): bool {
+						return $error->getMessage() === ( $context['error_message'] ?? '' );
+					}
+				)
+			);
+
+		return $mock_logger;
+	}
+
+	/**
+	 * The classic fragment error handling must limit messages returned to callers while logging details.
+	 *
+	 * @dataProvider provide_synchronization_failures
+	 *
+	 * @param Throwable   $error                   Error that should be thrown and handled.
+	 * @param string|null $expected_public_message Expected shopper-facing message, or null for the generic runtime error message.
+	 */
+	public function test_classic_fragment_handles_errors( Throwable $error, ?string $expected_public_message ): void {
+		$expected_message = $expected_public_message ?? WC_Stripe_Checkout_Session_Manager::get_runtime_error_message();
+		$restore          = $this->enable_adaptive_pricing();
+
+		$original_logger          = WC_Stripe_Logger::$logger;
+		WC_Stripe_Logger::$logger = $this->get_logger_expecting_error( 'Native classic checkout session synchronization failed.', $error );
+
+		try {
+			$lifecycle = new WC_Stripe_Checkout_Session_Lifecycle( $this->get_manager_with_failing_synchronize( $error ) );
+			$fragments = $lifecycle->add_classic_fragment( [] );
+		} finally {
+			WC_Stripe_Logger::$logger = $original_logger;
+			$restore();
+		}
+
+		$this->assertArrayHasKey( '#wc-stripe-checkout-session-data', $fragments );
+		$data = json_decode( $this->get_fragment_session_data( $fragments['#wc-stripe-checkout-session-data'] ), true );
+		$this->assertSame( 'error', $data['status'] );
+		$this->assertSame( $expected_message, $data['message'] );
+		foreach ( $data as $value ) {
+			if ( is_scalar( $value ) ) {
+				$this->assertStringNotContainsString( $error->getMessage(), (string) $value );
+			}
+		}
+
+		// The persisted record feeds later renders, so the masking must hold there too.
+		$record = WC()->session->get( 'wc_stripe_checkout_session' );
+		$this->assertSame( $expected_message, $record['message'] );
+	}
+
+	/**
+	 * The Store API error handling must limit messages returned to callers while logging details.
+	 *
+	 * @dataProvider provide_synchronization_failures
+	 *
+	 * @param Throwable   $error                   Error that should be thrown and handled.
+	 * @param string|null $expected_public_message Expected shopper-facing message, or null for the generic runtime error message.
+	 */
+	public function test_store_api_data_handles_errors( Throwable $error, ?string $expected_public_message ): void {
+		$expected_message = $expected_public_message ?? WC_Stripe_Checkout_Session_Manager::get_runtime_error_message();
+		$restore          = $this->enable_adaptive_pricing();
+		$this->set_store_api_sync_requested( true );
+		$this->set_manager_instance( $this->get_manager_with_failing_synchronize( $error ) );
+
+		$original_logger          = WC_Stripe_Logger::$logger;
+		WC_Stripe_Logger::$logger = $this->get_logger_expecting_error( 'Native Store API checkout session synchronization failed.', $error );
+
+		try {
+			$data = WC_Stripe_Checkout_Session_Lifecycle::get_store_api_data();
+		} finally {
+			WC_Stripe_Logger::$logger = $original_logger;
+			$this->set_manager_instance( null );
+			$restore();
+		}
+
+		$this->assertSame( 'error', $data['status'] );
+		$this->assertSame( $expected_message, $data['message'] );
+		foreach ( $data as $value ) {
+			if ( is_scalar( $value ) ) {
+				$this->assertStringNotContainsString( $error->getMessage(), (string) $value );
+			}
+		}
+	}
+
+	/**
+	 * Data provider for the error handling tests.
+	 *
+	 * @return array[]
+	 */
+	public function provide_synchronization_failures(): array {
+		return [
+			'PHP engine error is logged and masked'                               => [
+				new TypeError( 'WC_Stripe_Checkout_Session_Manager::build_line_items(): Argument #1 ($cart_context) must be of type array, null given, called in /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/includes/class-wc-stripe-checkout-session-manager.php on line 123' ),
+				null,
+			],
+			'standard Exception is logged and masked'                             => [
+				new Exception( 'SQLSTATE[HY000] [2002] Connection refused in /var/www/html/wp-content/plugins/some-plugin/includes/class-db.php:87' ),
+				null,
+			],
+			'Localised WC_Stripe_Exception is logged and shows localized message' => [
+				new WC_Stripe_Exception( 'Array ( [body] => raw Stripe response dump )', 'There was a problem sending a request to the Stripe API endpoint.' ),
+				'There was a problem sending a request to the Stripe API endpoint.',
+			],
+		];
 	}
 }

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -187,6 +187,9 @@ register_deactivation_hook( __FILE__, 'wcstripe_deactivated' );
 add_action( 'woocommerce_blocks_loaded', 'woocommerce_gateway_stripe_woocommerce_block_support' );
 
 function woocommerce_gateway_stripe_woocommerce_block_support() {
+	woocommerce_stripe_init_autoloader();
+	WC_Stripe_Checkout_Session_Lifecycle::init_store_api();
+
 	if ( class_exists( 'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) ) {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-blocks-support.php';
 		// priority is important here because this ensures this integration is


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Towards STRIPE-1312

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR updates our Checkout Sessions implementation to use existing WooCommerce extension points to handle and manage Checkout Sessions data, with the primary goal of ensuring that we can guarantee that our session management code is always using up-to-date and valid cart data from WooCommerce after any plugins have interacted with the cart. A key issue with our current implementation is that we rely on custom AJAX APIs to create and update our Checkout Sessions data, and we can't guarantee that other plugins will correctly hook into cart-related calculations that occur via those APIs. (One such incompatible pattern involves plugins that only add hooks for certain request URLs, or skip processing when the request URLs don't match their allowlist.)

From an approach perspective, the implementation for classic and block checkouts differ.
 * **Classic Checkout** - we hook into `'woocommerce_update_order_review_fragments'` to include session-related data in a custom HTML fragment that uses a data attribute to return the checkout session details to the client every time the `update_order_review` AJAX endpoint is called from classic checkout, which occurs for all relevant data changes in classic checkout
   - The client code then relies on that data to initialise the Stripe payment element from within the `checkout_updated` jQuery event/trigger
      - It's worth noting that we can't change the checkout session ID for the payment element after it has been created - @diegocurbelo helped me get this right
 * **Block Checkout** - we register an extension to the Store API Cart data that means that all Store API requests that return cart data will include the checkout session data, and we then use the related callbacks to ensure that our Checkout Session state is up to date with the cart, as well as ensuring that the client code has the data we need.
   - At present, we're currently calling `extensionCartUpdate()` with a custom action to initialise the Checkout Session, which ensures that we only initialise the checkout session in response to a valid blocks checkout context, though it does require a dedicated API request to the Store API Cart endpoint.

### Open questions or possible improvements

* Can we avoid the dedicated API request from the blocks context? We may be able to trigger initialisation of the checkout session via other hooks.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

* Run this branch on a configured store that is connected to Stripe, has Adaptive Pricing enabled, and has one or more plugins or configuration settings that manipulate the cart
 * Verify that Adaptive Pricing purchases via classic and blocks checkout complete successfully

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
