### PR TITLE
Fix tests for release/10.9.0

### DIFF
--- a/tests/e2e/tests/checkout/blocks/card-failures.spec.js
+++ b/tests/e2e/tests/checkout/blocks/card-failures.spec.js
@@ -7,6 +7,7 @@ const {
 	setupCart,
 	setupBlocksCheckout,
 	fillCreditCardDetails,
+	getPaymentElementFrame,
 	clickPlaceOrder,
 } = payments;
 
@@ -31,12 +32,8 @@ const testCard = async ( page, cardKey ) => {
 	 */
 	let expected;
 	if ( cardKey === 'cards.declined-incorrect' ) {
-		expected = await page
-			.frameLocator(
-				'.wcstripe-payment-element iframe[name^="__privateStripeFrame"]'
-			)
-			.locator( '#Field-numberError' )
-			.innerText();
+		const form = await getPaymentElementFrame( page );
+		expected = await form.locator( '#Field-numberError' ).innerText();
 	} else {
 		expected = await page.innerText(
 			'.wc-block-store-notice.is-error .wc-block-components-notice-banner__content'

--- a/tests/e2e/tests/express-checkout/utils.js
+++ b/tests/e2e/tests/express-checkout/utils.js
@@ -17,11 +17,19 @@ export const assertLinkModalLoads = async ( page, isBlockPage = false ) => {
 	await expect( linkButton ).toBeVisible( { timeout: 60 * 1000 } );
 	await expect( linkButton ).toBeEnabled();
 
+	// The Express Checkout Element ignores clicks that land before Stripe has
+	// re-synced the iframe's position after a scroll, and Playwright scrolls the
+	// button into view as part of the click itself. So the first click is
+	// silently swallowed whenever the button starts below the fold, as it does
+	// on the Cart block; by the second the page no longer needs to scroll.
 	const context = page.context();
-	const [ popup ] = await Promise.all( [
-		context.waitForEvent( 'page', { timeout: 60 * 1000 } ),
-		linkButton.click(),
-	] );
+	let popup;
+	await expect( async () => {
+		[ popup ] = await Promise.all( [
+			context.waitForEvent( 'page', { timeout: 10 * 1000 } ),
+			linkButton.click(),
+		] );
+	} ).toPass( { timeout: 45 * 1000 } );
 
 	await popup.waitForLoadState();
 

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -232,13 +232,16 @@ export async function retryWithBackoff( fn, options = {} ) {
 }
 
 /**
- * Fills in the credit card details on the default (blocks) checkout page.
+ * Resolves the Stripe payment element frame on the default (blocks) checkout page.
+ *
+ * Stripe injects extra iframes alongside the payment element (bank details, the
+ * ACH bank search results), so we require a visible frame to avoid picking the
+ * wrong one.
+ *
  * @param {Page} page Playwright page fixture.
- * @param {Object} card The CC info in the format provided on the test-data.
+ * @return {FrameLocator} The payment element frame.
  */
-export async function fillCreditCardDetails( page, card ) {
-	// Stripe may inject a second iframe for bank details, so
-	// we require a visible frame to avoid picking the wrong one.
+export async function getPaymentElementFrame( page ) {
 	const paymentIframe = page
 		.locator(
 			'.wcstripe-payment-element iframe[name^="__privateStripeFrame"]'
@@ -247,7 +250,16 @@ export async function fillCreditCardDetails( page, card ) {
 		.first();
 	await paymentIframe.waitFor( { state: 'visible', timeout: 10000 } );
 
-	const form = paymentIframe.contentFrame();
+	return paymentIframe.contentFrame();
+}
+
+/**
+ * Fills in the credit card details on the default (blocks) checkout page.
+ * @param {Page} page Playwright page fixture.
+ * @param {Object} card The CC info in the format provided on the test-data.
+ */
+export async function fillCreditCardDetails( page, card ) {
+	const form = await getPaymentElementFrame( page );
 
 	await form.locator( '[name="number"]' ).fill( card.number );
 

--- a/tests/phpunit/admin/class-wc-rest-stripe-agentic-commerce-controller-test.php
+++ b/tests/phpunit/admin/class-wc-rest-stripe-agentic-commerce-controller-test.php
@@ -93,6 +93,35 @@ class WC_REST_Stripe_Agentic_Commerce_Controller_Test extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
+	/**
+	 * Create a published product the feed validator accepts.
+	 *
+	 * The validator requires a category, and a product saved without one only gets
+	 * whatever `default_product_cat` points at. That option stops resolving as soon as
+	 * another test class has run in the process: WP's tear_down_after_class() empties
+	 * the term tables and commits, while the option survives in wp_options. Assigning
+	 * a category here keeps these tests independent of that ordering.
+	 *
+	 * @return WC_Product_Simple
+	 */
+	private function create_feed_product(): WC_Product_Simple {
+		$category    = wp_insert_term( 'Feed Category', 'product_cat' );
+		$category_id = is_wp_error( $category ) ? (int) $category->get_error_data() : (int) $category['term_id'];
+
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_regular_price( '10.00' );
+		$product->set_status( 'publish' );
+
+		if ( $category_id > 0 ) {
+			$product->set_category_ids( [ $category_id ] );
+		}
+
+		$product->save();
+
+		return $product;
+	}
+
 	// -------------------------------------------------------------------------
 	// Authentication
 	// -------------------------------------------------------------------------
@@ -834,11 +863,7 @@ class WC_REST_Stripe_Agentic_Commerce_Controller_Test extends WP_UnitTestCase {
 		update_option( 'woocommerce_stripe_settings', $settings );
 
 		// Create a simple product so the walker finds at least one.
-		$product = new WC_Product_Simple();
-		$product->set_name( 'Test Product' );
-		$product->set_regular_price( '10.00' );
-		$product->set_status( 'publish' );
-		$product->save();
+		$product = $this->create_feed_product();
 
 		// Stub the Files API cURL upload (which bypasses pre_http_request).
 		$files_stub = function () {
@@ -1394,11 +1419,7 @@ class WC_REST_Stripe_Agentic_Commerce_Controller_Test extends WP_UnitTestCase {
 		update_option( 'woocommerce_stripe_settings', $settings );
 
 		// Create a simple product so the walker finds at least one.
-		$product = new WC_Product_Simple();
-		$product->set_name( 'Test Product' );
-		$product->set_regular_price( '10.00' );
-		$product->set_status( 'publish' );
-		$product->save();
+		$product = $this->create_feed_product();
 
 		// Stub the Files API cURL upload.
 		$files_stub = function () {
@@ -1476,11 +1497,7 @@ class WC_REST_Stripe_Agentic_Commerce_Controller_Test extends WP_UnitTestCase {
 		$settings['test_secret_key'] = 'sk_test_fake';
 		update_option( 'woocommerce_stripe_settings', $settings );
 
-		$product = new WC_Product_Simple();
-		$product->set_name( 'Test Product' );
-		$product->set_regular_price( '10.00' );
-		$product->set_status( 'publish' );
-		$product->save();
+		$product = $this->create_feed_product();
 
 		$files_stub = function () {
 			return [ 'id' => 'file_stub' ];

--- a/tests/phpunit/class-wc-mock-stripe-api-unit-test-case.php
+++ b/tests/phpunit/class-wc-mock-stripe-api-unit-test-case.php
@@ -25,11 +25,19 @@ abstract class WC_Mock_Stripe_API_Unit_Test_Case extends WP_UnitTestCase {
 	private $payment_method_configurations_response = null;
 
 	/**
+	 * The account service as it was before this test replaced it.
+	 *
+	 * @var WC_Stripe_Account|null
+	 */
+	private $original_account = null;
+
+	/**
 	 * Set up.
 	 */
 	public function set_up() {
 		parent::set_up();
-		$this->stripe_api = $this->createMock( WC_Stripe_API::class );
+		$this->original_account = WC_Stripe::get_instance()->account;
+		$this->stripe_api       = $this->createMock( WC_Stripe_API::class );
 		$this->stripe_api->method( 'get_payment_method_configurations' )->willReturnCallback(
 			function () {
 				return $this->payment_method_configurations_response;
@@ -43,6 +51,15 @@ abstract class WC_Mock_Stripe_API_Unit_Test_Case extends WP_UnitTestCase {
 	 * Tear down.
 	 */
 	public function tear_down() {
+		// Tests here swap the WC_Stripe singleton's account for a partial mock built with
+		// disableOriginalConstructor(). Nothing else resets that singleton, so a mock left
+		// installed keeps answering later tests, and its unstubbed real methods run against a
+		// null $connect — a fatal in whichever test next reaches the account.
+		if ( null !== $this->original_account ) {
+			WC_Stripe::get_instance()->account = $this->original_account;
+			$this->original_account            = null;
+		}
+
 		parent::tear_down();
 		$this->reset_payment_method_configuration_state();
 		// Restore the real API singleton: the mock's stub closure is bound to this test case, so

--- a/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
+++ b/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
@@ -70,24 +70,25 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 		$original_settings = WC_Stripe_Helper::get_stripe_settings();
 		$original_account  = WC_Stripe::get_instance()->account;
 
+		// Write the full set rather than merging onto whatever is stored: otherwise settings written
+		// from a set_up_before_class() elsewhere in the suite are committed outside the per-test
+		// transaction and survive into this test.
 		WC_Stripe_Helper::update_main_stripe_settings(
-			array_merge(
-				$original_settings,
-				[
-					'adaptive_pricing'           => 'yes',
-					'optimized_checkout_element' => 'yes',
-					'pmc_enabled'                => 'yes',
-					'capture'                    => 'yes',
-					'webhook_data'               => [
-						'id'     => 'we_live',
-						'secret' => 'whsec_live',
-					],
-					'test_webhook_data'          => [
-						'id'     => 'we_test',
-						'secret' => 'whsec_test',
-					],
-				]
-			)
+			[
+				'adaptive_pricing'           => 'yes',
+				'optimized_checkout_element' => 'yes',
+				'pmc_enabled'                => 'yes',
+				'capture'                    => 'yes',
+				'testmode'                   => 'yes',
+				'webhook_data'               => [
+					'id'     => 'we_live',
+					'secret' => 'whsec_live',
+				],
+				'test_webhook_data'          => [
+					'id'     => 'we_test',
+					'secret' => 'whsec_test',
+				],
+			]
 		);
 
 		$reflection = new ReflectionProperty( WC_Stripe::class, 'stripe_gateway' );

--- a/tests/phpunit/class-wc-stripe-connect-test.php
+++ b/tests/phpunit/class-wc-stripe-connect-test.php
@@ -13,10 +13,20 @@ class WC_Stripe_Connect_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	private $connect;
 
 	/**
+	 * REQUEST_URI as the test bootstrap left it, restored in tear_down().
+	 *
+	 * @var string|null
+	 */
+	private $original_request_uri;
+
+	/**
 	 * @inheritDoc
 	 */
 	public function set_up() {
 		parent::set_up();
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Snapshot restored verbatim in tear_down(); unslashing or sanitizing here would restore a different value than the bootstrap set.
+		$this->original_request_uri = $_SERVER['REQUEST_URI'] ?? null;
 
 		// The settings-update filter merges defaults when saving settings, which would
 		// inject `optimized_checkout_element` / `adaptive_pricing` defaults and obscure
@@ -34,6 +44,15 @@ class WC_Stripe_Connect_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 * @inheritDoc
 	 */
 	public function tear_down() {
+		// PHPUnit runs with backupGlobals disabled, so a REQUEST_URI left pointing at
+		// wp-admin leaks into every later test in the process: wp_validate_redirect()
+		// resolves schemeless relative redirects against dirname( REQUEST_URI ).
+		if ( null === $this->original_request_uri ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $this->original_request_uri;
+		}
+
 		delete_option( 'wc_stripe_optimized_checkout_default_on' );
 		delete_option( 'wc_stripe_oauth_failed_attempts' );
 		WC_Stripe_Helper::update_main_stripe_settings( [] );

--- a/tests/phpunit/class-wc-stripe-inbox-notes-test.php
+++ b/tests/phpunit/class-wc-stripe-inbox-notes-test.php
@@ -121,6 +121,11 @@ class WC_Stripe_Inbox_Notes_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 
 		$wc_stripe_instance_reflection = new ReflectionProperty( WC_Stripe::class, 'instance' );
 		$wc_stripe_instance_reflection->setAccessible( true );
+		// The original instance has to come back: clearing the singleton makes the next
+		// get_instance() build a replacement whose hook registrations the WP test case
+		// wipes on the next tear_down, so every later test in the process would see a
+		// WC_Stripe with none of its hooks attached.
+		$original_wc_stripe = $wc_stripe_instance_reflection->getValue();
 		$wc_stripe_instance_reflection->setValue( null, $mock_wc_stripe );
 
 		try {
@@ -129,7 +134,7 @@ class WC_Stripe_Inbox_Notes_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			$admin_note_store = WC_Data_Store::load( 'admin-note' );
 			$this->assertSame( 0, count( $admin_note_store->get_notes_with_name( WC_Stripe_UPE_StripeLink_Note::NOTE_NAME ) ) );
 		} finally {
-			$wc_stripe_instance_reflection->setValue( null, null );
+			$wc_stripe_instance_reflection->setValue( null, $original_wc_stripe );
 		}
 	}
 

--- a/tests/phpunit/compat/class-wc-stripe-subscription-renewal-test.php
+++ b/tests/phpunit/compat/class-wc-stripe-subscription-renewal-test.php
@@ -35,6 +35,13 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
+		// WC_Stripe_API::retrieve() returns null once the consecutive-401 counter reaches its
+		// threshold, and earlier test class trip it with their mocked API keys.
+		// TODO: The proper fix is to remove any non stubbed call to Stripe; which is also the
+		// correct implementation for a phpunit test.
+		WC_Stripe_Database_Cache::delete_with_mode( WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY, 'test' );
+		WC_Stripe_Database_Cache::delete_with_mode( WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY, 'live' );
+
 		$this->wc_gateway_stripe = $this->getMockBuilder( 'WC_Stripe_UPE_Payment_Gateway' )
 			->disableOriginalConstructor()
 			->onlyMethods( [ 'prepare_order_source', 'has_subscription' ] )


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR fixes several test errors found during release 10.9.0

**PHPUnit**
- Some tests replaced `$_SERVER['REQUEST_URI']`, they now restore it
- Some tests nulled the `WC_Stripe` singleton, they now restore it
- Added a `create_feed_product()` helper that inserts a `product_cat` term and assigns it to the product, and used it in the three sync tests
- `enable_adaptive_pricing()` now writes the complete settings array it needs (including an explicit testmode) rather than merging onto the stored value
-  Changed `tests/phpunit/class-wc-mock-stripe-api-unit-test-case.php` to save `WC_Stripe::get_instance()->account` in `set_up()`, and restore it in `tear_down()`

**E2E**
- `tests/e2e/utils/payments.js`: new exported `getPaymentElementFrame( page )` holding the visible-frame filter; `fillCreditCardDetails` now calls it instead of duplicating the locator.
- `tests/e2e/tests/checkout/blocks/card-failures.spec.js`: imports `getPaymentElementFrame` and uses it in place of the inline `frameLocator`, which was hitting a strict-mode violation once Stripe's hidden bank-search frame appeared after Place Order.
- `tests/e2e/tests/express-checkout/utils.js`: the click + `waitForEvent('page')` pair is wrapped in `expect(...).toPass({ timeout: 45s })` with a 10s per-attempt popup wait, so the click swallowed by Stripe's post-scroll iframe re-sync gets retried.

## Testing instructions

Make sure all PR checks pass, those checks include the parallel PHPUnit and the E2E suites

1. Manually run the normal PHPUnit test suite:
    ```
    npm run test:php
    ```
2. Verify all tests pass (and 2 are skipped) 

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
