### PR TITLE
Ensure Adaptive Pricing settings changes bypass amount mismatch migration

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -107,6 +107,7 @@ xxxx-xx-xx - version 10.9.0
 * Fix - Allow express checkout payments when automatic account password generation is disabled
 * Tweak - Add PHPDoc for some deprecated hooks
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
+* Fix - Ensure that manual Adaptive Pricing changes after upgrades get precedence
 
 2026-08-05 - version 10.8.5
 * Update - Improve webhook handling

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -316,6 +316,7 @@ class WC_Stripe {
 			add_filter( 'plugin_action_links_' . plugin_basename( WC_STRIPE_MAIN_FILE ), [ $this, 'plugin_action_links' ] );
 			add_filter( 'plugin_row_meta', [ $this, 'plugin_row_meta' ], 10, 2 );
 			add_action( 'update_option_woocommerce_gateway_order', [ $this, 'set_stripe_gateways_in_list' ] );
+			add_action( 'update_option_' . self::SETTINGS_OPTION_NAME, [ $this, 'maybe_mark_adaptive_pricing_migration_complete' ], 10, 2 );
 		}
 
 		// Update the email field position.
@@ -758,6 +759,37 @@ class WC_Stripe {
 		$this->maybe_reset_stripe_in_memory_key( $settings, $old_settings );
 
 		return $this->toggle_upe( $settings, $old_settings );
+	}
+
+
+	/**
+	 * When the Adaptive Pricing amount mismatch migration is incomplete and
+	 * the merchant toggles the Adaptive Pricing setting, we need to mark the
+	 * amount mismatch migration as complete.
+	 *
+	 * @param array|false $old_settings Previous settings; false if no previous settings existed.
+	 * @param array       $settings     New settings that were saved.
+	 * @return void
+	 */
+	public function maybe_mark_adaptive_pricing_migration_complete( $old_settings, $settings ): void {
+		// Note that we tackle all in-memory checks first so we only check options when we are making relevant changes.
+		if ( ! is_array( $old_settings ) || ! is_array( $settings ) || ! isset( $settings['adaptive_pricing'] ) ) {
+			return;
+		}
+
+		$old_adaptive_pricing = $old_settings['adaptive_pricing'] ?? null;
+		$new_adaptive_pricing = $settings['adaptive_pricing'] ?? null;
+
+		if ( $old_adaptive_pricing === $new_adaptive_pricing ) {
+			return;
+		}
+
+		if ( ! WC_Stripe_Restore_Adaptive_Pricing_After_Amount_Mismatch_Update::is_migration_needed() ) {
+			return;
+		}
+
+		// The merchant is changing the Adaptive Pricing setting, so we need to mark the amount mismatch migration as complete.
+		WC_Stripe_Restore_Adaptive_Pricing_After_Amount_Mismatch_Update::mark_migration_complete();
 	}
 
 	/**

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -788,8 +788,9 @@ class WC_Stripe {
 			return;
 		}
 
-		// The merchant is changing the Adaptive Pricing setting, so we need to mark the amount mismatch migration as complete.
-		WC_Stripe_Restore_Adaptive_Pricing_After_Amount_Mismatch_Update::mark_migration_complete();
+		if ( WC_Stripe_Restore_Adaptive_Pricing_After_Amount_Mismatch_Update::delete_amount_mismatch_option() ) {
+			WC_Stripe_Restore_Adaptive_Pricing_After_Amount_Mismatch_Update::mark_migration_complete();
+		}
 	}
 
 	/**

--- a/includes/migrations/class-wc-stripe-restore-adaptive-pricing-after-amount-mismatch-update.php
+++ b/includes/migrations/class-wc-stripe-restore-adaptive-pricing-after-amount-mismatch-update.php
@@ -29,28 +29,27 @@ class WC_Stripe_Restore_Adaptive_Pricing_After_Amount_Mismatch_Update {
 	 * @return void
 	 */
 	public function maybe_migrate( $previous_version = false ): void {
-		if ( 'yes' === get_option( self::MIGRATION_FLAG_OPTION ) ) {
+		if ( self::is_migration_complete() ) {
 			return;
 		}
 
 		if ( false === $previous_version ) {
-			update_option( self::MIGRATION_FLAG_OPTION, 'yes' );
+			self::mark_migration_complete();
 			return;
 		}
 
-		if ( 'yes' !== get_option( self::AMOUNT_MISMATCH_OPTION, 'no' ) ) {
-			update_option( self::MIGRATION_FLAG_OPTION, 'yes' );
+		if ( ! self::is_migration_needed() ) {
+			self::mark_migration_complete();
 			return;
 		}
 
-		$stripe          = WC_Stripe::get_instance();
-		$stripe_settings = $stripe->get_settings();
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 
 		$stripe_settings['adaptive_pricing'] = 'yes';
-		$stripe->update_settings( $stripe_settings );
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
 		// Re-read persisted settings. Leave the migration flag unset if the update did not take effect so a later update can retry.
-		if ( 'yes' !== ( $stripe->get_settings()['adaptive_pricing'] ?? 'no' ) ) {
+		if ( 'yes' !== ( WC_Stripe_Helper::get_stripe_settings()['adaptive_pricing'] ?? 'no' ) ) {
 			return;
 		}
 
@@ -61,14 +60,44 @@ class WC_Stripe_Restore_Adaptive_Pricing_After_Amount_Mismatch_Update {
 				return;
 			}
 			// Otherwise the option no longer exists, mark the migration as complete.
-			return;
 		}
 
-		update_option( self::MIGRATION_FLAG_OPTION, 'yes' );
+		self::mark_migration_complete();
 
 		WC_Stripe_Logger::error(
 			'Adaptive Pricing re-enabled during plugin update after a previous automatic disable caused by a Checkout Session amount mismatch.',
 			[ 'previous_version' => (string) $previous_version ]
 		);
+	}
+
+	/**
+	 * Marks the Adaptive Pricing amount mismatch migration as complete.
+	 *
+	 * @return void
+	 */
+	public static function mark_migration_complete(): void {
+		update_option( self::MIGRATION_FLAG_OPTION, 'yes' );
+	}
+
+	/**
+	 * Checks if the Adaptive Pricing amount mismatch migration has been completed.
+	 *
+	 * @return bool True if the amount mismatch migration has been completed, false otherwise.
+	 */
+	public static function is_migration_complete(): bool {
+		return 'yes' === get_option( self::MIGRATION_FLAG_OPTION );
+	}
+
+	/**
+	 * Checks if the Adaptive Pricing amount mismatch migration is needed.
+	 *
+	 * @return bool True if the amount mismatch migration is needed, false otherwise.
+	 */
+	public static function is_migration_needed(): bool {
+		if ( self::is_migration_complete() ) {
+			return false;
+		}
+
+		return 'yes' === get_option( self::AMOUNT_MISMATCH_OPTION, 'no' );
 	}
 }

--- a/includes/migrations/class-wc-stripe-restore-adaptive-pricing-after-amount-mismatch-update.php
+++ b/includes/migrations/class-wc-stripe-restore-adaptive-pricing-after-amount-mismatch-update.php
@@ -53,13 +53,9 @@ class WC_Stripe_Restore_Adaptive_Pricing_After_Amount_Mismatch_Update {
 			return;
 		}
 
-		// A failed marker deletion must remain retryable on a later plugin update.
-		if ( ! delete_option( self::AMOUNT_MISMATCH_OPTION ) ) {
-			// If the option still exists, then return early.
-			if ( false !== get_option( self::AMOUNT_MISMATCH_OPTION, false ) ) {
-				return;
-			}
-			// Otherwise the option no longer exists, mark the migration as complete.
+		// If we can't delete the amount mismatch option, then we can't mark the migration as complete.
+		if ( ! self::delete_amount_mismatch_option() ) {
+			return;
 		}
 
 		self::mark_migration_complete();
@@ -99,5 +95,20 @@ class WC_Stripe_Restore_Adaptive_Pricing_After_Amount_Mismatch_Update {
 		}
 
 		return 'yes' === get_option( self::AMOUNT_MISMATCH_OPTION, 'no' );
+	}
+
+	/**
+	 * Deletes the amount mismatch option if it exists.
+	 *
+	 * @return bool True if the option was deleted, false otherwise.
+	 */
+	public static function delete_amount_mismatch_option(): bool {
+		$delete_result = delete_option( self::AMOUNT_MISMATCH_OPTION );
+		if ( $delete_result ) {
+			return true;
+		}
+
+		// Check whether the option does not exist by confirming we always get the fallback value.
+		return ( false === get_option( self::AMOUNT_MISMATCH_OPTION, false ) && 'no' === get_option( self::AMOUNT_MISMATCH_OPTION, 'no' ) );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -264,5 +264,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Allow express checkout payments when automatic account password generation is disabled
 * Tweak - Add PHPDoc for some deprecated hooks
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
+* Fix - Ensure that manual Adaptive Pricing changes after upgrades get precedence
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-test.php
+++ b/tests/phpunit/class-wc-stripe-test.php
@@ -929,6 +929,161 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		];
 	}
 
+	/**
+	 * Toggling the Adaptive Pricing setting marks the amount mismatch migration as
+	 * complete, so a later plugin update cannot override the merchant's explicit choice.
+	 *
+	 * @param array|false $old_value              Previous option value passed by the hook.
+	 * @param array|false $new_value              New option value passed by the hook.
+	 * @param string|null $flag_before            Migration flag stored before the update; null when absent.
+	 * @param string|null $amount_mismatch_before Amount mismatch option stored before the update; null when absent.
+	 * @param bool        $expect_marked Whether the migration should be marked complete.
+	 *
+	 * @dataProvider provide_test_maybe_mark_adaptive_pricing_migration_complete
+	 */
+	public function test_maybe_mark_adaptive_pricing_migration_complete( $old_value, $new_value, ?string $flag_before, ?string $amount_mismatch_before, bool $expect_marked ): void {
+		$flag_option = $this->get_adaptive_pricing_migration_flag_option_name();
+
+		if ( null === $flag_before ) {
+			delete_option( $flag_option );
+		} else {
+			update_option( $flag_option, $flag_before );
+		}
+
+		$amount_mismatch_option = WC_Stripe_Test_Helper::get_class_const_value(
+			WC_Stripe_Restore_Adaptive_Pricing_After_Amount_Mismatch_Update::class,
+			'AMOUNT_MISMATCH_OPTION',
+			'string'
+		);
+		if ( null === $amount_mismatch_before ) {
+			delete_option( $amount_mismatch_option );
+		} else {
+			update_option( $amount_mismatch_option, $amount_mismatch_before );
+		}
+
+		// mark_migration_complete() is a static call, so observe it through the
+		// pre_update_option filter its update_option() always applies — the stored
+		// value alone cannot distinguish "left at yes" from "redundantly re-written".
+		$mark_migration_complete_calls = 0;
+		$mark_migration_complete_spy   = function ( $value ) use ( &$mark_migration_complete_calls ) {
+			++$mark_migration_complete_calls;
+			return $value;
+		};
+		add_filter( 'pre_update_option_' . $flag_option, $mark_migration_complete_spy );
+
+		try {
+			do_action( 'update_option_' . WC_Stripe::SETTINGS_OPTION_NAME, $old_value, $new_value, WC_Stripe::SETTINGS_OPTION_NAME );
+		} finally {
+			remove_filter( 'pre_update_option_' . $flag_option, $mark_migration_complete_spy );
+		}
+
+		$this->assertSame( $expect_marked ? 1 : 0, $mark_migration_complete_calls );
+		$this->assertSame(
+			$expect_marked ? 'yes' : ( $flag_before ?? false ),
+			get_option( $flag_option )
+		);
+	}
+
+	/**
+	 * Data provider for {@see test_maybe_mark_adaptive_pricing_migration_complete()}.
+	 *
+	 * @return array
+	 */
+	public function provide_test_maybe_mark_adaptive_pricing_migration_complete(): array {
+		return [
+			'AP enabled, migration incomplete'       => [
+				'old_value'              => [ 'adaptive_pricing' => 'no' ],
+				'new_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'flag_before'            => null,
+				'amount_mismatch_before' => 'yes',
+				'expect_marked'          => true,
+			],
+			'AP disabled, migration incomplete'      => [
+				'old_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'new_value'              => [ 'adaptive_pricing' => 'no' ],
+				'flag_before'            => null,
+				'amount_mismatch_before' => 'yes',
+				'expect_marked'          => true,
+			],
+			'AP set for the first time'              => [
+				'old_value'              => [ 'enabled' => 'yes' ],
+				'new_value'              => [ 'adaptive_pricing' => 'no' ],
+				'flag_before'            => null,
+				'amount_mismatch_before' => 'yes',
+				'expect_marked'          => true,
+			],
+			'AP unchanged'                           => [
+				'old_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'new_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'flag_before'            => null,
+				'amount_mismatch_before' => 'yes',
+				'expect_marked'          => false,
+			],
+			'new value missing the AP key'           => [
+				'old_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'new_value'              => [ 'enabled' => 'yes' ],
+				'flag_before'            => null,
+				'amount_mismatch_before' => 'yes',
+				'expect_marked'          => false,
+			],
+			'old value not an array'                 => [
+				'old_value'              => false,
+				'new_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'flag_before'            => null,
+				'amount_mismatch_before' => 'yes',
+				'expect_marked'          => false,
+			],
+			'new value not an array'                 => [
+				'old_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'new_value'              => false,
+				'flag_before'            => null,
+				'amount_mismatch_before' => 'yes',
+				'expect_marked'          => false,
+			],
+			'migration already complete, AP toggled' => [
+				'old_value'              => [ 'adaptive_pricing' => 'no' ],
+				'new_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'flag_before'            => 'yes',
+				'amount_mismatch_before' => 'yes',
+				'expect_marked'          => false,
+			],
+			'non-yes flag is treated as incomplete'  => [
+				'old_value'              => [ 'adaptive_pricing' => 'no' ],
+				'new_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'flag_before'            => 'no',
+				'amount_mismatch_before' => 'yes',
+				'expect_marked'          => true,
+			],
+			'AP enabled, migration not needed'       => [
+				'old_value'              => [ 'adaptive_pricing' => 'no' ],
+				'new_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'flag_before'            => null,
+				'amount_mismatch_before' => null,
+				'expect_marked'          => false,
+			],
+			'AP disabled, migration not needed'      => [
+				'old_value'              => [ 'adaptive_pricing' => 'yes' ],
+				'new_value'              => [ 'adaptive_pricing' => 'no' ],
+				'flag_before'            => null,
+				'amount_mismatch_before' => 'no',
+				'expect_marked'          => false,
+			],
+		];
+	}
+
+	/**
+	 * Helper: resolve the migration flag option name from the migration class's private const.
+	 *
+	 * @return string
+	 */
+	private function get_adaptive_pricing_migration_flag_option_name(): string {
+		return WC_Stripe_Test_Helper::get_class_const_value(
+			WC_Stripe_Restore_Adaptive_Pricing_After_Amount_Mismatch_Update::class,
+			'MIGRATION_FLAG_OPTION',
+			'string'
+		);
+	}
+
 	/* -----------------------------------------------------------------
 	 * Plugin initialization guards
 	 *
@@ -1013,6 +1168,7 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			[ 'woocommerce_init', 'initialize_agentic_commerce', 10 ],
 			[ 'wc_payment_gateways_initialized', 'maybe_toggle_payment_methods', 10 ],
 			[ 'update_option_woocommerce_stripe_settings', 'maybe_reconfigure_webhooks_after_adaptive_pricing_enabled', 10 ],
+			[ 'update_option_woocommerce_stripe_settings', 'maybe_mark_adaptive_pricing_migration_complete', 10 ],
 		];
 
 		$first = WC_Stripe::get_instance();


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Related to #5804
Related to #5806

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR addresses the problem raised in [this review comment on #5804](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5804#discussion_r3776360043), where we need to ensure that merchant modifications to the Adaptive Pricing settings are not overridden after the migration does not succeed during an upgrade. With only #5804, we prevent merchants from toggling the value after a mismatch was detected, but #5806 removes the UI restriction, so merchants can update the Adaptive Pricing settings when a migration didn't succeed. This PR handles that edge case by marking the migration as complete when such a manual update occurs.

The PR does that by listening to the `option_update_woocommerce_stripe_settings` action and detecting when the `adaptive_pricing` key is modified, and when that happens, checking if we need to complete the migration. If we do need to complete the migration, we remove the amount mismatch option and mark the migration as complete.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

Get a site connected to Stripe, and then mimic the mismatch migration failure mode by running the following commands:
```
wp option update wc_stripe_adaptive_pricing_session_amount_mismatch_detected yes
wp option delete wc_stripe_restored_adaptive_pricing_after_amount_mismatch
```

Navigate to the Stripe Settings UI and modify the Adaptive Pricing setting, and ensure the settings got saved.

Verify that the migration was run by verifying that the amount mismatch option was deleted and the migration option was run:
 * Verify that the migration option is set to `'yes'`:
```
wp option get wc_stripe_restored_adaptive_pricing_after_amount_mismatch
```
* Verify that the amount mismatch option was deleted:
```
wp option get wc_stripe_adaptive_pricing_session_amount_mismatch_detected
```
This should return something like the following:
```
Error: Could not get 'wc_stripe_adaptive_pricing_session_amount_mismatch_detected' option. Does it exist?
```
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
