### PR TITLE
Agentic Commerce: send delete=true rows so ineligible products leave Stripe's catalog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ xxxx-xx-xx - version 11.0.0
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
 * Fix - Exclude password-protected products and products hidden from the catalog from the Agentic Commerce feed
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
+* Fix - Remove excluded, trashed, deleted, and unpublished products from the Stripe Agentic Commerce catalog by sending explicit removal rows, instead of leaving them visible to AI agents indefinitely
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,7 +17,7 @@ xxxx-xx-xx - version 11.0.0
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
 * Fix - Exclude password-protected products and products hidden from the catalog from the Agentic Commerce feed
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
-* Fix - Remove excluded, trashed, deleted, and unpublished products from the Stripe Agentic Commerce catalog by sending explicit removal rows, instead of leaving them visible to AI agents indefinitely
+* Fix - Remove excluded, trashed, deleted, and unpublished products from the Stripe Agentic Commerce catalog instead of leaving them visible to AI agents
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/includes/agentic-commerce/README.md
+++ b/includes/agentic-commerce/README.md
@@ -376,6 +376,7 @@ The feed query selects published simple products and variations, so grouped, ext
 | Products hidden from catalog **and** search | `hidden` is the strongest "do not surface this" signal WooCommerce offers. |
 | Products with the per-product exclude flag | The merchant opted the product out explicitly. |
 | Unpublished products, and variations of an unpublished parent | The feed query only checks the row's own status, so variations of a draft or private variable product would otherwise keep syncing with a `link` that 404s. |
+| Variations whose parent is missing or no longer variable | Variation posts survive a parent type switch and still match the feed query; these would otherwise keep syncing as stale rows. |
 
 Catalog visibility values that hide a product from only one surface (`catalog`, `search`) are **not** treated as exclusions — the product is still meant to be reachable by the other route.
 
@@ -390,11 +391,11 @@ Stripe processes catalog imports in **upsert mode**: omitting a product from an 
 The integration therefore emits delete rows on two paths:
 
 - **Full feed:** the mapper exports every ineligible product still in the feed query (excluded, password-protected, hidden, filtered out) as a `delete=true` row instead of omitting it. The rows recur on every sync by design — deletes are idempotent, and a stateless feed self-heals if an earlier removal upload was lost.
-- **Archive batches:** products that leave the feed query entirely (trashed, permanently deleted, or unpublished, including a variable parent expanded into its variations) are captured by `WC_Stripe_Agentic_Commerce_Inventory_Tracker`, which queues a `delete=true` row per feed id and flushes them as a small product_catalog_feed upload about a minute later. Republishing before the flush cancels the queued removal.
+- **Archive batches:** products that leave the feed query entirely (trashed, permanently deleted, unpublished, or type-changed out of it, including a variable parent expanded into its variations) are captured by `WC_Stripe_Agentic_Commerce_Inventory_Tracker`, which queues a `delete=true` row per feed id and flushes them as a small product_catalog_feed upload about a minute later. Republishing before the flush cancels the queued removal.
 
 `WC_Stripe_Agentic_Commerce_Product_Visibility` watches product saves and per-product exclude-flag writes, and fires `wc_stripe_agentic_commerce_schedule_full_resync` when a product crosses the eligibility boundary so the sync carrying the delete row runs promptly — adapters whose own filter verdict changes must fire the same action.
 
-Known gap: a published product whose *type* changes out of the feed query (for example simple to grouped or external) neither stays in the query nor changes post status, so no delete row is emitted for it until it is unpublished, trashed, or removed some other way.
+Deletes for ids Stripe never ingested are safe: the import reports them as successes, not row errors (verified against the test-mode import API), so the recurring delete rows cost nothing beyond feed size.
 
 ## Coupons and discounts
 

--- a/includes/agentic-commerce/README.md
+++ b/includes/agentic-commerce/README.md
@@ -375,6 +375,7 @@ The feed query selects published simple products and variations, so grouped, ext
 | Password-protected products | The password gate states who may view the product, and the exported `link` would only render a password prompt. |
 | Products hidden from catalog **and** search | `hidden` is the strongest "do not surface this" signal WooCommerce offers. |
 | Products with the per-product exclude flag | The merchant opted the product out explicitly. |
+| Unpublished products, and variations of an unpublished parent | The feed query only checks the row's own status, so variations of a draft or private variable product would otherwise keep syncing with a `link` that 404s. |
 
 Catalog visibility values that hide a product from only one surface (`catalog`, `search`) are **not** treated as exclusions — the product is still meant to be reachable by the other route.
 
@@ -382,7 +383,18 @@ A variation inherits its parent's catalog visibility but **not** its `post_passw
 
 All of these are defaults rather than hard blocks: `woocommerce_agentic_commerce_should_sync_product` can return `true` to opt a product back in.
 
-Because the filter only governs what is *sent*, a product that was already exported and later becomes ineligible stays in Stripe's catalog until a full feed replacement. `WC_Stripe_Agentic_Commerce_Product_Visibility` watches product saves and per-product exclude-flag writes, and fires `wc_stripe_agentic_commerce_schedule_full_resync` when a product crosses that boundary — adapters whose own filter verdict changes must fire the same action.
+## Removing products from Stripe's catalog
+
+Stripe processes catalog imports in **upsert mode**: omitting a product from an uploaded feed leaves it in the catalog unchanged, indefinitely. The only removal signal is a row with `delete=true`, from which Stripe reads just `id` and `delete` and ignores every other column.
+
+The integration therefore emits delete rows on two paths:
+
+- **Full feed:** the mapper exports every ineligible product still in the feed query (excluded, password-protected, hidden, filtered out) as a `delete=true` row instead of omitting it. The rows recur on every sync by design — deletes are idempotent, and a stateless feed self-heals if an earlier removal upload was lost.
+- **Archive batches:** products that leave the feed query entirely (trashed, permanently deleted, or unpublished, including a variable parent expanded into its variations) are captured by `WC_Stripe_Agentic_Commerce_Inventory_Tracker`, which queues a `delete=true` row per feed id and flushes them as a small product_catalog_feed upload about a minute later. Republishing before the flush cancels the queued removal.
+
+`WC_Stripe_Agentic_Commerce_Product_Visibility` watches product saves and per-product exclude-flag writes, and fires `wc_stripe_agentic_commerce_schedule_full_resync` when a product crosses the eligibility boundary so the sync carrying the delete row runs promptly — adapters whose own filter verdict changes must fire the same action.
+
+Known gap: a published product whose *type* changes out of the feed query (for example simple to grouped or external) neither stays in the query nor changes post status, so no delete row is emitted for it until it is unpublished, trashed, or removed some other way.
 
 ## Coupons and discounts
 

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-feed-preview.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-feed-preview.php
@@ -199,10 +199,8 @@ class WC_Stripe_Agentic_Commerce_Feed_Preview {
 				$errors = $validator->validate_entry( $row, $product );
 
 				// An excluded product surfaces as a `delete=true` removal row
-				// (which validates clean — it enters the feed to pull the product
-				// out of Stripe's catalog) or, from external mappers, as the
-				// legacy empty-row skip signal. Either way it counts as excluded
-				// here, not included.
+				// (which validates clean) or, from external mappers, as the legacy
+				// empty-row skip signal. Either way it counts as excluded here.
 				$is_removal = empty( $row ) || WC_Stripe_Agentic_Commerce_Product_Mapper::is_delete_row( $row );
 
 				if ( empty( $errors ) && ! $is_removal ) {

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-feed-preview.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-feed-preview.php
@@ -198,21 +198,28 @@ class WC_Stripe_Agentic_Commerce_Feed_Preview {
 
 				$errors = $validator->validate_entry( $row, $product );
 
-				if ( empty( $errors ) ) {
+				// An excluded product surfaces as a `delete=true` removal row
+				// (which validates clean — it enters the feed to pull the product
+				// out of Stripe's catalog) or, from external mappers, as the
+				// legacy empty-row skip signal. Either way it counts as excluded
+				// here, not included.
+				$is_removal = empty( $row ) || WC_Stripe_Agentic_Commerce_Product_Mapper::is_delete_row( $row );
+
+				if ( empty( $errors ) && ! $is_removal ) {
 					++$included_count;
 					continue;
 				}
 
-				// An empty row means should_sync_product() excluded it. Attribute it
-				// to the reason the merchant can act on, so the UI can say which
-				// setting hid the product rather than just "a store rule".
+				// Attribute the exclusion to the reason the merchant can act on,
+				// so the UI can say which setting hid the product rather than
+				// just "a store rule".
 				//
 				// First match wins, so the buckets always sum to $excluded_count
 				// even when a product trips several. The per-product toggle and
 				// third-party filters share the generic bucket: the toggle is
 				// already a deliberate act, and a filter's reason is unknowable
 				// from here.
-				if ( empty( $row ) ) {
+				if ( $is_removal ) {
 					++$excluded_count;
 
 					if ( WC_Stripe_Agentic_Commerce_Product_Mapper::is_subscription_product( $product ) ) {

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-feed-validator.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-feed-validator.php
@@ -83,6 +83,17 @@ class WC_Stripe_Agentic_Commerce_Feed_Validator implements FeedValidatorInterfac
 	protected int $excluded_count = 0;
 
 	/**
+	 * `delete=true` rows waved into the feed. Counted separately because they
+	 * are feed entries (unlike exclusions) but not synced products — the caller
+	 * subtracts this from the entry count when reporting how many products the
+	 * catalog holds.
+	 *
+	 * @since 11.0.0
+	 * @var int
+	 */
+	protected int $removed_count = 0;
+
+	/**
 	 * Non-empty return from {@see self::validate_entry()} for an excluded product,
 	 * so the walker drops the row without recording it as a validation error.
 	 *
@@ -115,6 +126,16 @@ class WC_Stripe_Agentic_Commerce_Feed_Validator implements FeedValidatorInterfac
 		if ( empty( $row ) && ! WC_Stripe_Agentic_Commerce_Product_Mapper::should_sync_product( $product ) ) {
 			++$this->excluded_count;
 			return [ self::EXCLUDED_SENTINEL ];
+		}
+
+		// A delete row is a removal signal, not product data: Stripe reads only
+		// `id` and `delete` from it, so the required-field and format checks
+		// below would wrongly reject its null-filled columns. Wave it into the
+		// feed as long as it can actually target something; without an id it
+		// falls through and fails required-field validation like any bad row.
+		if ( WC_Stripe_Agentic_Commerce_Product_Mapper::is_delete_row( $row ) && ! empty( $row['id'] ) ) {
+			++$this->removed_count;
+			return [];
 		}
 
 		$errors = array_merge(
@@ -177,6 +198,16 @@ class WC_Stripe_Agentic_Commerce_Feed_Validator implements FeedValidatorInterfac
 	 */
 	public function get_excluded_count(): int {
 		return $this->excluded_count;
+	}
+
+	/**
+	 * Count of `delete=true` removal rows admitted into the feed this run.
+	 *
+	 * @since 11.0.0
+	 * @return int
+	 */
+	public function get_removed_count(): int {
+		return $this->removed_count;
 	}
 
 	/**

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-feed-validator.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-feed-validator.php
@@ -83,10 +83,8 @@ class WC_Stripe_Agentic_Commerce_Feed_Validator implements FeedValidatorInterfac
 	protected int $excluded_count = 0;
 
 	/**
-	 * `delete=true` rows waved into the feed. Counted separately because they
-	 * are feed entries (unlike exclusions) but not synced products — the caller
-	 * subtracts this from the entry count when reporting how many products the
-	 * catalog holds.
+	 * `delete=true` rows waved into the feed — entries, but not synced
+	 * products, so the caller subtracts this from the entry count.
 	 *
 	 * @since 11.0.0
 	 * @var int
@@ -128,11 +126,9 @@ class WC_Stripe_Agentic_Commerce_Feed_Validator implements FeedValidatorInterfac
 			return [ self::EXCLUDED_SENTINEL ];
 		}
 
-		// A delete row is a removal signal, not product data: Stripe reads only
-		// `id` and `delete` from it, so the required-field and format checks
-		// below would wrongly reject its null-filled columns. Wave it into the
-		// feed as long as it can actually target something; without an id it
-		// falls through and fails required-field validation like any bad row.
+		// Stripe reads only `id` and `delete` from a removal row, so the checks
+		// below would wrongly reject its null-filled columns. Admit it when it
+		// has an id; without one it falls through and fails like any bad row.
 		if ( WC_Stripe_Agentic_Commerce_Product_Mapper::is_delete_row( $row ) && ! empty( $row['id'] ) ) {
 			++$this->removed_count;
 			return [];

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-integration.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-integration.php
@@ -627,6 +627,15 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 			$dropped_count  = max( 0, $iterated_products - $total_products );
 			$skipped_count  = max( 0, $dropped_count - $excluded_count );
 
+			// Delete rows are feed entries but not catalog products: subtract
+			// them so "products synced" keeps meaning what merchants read it as.
+			$removed_count   = $validator instanceof WC_Stripe_Agentic_Commerce_Feed_Validator
+				? $validator->get_removed_count()
+				: 0;
+			$synced_products = max( 0, $total_products - $removed_count );
+
+			// Entry count, not $synced_products: a feed holding only delete rows
+			// must still upload, or the removals would never reach Stripe.
 			if ( 0 === $total_products ) {
 				WC_Stripe_Logger::info( 'Agentic Commerce: Sync skipped - no products to sync' );
 				$file_path = $feed->get_file_path();
@@ -649,10 +658,11 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 			WC_Stripe_Logger::info(
 				'Agentic Commerce: Feed generated successfully',
 				[
-					'total_products'    => $total_products,
+					'total_products'    => $synced_products,
 					'iterated_products' => $iterated_products,
 					'skipped_products'  => $skipped_count,
 					'excluded_products' => $excluded_count,
+					'removed_products'  => $removed_count,
 					'generation_time'   => round( $generation_time, 2 ) . 's',
 					'file_path'         => $file_path,
 					'file_size_mb'      => round( $file_size / 1024 / 1024, 2 ),
@@ -736,12 +746,13 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 			// Persist sync result for dashboard display.
 			$this->store_sync_result(
 				[
-					'products'         => $total_products,
+					'products'         => $synced_products,
 					'status'           => $status,
 					'file_id'          => $result['file_id'] ?? '',
 					'import_set_id'    => $import_set_id,
 					'error'            => '',
 					'skipped_products' => $skipped_count,
+					'removed_products' => $removed_count,
 				],
 				$mode
 			);
@@ -793,6 +804,8 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 	 *                                    can upgrade a Stripe-reported `succeeded`
 	 *                                    to `succeeded_with_errors` once the
 	 *                                    ImportSet completes.
+	 *     @type int    $removed_products Count of `delete=true` removal rows the
+	 *                                    feed carried for ineligible products.
 	 * }
 	 * @param string|null $mode The mode ('test'/'live') the sync ran against, as
 	 *                          captured when it started; null falls back to the
@@ -814,6 +827,7 @@ class WC_Stripe_Agentic_Commerce_Integration implements IntegrationInterface {
 			'import_set_id'    => $result['import_set_id'] ?? '',
 			'error'            => $result['error'] ?? '',
 			'skipped_products' => isset( $result['skipped_products'] ) ? max( 0, (int) $result['skipped_products'] ) : 0,
+			'removed_products' => isset( $result['removed_products'] ) ? max( 0, (int) $result['removed_products'] ) : 0,
 			'mode'             => $mode ?? self::get_current_mode(),
 		];
 

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-inventory-tracker.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-inventory-tracker.php
@@ -87,13 +87,11 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 		// $product->delete() calls, not through the WordPress admin UI.
 		add_action( 'before_delete_post', [ $this, 'maybe_track_product_archive' ] );
 		add_action( 'wp_trash_post', [ $this, 'maybe_track_product_archive' ] );
-		// One transition hook covers both directions: leaving `publish` (draft,
-		// private, pending — statuses the feed query stops selecting, so only an
-		// explicit delete row can pull the product out of Stripe's catalog) and
-		// entering `publish`, which cancels a queued removal. Untrash routes
-		// through here too: WordPress restores to draft by default, and in that
-		// case the queued delete must survive — cancelling on `untrash_post`
-		// unconditionally would leave a draft product live on Stripe.
+		// One transition hook covers both directions: leaving `publish` queues a
+		// removal (the feed query stops selecting the product, so only a delete
+		// row can pull it off Stripe), entering `publish` cancels one. Untrash
+		// restores to draft by default, so an unconditional `untrash_post`
+		// cancel would leave a draft product live on Stripe.
 		add_action( 'transition_post_status', [ $this, 'handle_status_transition' ], 10, 3 );
 		add_action( self::ARCHIVE_SCHEDULED_ACTION, [ $this, 'sync_archives' ] );
 	}
@@ -189,9 +187,8 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 		}
 
 		if ( 'publish' === $new_status ) {
-			// The next full sync re-adds the product (the visibility watcher
-			// schedules one when eligibility flips back), so a queued removal
-			// that hasn't flushed yet only risks a pointless delete/re-add churn.
+			// The next full sync re-adds the product anyway; an unflushed
+			// removal would only cause pointless delete/re-add churn.
 			$this->maybe_cancel_pending_archive( (int) $post->ID );
 			return;
 		}
@@ -264,17 +261,10 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 	 * the ones whose filter outcome flipped to false between enqueue and flush.
 	 *
 	 * The event-driven eviction in `track_stock_change()` only fires when a
-	 * follow-up event arrives. If a merchant hides a product during the
-	 * 60-second batch window and no further event lands for it, the queued row
-	 * would otherwise still ship on the next flush — defeating the filter's
-	 * "this product should not be synced" contract. Reading the option blind at
-	 * flush time isn't enough; the visibility decision can move.
-	 *
-	 * Permanently-deleted products (`wc_get_product()` returns false) are
-	 * dropped too: the stock delta references a SKU that no longer exists.
-	 *
-	 * Only inventory entries are pruned this way. Pending archives are
-	 * `delete=true` removal signals, valid regardless of eligibility.
+	 * follow-up event arrives, so a product hidden mid-window would otherwise
+	 * still ship its queued row. Permanently-deleted products are dropped too:
+	 * the delta references a SKU that no longer exists. Pending archives are
+	 * never pruned — `delete=true` rows stay valid regardless of eligibility.
 	 *
 	 * @since 10.8.0
 	 * @param string $option_key Pending option to prune.
@@ -309,24 +299,19 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 	/**
 	 * Track a product removal (permanent delete, trash, or unpublish) for deletion on Stripe.
 	 *
-	 * Captures the feed id (SKU or product ID) before the product disappears and
-	 * queues a `delete=true` row, which removes the product from Stripe's
-	 * catalog. Runs even for excluded products: a delete is idempotent, and
-	 * bailing on eligibility here would mean an exclude-then-trash inside one
-	 * resync window never lands a removal at all.
-	 *
-	 * Schedules a sync 60 seconds later if one is not already scheduled. The
-	 * product is also removed from any pending inventory updates since the stock
-	 * quantity is no longer relevant once the product is removed.
+	 * Captures the feed id before the product disappears and queues a
+	 * `delete=true` row. Runs even for excluded products — a delete is
+	 * idempotent, and bailing on eligibility would mean exclude-then-trash
+	 * inside one resync window never lands a removal. Also evicts the product's
+	 * pending inventory delta and schedules the flush.
 	 *
 	 * @since 10.6.0
 	 * @param \WC_Product $product The product being deleted, trashed, or unpublished.
 	 * @return void
 	 */
 	public function track_product_archive( \WC_Product $product ): void {
-		// Variations are the actual feed entries, but trashing or drafting a
-		// variable parent doesn't cascade a status change to them — expand the
-		// parent into its children so each exported row gets a removal.
+		// Variations are the actual feed entries and a parent's status change
+		// doesn't cascade to them — expand the parent into its children.
 		$products = [ $product ];
 		if ( $product->is_type( 'variable' ) ) {
 			$products = [];
@@ -525,12 +510,10 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 	}
 
 	/**
-	 * Generate an archive feed CSV from pending product archives.
+	 * Generate an archive feed CSV of `delete=true` rows from pending archives.
 	 *
-	 * Returns a finalized CSV feed of `delete=true` rows. The full column set is
-	 * kept so the file matches the standard product_catalog_feed header layout;
-	 * Stripe reads only `id` and `delete` from a removal row and ignores the
-	 * rest.
+	 * Keeps the full column set to match the standard product_catalog_feed
+	 * header layout; Stripe reads only `id` and `delete` from a removal row.
 	 *
 	 * @since 10.6.0
 	 * @return WC_Stripe_Agentic_Commerce_Csv_Feed|null Finalized feed, or null if nothing to sync.
@@ -566,18 +549,11 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 	/**
 	 * Execute archive sync process.
 	 *
-	 * Called by Action Scheduler one minute after the first tracked product
-	 * deletion, trash, or unpublish event. Generates a product catalog CSV of
-	 * `delete=true` rows and uploads it to Stripe as a product_catalog_feed
-	 * ImportSet, removing each product from Stripe's catalog.
-	 *
-	 * On success, pending archives are cleared. On failure they are retained so
-	 * the next scheduled sync can retry.
-	 *
-	 * Unlike inventory, the queue is neither deferred to the full catalog sync
-	 * (which cannot delete products no longer in the feed query) nor pruned by
-	 * eligibility (a removal is valid for an excluded product); republished
-	 * products are already cancelled out at transition time.
+	 * Runs one minute after the first tracked deletion, trash, or unpublish and
+	 * uploads the pending `delete=true` rows as a product_catalog_feed
+	 * ImportSet. On failure the queue is retained for retry. Unlike inventory,
+	 * it is neither deferred to the full sync (which cannot delete out-of-query
+	 * products) nor pruned by eligibility (removals stay valid when excluded).
 	 *
 	 * @since 10.6.0
 	 * @return void

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-inventory-tracker.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-inventory-tracker.php
@@ -15,6 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Automattic\WooCommerce\Enums\ProductStatus;
+
 /**
  * Tracks product stock changes and syncs incremental inventory updates to Stripe.
  *
@@ -182,18 +184,18 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 			return;
 		}
 
-		if ( $new_status === $old_status || 'trash' === $new_status ) {
+		if ( $new_status === $old_status || ProductStatus::TRASH === $new_status ) {
 			return;
 		}
 
-		if ( 'publish' === $new_status ) {
+		if ( ProductStatus::PUBLISH === $new_status ) {
 			// The next full sync re-adds the product anyway; an unflushed
 			// removal would only cause pointless delete/re-add churn.
 			$this->maybe_cancel_pending_archive( (int) $post->ID );
 			return;
 		}
 
-		if ( 'publish' !== $old_status ) {
+		if ( ProductStatus::PUBLISH !== $old_status ) {
 			return;
 		}
 

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-inventory-tracker.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-inventory-tracker.php
@@ -87,7 +87,14 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 		// $product->delete() calls, not through the WordPress admin UI.
 		add_action( 'before_delete_post', [ $this, 'maybe_track_product_archive' ] );
 		add_action( 'wp_trash_post', [ $this, 'maybe_track_product_archive' ] );
-		add_action( 'untrash_post', [ $this, 'maybe_cancel_pending_archive' ] );
+		// One transition hook covers both directions: leaving `publish` (draft,
+		// private, pending — statuses the feed query stops selecting, so only an
+		// explicit delete row can pull the product out of Stripe's catalog) and
+		// entering `publish`, which cancels a queued removal. Untrash routes
+		// through here too: WordPress restores to draft by default, and in that
+		// case the queued delete must survive — cancelling on `untrash_post`
+		// unconditionally would leave a draft product live on Stripe.
+		add_action( 'transition_post_status', [ $this, 'handle_status_transition' ], 10, 3 );
 		add_action( self::ARCHIVE_SCHEDULED_ACTION, [ $this, 'sync_archives' ] );
 	}
 
@@ -140,7 +147,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 	 *
 	 * Hooked to before_delete_post and wp_trash_post so that product removals via the
 	 * WordPress admin UI are captured in addition to programmatic / REST API deletions.
-	 * Loads the full WC_Product so that all required feed fields can be captured before
+	 * Loads the WC_Product so the feed id (SKU or product ID) can be captured before
 	 * the product is permanently deleted.
 	 *
 	 * @since 10.6.0
@@ -161,11 +168,52 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 	}
 
 	/**
-	 * Remove a product from the pending archives queue when it is restored from trash.
+	 * Queue or cancel a removal when a product's post status changes.
 	 *
-	 * If a merchant trashes a product and then restores it before the 60-second
-	 * batch window elapses, this prevents the product from being synced to Stripe
-	 * as out_of_stock.
+	 * Trash is skipped here: `wp_trash_post` fires before the status is written,
+	 * while the product still loads cleanly, and handles that path.
+	 *
+	 * @since 11.0.0
+	 * @param string  $new_status Status the post is entering.
+	 * @param string  $old_status Status the post is leaving.
+	 * @param WP_Post $post       The post being transitioned.
+	 * @return void
+	 */
+	public function handle_status_transition( $new_status, $old_status, $post ): void {
+		if ( ! $post instanceof WP_Post || ! in_array( $post->post_type, [ 'product', 'product_variation' ], true ) ) {
+			return;
+		}
+
+		if ( $new_status === $old_status || 'trash' === $new_status ) {
+			return;
+		}
+
+		if ( 'publish' === $new_status ) {
+			// The next full sync re-adds the product (the visibility watcher
+			// schedules one when eligibility flips back), so a queued removal
+			// that hasn't flushed yet only risks a pointless delete/re-add churn.
+			$this->maybe_cancel_pending_archive( (int) $post->ID );
+			return;
+		}
+
+		if ( 'publish' !== $old_status ) {
+			return;
+		}
+
+		$product = wc_get_product( $post->ID );
+		if ( ! $product ) {
+			return;
+		}
+
+		$this->track_product_archive( $product );
+	}
+
+	/**
+	 * Remove a product from the pending archives queue when it returns to `publish`.
+	 *
+	 * If a merchant trashes or unpublishes a product and then republishes it
+	 * before the 60-second batch window elapses, this prevents the queued
+	 * `delete=true` row from removing a live product from Stripe's catalog.
 	 *
 	 * @since 10.6.0
 	 * @param int $post_id The ID of the post being restored.
@@ -188,11 +236,12 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 	}
 
 	/**
-	 * Remove any pending inventory or archive entry queued for $product_id.
+	 * Remove any pending inventory entry queued for $product_id.
 	 *
-	 * Called from the track_* methods when the visibility filter votes false so
-	 * a product that was queued before the filter flipped doesn't still flush
-	 * to Stripe on the next batch.
+	 * Called when the visibility filter votes false so a product queued before
+	 * the filter flipped doesn't still flush a stock delta on the next batch.
+	 * Pending archives are deliberately left alone: they are `delete=true`
+	 * removal signals, valid for excluded products.
 	 *
 	 * @since 10.8.0
 	 * @param int $product_id Product ID to evict.
@@ -208,40 +257,30 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 				update_option( self::PENDING_UPDATES_OPTION, $updates, false );
 			}
 		}
-
-		$archives = get_option( self::PENDING_ARCHIVES_OPTION, [] );
-		if ( isset( $archives[ $product_id ] ) ) {
-			unset( $archives[ $product_id ] );
-			if ( empty( $archives ) ) {
-				delete_option( self::PENDING_ARCHIVES_OPTION );
-			} else {
-				update_option( self::PENDING_ARCHIVES_OPTION, $archives, false );
-			}
-		}
 	}
 
 	/**
-	 * Re-check `should_sync_product()` for each pending entry and drop the
-	 * ones whose filter outcome flipped to false between enqueue and flush.
+	 * Re-check `should_sync_product()` for each pending inventory entry and drop
+	 * the ones whose filter outcome flipped to false between enqueue and flush.
 	 *
-	 * The event-driven eviction in `track_stock_change()` and `track_product_archive()`
-	 * only fires when a follow-up event arrives. If a merchant hides a product
-	 * during the 60-second batch window and no further event lands for it, the
-	 * queued row would otherwise still ship on the next flush — defeating the
-	 * filter's "this product should not be synced" contract. Reading the option
-	 * blind at flush time isn't enough; the visibility decision can move.
+	 * The event-driven eviction in `track_stock_change()` only fires when a
+	 * follow-up event arrives. If a merchant hides a product during the
+	 * 60-second batch window and no further event lands for it, the queued row
+	 * would otherwise still ship on the next flush — defeating the filter's
+	 * "this product should not be synced" contract. Reading the option blind at
+	 * flush time isn't enough; the visibility decision can move.
 	 *
-	 * For permanently-deleted products (`wc_get_product()` returns false): inventory
-	 * entries are dropped (the stock delta references a SKU that no longer exists),
-	 * but archive entries are kept because the row data was already captured at
-	 * archive time and Stripe still has the product to mark out_of_stock.
+	 * Permanently-deleted products (`wc_get_product()` returns false) are
+	 * dropped too: the stock delta references a SKU that no longer exists.
+	 *
+	 * Only inventory entries are pruned this way. Pending archives are
+	 * `delete=true` removal signals, valid regardless of eligibility.
 	 *
 	 * @since 10.8.0
 	 * @param string $option_key Pending option to prune.
-	 * @param bool   $is_archive Whether the option holds archive entries (changes the missing-product policy).
 	 * @return array Pruned pending entries — also persisted back to `$option_key` if anything changed.
 	 */
-	private function prune_stale_pending_entries( string $option_key, bool $is_archive ): array {
+	private function prune_stale_pending_entries( string $option_key ): array {
 		$pending = get_option( $option_key, [] );
 		if ( empty( $pending ) ) {
 			return [];
@@ -250,13 +289,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 		$kept = [];
 		foreach ( $pending as $id => $row ) {
 			$product = wc_get_product( $id );
-			if ( ! $product ) {
-				if ( $is_archive ) {
-					$kept[ $id ] = $row;
-				}
-				continue;
-			}
-			if ( WC_Stripe_Agentic_Commerce_Product_Mapper::should_sync_product( $product ) ) {
+			if ( $product && WC_Stripe_Agentic_Commerce_Product_Mapper::should_sync_product( $product ) ) {
 				$kept[ $id ] = $row;
 			}
 		}
@@ -274,64 +307,64 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 	}
 
 	/**
-	 * Track a product deletion (permanent delete or trash) for archiving on Stripe.
+	 * Track a product removal (permanent delete, trash, or unpublish) for deletion on Stripe.
 	 *
-	 * Uses the product mapper to capture all required feed fields (title, description,
-	 * link, price, image, etc.) before the product is permanently deleted, then stores
-	 * the full mapped row in the pending archives option. This is necessary because
-	 * Stripe's product_catalog_feed ImportSet requires all mandatory fields even when
-	 * the purpose is to mark a product as out_of_stock.
+	 * Captures the feed id (SKU or product ID) before the product disappears and
+	 * queues a `delete=true` row, which removes the product from Stripe's
+	 * catalog. Runs even for excluded products: a delete is idempotent, and
+	 * bailing on eligibility here would mean an exclude-then-trash inside one
+	 * resync window never lands a removal at all.
 	 *
-	 * Schedules a sync 60 seconds later if one is not already scheduled. The product
-	 * is also removed from any pending inventory updates since the stock quantity is
-	 * no longer relevant once the product is removed.
+	 * Schedules a sync 60 seconds later if one is not already scheduled. The
+	 * product is also removed from any pending inventory updates since the stock
+	 * quantity is no longer relevant once the product is removed.
 	 *
 	 * @since 10.6.0
-	 * @param \WC_Product $product The product being deleted or trashed.
+	 * @param \WC_Product $product The product being deleted, trashed, or unpublished.
 	 * @return void
 	 */
 	public function track_product_archive( \WC_Product $product ): void {
-		if ( ! WC_Stripe_Agentic_Commerce_Product_Mapper::should_sync_product( $product ) ) {
-			// Evict any stale entries that were queued before the visibility filter
-			// flipped — otherwise a now-excluded product would still flush to Stripe
-			// on the next batch.
-			$this->evict_pending_entries( $product->get_id() );
-			return;
-		}
-
-		$product_id = $product->get_id();
-
-		// Remove from pending inventory updates — stock quantity is irrelevant for archived products.
-		$pending_inventory = get_option( self::PENDING_UPDATES_OPTION, [] );
-		if ( isset( $pending_inventory[ $product_id ] ) ) {
-			unset( $pending_inventory[ $product_id ] );
-			update_option( self::PENDING_UPDATES_OPTION, $pending_inventory, false );
+		// Variations are the actual feed entries, but trashing or drafting a
+		// variable parent doesn't cascade a status change to them — expand the
+		// parent into its children so each exported row gets a removal.
+		$products = [ $product ];
+		if ( $product->is_type( 'variable' ) ) {
+			$products = [];
+			foreach ( $product->get_children() as $child_id ) {
+				$child = wc_get_product( $child_id );
+				if ( $child instanceof \WC_Product ) {
+					$products[] = $child;
+				}
+			}
 		}
 
 		$pending = get_option( self::PENDING_ARCHIVES_OPTION, [] );
+		$queued  = false;
 
-		if ( count( $pending ) >= self::MAX_PENDING_UPDATES ) {
+		foreach ( $products as $item ) {
+			$this->evict_pending_entries( $item->get_id() );
+
+			if ( count( $pending ) >= self::MAX_PENDING_UPDATES && ! isset( $pending[ $item->get_id() ] ) ) {
+				WC_Stripe_Logger::warning(
+					'Agentic Commerce: Pending archive threshold reached - removal not queued',
+					[ 'product_id' => $item->get_id() ]
+				);
+				continue;
+			}
+
+			// Stripe reads only `id` and `delete` from a removal row, so the feed
+			// id is the only product data worth capturing before deletion.
+			$pending[ $item->get_id() ] = [
+				'id'        => WC_Stripe_Agentic_Commerce_Product_Mapper::get_feed_id( $item ),
+				'delete'    => 'true',
+				'timestamp' => time(),
+			];
+			$queued                     = true;
+		}
+
+		if ( ! $queued ) {
 			return;
 		}
-
-		// Capture full product data now, before the product is deleted. The mapper
-		// populates all required fields (title, description, link, price, image_link,
-		// mpn/gtin, product_category, inventory) that Stripe requires.
-		$mapper = new WC_Stripe_Agentic_Commerce_Product_Mapper();
-		try {
-			$row = $mapper->map_product( $product );
-		} catch ( \RuntimeException $e ) {
-			// If mapping fails (e.g. missing parent for variation), store minimal data.
-			// The sync will still attempt delivery with the fields we have.
-			$row = [ 'id' => (string) $product_id ];
-		}
-
-		// Force availability to out_of_stock regardless of current stock status.
-		$row['availability'] = 'out_of_stock';
-
-		$row['timestamp'] = time();
-
-		$pending[ $product_id ] = $row;
 
 		update_option( self::PENDING_ARCHIVES_OPTION, $pending, false );
 
@@ -419,7 +452,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 		// the outcome can flip between enqueue and the batch window elapsing,
 		// and the event-driven eviction only catches products that get a
 		// follow-up stock or archive event in that window.
-		$pending = $this->prune_stale_pending_entries( self::PENDING_UPDATES_OPTION, false );
+		$pending = $this->prune_stale_pending_entries( self::PENDING_UPDATES_OPTION );
 
 		if ( empty( $pending ) ) {
 			WC_Stripe_Logger::info( 'Agentic Commerce: Inventory sync skipped - all pending updates pruned by visibility filter' );
@@ -494,11 +527,10 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 	/**
 	 * Generate an archive feed CSV from pending product archives.
 	 *
-	 * Returns a finalized CSV feed containing all product catalog fields with
-	 * availability set to out_of_stock. The full field set is required because
-	 * Stripe's product_catalog_feed ImportSet validates all mandatory columns
-	 * (title, description, link, price, image_link, mpn/gtin, product_category,
-	 * inventory_quantity/inventory_not_tracked).
+	 * Returns a finalized CSV feed of `delete=true` rows. The full column set is
+	 * kept so the file matches the standard product_catalog_feed header layout;
+	 * Stripe reads only `id` and `delete` from a removal row and ignores the
+	 * rest.
 	 *
 	 * @since 10.6.0
 	 * @return WC_Stripe_Agentic_Commerce_Csv_Feed|null Finalized feed, or null if nothing to sync.
@@ -520,8 +552,9 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 			foreach ( $columns as $column ) {
 				$entry[ $column ] = $archive[ $column ] ?? null;
 			}
-			// Ensure availability is always out_of_stock.
-			$entry['availability'] = 'out_of_stock';
+			// Forced unconditionally so entries queued by an older plugin version
+			// (full out_of_stock rows) also flush as removals.
+			$entry['delete'] = 'true';
 			$feed->add_entry( $entry );
 		}
 
@@ -533,17 +566,18 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 	/**
 	 * Execute archive sync process.
 	 *
-	 * Called by Action Scheduler one minute after the first tracked product deletion
-	 * or trash event. Generates a minimal product catalog CSV (id + availability:
-	 * out_of_stock) and uploads it to Stripe as a product_catalog_feed ImportSet,
-	 * marking each product as unavailable without permanently removing it.
+	 * Called by Action Scheduler one minute after the first tracked product
+	 * deletion, trash, or unpublish event. Generates a product catalog CSV of
+	 * `delete=true` rows and uploads it to Stripe as a product_catalog_feed
+	 * ImportSet, removing each product from Stripe's catalog.
 	 *
 	 * On success, pending archives are cleared. On failure they are retained so
 	 * the next scheduled sync can retry.
 	 *
-	 * If the number of pending archives exceeds MAX_PENDING_UPDATES, the queue
-	 * is cleared and the regular full catalog sync will handle the backlog on its
-	 * next run.
+	 * Unlike inventory, the queue is neither deferred to the full catalog sync
+	 * (which cannot delete products no longer in the feed query) nor pruned by
+	 * eligibility (a removal is valid for an excluded product); republished
+	 * products are already cancelled out at transition time.
 	 *
 	 * @since 10.6.0
 	 * @return void
@@ -558,29 +592,6 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 
 		if ( empty( $pending ) ) {
 			WC_Stripe_Logger::info( 'Agentic Commerce: Archive sync skipped - no pending archives' );
-			return;
-		}
-
-		// Too many pending archives — fall back to full catalog sync on its next scheduled run.
-		// Run this before the visibility re-check so an enormous queue still defers cleanly
-		// instead of paying the per-row product load cost.
-		if ( count( $pending ) >= self::MAX_PENDING_UPDATES ) {
-			WC_Stripe_Logger::info(
-				'Agentic Commerce: Archive sync - pending archive threshold exceeded, deferring to full catalog sync',
-				[ 'pending_count' => count( $pending ) ]
-			);
-			delete_option( self::PENDING_ARCHIVES_OPTION );
-			return;
-		}
-
-		// Re-check the visibility filter for each pending entry before flushing —
-		// see the matching note in sync_inventory(). For permanently-deleted
-		// products the helper keeps archive entries (the mapped row was captured
-		// before the delete) so Stripe still receives the out_of_stock signal.
-		$pending = $this->prune_stale_pending_entries( self::PENDING_ARCHIVES_OPTION, true );
-
-		if ( empty( $pending ) ) {
-			WC_Stripe_Logger::info( 'Agentic Commerce: Archive sync skipped - all pending archives pruned by visibility filter' );
 			return;
 		}
 

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-inventory-tracker.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-inventory-tracker.php
@@ -16,6 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Automattic\WooCommerce\Enums\ProductStatus;
+use Automattic\WooCommerce\Enums\ProductType;
 
 /**
  * Tracks product stock changes and syncs incremental inventory updates to Stripe.
@@ -95,6 +96,9 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 		// restores to draft by default, so an unconditional `untrash_post`
 		// cancel would leave a draft product live on Stripe.
 		add_action( 'transition_post_status', [ $this, 'handle_status_transition' ], 10, 3 );
+		// A type change out of the feed query (e.g. simple→grouped) fires no
+		// status transition, so it needs its own removal hook.
+		add_action( 'woocommerce_product_type_changed', [ $this, 'handle_product_type_change' ], 10, 3 );
 		add_action( self::ARCHIVE_SCHEDULED_ACTION, [ $this, 'sync_archives' ] );
 	}
 
@@ -315,16 +319,89 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker {
 		// Variations are the actual feed entries and a parent's status change
 		// doesn't cascade to them — expand the parent into its children.
 		$products = [ $product ];
-		if ( $product->is_type( 'variable' ) ) {
-			$products = [];
-			foreach ( $product->get_children() as $child_id ) {
-				$child = wc_get_product( $child_id );
-				if ( $child instanceof \WC_Product ) {
-					$products[] = $child;
-				}
-			}
+		if ( $product->is_type( ProductType::VARIABLE ) ) {
+			$products = $this->load_variations( $product->get_id() );
 		}
 
+		$this->queue_removals( $products );
+	}
+
+	/**
+	 * Queue a removal when a product's type change takes it out of the feed query.
+	 *
+	 * Only leaving-the-feed transitions matter: entering ones are picked up by
+	 * the next full sync, and a product that was never in the feed has nothing
+	 * to remove.
+	 *
+	 * @since 11.0.0
+	 * @param \WC_Product|mixed $product  The saved product, carrying the new type.
+	 * @param string            $old_type Product type before the change.
+	 * @param string            $new_type Product type after the change.
+	 * @return void
+	 */
+	public function handle_product_type_change( $product, $old_type, $new_type ): void {
+		if ( ! $product instanceof \WC_Product ) {
+			return;
+		}
+
+		if ( ProductType::SIMPLE === $old_type ) {
+			// For simple→variable on a SKU'd product, SKU-less variations inherit
+			// the parent SKU as their feed id, so a delete could remove the live
+			// variation row — and on that id collision the variation's upsert
+			// overwrites the stale simple row anyway.
+			$sku_collision = ProductType::VARIABLE === $new_type && '' !== $product->get_sku();
+			if ( ! $sku_collision ) {
+				$this->queue_removals( [ $product ] );
+			}
+			return;
+		}
+
+		if ( ProductType::VARIABLE === $old_type ) {
+			// The variation posts survive the type switch; the orphaned-variation
+			// eligibility check also converges them on the next full sync.
+			$this->queue_removals( $this->load_variations( $product->get_id() ) );
+		}
+	}
+
+	/**
+	 * Load the variation products attached to a parent, regardless of the
+	 * parent's current type — `WC_Product::get_children()` is only populated
+	 * for variable products, and removal paths run after the parent stopped
+	 * being one.
+	 *
+	 * @since 11.0.0
+	 * @param int $parent_id Parent product ID.
+	 * @return \WC_Product[]
+	 */
+	private function load_variations( int $parent_id ): array {
+		$variation_ids = get_posts(
+			[
+				'post_type'   => 'product_variation',
+				'post_parent' => $parent_id,
+				'post_status' => 'any',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+			]
+		);
+
+		$variations = [];
+		foreach ( $variation_ids as $variation_id ) {
+			$variation = wc_get_product( $variation_id );
+			if ( $variation instanceof \WC_Product ) {
+				$variations[] = $variation;
+			}
+		}
+		return $variations;
+	}
+
+	/**
+	 * Queue `delete=true` rows for the given products and schedule the flush.
+	 *
+	 * @since 11.0.0
+	 * @param \WC_Product[] $products Products to remove from Stripe's catalog.
+	 * @return void
+	 */
+	private function queue_removals( array $products ): void {
 		$pending = get_option( self::PENDING_ARCHIVES_OPTION, [] );
 		$queued  = false;
 

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper.php
@@ -67,13 +67,14 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 	 * @throws RuntimeException If the parent product is not found.
 	 */
 	public function map_product( \WC_Product $product ): array {
-		// Per-product visibility gate. Returning an empty row causes the validator's
-		// required-field check to reject it, so the walker skips the entry. Adapters
-		// (e.g. WC AI Storefront) that want to scope the catalog at query time should
-		// prefer the `wc_stripe_agentic_commerce_product_query_args` filter so excluded
-		// products aren't iterated at all; this hook is the per-product safety net.
+		// Per-product visibility gate. Stripe processes catalog imports in upsert
+		// mode, where omitting a product leaves it in the catalog indefinitely —
+		// so an ineligible product maps to a `delete=true` row (the explicit
+		// removal signal) rather than being dropped from the feed. Emitting the
+		// row on every sync is deliberate: deletes are idempotent, and a
+		// stateless feed self-heals if an earlier removal upload was lost.
 		if ( ! self::should_sync_product( $product ) ) {
-			return [];
+			return $this->map_delete_row( $product );
 		}
 
 		$row = [];
@@ -101,12 +102,44 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 		/**
 		 * Filter mapped product data before validation.
 		 *
+		 * Not applied to delete rows: excluded products historically never
+		 * reached this filter, and callbacks written against full rows should
+		 * not start receiving null-filled removal rows.
+		 *
 		 * @since 10.5.0
 		 * @param array            $row             Mapped product data.
 		 * @param \WC_Product      $product         Product object.
 		 * @param \WC_Product|null $parent_product  Parent product for variations.
 		 */
 		return apply_filters( 'wc_stripe_agentic_commerce_map_product', $row, $product, $parent_product );
+	}
+
+	/**
+	 * Build a `delete=true` removal row for an ineligible product.
+	 *
+	 * Stripe reads only `id` and `delete` from such a row; the remaining
+	 * columns stay null purely to keep the CSV aligned with the feed headers.
+	 *
+	 * @since 11.0.0
+	 * @param \WC_Product $product Product to remove from Stripe's catalog.
+	 * @return array Full-width row with only `id` and `delete` populated.
+	 */
+	protected function map_delete_row( \WC_Product $product ): array {
+		$row           = array_fill_keys( array_keys( $this->schema ), null );
+		$row['id']     = self::get_feed_id( $product );
+		$row['delete'] = 'true';
+		return $row;
+	}
+
+	/**
+	 * Whether a mapped row is a `delete=true` removal signal.
+	 *
+	 * @since 11.0.0
+	 * @param array $row Mapped row.
+	 * @return bool
+	 */
+	public static function is_delete_row( array $row ): bool {
+		return isset( $row['delete'] ) && in_array( $row['delete'], [ 'true', true ], true );
 	}
 
 	/**
@@ -180,6 +213,20 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 	 * @return string SKU when present, otherwise the product ID as a string.
 	 */
 	protected function get_id( \WC_Product $product ): string {
+		return self::get_feed_id( $product );
+	}
+
+	/**
+	 * The catalog row id for a product: SKU when present, product ID otherwise.
+	 *
+	 * Static so removal paths (delete rows queued outside a full feed walk) can
+	 * target the same id the product was originally exported under.
+	 *
+	 * @since 11.0.0
+	 * @param \WC_Product $product Product object.
+	 * @return string SKU when present, otherwise the product ID as a string.
+	 */
+	public static function get_feed_id( \WC_Product $product ): string {
 		$sku = $product->get_sku();
 		if ( '' !== $sku ) {
 			return $sku;
@@ -1065,11 +1112,33 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 	}
 
 	/**
+	 * Whether the product, or a variation's parent, is not published.
+	 *
+	 * The feed query already selects `publish` status, but only on the row
+	 * itself: variations of a draft or private variable product still match the
+	 * variation query, and without this check they would keep syncing with a
+	 * `link` that 404s for shoppers.
+	 *
+	 * @since 11.0.0
+	 * @param \WC_Product $product Product to check.
+	 * @return bool
+	 */
+	public static function is_unpublished( \WC_Product $product ): bool {
+		if ( 'publish' !== $product->get_status() ) {
+			return true;
+		}
+
+		$parent_id = $product->get_parent_id();
+		return $parent_id > 0 && 'publish' !== get_post_status( $parent_id );
+	}
+
+	/**
 	 * Whether the given product should be included in any Agentic Commerce sync
 	 * (full feed, inventory updates, archive events).
 	 *
 	 * Defaults to true, minus the built-in exclusions: subscriptions,
-	 * password-protected products, and products hidden from catalog and search.
+	 * password-protected products, products hidden from catalog and search, and
+	 * unpublished products (including variations of an unpublished parent).
 	 * Integrations such as WC AI Storefront can return false to exclude a product,
 	 * or true to re-include one the defaults dropped.
 	 *
@@ -1083,11 +1152,13 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 		// they fail validation and downgrade every sync to a partial success.
 		// Excluded by default, still overridable via the filters below.
 		//
-		// The other two express intent the query cannot: it selects on status and
-		// type only, so a protected or hidden product is still `publish`.
+		// The others express intent the query cannot: it selects on status and
+		// type of the row itself, so a protected or hidden product is still
+		// `publish`, and a variation of an unpublished parent still matches.
 		$default_should_sync = ! self::is_subscription_product( $product )
 			&& ! self::is_password_protected( $product )
-			&& ! self::is_hidden_from_catalog( $product );
+			&& ! self::is_hidden_from_catalog( $product )
+			&& ! self::is_unpublished( $product );
 
 		// The Stripe-prefixed filter is retained for backward compatibility. Its
 		// result seeds the default for the canonical filter below, so existing
@@ -1118,12 +1189,12 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 		 * to scope the full-feed query — that avoids loading the product at all
 		 * and keeps the validator's skipped-product log unpolluted.
 		 *
-		 * Lifecycle contract: this filter only governs what gets *sent* to Stripe.
-		 * A product that was previously exported and is now excluded stays in
-		 * Stripe's catalog until the next full feed replacement overwrites it —
-		 * the inventory tracker intentionally drops delta events for excluded
-		 * products. Adapters that want immediate convergence when their filter
-		 * outcome changes (e.g. a merchant flips a visibility setting) MUST fire
+		 * Lifecycle contract: a product this filter excludes is exported as a
+		 * `delete=true` row, which removes it from Stripe's catalog on the next
+		 * full sync (Stripe's default upsert mode ignores mere omission). The
+		 * inventory tracker still drops delta events for excluded products.
+		 * Adapters that want immediate convergence when their filter outcome
+		 * changes (e.g. a merchant flips a visibility setting) MUST fire
 		 * `do_action( 'wc_stripe_agentic_commerce_schedule_full_resync' )` to
 		 * enqueue an immediate full-catalog sync.
 		 *
@@ -1132,8 +1203,8 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 		 *
 		 * @since 10.9.0
 		 * @param bool        $should_sync Whether to include the product. Default true, except for
-		 *                                 subscriptions, password-protected products, and products
-		 *                                 hidden from catalog and search.
+		 *                                 subscriptions, password-protected products, products
+		 *                                 hidden from catalog and search, and unpublished products.
 		 * @param \WC_Product $product     Product being evaluated.
 		 */
 		return wp_validate_boolean( apply_filters( 'woocommerce_agentic_commerce_should_sync_product', $should_sync, $product ) );

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper.php
@@ -67,12 +67,9 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 	 * @throws RuntimeException If the parent product is not found.
 	 */
 	public function map_product( \WC_Product $product ): array {
-		// Per-product visibility gate. Stripe processes catalog imports in upsert
-		// mode, where omitting a product leaves it in the catalog indefinitely —
-		// so an ineligible product maps to a `delete=true` row (the explicit
-		// removal signal) rather than being dropped from the feed. Emitting the
-		// row on every sync is deliberate: deletes are idempotent, and a
-		// stateless feed self-heals if an earlier removal upload was lost.
+		// Stripe imports run in upsert mode, so omission never removes a product —
+		// ineligible products map to an explicit `delete=true` row instead.
+		// Re-emitted every sync: deletes are idempotent and self-heal a lost upload.
 		if ( ! self::should_sync_product( $product ) ) {
 			return $this->map_delete_row( $product );
 		}
@@ -102,9 +99,8 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 		/**
 		 * Filter mapped product data before validation.
 		 *
-		 * Not applied to delete rows: excluded products historically never
-		 * reached this filter, and callbacks written against full rows should
-		 * not start receiving null-filled removal rows.
+		 * Not applied to delete rows: excluded products never reached this
+		 * filter, and its callbacks expect full rows.
 		 *
 		 * @since 10.5.0
 		 * @param array            $row             Mapped product data.
@@ -117,8 +113,8 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 	/**
 	 * Build a `delete=true` removal row for an ineligible product.
 	 *
-	 * Stripe reads only `id` and `delete` from such a row; the remaining
-	 * columns stay null purely to keep the CSV aligned with the feed headers.
+	 * Stripe reads only `id` and `delete`; the other columns stay null just to
+	 * keep the CSV aligned with the feed headers.
 	 *
 	 * @since 11.0.0
 	 * @param \WC_Product $product Product to remove from Stripe's catalog.
@@ -219,8 +215,7 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 	/**
 	 * The catalog row id for a product: SKU when present, product ID otherwise.
 	 *
-	 * Static so removal paths (delete rows queued outside a full feed walk) can
-	 * target the same id the product was originally exported under.
+	 * Static so removal paths queued outside a feed walk target the exported id.
 	 *
 	 * @since 11.0.0
 	 * @param \WC_Product $product Product object.
@@ -1114,10 +1109,8 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 	/**
 	 * Whether the product, or a variation's parent, is not published.
 	 *
-	 * The feed query already selects `publish` status, but only on the row
-	 * itself: variations of a draft or private variable product still match the
-	 * variation query, and without this check they would keep syncing with a
-	 * `link` that 404s for shoppers.
+	 * The feed query checks `publish` only on the row itself, so variations of
+	 * a draft or private parent would otherwise keep syncing with a dead link.
 	 *
 	 * @since 11.0.0
 	 * @param \WC_Product $product Product to check.
@@ -1189,14 +1182,12 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 		 * to scope the full-feed query — that avoids loading the product at all
 		 * and keeps the validator's skipped-product log unpolluted.
 		 *
-		 * Lifecycle contract: a product this filter excludes is exported as a
-		 * `delete=true` row, which removes it from Stripe's catalog on the next
-		 * full sync (Stripe's default upsert mode ignores mere omission). The
-		 * inventory tracker still drops delta events for excluded products.
-		 * Adapters that want immediate convergence when their filter outcome
-		 * changes (e.g. a merchant flips a visibility setting) MUST fire
-		 * `do_action( 'wc_stripe_agentic_commerce_schedule_full_resync' )` to
-		 * enqueue an immediate full-catalog sync.
+		 * Lifecycle contract: an excluded product is exported as a `delete=true`
+		 * row, removing it from Stripe's catalog on the next full sync (upsert
+		 * mode ignores mere omission); the inventory tracker still drops delta
+		 * events for it. Adapters whose filter outcome changes MUST fire
+		 * `do_action( 'wc_stripe_agentic_commerce_schedule_full_resync' )` for
+		 * immediate convergence.
 		 *
 		 * Also runs per row on the admin Products list (sync-status column),
 		 * so callbacks must be fast.

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Internal\ProductFeed\Feed\ProductMapperInterface;
@@ -1117,12 +1118,12 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 	 * @return bool
 	 */
 	public static function is_unpublished( \WC_Product $product ): bool {
-		if ( 'publish' !== $product->get_status() ) {
+		if ( ProductStatus::PUBLISH !== $product->get_status() ) {
 			return true;
 		}
 
 		$parent_id = $product->get_parent_id();
-		return $parent_id > 0 && 'publish' !== get_post_status( $parent_id );
+		return $parent_id > 0 && ProductStatus::PUBLISH !== get_post_status( $parent_id );
 	}
 
 	/**

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper.php
@@ -1127,6 +1127,26 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 	}
 
 	/**
+	 * Whether the variation's parent is missing or no longer a variable product.
+	 *
+	 * Switching a variable product to another type keeps its variation posts,
+	 * and the feed query still selects them; without this check those stale
+	 * rows would keep syncing (or, for a deleted parent, hard-fail the walk).
+	 *
+	 * @since 11.0.0
+	 * @param \WC_Product $product Product to check.
+	 * @return bool
+	 */
+	public static function is_orphaned_variation( \WC_Product $product ): bool {
+		if ( ProductType::VARIATION !== $product->get_type() ) {
+			return false;
+		}
+
+		$parent = wc_get_product( $product->get_parent_id() );
+		return ! $parent instanceof \WC_Product || ! $parent->is_type( ProductType::VARIABLE );
+	}
+
+	/**
 	 * Whether the given product should be included in any Agentic Commerce sync
 	 * (full feed, inventory updates, archive events).
 	 *
@@ -1152,7 +1172,8 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper implements ProductMapperInterfac
 		$default_should_sync = ! self::is_subscription_product( $product )
 			&& ! self::is_password_protected( $product )
 			&& ! self::is_hidden_from_catalog( $product )
-			&& ! self::is_unpublished( $product );
+			&& ! self::is_unpublished( $product )
+			&& ! self::is_orphaned_variation( $product );
 
 		// The Stripe-prefixed filter is retained for backward compatibility. Its
 		// result seeds the default for the canonical filter below, so existing

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-product-visibility.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-product-visibility.php
@@ -17,11 +17,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Watches product saves and exclude-flag writes, and schedules a full resync
  * when a product's `should_sync_product()` outcome flips.
  *
- * Stripe processes imports in upsert mode, so an already-exported product only
- * leaves the catalog when a feed carries its `delete=true` row. The mapper
- * emits that row for every ineligible product still in the feed query; this
- * class exists so the sync carrying it runs promptly after the flip rather
- * than at the next scheduled interval.
+ * Upsert-mode imports only drop a product when a feed carries its
+ * `delete=true` row; the mapper emits one for every in-query ineligible
+ * product, and this class makes the sync carrying it run promptly.
  *
  * @internal
  * @since 10.9.0

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-product-visibility.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-product-visibility.php
@@ -17,9 +17,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Watches product saves and exclude-flag writes, and schedules a full resync
  * when a product's `should_sync_product()` outcome flips.
  *
- * The filter only governs what is *sent*, so an already-exported product stays
- * live until a full feed replacement. The tracker can't close that gap — its
- * archive path bails on the same predicate, so a later trash never lands.
+ * Stripe processes imports in upsert mode, so an already-exported product only
+ * leaves the catalog when a feed carries its `delete=true` row. The mapper
+ * emits that row for every ineligible product still in the feed query; this
+ * class exists so the sync carrying it runs promptly after the flip rather
+ * than at the next scheduled interval.
  *
  * @internal
  * @since 10.9.0

--- a/readme.txt
+++ b/readme.txt
@@ -174,5 +174,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
 * Fix - Exclude password-protected products and products hidden from the catalog from the Agentic Commerce feed
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
+* Fix - Remove excluded, trashed, deleted, and unpublished products from the Stripe Agentic Commerce catalog by sending explicit removal rows, instead of leaving them visible to AI agents indefinitely
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -174,6 +174,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
 * Fix - Exclude password-protected products and products hidden from the catalog from the Agentic Commerce feed
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
-* Fix - Remove excluded, trashed, deleted, and unpublished products from the Stripe Agentic Commerce catalog by sending explicit removal rows, instead of leaving them visible to AI agents indefinitely
+* Fix - Remove excluded, trashed, deleted, and unpublished products from the Stripe Agentic Commerce catalog instead of leaving them visible to AI agents
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-feed-validator-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-feed-validator-test.php
@@ -760,4 +760,51 @@ class WC_Stripe_Agentic_Commerce_Feed_Validator_Test extends WP_UnitTestCase {
 
 		$product->delete( true );
 	}
+
+	/**
+	 * A `delete=true` row with an id validates clean despite its null-filled
+	 * required columns: Stripe reads only `id` and `delete` from it, and it must
+	 * enter the feed to remove the product from the catalog. Counted as removed,
+	 * not excluded and not failed.
+	 *
+	 * @return void
+	 */
+	public function test_validate_entry_admits_delete_row_and_counts_it_removed() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$row           = array_fill_keys( WC_Stripe_Agentic_Commerce_Feed_Schema::get_csv_headers(), null );
+		$row['id']     = (string) $product->get_id();
+		$row['delete'] = 'true';
+
+		$validator = new \WC_Stripe_Agentic_Commerce_Feed_Validator();
+		$errors    = $validator->validate_entry( $row, $product );
+
+		$this->assertSame( [], $errors, 'A delete row with an id must pass validation.' );
+		$this->assertSame( 1, $validator->get_removed_count() );
+		$this->assertSame( 0, $validator->get_excluded_count() );
+		$this->assertSame( [], $validator->get_collected_errors()['products'] );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * A `delete=true` row without an id cannot target anything on Stripe, so it
+	 * falls through to normal validation and fails like any malformed row.
+	 *
+	 * @return void
+	 */
+	public function test_validate_entry_rejects_delete_row_without_id() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$row           = array_fill_keys( WC_Stripe_Agentic_Commerce_Feed_Schema::get_csv_headers(), null );
+		$row['delete'] = 'true';
+
+		$validator = new \WC_Stripe_Agentic_Commerce_Feed_Validator();
+		$errors    = $validator->validate_entry( $row, $product );
+
+		$this->assertNotEmpty( $errors, 'A delete row without an id is a validation failure.' );
+		$this->assertSame( 0, $validator->get_removed_count() );
+
+		$product->delete( true );
+	}
 }

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-integration-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-integration-test.php
@@ -240,9 +240,10 @@ class WC_Stripe_Agentic_Commerce_Integration_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * An excluded product must stay out of the feed without counting as a
-	 * validation skip: `skipped_products` (which drives the "Partial success"
-	 * badge) must persist as 0 for a pure exclusion.
+	 * An excluded product ships as a `delete=true` removal row, not as product
+	 * data, and must count as neither a synced product nor a validation skip:
+	 * `skipped_products` (which drives the "Partial success" badge) must persist
+	 * as 0 and `products` must reflect only real catalog rows.
 	 *
 	 * @return void
 	 */
@@ -318,7 +319,8 @@ class WC_Stripe_Agentic_Commerce_Integration_Test extends WP_UnitTestCase {
 
 			$last_sync = \WC_Stripe_Agentic_Commerce_Integration::get_last_sync();
 			$this->assertSame( 0, (int) $last_sync['skipped_products'], 'An excluded product must not be counted as a validation skip.' );
-			$this->assertSame( 1, (int) $last_sync['products'], 'Only the kept product belongs in the feed; the excluded one is dropped.' );
+			$this->assertSame( 1, (int) $last_sync['products'], 'Only the kept product counts as synced; the excluded one ships as a removal.' );
+			$this->assertSame( 1, (int) $last_sync['removed_products'], 'The excluded product must be recorded as a removal.' );
 			$this->assertNotSame( 'succeeded_with_errors', $last_sync['status'], 'A pure exclusion must not flip the sync to Partial success.' );
 		} finally {
 			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $filter, 10 );

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-inventory-tracker-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-inventory-tracker-test.php
@@ -60,7 +60,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 			remove_action( WC_Stripe_Agentic_Commerce_Inventory_Tracker::SCHEDULED_ACTION, [ $this->sut, 'sync_inventory' ] );
 			remove_action( 'before_delete_post', [ $this->sut, 'maybe_track_product_archive' ] );
 			remove_action( 'wp_trash_post', [ $this->sut, 'maybe_track_product_archive' ] );
-			remove_action( 'untrash_post', [ $this->sut, 'maybe_cancel_pending_archive' ] );
+			remove_action( 'transition_post_status', [ $this->sut, 'handle_status_transition' ] );
 			remove_action( WC_Stripe_Agentic_Commerce_Inventory_Tracker::ARCHIVE_SCHEDULED_ACTION, [ $this->sut, 'sync_archives' ] );
 		}
 
@@ -145,7 +145,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 
 		$this->assertNotFalse( has_action( 'before_delete_post', [ $this->sut, 'maybe_track_product_archive' ] ) );
 		$this->assertNotFalse( has_action( 'wp_trash_post', [ $this->sut, 'maybe_track_product_archive' ] ) );
-		$this->assertNotFalse( has_action( 'untrash_post', [ $this->sut, 'maybe_cancel_pending_archive' ] ) );
+		$this->assertNotFalse( has_action( 'transition_post_status', [ $this->sut, 'handle_status_transition' ] ) );
 		$this->assertNotFalse(
 			has_action(
 				WC_Stripe_Agentic_Commerce_Inventory_Tracker::ARCHIVE_SCHEDULED_ACTION,
@@ -209,7 +209,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 
 		$pending = get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] );
 		$this->assertArrayHasKey( $variation->get_id(), $pending );
-		$this->assertEquals( 'out_of_stock', $pending[ $variation->get_id() ]['availability'] );
+		$this->assertEquals( 'true', $pending[ $variation->get_id() ]['delete'] );
 	}
 
 	// -------------------------------------------------------------------------
@@ -830,23 +830,18 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 
 		$this->assertArrayHasKey( $product->get_id(), $pending );
 		$this->assertEquals( (string) $product->get_id(), $pending[ $product->get_id() ]['id'] );
-		$this->assertEquals( 'out_of_stock', $pending[ $product->get_id() ]['availability'] );
-		$this->assertArrayHasKey( 'title', $pending[ $product->get_id() ] );
-		$this->assertArrayHasKey( 'description', $pending[ $product->get_id() ] );
-		$this->assertArrayHasKey( 'link', $pending[ $product->get_id() ] );
-		$this->assertArrayHasKey( 'price', $pending[ $product->get_id() ] );
+		$this->assertEquals( 'true', $pending[ $product->get_id() ]['delete'] );
 		$this->assertArrayHasKey( 'timestamp', $pending[ $product->get_id() ] );
 	}
 
 	/**
-	 * Test that `track_product_archive` skips products an adapter excluded via
-	 * `woocommerce_agentic_commerce_should_sync_product`. An excluded product was
-	 * never on Stripe in the first place, so emitting an out_of_stock entry for
-	 * it on deletion would surface a SKU Stripe doesn't recognise.
+	 * A removal for an excluded product still queues: a `delete=true` row is
+	 * idempotent, and bailing on eligibility would mean exclude-then-trash
+	 * inside one resync window never lands a removal on Stripe at all.
 	 *
 	 * @return void
 	 */
-	public function test_track_product_archive_skips_excluded_product() {
+	public function test_track_product_archive_queues_delete_for_excluded_product() {
 		$product  = $this->create_simple_product_with_stock( 3 );
 		$callback = static fn( $sync, $candidate ) => $candidate->get_id() !== $product->get_id();
 		add_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10, 2 );
@@ -854,30 +849,29 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 		try {
 			$this->sut->track_product_archive( $product );
 
-			$this->assertSame( [], get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] ) );
+			$pending = get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] );
+			$this->assertArrayHasKey( $product->get_id(), $pending );
+			$this->assertEquals( 'true', $pending[ $product->get_id() ]['delete'] );
 		} finally {
 			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10 );
 		}
 	}
 
 	/**
-	 * Test that `track_product_archive` evicts previously-queued inventory and
-	 * archive entries for a product whose visibility just flipped to excluded.
-	 * Guards both stale-entry families: a hidden product that had been queued
-	 * for an inventory delta or an archive must not flush to Stripe on the
-	 * next batch.
+	 * A removal event for a product whose visibility flipped to excluded evicts
+	 * its stale inventory delta (that data must not flush) but keeps the
+	 * archive queue populated with the removal itself.
 	 *
 	 * @return void
 	 */
-	public function test_track_product_archive_evicts_stale_entries_when_filter_now_excludes() {
+	public function test_track_product_archive_evicts_stale_inventory_when_filter_now_excludes() {
 		$product = $this->create_simple_product_with_stock( 7 );
 
-		// Seed both queues while the filter still allows it.
+		// Seed the inventory queue while the filter still allows it.
 		$this->sut->track_stock_change( $product );
-		$this->sut->track_product_archive( $product );
-		$this->assertArrayHasKey( $product->get_id(), get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] ) );
+		$this->assertArrayHasKey( $product->get_id(), get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_UPDATES_OPTION, [] ) );
 
-		// Flip the filter, then trigger another archive event.
+		// Flip the filter, then trigger an archive event.
 		$callback = static fn( $sync, $candidate ) => $candidate->get_id() !== $product->get_id();
 		add_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10, 2 );
 
@@ -885,7 +879,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 			$this->sut->track_product_archive( $product );
 
 			$this->assertSame( [], get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_UPDATES_OPTION, [] ) );
-			$this->assertSame( [], get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] ) );
+			$this->assertArrayHasKey( $product->get_id(), get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] ) );
 		} finally {
 			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10 );
 		}
@@ -996,7 +990,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 	}
 
 	/**
-	 * Test generate_archive_feed CSV contains correct id and availability columns.
+	 * Test generate_archive_feed CSV carries the id and a `delete=true` flag.
 	 *
 	 * @return void
 	 */
@@ -1020,17 +1014,14 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 		$expected_headers = WC_Stripe_Agentic_Commerce_Feed_Schema::get_csv_headers();
 		$this->assertEquals( $expected_headers, $header_cols );
 
-		// Verify data row contains the expected product data.
+		// Verify the data row is a removal: Stripe reads only id + delete.
 		$data_row = str_getcsv( reset( $lines ) );
 		$row      = array_combine( $header_cols, $data_row );
 
 		$this->assertEquals( (string) $product->get_id(), $row['id'] );
-		$this->assertEquals( 'out_of_stock', $row['availability'] );
-		$this->assertNotEmpty( $row['title'] );
-		$this->assertNotEmpty( $row['description'] );
-		$this->assertNotEmpty( $row['link'] );
-		$this->assertNotEmpty( $row['price'] );
-		$this->assertNotEmpty( $row['image_link'] );
+		$this->assertEquals( 'true', $row['delete'] );
+		$this->assertEmpty( $row['title'] );
+		$this->assertEmpty( $row['price'] );
 
 		wp_delete_file( $file_path );
 	}
@@ -1099,23 +1090,44 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 	 *
 	 * @return void
 	 */
-	public function test_sync_archives_clears_pending_when_threshold_exceeded() {
+	public function test_sync_archives_flushes_full_queue_at_threshold() {
 		add_filter( 'wc_stripe_is_agentic_commerce_enabled', '__return_true' );
+		WC_Stripe_API::set_secret_key( 'sk_test_fake' );
 
 		$max     = WC_Stripe_Agentic_Commerce_Inventory_Tracker::MAX_PENDING_UPDATES;
 		$pending = [];
 		for ( $i = 1; $i <= $max; $i++ ) {
 			$pending[ $i ] = [
-				'id'        => $i,
+				'id'        => (string) $i,
+				'delete'    => 'true',
 				'timestamp' => time(),
 			];
 		}
 		update_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, $pending );
 
+		$uploaded = false;
+		add_filter(
+			'wc_stripe_agentic_commerce_files_api_pre_request',
+			function () use ( &$uploaded ) {
+				$uploaded = true;
+				return [ 'id' => 'file_test_123' ];
+			}
+		);
+		add_filter(
+			'wc_stripe_agentic_commerce_import_set_pre_request',
+			fn() => [
+				'id'     => 'impset_test_456',
+				'status' => 'pending',
+			]
+		);
+
 		$this->sut->sync_archives();
 
-		$after = get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] );
-		$this->assertEmpty( $after );
+		// A full queue must upload, not defer: the full catalog sync cannot
+		// delete products that already left the feed query, so dropping the
+		// queue here would permanently orphan those entries on Stripe.
+		$this->assertTrue( $uploaded );
+		$this->assertEmpty( get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] ) );
 	}
 
 	/**
@@ -1171,14 +1183,13 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 	 * @return void
 	 */
 	/**
-	 * Same race as the inventory side: an archive event queued before the
-	 * filter flipped must not still ship if the merchant has since hidden
-	 * the product. Only fires when the product is still resolvable — the
-	 * permanent-delete case is covered separately.
+	 * Unlike the inventory side, an archive entry ships even when the filter has
+	 * since flipped to excluded: it is a `delete=true` removal signal, and an
+	 * excluded product is exactly one that should not stay on Stripe.
 	 *
 	 * @return void
 	 */
-	public function test_sync_archives_prunes_entries_whose_filter_now_excludes() {
+	public function test_sync_archives_ships_entries_even_when_filter_now_excludes() {
 		add_filter( 'wc_stripe_is_agentic_commerce_enabled', '__return_true' );
 		WC_Stripe_API::set_secret_key( 'sk_test_fake' );
 
@@ -1215,20 +1226,19 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10 );
 		}
 
-		$this->assertNotNull( $uploaded_ids, 'A feed should have been uploaded for the kept product.' );
+		$this->assertNotNull( $uploaded_ids, 'A feed should have been uploaded.' );
 		$this->assertContains( (string) $kept_product->get_id(), $uploaded_ids, 'Kept archive must be in the uploaded feed.' );
-		$this->assertNotContains( (string) $flipped_id, $uploaded_ids, 'Pruned archive must not be in the uploaded feed.' );
+		$this->assertContains( (string) $flipped_id, $uploaded_ids, 'The removal for the now-excluded product must still ship.' );
 
 		$pending = get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] );
-		$this->assertEmpty( $pending, 'Both entries cleared post-sync — kept was uploaded, flipped was pruned.' );
+		$this->assertEmpty( $pending, 'Both entries cleared post-sync after upload.' );
 	}
 
 	/**
 	 * Opposite policy from the inventory path: when an archive entry is queued
-	 * and the product is then permanently deleted, the row data has already
-	 * been mapped (Mapper output captured at archive time) and Stripe still
-	 * has the product in its catalog. We can't re-check the filter against a
-	 * non-existent product, so we keep the entry and let it ship.
+	 * and the product is then permanently deleted, the feed id was already
+	 * captured at archive time and Stripe still has the product in its catalog,
+	 * so the `delete=true` row must ship.
 	 *
 	 * @return void
 	 */
@@ -1274,21 +1284,16 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 	}
 
 	/**
-	 * Guards the one case prune can't cover: a product excluded by the filter
-	 * and then permanently deleted. prune keeps archive rows for unresolvable
-	 * products (it has no `WC_Product` to re-check), so the only place the
-	 * filter is honored for a to-be-deleted product is `track_product_archive`,
-	 * which evicts the queued row at delete time while the product still loads.
+	 * A product excluded by the filter and then permanently deleted still ships
+	 * its `delete=true` row: the removal is the exact outcome the exclusion
+	 * wanted, and it is the only signal that pulls the product off Stripe.
 	 *
-	 * Sequence: included → archived (row queued) → excluded → permanently
-	 * deleted. Without the eviction, prune's keep-policy would re-ship the
-	 * `out_of_stock` row for a product the merchant hid — the leak this filter
-	 * exists to close. Distinct from the eager track-time assertion: this drives
-	 * the full flush after the product is gone.
+	 * Sequence: included → archived (row queued) → excluded → delete-time
+	 * archive event → permanently deleted → flush.
 	 *
 	 * @return void
 	 */
-	public function test_sync_archives_does_not_ship_excluded_product_after_permanent_delete() {
+	public function test_sync_archives_ships_excluded_product_after_permanent_delete() {
 		add_filter( 'wc_stripe_is_agentic_commerce_enabled', '__return_true' );
 		WC_Stripe_API::set_secret_key( 'sk_test_fake' );
 
@@ -1305,13 +1310,22 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 		$callback = static fn( $sync, $candidate ) => $candidate->get_id() !== $id;
 		add_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10, 2 );
 
-		$uploaded = false;
+		$uploaded_ids = null;
 		add_filter(
 			'wc_stripe_agentic_commerce_files_api_pre_request',
-			function () use ( &$uploaded ) {
-				$uploaded = true;
+			function ( $pre, $file_path ) use ( &$uploaded_ids ) {
+				$uploaded_ids = $this->read_column_from_csv( $file_path, 'id' );
 				return [ 'id' => 'file_test_123' ];
-			}
+			},
+			10,
+			2
+		);
+		add_filter(
+			'wc_stripe_agentic_commerce_import_set_pre_request',
+			fn() => [
+				'id'     => 'impset_test_456',
+				'status' => 'pending',
+			]
 		);
 
 		try {
@@ -1323,8 +1337,9 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10 );
 		}
 
-		$this->assertFalse( $uploaded, 'Excluded product evicted at delete time must not ship despite prune keeping rows for deleted products.' );
-		$this->assertEmpty( get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] ), 'Eviction emptied the archive queue, so nothing remains to flush.' );
+		$this->assertNotNull( $uploaded_ids, 'The removal must upload despite the exclusion and permanent delete.' );
+		$this->assertContains( (string) $id, $uploaded_ids, 'The delete row must target the removed product.' );
+		$this->assertEmpty( get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] ), 'Queue cleared after a successful flush.' );
 	}
 
 	public function test_sync_archives_retains_pending_on_failure() {
@@ -1411,5 +1426,114 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 	 */
 	private function read_sku_ids_from_csv( string $file_path ): array {
 		return $this->read_column_from_csv( $file_path, 'sku_id' );
+	}
+
+	// -------------------------------------------------------------------------
+	// handle_status_transition
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Unpublishing a product queues its `delete=true` row: a draft product
+	 * leaves the feed query, so no full sync could remove it otherwise.
+	 *
+	 * @dataProvider provide_leaving_publish_statuses
+	 * @param string $new_status Status the product moves to.
+	 * @return void
+	 */
+	public function test_handle_status_transition_queues_delete_when_leaving_publish( string $new_status ) {
+		$product = $this->create_simple_product_with_stock( 5 );
+
+		$this->sut->handle_status_transition( $new_status, 'publish', get_post( $product->get_id() ) );
+
+		$pending = get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] );
+		$this->assertArrayHasKey( $product->get_id(), $pending );
+		$this->assertEquals( 'true', $pending[ $product->get_id() ]['delete'] );
+	}
+
+	/**
+	 * Data provider of statuses a published product can move to that must queue
+	 * a removal.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function provide_leaving_publish_statuses(): array {
+		return [
+			'draft'   => [ 'draft' ],
+			'private' => [ 'private' ],
+			'pending' => [ 'pending' ],
+		];
+	}
+
+	/**
+	 * Returning to `publish` cancels a queued removal so a quick unpublish and
+	 * republish doesn't delete a live product from Stripe's catalog.
+	 *
+	 * @return void
+	 */
+	public function test_handle_status_transition_cancels_pending_on_republish() {
+		$product = $this->create_simple_product_with_stock( 5 );
+
+		$this->sut->handle_status_transition( 'draft', 'publish', get_post( $product->get_id() ) );
+		$this->assertArrayHasKey( $product->get_id(), get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] ) );
+
+		$this->sut->handle_status_transition( 'publish', 'draft', get_post( $product->get_id() ) );
+		$this->assertArrayNotHasKey( $product->get_id(), get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] ) );
+	}
+
+	/**
+	 * The trash transition is left to the `wp_trash_post` hook (which fires
+	 * while the product still loads), and transitions between two non-publish
+	 * statuses or on non-product posts must not queue anything.
+	 *
+	 * @return void
+	 */
+	public function test_handle_status_transition_ignores_trash_non_publish_and_non_products() {
+		$product = $this->create_simple_product_with_stock( 5 );
+		$page_id = $this->factory()->post->create( [ 'post_type' => 'page' ] );
+
+		$this->sut->handle_status_transition( 'trash', 'publish', get_post( $product->get_id() ) );
+		$this->sut->handle_status_transition( 'draft', 'pending', get_post( $product->get_id() ) );
+		$this->sut->handle_status_transition( 'draft', 'publish', get_post( $page_id ) );
+
+		$this->assertEmpty( get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] ) );
+	}
+
+	/**
+	 * Unpublishing (or trashing) a variable parent expands to its variations:
+	 * they are the actual feed entries, and WordPress doesn't cascade the
+	 * parent's status change to them.
+	 *
+	 * @return void
+	 */
+	public function test_track_product_archive_expands_variable_parent_to_variations() {
+		$parent        = WC_Helper_Product::create_variation_product();
+		$variation_ids = $parent->get_children();
+
+		$this->sut->track_product_archive( $parent );
+
+		$pending = get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] );
+
+		$this->assertArrayNotHasKey( $parent->get_id(), $pending, 'The parent itself was never a feed entry.' );
+		foreach ( $variation_ids as $variation_id ) {
+			$this->assertArrayHasKey( $variation_id, $pending );
+			$this->assertEquals( 'true', $pending[ $variation_id ]['delete'] );
+		}
+	}
+
+	/**
+	 * The queued removal targets the feed id the product was exported under:
+	 * the SKU when one exists, not the numeric product ID.
+	 *
+	 * @return void
+	 */
+	public function test_track_product_archive_uses_sku_feed_id() {
+		$product = $this->create_simple_product_with_stock( 5 );
+		$product->set_sku( 'ARCHIVE-SKU-1' );
+		$product->save();
+
+		$this->sut->track_product_archive( $product );
+
+		$pending = get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] );
+		$this->assertEquals( 'ARCHIVE-SKU-1', $pending[ $product->get_id() ]['id'] );
 	}
 }

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-inventory-tracker-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-inventory-tracker-test.php
@@ -61,6 +61,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 			remove_action( 'before_delete_post', [ $this->sut, 'maybe_track_product_archive' ] );
 			remove_action( 'wp_trash_post', [ $this->sut, 'maybe_track_product_archive' ] );
 			remove_action( 'transition_post_status', [ $this->sut, 'handle_status_transition' ] );
+			remove_action( 'woocommerce_product_type_changed', [ $this->sut, 'handle_product_type_change' ] );
 			remove_action( WC_Stripe_Agentic_Commerce_Inventory_Tracker::ARCHIVE_SCHEDULED_ACTION, [ $this->sut, 'sync_archives' ] );
 		}
 
@@ -146,6 +147,7 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 		$this->assertNotFalse( has_action( 'before_delete_post', [ $this->sut, 'maybe_track_product_archive' ] ) );
 		$this->assertNotFalse( has_action( 'wp_trash_post', [ $this->sut, 'maybe_track_product_archive' ] ) );
 		$this->assertNotFalse( has_action( 'transition_post_status', [ $this->sut, 'handle_status_transition' ] ) );
+		$this->assertNotFalse( has_action( 'woocommerce_product_type_changed', [ $this->sut, 'handle_product_type_change' ] ) );
 		$this->assertNotFalse(
 			has_action(
 				WC_Stripe_Agentic_Commerce_Inventory_Tracker::ARCHIVE_SCHEDULED_ACTION,
@@ -1518,6 +1520,86 @@ class WC_Stripe_Agentic_Commerce_Inventory_Tracker_Test extends WP_UnitTestCase 
 			$this->assertArrayHasKey( $variation_id, $pending );
 			$this->assertEquals( 'true', $pending[ $variation_id ]['delete'] );
 		}
+	}
+
+	// -------------------------------------------------------------------------
+	// handle_product_type_change
+	// -------------------------------------------------------------------------
+
+	/**
+	 * A simple product converted to a type outside the feed query gets a queued
+	 * removal: no status transition fires for a type change, so this hook is
+	 * the only removal signal.
+	 *
+	 * @return void
+	 */
+	public function test_handle_product_type_change_queues_delete_when_simple_leaves_feed() {
+		$product = $this->create_simple_product_with_stock( 5 );
+
+		$this->sut->handle_product_type_change( $product, 'simple', 'external' );
+
+		$pending = get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] );
+		$this->assertArrayHasKey( $product->get_id(), $pending );
+		$this->assertEquals( 'true', $pending[ $product->get_id() ]['delete'] );
+	}
+
+	/**
+	 * simple→variable on a SKU'd product must NOT queue a removal: SKU-less
+	 * variations inherit the parent SKU as their feed id, so the delete could
+	 * remove the live variation row (whose upsert overwrites the stale simple
+	 * row on that id anyway).
+	 *
+	 * @return void
+	 */
+	public function test_handle_product_type_change_skips_sku_collision_on_simple_to_variable() {
+		$with_sku = $this->create_simple_product_with_stock( 5 );
+		$with_sku->set_sku( 'TYPE-CHANGE-SKU' );
+		$with_sku->save();
+
+		$this->sut->handle_product_type_change( $with_sku, 'simple', 'variable' );
+		$this->assertEmpty( get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] ) );
+
+		// Without a SKU there is no collision, so the old simple row is removed.
+		$no_sku = $this->create_simple_product_with_stock( 5 );
+		$this->sut->handle_product_type_change( $no_sku, 'simple', 'variable' );
+		$this->assertArrayHasKey( $no_sku->get_id(), get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] ) );
+	}
+
+	/**
+	 * variable→simple queues removals for the variation posts, which survive
+	 * the type switch and were the actual feed entries.
+	 *
+	 * @return void
+	 */
+	public function test_handle_product_type_change_queues_variation_deletes_when_variable_converts() {
+		$parent        = WC_Helper_Product::create_variation_product();
+		$variation_ids = $parent->get_children();
+
+		// Simulate the type switch WC performs before firing the hook.
+		wp_set_object_terms( $parent->get_id(), 'simple', 'product_type' );
+		$converted = wc_get_product( $parent->get_id() );
+
+		$this->sut->handle_product_type_change( $converted, 'variable', 'simple' );
+
+		$pending = get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] );
+		foreach ( $variation_ids as $variation_id ) {
+			$this->assertArrayHasKey( $variation_id, $pending );
+			$this->assertEquals( 'true', $pending[ $variation_id ]['delete'] );
+		}
+	}
+
+	/**
+	 * Types that were never in the feed (e.g. grouped) have nothing to remove
+	 * when converted.
+	 *
+	 * @return void
+	 */
+	public function test_handle_product_type_change_ignores_types_never_in_feed() {
+		$product = $this->create_simple_product_with_stock( 5 );
+
+		$this->sut->handle_product_type_change( $product, 'grouped', 'simple' );
+
+		$this->assertEmpty( get_option( WC_Stripe_Agentic_Commerce_Inventory_Tracker::PENDING_ARCHIVES_OPTION, [] ) );
 	}
 
 	/**

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper-test.php
@@ -1125,21 +1125,25 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * map_product short-circuits subscription products to an empty row, the
-	 * signal the validator treats as a clean exclusion.
+	 * map_product short-circuits subscription products to a `delete=true` row,
+	 * the explicit removal signal Stripe's upsert-mode imports require.
 	 *
 	 * @return void
 	 */
-	public function test_map_product_returns_empty_row_for_subscription_products() {
+	public function test_map_product_returns_delete_row_for_subscription_products() {
 		$product = $this->getMockBuilder( WC_Product::class )
 			->disableOriginalConstructor()
-			->onlyMethods( [ 'get_type' ] )
+			->onlyMethods( [ 'get_type', 'get_sku', 'get_id' ] )
 			->getMock();
 		$product->method( 'get_type' )->willReturn( 'subscription_variation' );
+		$product->method( 'get_sku' )->willReturn( '' );
+		$product->method( 'get_id' )->willReturn( 123 );
 
 		$mapper = new \WC_Stripe_Agentic_Commerce_Product_Mapper();
+		$row    = $mapper->map_product( $product );
 
-		$this->assertSame( [], $mapper->map_product( $product ) );
+		$this->assertTrue( \WC_Stripe_Agentic_Commerce_Product_Mapper::is_delete_row( $row ) );
+		$this->assertSame( '123', $row['id'] );
 	}
 
 	/**
@@ -1185,15 +1189,15 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that `map_product` short-circuits to an empty row when the visibility
-	 * hook excludes the product. An empty row is the agreed signal the feed
-	 * validator's required-field check rejects, so the walker skips the entry
-	 * without polluting the validator's per-product error accumulator with
-	 * intentional exclusions.
+	 * Test that `map_product` short-circuits to a `delete=true` row when the
+	 * visibility hook excludes the product. Stripe's upsert-mode imports leave
+	 * omitted products in the catalog, so the removal must be explicit; only
+	 * `id` and `delete` carry data, keeping the walker's entry aligned with the
+	 * feed headers without exporting the excluded product's fields.
 	 *
 	 * @return void
 	 */
-	public function test_map_product_returns_empty_row_when_filter_excludes_product() {
+	public function test_map_product_returns_delete_row_when_filter_excludes_product() {
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_regular_price( '9.99' );
 		$product->save();
@@ -1205,7 +1209,10 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper_Test extends WP_UnitTestCase {
 			$mapper = new \WC_Stripe_Agentic_Commerce_Product_Mapper();
 			$result = $mapper->map_product( $product );
 
-			$this->assertSame( [], $result );
+			$this->assertTrue( \WC_Stripe_Agentic_Commerce_Product_Mapper::is_delete_row( $result ) );
+			$this->assertSame( \WC_Stripe_Agentic_Commerce_Product_Mapper::get_feed_id( $product ), $result['id'] );
+			$this->assertNull( $result['title'] );
+			$this->assertNull( $result['price'] );
 		} finally {
 			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10 );
 			$product->delete( true );
@@ -1233,8 +1240,8 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper_Test extends WP_UnitTestCase {
 
 		try {
 			$mapper = new \WC_Stripe_Agentic_Commerce_Product_Mapper();
-			$this->assertNotEmpty( $mapper->map_product( $included ) );
-			$this->assertSame( [], $mapper->map_product( $excluded ) );
+			$this->assertFalse( \WC_Stripe_Agentic_Commerce_Product_Mapper::is_delete_row( $mapper->map_product( $included ) ) );
+			$this->assertTrue( \WC_Stripe_Agentic_Commerce_Product_Mapper::is_delete_row( $mapper->map_product( $excluded ) ) );
 		} finally {
 			remove_filter( 'woocommerce_agentic_commerce_should_sync_product', $callback, 10 );
 			$included->delete( true );
@@ -1494,6 +1501,94 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper_Test extends WP_UnitTestCase {
 		} finally {
 			remove_filter( 'woocommerce_agentic_commerce_disable_checkout', $callback, 10 );
 			$parent->delete( true );
+		}
+	}
+
+	/**
+	 * Data provider of non-publish statuses that make a product ineligible.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function provide_unpublished_statuses(): array {
+		return [
+			'draft'   => [ 'draft' ],
+			'private' => [ 'private' ],
+			'pending' => [ 'pending' ],
+		];
+	}
+
+	/**
+	 * An unpublished product is ineligible: it left the storefront, so the feed
+	 * must carry its removal rather than keep exporting stale data.
+	 *
+	 * @dataProvider provide_unpublished_statuses
+	 * @param string $status Post status to test.
+	 * @return void
+	 */
+	public function test_should_sync_product_excludes_unpublished_product( string $status ) {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_status( $status );
+		$product->save();
+
+		try {
+			$this->assertFalse( \WC_Stripe_Agentic_Commerce_Product_Mapper::should_sync_product( $product ) );
+		} finally {
+			$product->delete( true );
+		}
+	}
+
+	/**
+	 * A variation of an unpublished parent is ineligible even though its own
+	 * status stays `publish` — the feed query only checks the variation row, so
+	 * without this the variation would keep syncing with a dead `link`.
+	 *
+	 * @return void
+	 */
+	public function test_should_sync_product_excludes_variation_of_unpublished_parent() {
+		$parent    = WC_Helper_Product::create_variation_product();
+		$variation = wc_get_product( $parent->get_children()[0] );
+
+		try {
+			$this->assertTrue( \WC_Stripe_Agentic_Commerce_Product_Mapper::should_sync_product( $variation ) );
+
+			wp_update_post(
+				[
+					'ID'          => $parent->get_id(),
+					'post_status' => 'draft',
+				]
+			);
+			// Re-read so the variation's parent lookup sees the fresh status.
+			$variation = wc_get_product( $variation->get_id() );
+
+			$this->assertFalse( \WC_Stripe_Agentic_Commerce_Product_Mapper::should_sync_product( $variation ) );
+
+			$mapper = new \WC_Stripe_Agentic_Commerce_Product_Mapper();
+			$this->assertTrue( \WC_Stripe_Agentic_Commerce_Product_Mapper::is_delete_row( $mapper->map_product( $variation ) ) );
+		} finally {
+			$parent->delete( true );
+		}
+	}
+
+	/**
+	 * The feed id survives to the delete row: a SKU'd product must be removed
+	 * under the SKU it was exported as, not its numeric ID.
+	 *
+	 * @return void
+	 */
+	public function test_delete_row_uses_sku_feed_id() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_sku( 'DELETE-ROW-SKU' );
+		$product->set_status( 'draft' );
+		$product->save();
+
+		try {
+			$mapper = new \WC_Stripe_Agentic_Commerce_Product_Mapper();
+			$row    = $mapper->map_product( $product );
+
+			$this->assertTrue( \WC_Stripe_Agentic_Commerce_Product_Mapper::is_delete_row( $row ) );
+			$this->assertSame( 'DELETE-ROW-SKU', $row['id'] );
+		} finally {
+			$product->delete( true );
 		}
 	}
 }

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-product-mapper-test.php
@@ -1570,6 +1570,36 @@ class WC_Stripe_Agentic_Commerce_Product_Mapper_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A variation whose parent is no longer a variable product is ineligible:
+	 * variation posts survive a parent type switch and still match the feed
+	 * query, so without this they would keep syncing as stale rows.
+	 *
+	 * @return void
+	 */
+	public function test_should_sync_product_excludes_variation_of_non_variable_parent() {
+		$parent    = WC_Helper_Product::create_variation_product();
+		$variation = wc_get_product( $parent->get_children()[0] );
+
+		try {
+			$this->assertTrue( \WC_Stripe_Agentic_Commerce_Product_Mapper::should_sync_product( $variation ) );
+
+			// Simulate the merchant switching the product type away from variable.
+			// A real save invalidates WC's product-type cache; the direct term
+			// write here doesn't, so invalidate it explicitly.
+			wp_set_object_terms( $parent->get_id(), 'simple', 'product_type' );
+			WC_Cache_Helper::invalidate_cache_group( 'product_' . $parent->get_id() );
+			$variation = wc_get_product( $variation->get_id() );
+
+			$this->assertFalse( \WC_Stripe_Agentic_Commerce_Product_Mapper::should_sync_product( $variation ) );
+
+			$mapper = new \WC_Stripe_Agentic_Commerce_Product_Mapper();
+			$this->assertTrue( \WC_Stripe_Agentic_Commerce_Product_Mapper::is_delete_row( $mapper->map_product( $variation ) ) );
+		} finally {
+			wp_delete_post( $parent->get_id(), true );
+		}
+	}
+
+	/**
 	 * The feed id survives to the delete row: a SKU'd product must be removed
 	 * under the SKU it was exported as, not its numeric ID.
 	 *


### PR DESCRIPTION
Fixes STRIPE-1352

## Changes proposed in this Pull Request:

Stripe processes catalog imports in upsert mode: omitting a product leaves it in the catalog indefinitely, so excluding, trashing, deleting, or unpublishing a product never removed it from Stripe. The spec's removal signal is a `delete=true` row, from which Stripe reads only `id` and `delete` ([docs](https://docs.stripe.com/agentic-commerce/product-feed#deletion-behavior)).

- Full feed: the mapper exports each in-query ineligible product as a `delete=true` row instead of omitting it. Rows recur every sync; deletes are idempotent and self-heal a lost upload.
- Eligibility: `should_sync_product()` now also excludes unpublished products (checking a variation's parent status) and variations whose parent is missing or no longer variable, both cases where the feed query would otherwise keep exporting stale rows with dead links.
- Archive path: the tracker queues minimal delete rows (feed id only) instead of full `out_of_stock` rows, no longer bails on excluded products, expands a trashed variable parent into its variations, and flushes a full queue instead of deferring to a full sync that cannot delete out-of-query products. The queue cap no longer discards removals either: a removal dropped there was lost for good, so a full queue (e.g. a bulk trash past the cap) is queued anyway and drained immediately instead of after the batch delay. The pending option can transiently exceed the cap, bounded by the bulk operation's own size.
- Status transitions: a `transition_post_status` handler queues removals when a product leaves `publish` and cancels them on republish. It replaces the `untrash_post` cancel, which would have left a product restored to draft (the WordPress default) live on Stripe.
- Type changes: a `woocommerce_product_type_changed` handler covers conversions out of the feed query (simple to grouped/external, variable to anything). simple→variable on a SKU'd product is deliberately skipped: SKU-less variations inherit the parent SKU as feed id, so the delete could remove the live variation row, whose upsert overwrites the stale one anyway. The mirror case is guarded too: on variable→simple of a SKU'd parent, variations whose feed id equals the parent SKU are skipped, so their delete rows cannot remove the simple row re-added under that id.
- Reporting: delete rows are counted separately (new additive `removed_products` field) and subtracted from "products synced"; the feed preview buckets them as exclusions.

**BC impact:** `map_product()` returns a delete row instead of `[]` for ineligible products; the validator and preview keep empty-row handling for external mappers, and the `wc_stripe_agentic_commerce_map_product` filter skips delete rows. New public symbols are additive only; no hooks, option keys, or signatures changed. Trashed products are now removed from Stripe instead of listed as out-of-stock.

**Sandbox-verified:** a `delete=true` row for an id Stripe never ingested imports as `succeeded` with zero row errors (test-mode import set `impset_test_61VFAWoZ...`), so the recurring delete rows for never-synced products are safe.

## Testing instructions

1. Enable Agentic Commerce and sync so a product is live in the Stripe sandbox catalog.
2. Exclude that product and let the resync run: its feed row carries only id and `delete=true`, and it leaves the Stripe catalog. Re-include it and confirm it returns.
3. Trash another synced product: an archive upload with its delete row fires within ~1 minute. Restore to published and confirm the next sync re-adds it.
4. Set a synced product to draft: same removal flow, without trashing.
5. Trash a variable product: each variation gets a delete row.
6. Change a synced simple product's type to External/Affiliate: its delete row is queued and it leaves the catalog.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
