### PR TITLE
Exclude core account fields from express checkout custom-field enforcement

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -101,6 +101,7 @@ xxxx-xx-xx - version 10.9.0
 * Tweak - Use database cache for webhook status tracking
 * Dev - Add WC_Stripe::get_settings()/update_settings() as the canonical accessors for the main Stripe settings, with the WC_Stripe_Helper shims delegating to them
 * Fix - Render classic-checkout card fields when a host optimizer defers render-blocking JavaScript (e.g. SiteGround Speed Optimizer)
+* Fix - Allow express checkout payments when automatic account password generation is disabled
 
 2026-08-05 - version 10.8.5
 * Update - Improve webhook handling

--- a/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
@@ -278,6 +278,16 @@ class WC_Stripe_Express_Checkout_Custom_Fields {
 			}
 
 			foreach ( $all_fields as $fieldset => $fields ) {
+				// Core's account fieldset (account_username/account_password when
+				// auto-generation is off) is marked required unconditionally, but core
+				// only enforces it when an account is actually being created. The
+				// express sheet can never collect these values — express flows rely on
+				// auto-generated credentials — so treating them as required custom
+				// fields would block every express payment.
+				if ( 'account' === $fieldset ) {
+					continue;
+				}
+
 				foreach ( $fields as $field_key => $field ) {
 					if ( in_array( $field_key, $standard_checkout_fields, true ) ) {
 						continue;

--- a/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
@@ -278,12 +278,8 @@ class WC_Stripe_Express_Checkout_Custom_Fields {
 			}
 
 			foreach ( $all_fields as $fieldset => $fields ) {
-				// Core's account fieldset (account_username/account_password when
-				// auto-generation is off) is marked required unconditionally, but core
-				// only enforces it when an account is actually being created. The
-				// express sheet can never collect these values — express flows rely on
-				// auto-generated credentials — so treating them as required custom
-				// fields would block every express payment.
+				// Core only enforces account fields when creating an account; the
+				// express sheet can't collect them, so never treat them as required.
 				if ( 'account' === $fieldset ) {
 					continue;
 				}

--- a/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
@@ -267,7 +267,8 @@ class WC_Stripe_Express_Checkout_Custom_Fields {
 			}
 		}
 
-		// Classic checkout page
+		// Classic checkout page. This branch also feeds the cart/product merge below,
+		// where the legacy field definitions apply even on block-based stores.
 		if ( is_checkout() || 'classic' === $context ) {
 			$classic_custom_checkout_fields = [];
 			$standard_checkout_fields       = $this->get_standard_checkout_fields();
@@ -278,8 +279,9 @@ class WC_Stripe_Express_Checkout_Custom_Fields {
 			}
 
 			foreach ( $all_fields as $fieldset => $fields ) {
-				// Core only enforces account fields when creating an account; the
-				// express sheet can't collect them, so never treat them as required.
+				// Core only enforces account fields when creating an account, and the
+				// express sheet can't collect any field in this fieldset — including
+				// third-party additions — so never treat them as required.
 				if ( 'account' === $fieldset ) {
 					continue;
 				}

--- a/readme.txt
+++ b/readme.txt
@@ -258,5 +258,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Use database cache for webhook status tracking
 * Dev - Add WC_Stripe::get_settings()/update_settings() as the canonical accessors for the main Stripe settings, with the WC_Stripe_Helper shims delegating to them
 * Fix - Render classic-checkout card fields when a host optimizer defers render-blocking JavaScript (e.g. SiteGround Speed Optimizer)
+* Fix - Allow express checkout payments when automatic account password generation is disabled
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-custom-fields-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-custom-fields-test.php
@@ -458,4 +458,72 @@ class WC_Stripe_Express_Checkout_Custom_Fields_Test extends WP_UnitTestCase {
 		WC()->checkout()->checkout_fields = null;
 		WC()->checkout()->get_checkout_fields();
 	}
+
+	/**
+	 * Core's conditionally-required account fields (added when auto-generation is
+	 * off) must not be treated as merchant custom fields, while genuine custom
+	 * fields keep being detected.
+	 *
+	 * @return void
+	 */
+	public function test_get_custom_checkout_fields_classic_excludes_core_account_fields() {
+		update_option( 'woocommerce_registration_generate_username', 'no' );
+		update_option( 'woocommerce_registration_generate_password', 'no' );
+
+		$custom_checkout_fields = function ( $fields ) {
+			$fields['billing']['billing_custom_field1'] = [
+				'type'     => 'text',
+				'label'    => 'Billing Custom Field 1',
+				'required' => true,
+			];
+			return $fields;
+		};
+		add_filter( 'woocommerce_checkout_fields', $custom_checkout_fields );
+		WC()->checkout()->checkout_fields = null;
+		WC()->checkout()->get_checkout_fields();
+
+		try {
+			$fields = $this->get_custom_fields_support()->get_custom_checkout_fields( 'classic' );
+
+			$this->assertArrayNotHasKey( 'account_username', $fields );
+			$this->assertArrayNotHasKey( 'account_password', $fields );
+			$this->assertArrayHasKey( 'billing_custom_field1', $fields );
+		} finally {
+			remove_filter( 'woocommerce_checkout_fields', $custom_checkout_fields );
+			update_option( 'woocommerce_registration_generate_username', 'yes' );
+			update_option( 'woocommerce_registration_generate_password', 'yes' );
+			WC()->checkout()->checkout_fields = null;
+			WC()->checkout()->get_checkout_fields();
+		}
+	}
+
+	/**
+	 * Regression: with auto-generated passwords disabled, an express payment with
+	 * no custom-field payload must not be rejected over core's account_password
+	 * field, which the express sheet can never collect.
+	 *
+	 * @return void
+	 */
+	public function test_process_custom_checkout_data_allows_express_payment_when_password_generation_disabled() {
+		update_option( 'woocommerce_registration_generate_password', 'no' );
+		WC()->checkout()->checkout_fields = null;
+		WC()->checkout()->get_checkout_fields();
+
+		$request = new \WP_REST_Request( 'POST', '/wc/stripe-ece/v1/test-request' );
+		$request->set_param( 'extensions', [] );
+
+		$order                 = WC_Helper_Order::create_order();
+		$custom_fields_support = $this->get_custom_fields_support();
+
+		try {
+			$custom_fields_support->process_custom_checkout_data( $order, $request );
+			$this->assertTrue( true );
+		} catch ( Exception $e ) {
+			$this->fail( 'Express payment must not require account_password, but got: ' . $e->getMessage() );
+		} finally {
+			update_option( 'woocommerce_registration_generate_password', 'yes' );
+			WC()->checkout()->checkout_fields = null;
+			WC()->checkout()->get_checkout_fields();
+		}
+	}
 }

--- a/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-custom-fields-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-custom-fields-test.php
@@ -460,9 +460,7 @@ class WC_Stripe_Express_Checkout_Custom_Fields_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Core's conditionally-required account fields (added when auto-generation is
-	 * off) must not be treated as merchant custom fields, while genuine custom
-	 * fields keep being detected.
+	 * Core account fields are not custom fields; merchant fields still are.
 	 *
 	 * @return void
 	 */
@@ -498,9 +496,8 @@ class WC_Stripe_Express_Checkout_Custom_Fields_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Regression: with auto-generated passwords disabled, an express payment with
-	 * no custom-field payload must not be rejected over core's account_password
-	 * field, which the express sheet can never collect.
+	 * Regression: express payments must not require account_password when
+	 * auto-generated passwords are disabled.
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
Fixes STRIPE-1345

## Changes proposed in this Pull Request:

With **"When creating an account, automatically generate an account password" disabled** (`woocommerce_registration_generate_password = no`), every express checkout payment (Apple Pay, Google Pay, Link, Amazon Pay) fails with `wc_stripe_express_checkout_missing_required_fields` — *"Create account password is a required field."* — for any product and any user, logged-in or guest, while the same cart completes classic checkout fine. Reported in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5631#issuecomment-5249775145; regression from the custom-fields enforcement introduced in #5640 (unreleased, 10.9.0).

**Root cause.** When that option is off, WooCommerce core adds `account_password` (and `account_username`, for the equivalent username option) to `WC()->checkout()->get_checkout_fields()` with `required => true` **unconditionally** — core itself only enforces those fields when an account is actually being created. `WC_Stripe_Express_Checkout_Custom_Fields::get_custom_checkout_fields( 'classic' )` treats every non-standard field as a merchant custom field, and its exclusion list only covers address fields, phone, email, and `order_comments` — so `account_password` becomes a "required custom field" the express sheet can never collect, and `process_custom_checkout_data()` rejects every express order.

**Fix.** Skip the `account` fieldset in the classic custom-field detection. Those are core's conditional account-creation fields, not merchant custom fields, and express flows can't collect them: express checkout relies on auto-generated credentials (`is_account_creation_possible()` already hides the buttons when guest checkout is disabled and generation is off).

## Testing instructions

1. In **WooCommerce → Settings → Accounts & Privacy**, uncheck **"When creating an account, automatically generate an account password"**. Keep guest checkout enabled.
2. Enable Apple Pay/Google Pay in the Stripe settings.
3. Add any product to the cart and pay with an express checkout button (product page, cart, or checkout).
4. Before this fix: the payment sheet errors with "Create account password is a required field." After: the payment completes.
5. Regression: with a required custom checkout field added by a plugin/snippet, express checkout from a product page still directs the buyer to the checkout page (unchanged #5640 behavior).

---

-   [x] Covered with tests
-   [x] Tested on mobile (or does not apply)

### Changelog entry

Fix - Allow express checkout payments when automatic account password generation is disabled

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
