### PR TITLE
Temporarily fallback to non Checkout Session flow after an amount mismatch

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -93,6 +93,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Register Multibanco, OXXO, Boleto, Link, and Cash App Pay hooks only once per request so email instructions and thank-you page content are not duplicated
 * Fix - Resync the Agentic Commerce catalog when switching between test and live mode, and scope the sync status shown in settings to the active mode
 * Fix - Ensure that settings with checked, disabled checkboxes look disabled
+* Fix - Temporarily disable Adaptive Pricing for a customer's session after a 3rd party plugin incompatibility error
 * Dev - Register Stripe.js through a single shared helper
 * Fix - Prevent dismissed admin banner notices from reappearing after navigating between Settings and Payment Methods tabs
 * Fix - Only load the Blocks checkout stylesheet on pages that render the Cart or Checkout block, instead of on every page of the store

--- a/changelog.txt
+++ b/changelog.txt
@@ -107,6 +107,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Allow express checkout payments when automatic account password generation is disabled
 * Tweak - Add PHPDoc for some deprecated hooks
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
+* Fix - Ensure that manual Adaptive Pricing changes after upgrades get precedence
 * Fix - Exclude password-protected products and products hidden from the catalog from the Agentic Commerce feed
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
 

--- a/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
+++ b/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
@@ -138,29 +138,6 @@ describe( 'Optimized Checkout Element feature setting', () => {
 		).toBeDisabled();
 	} );
 
-	it( 'disables Adaptive Pricing and explains why when disabled due to amount mismatches', () => {
-		global.wc_stripe_settings_params = {
-			is_cs_available: true,
-			adaptive_pricing_unavailable_reason: 'amount-mismatch-detected',
-		};
-
-		useIsOCEnabled.mockReturnValue( [ true, jest.fn() ] );
-
-		render( <OptimizedCheckoutFeature isOCAvailable={ true } /> );
-
-		expect(
-			screen.getByText(
-				'Adaptive Pricing was disabled due to a plugin compatibility issue. Please contact WooCommerce support to report the issue so we can investigate the cause.'
-			)
-		).toBeInTheDocument();
-
-		expect(
-			screen.getByLabelText(
-				'Let customers pay in their local currency with Adaptive Pricing'
-			)
-		).toBeDisabled();
-	} );
-
 	it( 'triggers the hook when changing the Adaptive Pricing setting', async () => {
 		global.wc_stripe_settings_params = {
 			is_cs_available: true,

--- a/client/settings/advanced-settings-section/optimized-checkout-feature.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-feature.js
@@ -79,11 +79,6 @@ const getAdaptivePricingUnavailableText = (
 				'Adaptive Pricing requires automatic capture. It’s unavailable while "Issue an authorization on checkout, and capture later" is enabled.',
 				'woocommerce-gateway-stripe'
 			);
-		case 'amount-mismatch-detected':
-			return __(
-				'Adaptive Pricing was disabled due to a plugin compatibility issue. Please contact WooCommerce support to report the issue so we can investigate the cause.',
-				'woocommerce-gateway-stripe'
-			);
 		default:
 			return __(
 				'Adaptive Pricing is currently unavailable.',

--- a/includes/class-wc-stripe-checkout-session-context.php
+++ b/includes/class-wc-stripe-checkout-session-context.php
@@ -392,6 +392,7 @@ class WC_Stripe_Checkout_Session_Context {
 			[
 				'checkout_session_id' => $session_id,
 				'order_id'            => $order->get_id(),
+				'customer_id'         => $order->get_customer_id(),
 				'session_amount'      => $context['amount'],
 				'order_amount'        => $order_amount,
 				'session_currency'    => $context['currency'],

--- a/includes/class-wc-stripe-checkout-session-context.php
+++ b/includes/class-wc-stripe-checkout-session-context.php
@@ -387,7 +387,7 @@ class WC_Stripe_Checkout_Session_Context {
 
 		self::delete_context( $session_id );
 
-		WC_Stripe_Logger::warning(
+		WC_Stripe_Logger::error(
 			'Checkout Session amount mismatch; Session invalidated.',
 			[
 				'checkout_session_id' => $session_id,

--- a/includes/class-wc-stripe-checkout-session-context.php
+++ b/includes/class-wc-stripe-checkout-session-context.php
@@ -23,11 +23,12 @@ class WC_Stripe_Checkout_Session_Context {
 	private const MUTATION_LOCK_OPTION_PREFIX = 'wc_stripe_checkout_session_lock_';
 
 	/**
-	 * Stable marker for support/admin code to distinguish an automatic safety disable from a manual setting change.
+	 * WC session key flagging that this customer hit a Checkout Session amount mismatch, so their
+	 * later checkouts use the standard intent flow instead of Adaptive Pricing.
 	 *
 	 * @var string
 	 */
-	private const ADAPTIVE_PRICING_AMOUNT_MISMATCH_OPTION = 'wc_stripe_adaptive_pricing_session_amount_mismatch_detected';
+	private const AMOUNT_MISMATCH_SESSION_KEY = 'wc_stripe_checkout_session_amount_mismatch';
 
 	/**
 	 * WooCommerce rewrites the session customer ID when checkout creates an account.
@@ -86,12 +87,16 @@ class WC_Stripe_Checkout_Session_Context {
 	}
 
 	/**
-	 * Check if an amount mismatch was detected.
+	 * Check if the current customer session previously hit a Checkout Session amount mismatch.
 	 *
 	 * @return bool
 	 */
 	public static function was_amount_mismatch_detected(): bool {
-		return 'yes' === get_option( self::ADAPTIVE_PRICING_AMOUNT_MISMATCH_OPTION, 'no' );
+		if ( ! WC()->session || ! is_callable( [ WC()->session, 'get' ] ) ) {
+			return false;
+		}
+
+		return 'yes' === WC()->session->get( self::AMOUNT_MISMATCH_SESSION_KEY );
 	}
 
 	/**
@@ -272,7 +277,7 @@ class WC_Stripe_Checkout_Session_Context {
 			(int) ( $context['amount'] ?? 0 ) !== $order_amount
 			|| strtolower( (string) ( $context['currency'] ?? '' ) ) !== $order_currency
 		) {
-			self::disable_adaptive_pricing_after_amount_mismatch( $session_id, $order, $context, $order_amount, $order_currency );
+			self::invalidate_session_after_amount_mismatch( $session_id, $order, $context, $order_amount, $order_currency );
 
 			throw new Exception( __( 'The payment amount no longer matches the order total. Please refresh the page and try again.', 'woocommerce-gateway-stripe' ) );
 		}
@@ -366,7 +371,7 @@ class WC_Stripe_Checkout_Session_Context {
 
 	/**
 	 * A stored Checkout Session total that disagrees with the order means the store may have an
-	 * incompatible totals integration, so future shoppers should use the standard intent flow.
+	 * incompatible totals integration; invalidate the session to use the standard intent flow.
 	 *
 	 * @param string   $session_id Stripe Checkout Session ID.
 	 * @param WC_Order $order WooCommerce order.
@@ -375,19 +380,15 @@ class WC_Stripe_Checkout_Session_Context {
 	 * @param string   $order_currency Order currency.
 	 * @return void
 	 */
-	private static function disable_adaptive_pricing_after_amount_mismatch( string $session_id, WC_Order $order, array $context, $order_amount, string $order_currency ): void {
-		update_option( self::ADAPTIVE_PRICING_AMOUNT_MISMATCH_OPTION, 'yes', false );
-
-		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
-		if ( 'no' !== ( $stripe_settings['adaptive_pricing'] ?? 'no' ) ) {
-			$stripe_settings['adaptive_pricing'] = 'no';
-			WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+	private static function invalidate_session_after_amount_mismatch( string $session_id, WC_Order $order, array $context, $order_amount, string $order_currency ): void {
+		if ( WC()->session && is_callable( [ WC()->session, 'set' ] ) ) {
+			WC()->session->set( self::AMOUNT_MISMATCH_SESSION_KEY, 'yes' );
 		}
 
 		self::delete_context( $session_id );
 
 		WC_Stripe_Logger::warning(
-			'Adaptive Pricing disabled after Checkout Session amount mismatch.',
+			'Checkout Session amount mismatch; Session invalidated.',
 			[
 				'checkout_session_id' => $session_id,
 				'order_id'            => $order->get_id(),

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1263,11 +1263,6 @@ class WC_Stripe_Helper {
 			return 'webhooks-disabled';
 		}
 
-		// If Adaptive Pricing was disabled due to an amount mismatch, keep Adaptive Pricing disabled.
-		if ( WC_Stripe_Checkout_Session_Context::was_amount_mismatch_detected() ) {
-			return 'amount-mismatch-detected';
-		}
-
 		// Adaptive Pricing requires automatic capture.
 		if ( 'yes' !== ( self::get_stripe_settings()['capture'] ?? 'yes' ) ) {
 			return 'manual-capture';
@@ -1324,6 +1319,12 @@ class WC_Stripe_Helper {
 
 		// False if adaptive pricing option is disabled.
 		if ( 'yes' !== self::get_settings( null, 'adaptive_pricing' ) ) {
+			return false;
+		}
+
+		// If this customer previously hit a Checkout Session amount mismatch,
+		// disable Adaptive Pricing for the session.
+		if ( WC_Stripe_Checkout_Session_Context::was_amount_mismatch_detected() ) {
 			return false;
 		}
 

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -316,6 +316,7 @@ class WC_Stripe {
 			add_filter( 'plugin_action_links_' . plugin_basename( WC_STRIPE_MAIN_FILE ), [ $this, 'plugin_action_links' ] );
 			add_filter( 'plugin_row_meta', [ $this, 'plugin_row_meta' ], 10, 2 );
 			add_action( 'update_option_woocommerce_gateway_order', [ $this, 'set_stripe_gateways_in_list' ] );
+			add_action( 'update_option_' . self::SETTINGS_OPTION_NAME, [ $this, 'maybe_mark_adaptive_pricing_migration_complete' ], 10, 2 );
 		}
 
 		// Update the email field position.
@@ -758,6 +759,38 @@ class WC_Stripe {
 		$this->maybe_reset_stripe_in_memory_key( $settings, $old_settings );
 
 		return $this->toggle_upe( $settings, $old_settings );
+	}
+
+
+	/**
+	 * When the Adaptive Pricing amount mismatch migration is incomplete and
+	 * the merchant toggles the Adaptive Pricing setting, we need to mark the
+	 * amount mismatch migration as complete.
+	 *
+	 * @param array|false $old_settings Previous settings; false if no previous settings existed.
+	 * @param array       $settings     New settings that were saved.
+	 * @return void
+	 */
+	public function maybe_mark_adaptive_pricing_migration_complete( $old_settings, $settings ): void {
+		// Note that we tackle all in-memory checks first so we only check options when we are making relevant changes.
+		if ( ! is_array( $old_settings ) || ! is_array( $settings ) || ! isset( $settings['adaptive_pricing'] ) ) {
+			return;
+		}
+
+		$old_adaptive_pricing = $old_settings['adaptive_pricing'] ?? null;
+		$new_adaptive_pricing = $settings['adaptive_pricing'] ?? null;
+
+		if ( $old_adaptive_pricing === $new_adaptive_pricing ) {
+			return;
+		}
+
+		if ( ! WC_Stripe_Restore_Adaptive_Pricing_After_Amount_Mismatch_Update::is_migration_needed() ) {
+			return;
+		}
+
+		if ( WC_Stripe_Restore_Adaptive_Pricing_After_Amount_Mismatch_Update::delete_amount_mismatch_option() ) {
+			WC_Stripe_Restore_Adaptive_Pricing_After_Amount_Mismatch_Update::mark_migration_complete();
+		}
 	}
 
 	/**

--- a/includes/migrations/class-wc-stripe-restore-adaptive-pricing-after-amount-mismatch-update.php
+++ b/includes/migrations/class-wc-stripe-restore-adaptive-pricing-after-amount-mismatch-update.php
@@ -29,46 +29,86 @@ class WC_Stripe_Restore_Adaptive_Pricing_After_Amount_Mismatch_Update {
 	 * @return void
 	 */
 	public function maybe_migrate( $previous_version = false ): void {
-		if ( 'yes' === get_option( self::MIGRATION_FLAG_OPTION ) ) {
+		if ( self::is_migration_complete() ) {
 			return;
 		}
 
 		if ( false === $previous_version ) {
-			update_option( self::MIGRATION_FLAG_OPTION, 'yes' );
+			self::mark_migration_complete();
 			return;
 		}
 
-		if ( 'yes' !== get_option( self::AMOUNT_MISMATCH_OPTION, 'no' ) ) {
-			update_option( self::MIGRATION_FLAG_OPTION, 'yes' );
+		if ( ! self::is_migration_needed() ) {
+			self::mark_migration_complete();
 			return;
 		}
 
-		$stripe          = WC_Stripe::get_instance();
-		$stripe_settings = $stripe->get_settings();
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 
 		$stripe_settings['adaptive_pricing'] = 'yes';
-		$stripe->update_settings( $stripe_settings );
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
 		// Re-read persisted settings. Leave the migration flag unset if the update did not take effect so a later update can retry.
-		if ( 'yes' !== ( $stripe->get_settings()['adaptive_pricing'] ?? 'no' ) ) {
+		if ( 'yes' !== ( WC_Stripe_Helper::get_stripe_settings()['adaptive_pricing'] ?? 'no' ) ) {
 			return;
 		}
 
-		// A failed marker deletion must remain retryable on a later plugin update.
-		if ( ! delete_option( self::AMOUNT_MISMATCH_OPTION ) ) {
-			// If the option still exists, then return early.
-			if ( false !== get_option( self::AMOUNT_MISMATCH_OPTION, false ) ) {
-				return;
-			}
-			// Otherwise the option no longer exists, mark the migration as complete.
+		// If we can't delete the amount mismatch option, then we can't mark the migration as complete.
+		if ( ! self::delete_amount_mismatch_option() ) {
 			return;
 		}
 
-		update_option( self::MIGRATION_FLAG_OPTION, 'yes' );
+		self::mark_migration_complete();
 
 		WC_Stripe_Logger::error(
 			'Adaptive Pricing re-enabled during plugin update after a previous automatic disable caused by a Checkout Session amount mismatch.',
 			[ 'previous_version' => (string) $previous_version ]
 		);
+	}
+
+	/**
+	 * Marks the Adaptive Pricing amount mismatch migration as complete.
+	 *
+	 * @return void
+	 */
+	public static function mark_migration_complete(): void {
+		update_option( self::MIGRATION_FLAG_OPTION, 'yes' );
+	}
+
+	/**
+	 * Checks if the Adaptive Pricing amount mismatch migration has been completed.
+	 *
+	 * @return bool True if the amount mismatch migration has been completed, false otherwise.
+	 */
+	public static function is_migration_complete(): bool {
+		return 'yes' === get_option( self::MIGRATION_FLAG_OPTION );
+	}
+
+	/**
+	 * Checks if the Adaptive Pricing amount mismatch migration is needed.
+	 *
+	 * @return bool True if the amount mismatch migration is needed, false otherwise.
+	 */
+	public static function is_migration_needed(): bool {
+		if ( self::is_migration_complete() ) {
+			return false;
+		}
+
+		return 'yes' === get_option( self::AMOUNT_MISMATCH_OPTION, 'no' );
+	}
+
+	/**
+	 * Deletes the amount mismatch option if it exists.
+	 *
+	 * @return bool True if the option was deleted, false otherwise.
+	 */
+	public static function delete_amount_mismatch_option(): bool {
+		$delete_result = delete_option( self::AMOUNT_MISMATCH_OPTION );
+		if ( $delete_result ) {
+			return true;
+		}
+
+		// Check whether the option does not exist by confirming we always get the fallback value.
+		return ( false === get_option( self::AMOUNT_MISMATCH_OPTION, false ) && 'no' === get_option( self::AMOUNT_MISMATCH_OPTION, 'no' ) );
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1542,7 +1542,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			}
 		}
 
-		if ( is_string( $checkout_session_id ) && ! empty( $checkout_session_id ) && ! WC_Stripe_Checkout_Session_Context::was_amount_mismatch_detected() ) {
+		if ( is_string( $checkout_session_id ) && ! empty( $checkout_session_id ) ) {
 			return $this->process_payment_with_checkout_session( $order_id, $checkout_session_id, $save_payment_method, $selected_payment_type );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -250,6 +250,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Register Multibanco, OXXO, Boleto, Link, and Cash App Pay hooks only once per request so email instructions and thank-you page content are not duplicated
 * Fix - Resync the Agentic Commerce catalog when switching between test and live mode, and scope the sync status shown in settings to the active mode
 * Fix - Ensure that settings with checked, disabled checkboxes look disabled
+* Fix - Temporarily disable Adaptive Pricing for a customer's session after a 3rd party plugin incompatibility error
 * Dev - Register Stripe.js through a single shared helper
 * Fix - Prevent dismissed admin banner notices from reappearing after navigating between Settings and Payment Methods tabs
 * Fix - Only load the Blocks checkout stylesheet on pages that render the Cart or Checkout block

--- a/readme.txt
+++ b/readme.txt
@@ -264,6 +264,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Allow express checkout payments when automatic account password generation is disabled
 * Tweak - Add PHPDoc for some deprecated hooks
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
+* Fix - Ensure that manual Adaptive Pricing changes after upgrades get precedence
 * Fix - Exclude password-protected products and products hidden from the catalog from the Agentic Commerce feed
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
 

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -11,6 +11,13 @@ use Automattic\WooCommerce\Enums\OrderStatus;
  */
 class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	/**
+	 * Mirrors the WC session key WC_Stripe_Checkout_Session_Context uses to flag a customer amount mismatch.
+	 *
+	 * @var string
+	 */
+	private const AMOUNT_MISMATCH_SESSION_KEY = 'wc_stripe_checkout_session_amount_mismatch';
+
+	/**
 	 * @var UPE_Test_Helper
 	 */
 	private $upe_helper;
@@ -1945,10 +1952,11 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 * @param bool   $expected           Expected result.
 	 * @param string $account_country    Two-letter ISO country code for the Stripe account. Defaults to 'US'.
 	 * @param bool   $webhook_enabled    Whether the Stripe webhook endpoint is enabled. Defaults to true.
+	 * @param bool   $customer_mismatch  Whether the current customer session is flagged for a Checkout Session amount mismatch. Defaults to false.
 	 * @return void
 	 * @dataProvider provide_is_adaptive_pricing_supported
 	 */
-	public function test_is_adaptive_pricing_supported( bool $is_checkout, bool $has_block, string $adaptive_pricing, ?array $cart_product_types, bool $expected, string $account_country = 'US', bool $webhook_enabled = true ): void {
+	public function test_is_adaptive_pricing_supported( bool $is_checkout, bool $has_block, string $adaptive_pricing, ?array $cart_product_types, bool $expected, string $account_country = 'US', bool $webhook_enabled = true, bool $customer_mismatch = false ): void {
 		$original_stripe_settings                          = WC_Stripe_Helper::get_stripe_settings();
 		$new_stripe_settings                               = $original_stripe_settings;
 		$new_stripe_settings['adaptive_pricing']           = $adaptive_pricing;
@@ -1976,6 +1984,11 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		} else {
 			WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'live' );
 			WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'test' );
+		}
+
+		if ( $customer_mismatch ) {
+			WC()->session->init();
+			WC()->session->set( self::AMOUNT_MISMATCH_SESSION_KEY, 'yes' );
 		}
 
 		$is_checkout_filter = function () use ( $is_checkout ) {
@@ -2038,6 +2051,9 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		$webhook_status_cache_key = WC_Stripe_Test_Helper::get_class_const_value( WC_Stripe_Account::class, 'WEBHOOK_STATUS_CACHE_KEY', 'string' );
 		WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'live' );
 		WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'test' );
+		if ( WC()->session ) {
+			WC()->session->set( self::AMOUNT_MISMATCH_SESSION_KEY, null );
+		}
 		\WC_Subscriptions_Product::set_is_subscription( false );
 		\WC_Subscriptions_Product::set_subscription_product_ids( [] );
 		\WC_Pre_Orders_Product::set_is_pre_order_charged_upon_release( false );
@@ -2164,6 +2180,16 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'account_country'    => 'US',
 				'webhook_enabled'    => false,
 			],
+			'customer hit an amount mismatch'           => [
+				'is_checkout'        => true,
+				'has_block'          => false,
+				'adaptive_pricing'   => 'yes',
+				'cart_product_types' => [ 'simple' ],
+				'expected'           => false,
+				'account_country'    => 'US',
+				'webhook_enabled'    => true,
+				'customer_mismatch'  => true,
+			],
 		];
 	}
 
@@ -2212,7 +2238,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 * @param string  $store_currency           WooCommerce store currency code.
 	 * @param ?string $expected                 Expected return value.
 	 * @param bool    $webhook_enabled          Whether the Stripe webhook endpoint is enabled. Defaults to true.
-	 * @param bool    $amount_mismatch_detected Whether Adaptive Pricing was disabled due to amount mismatches. Defaults to false.
+	 * @param bool    $amount_mismatch_detected Whether the legacy storewide amount-mismatch marker option is set. Defaults to false.
 	 * @param bool    $manual_capture           Whether manual capture is enabled. Defaults to false.
 	 * @return void
 	 * @dataProvider provide_test_get_adaptive_pricing_account_unavailable_reason
@@ -2438,7 +2464,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'expected'        => 'webhooks-disabled',
 				'webhook_enabled' => false,
 			],
-			'Live mode, disabled due to amount mismatch → amount-mismatch-detected'         => [
+			'Live mode, stale amount-mismatch marker is ignored → null'                     => [
 				'account_data'             => [
 					'country'           => 'US',
 					'external_accounts' => [
@@ -2449,11 +2475,11 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				],
 				'test_mode'                => false,
 				'store_currency'           => 'USD',
-				'expected'                 => 'amount-mismatch-detected',
+				'expected'                 => null,
 				'webhook_enabled'          => true,
 				'amount_mismatch_detected' => true,
 			],
-			'Test mode, disabled due to amount mismatches → amount-mismatches-encountered (gate applies before test mode)' => [
+			'Test mode, stale amount-mismatch marker is ignored → null'                     => [
 				'account_data'             => [
 					'country'           => 'US',
 					'external_accounts' => [
@@ -2462,37 +2488,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				],
 				'test_mode'                => true,
 				'store_currency'           => 'USD',
-				'expected'                 => 'amount-mismatch-detected',
-				'webhook_enabled'          => true,
-				'amount_mismatch_detected' => true,
-			],
-			'Webhooks disabled takes precedence over amount mismatches → webhooks-disabled' => [
-				'account_data'             => [
-					'country'           => 'US',
-					'external_accounts' => [
-						'data' => [
-							[ 'currency' => 'usd' ],
-						],
-					],
-				],
-				'test_mode'                => false,
-				'store_currency'           => 'USD',
-				'expected'                 => 'webhooks-disabled',
-				'webhook_enabled'          => false,
-				'amount_mismatch_detected' => true,
-			],
-			'India account takes precedence over amount mismatches → account-country'       => [
-				'account_data'             => [
-					'country'           => 'IN',
-					'external_accounts' => [
-						'data' => [
-							[ 'currency' => 'inr' ],
-						],
-					],
-				],
-				'test_mode'                => false,
-				'store_currency'           => 'USD',
-				'expected'                 => 'account-country',
+				'expected'                 => null,
 				'webhook_enabled'          => true,
 				'amount_mismatch_detected' => true,
 			],

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -2238,7 +2238,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 * @param string  $store_currency           WooCommerce store currency code.
 	 * @param ?string $expected                 Expected return value.
 	 * @param bool    $webhook_enabled          Whether the Stripe webhook endpoint is enabled. Defaults to true.
-	 * @param bool    $amount_mismatch_detected Whether the legacy storewide amount-mismatch marker option is set. Defaults to false.
+	 * @param bool    $amount_mismatch_detected Whether the legacy amount-mismatch marker option is set. Defaults to false.
 	 * @param bool    $manual_capture           Whether manual capture is enabled. Defaults to false.
 	 * @return void
 	 * @dataProvider provide_test_get_adaptive_pricing_account_unavailable_reason

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -11,13 +11,6 @@ use Automattic\WooCommerce\Enums\OrderStatus;
  */
 class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	/**
-	 * Mirrors the WC session key WC_Stripe_Checkout_Session_Context uses to flag a customer amount mismatch.
-	 *
-	 * @var string
-	 */
-	private const AMOUNT_MISMATCH_SESSION_KEY = 'wc_stripe_checkout_session_amount_mismatch';
-
-	/**
 	 * @var UPE_Test_Helper
 	 */
 	private $upe_helper;
@@ -1988,7 +1981,8 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 
 		if ( $customer_mismatch ) {
 			WC()->session->init();
-			WC()->session->set( self::AMOUNT_MISMATCH_SESSION_KEY, 'yes' );
+			$amount_mismatch_session_key = WC_Stripe_Test_Helper::get_class_const_value( WC_Stripe_Checkout_Session_Context::class, 'AMOUNT_MISMATCH_SESSION_KEY', 'string' );
+			WC()->session->set( $amount_mismatch_session_key, 'yes' );
 		}
 
 		$is_checkout_filter = function () use ( $is_checkout ) {
@@ -2052,7 +2046,8 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'live' );
 		WC_Stripe_Database_Cache::delete_with_mode( $webhook_status_cache_key, 'test' );
 		if ( WC()->session ) {
-			WC()->session->set( self::AMOUNT_MISMATCH_SESSION_KEY, null );
+			$amount_mismatch_session_key = WC_Stripe_Test_Helper::get_class_const_value( WC_Stripe_Checkout_Session_Context::class, 'AMOUNT_MISMATCH_SESSION_KEY', 'string' );
+			WC()->session->set( $amount_mismatch_session_key, null );
 		}
 		\WC_Subscriptions_Product::set_is_subscription( false );
 		\WC_Subscriptions_Product::set_subscription_product_ids( [] );

--- a/tests/phpunit/class-wc-stripe-test.php
+++ b/tests/phpunit/class-wc-stripe-test.php
@@ -982,6 +982,10 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			$expect_marked ? 'yes' : ( $flag_before ?? false ),
 			get_option( $flag_option )
 		);
+		$this->assertSame(
+			$expect_marked ? false : ( $amount_mismatch_before ?? false ),
+			get_option( $amount_mismatch_option, false )
+		);
 	}
 
 	/**

--- a/tests/phpunit/class-wc-stripe-test.php
+++ b/tests/phpunit/class-wc-stripe-test.php
@@ -929,6 +929,161 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		];
 	}
 
+	/**
+	 * Toggling the Adaptive Pricing setting marks the amount mismatch migration as
+	 * complete, so a later plugin update cannot override the merchant's explicit choice.
+	 *
+	 * @param array|false $old_value              Previous option value passed by the hook.
+	 * @param array|false $new_value              New option value passed by the hook.
+	 * @param string|null $flag_before            Migration flag stored before the update; null when absent.
+	 * @param string|null $amount_mismatch_before Amount mismatch option stored before the update; null when absent.
+	 * @param bool        $expect_marked Whether the migration should be marked complete.
+	 *
+	 * @dataProvider provide_test_maybe_mark_adaptive_pricing_migration_complete
+	 */
+	public function test_maybe_mark_adaptive_pricing_migration_complete( $old_value, $new_value, ?string $flag_before, ?string $amount_mismatch_before, bool $expect_marked ): void {
+		$flag_option = $this->get_adaptive_pricing_migration_flag_option_name();
+
+		if ( null === $flag_before ) {
+			delete_option( $flag_option );
+		} else {
+			update_option( $flag_option, $flag_before );
+		}
+
+		$amount_mismatch_option = WC_Stripe_Test_Helper::get_class_const_value(
+			WC_Stripe_Restore_Adaptive_Pricing_After_Amount_Mismatch_Update::class,
+			'AMOUNT_MISMATCH_OPTION',
+			'string'
+		);
+		if ( null === $amount_mismatch_before ) {
+			delete_option( $amount_mismatch_option );
+		} else {
+			update_option( $amount_mismatch_option, $amount_mismatch_before );
+		}
+
+		// mark_migration_complete() is a static call, so observe it through the
+		// pre_update_option filter its update_option() always applies — the stored
+		// value alone cannot distinguish "left at yes" from "redundantly re-written".
+		$mark_migration_complete_calls = 0;
+		$mark_migration_complete_spy   = function ( $value ) use ( &$mark_migration_complete_calls ) {
+			++$mark_migration_complete_calls;
+			return $value;
+		};
+		add_filter( 'pre_update_option_' . $flag_option, $mark_migration_complete_spy );
+
+		try {
+			do_action( 'update_option_' . WC_Stripe::SETTINGS_OPTION_NAME, $old_value, $new_value, WC_Stripe::SETTINGS_OPTION_NAME );
+		} finally {
+			remove_filter( 'pre_update_option_' . $flag_option, $mark_migration_complete_spy );
+		}
+
+		$this->assertSame( $expect_marked ? 1 : 0, $mark_migration_complete_calls );
+		$this->assertSame(
+			$expect_marked ? 'yes' : ( $flag_before ?? false ),
+			get_option( $flag_option )
+		);
+	}
+
+	/**
+	 * Data provider for {@see test_maybe_mark_adaptive_pricing_migration_complete()}.
+	 *
+	 * @return array
+	 */
+	public function provide_test_maybe_mark_adaptive_pricing_migration_complete(): array {
+		return [
+			'AP enabled, migration incomplete'       => [
+				'old_value'              => [ 'adaptive_pricing' => 'no' ],
+				'new_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'flag_before'            => null,
+				'amount_mismatch_before' => 'yes',
+				'expect_marked'          => true,
+			],
+			'AP disabled, migration incomplete'      => [
+				'old_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'new_value'              => [ 'adaptive_pricing' => 'no' ],
+				'flag_before'            => null,
+				'amount_mismatch_before' => 'yes',
+				'expect_marked'          => true,
+			],
+			'AP set for the first time'              => [
+				'old_value'              => [ 'enabled' => 'yes' ],
+				'new_value'              => [ 'adaptive_pricing' => 'no' ],
+				'flag_before'            => null,
+				'amount_mismatch_before' => 'yes',
+				'expect_marked'          => true,
+			],
+			'AP unchanged'                           => [
+				'old_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'new_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'flag_before'            => null,
+				'amount_mismatch_before' => 'yes',
+				'expect_marked'          => false,
+			],
+			'new value missing the AP key'           => [
+				'old_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'new_value'              => [ 'enabled' => 'yes' ],
+				'flag_before'            => null,
+				'amount_mismatch_before' => 'yes',
+				'expect_marked'          => false,
+			],
+			'old value not an array'                 => [
+				'old_value'              => false,
+				'new_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'flag_before'            => null,
+				'amount_mismatch_before' => 'yes',
+				'expect_marked'          => false,
+			],
+			'new value not an array'                 => [
+				'old_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'new_value'              => false,
+				'flag_before'            => null,
+				'amount_mismatch_before' => 'yes',
+				'expect_marked'          => false,
+			],
+			'migration already complete, AP toggled' => [
+				'old_value'              => [ 'adaptive_pricing' => 'no' ],
+				'new_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'flag_before'            => 'yes',
+				'amount_mismatch_before' => 'yes',
+				'expect_marked'          => false,
+			],
+			'non-yes flag is treated as incomplete'  => [
+				'old_value'              => [ 'adaptive_pricing' => 'no' ],
+				'new_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'flag_before'            => 'no',
+				'amount_mismatch_before' => 'yes',
+				'expect_marked'          => true,
+			],
+			'AP enabled, migration not needed'       => [
+				'old_value'              => [ 'adaptive_pricing' => 'no' ],
+				'new_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'flag_before'            => null,
+				'amount_mismatch_before' => null,
+				'expect_marked'          => false,
+			],
+			'AP disabled, migration not needed'      => [
+				'old_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'new_value'              => [ 'adaptive_pricing' => 'no' ],
+				'flag_before'            => null,
+				'amount_mismatch_before' => 'no',
+				'expect_marked'          => false,
+			],
+		];
+	}
+
+	/**
+	 * Helper: resolve the migration flag option name from the migration class's private const.
+	 *
+	 * @return string
+	 */
+	private function get_adaptive_pricing_migration_flag_option_name(): string {
+		return WC_Stripe_Test_Helper::get_class_const_value(
+			WC_Stripe_Restore_Adaptive_Pricing_After_Amount_Mismatch_Update::class,
+			'MIGRATION_FLAG_OPTION',
+			'string'
+		);
+	}
+
 	/* -----------------------------------------------------------------
 	 * Plugin initialization guards
 	 *
@@ -1013,6 +1168,7 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			[ 'woocommerce_init', 'initialize_agentic_commerce', 10 ],
 			[ 'wc_payment_gateways_initialized', 'maybe_toggle_payment_methods', 10 ],
 			[ 'update_option_woocommerce_stripe_settings', 'maybe_reconfigure_webhooks_after_adaptive_pricing_enabled', 10 ],
+			[ 'update_option_woocommerce_stripe_settings', 'maybe_mark_adaptive_pricing_migration_complete', 10 ],
 		];
 
 		$first = WC_Stripe::get_instance();

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -14,13 +14,6 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	private const ADAPTIVE_PRICING_AMOUNT_MISMATCH_OPTION = 'wc_stripe_adaptive_pricing_session_amount_mismatch_detected';
 
 	/**
-	 * Asserts the exact persisted WC session flag without exposing a production setter only for tests.
-	 *
-	 * @var string
-	 */
-	private const AMOUNT_MISMATCH_SESSION_KEY = 'wc_stripe_checkout_session_amount_mismatch';
-
-	/**
 	 * Mock UPE Gateway
 	 *
 	 * @var WC_Stripe_UPE_Payment_Gateway
@@ -242,7 +235,8 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		delete_option( self::ADAPTIVE_PRICING_AMOUNT_MISMATCH_OPTION );
 
 		if ( WC()->session ) {
-			WC()->session->set( self::AMOUNT_MISMATCH_SESSION_KEY, null );
+			$amount_mismatch_session_key = WC_Stripe_Test_Helper::get_class_const_value( WC_Stripe_Checkout_Session_Context::class, 'AMOUNT_MISMATCH_SESSION_KEY', 'string' );
+			WC()->session->set( $amount_mismatch_session_key, null );
 		}
 
 		// The tests in this file do not mock ALL the calls to the Stripe API, and as we use mocked API keys they trigger the 401 rate-limiter,
@@ -2184,7 +2178,8 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			unset( $_POST['wc_stripe_checkout_session_id'], $_POST['payment_method'], $_POST['wc-stripe-payment-method'] );
 			WC_Stripe_Helper::update_main_stripe_settings( $original_stripe_settings );
 			delete_option( self::ADAPTIVE_PRICING_AMOUNT_MISMATCH_OPTION );
-			WC()->session->set( self::AMOUNT_MISMATCH_SESSION_KEY, null );
+			$amount_mismatch_session_key = WC_Stripe_Test_Helper::get_class_const_value( WC_Stripe_Checkout_Session_Context::class, 'AMOUNT_MISMATCH_SESSION_KEY', 'string' );
+			WC()->session->set( $amount_mismatch_session_key, null );
 		}
 
 		$this->assertSame( 'failure', $result['result'] );

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -2150,8 +2150,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
-	 * A Checkout Session amount mismatch fails only that checkout: the Session is invalidated and
-	 * the customer session is flagged, while storewide settings and the legacy marker stay untouched.
+	 * A Checkout Session amount mismatch fails only that checkout: the Session is invalidated and the customer session is flagged.
 	 */
 	public function test_process_payment_with_checkout_session_rejects_amount_mismatch() {
 		$session_id       = 'cs_test_amount_mismatch';

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -14,6 +14,13 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	private const ADAPTIVE_PRICING_AMOUNT_MISMATCH_OPTION = 'wc_stripe_adaptive_pricing_session_amount_mismatch_detected';
 
 	/**
+	 * Asserts the exact persisted WC session flag without exposing a production setter only for tests.
+	 *
+	 * @var string
+	 */
+	private const AMOUNT_MISMATCH_SESSION_KEY = 'wc_stripe_checkout_session_amount_mismatch';
+
+	/**
 	 * Mock UPE Gateway
 	 *
 	 * @var WC_Stripe_UPE_Payment_Gateway
@@ -233,6 +240,10 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	public function tear_down() {
 		delete_option( WC_Stripe_Feature_Flags::AMAZON_PAY_FEATURE_FLAG_NAME );
 		delete_option( self::ADAPTIVE_PRICING_AMOUNT_MISMATCH_OPTION );
+
+		if ( WC()->session ) {
+			WC()->session->set( self::AMOUNT_MISMATCH_SESSION_KEY, null );
+		}
 
 		// The tests in this file do not mock ALL the calls to the Stripe API, and as we use mocked API keys they trigger the 401 rate-limiter,
 		// this is not a problem for these tests as they don't depend on the reponses.
@@ -2139,7 +2150,8 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
-	 * Checkout Session payment processing rejects sessions whose amount no longer matches the order total.
+	 * A Checkout Session amount mismatch fails only that checkout: the Session is invalidated and
+	 * the customer session is flagged, while storewide settings and the legacy marker stay untouched.
 	 */
 	public function test_process_payment_with_checkout_session_rejects_amount_mismatch() {
 		$session_id       = 'cs_test_amount_mismatch';
@@ -2163,20 +2175,25 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		$this->store_checkout_session_context_for_order( $session_id, $order, [ 'amount' => 100 ] );
 
 		try {
-			$result                   = $this->mock_gateway->process_payment( $order->get_id() );
-			$adaptive_pricing_setting = WC_Stripe_Helper::get_settings( null, 'adaptive_pricing' );
-			$mismatch_detected        = WC_Stripe_Checkout_Session_Context::was_amount_mismatch_detected();
+			$result                     = $this->mock_gateway->process_payment( $order->get_id() );
+			$adaptive_pricing_setting   = WC_Stripe_Helper::get_settings( null, 'adaptive_pricing' );
+			$customer_mismatch_detected = WC_Stripe_Checkout_Session_Context::was_amount_mismatch_detected();
+			$legacy_marker_option       = get_option( self::ADAPTIVE_PRICING_AMOUNT_MISMATCH_OPTION, 'no' );
+			$remaining_context          = WC_Stripe_Checkout_Session_Context::get_context( $session_id );
 		} finally {
 			WC_Stripe_Checkout_Session_Context::delete_context( $session_id );
 			unset( $_POST['wc_stripe_checkout_session_id'], $_POST['payment_method'], $_POST['wc-stripe-payment-method'] );
 			WC_Stripe_Helper::update_main_stripe_settings( $original_stripe_settings );
 			delete_option( self::ADAPTIVE_PRICING_AMOUNT_MISMATCH_OPTION );
+			WC()->session->set( self::AMOUNT_MISMATCH_SESSION_KEY, null );
 		}
 
 		$this->assertSame( 'failure', $result['result'] );
 		$this->assertSame( $expected_message, $result['message'] );
-		$this->assertSame( 'no', $adaptive_pricing_setting );
-		$this->assertTrue( $mismatch_detected );
+		$this->assertSame( 'yes', $adaptive_pricing_setting );
+		$this->assertSame( 'no', $legacy_marker_option );
+		$this->assertTrue( $customer_mismatch_detected );
+		$this->assertNull( $remaining_context );
 		$this->assert_checkout_session_failure_notice( $expected_message );
 		$this->assertEmpty(
 			WC_Stripe_Order_Helper::get_instance()->get_stripe_checkout_session_id( wc_get_order( $order->get_id() ) )


### PR DESCRIPTION
Fixes STRIPE-1312

## Changes proposed in this Pull Request:

As a follow-up of #5799 and the CS/AP `WC_Stripe_Checkout_Session_Context::validate_for_order()` incompatibility issues with 3rd party plugins from `10.8.x` this PR adds a temporally fallback to the payment intent flow when a mismatch/incompatibility is detected to avoid a second retry error.

#5799 fixed the underlying incompatibility problem, but we discussed including this fallback as a preemptive workaround.

## Testing instructions

Code review should be enough

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
