### PR TITLE
Show Apple Pay and Google Pay express buttons only on their own enabled locations

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ xxxx-xx-xx - version 11.0.0
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
 * Fix - Exclude password-protected products and products hidden from the catalog from the Agentic Commerce feed
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
+* Fix - Hide the Apple Pay and Google Pay express buttons on pages unchecked in their own locations setting, instead of following other wallets' locations
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/client/blocks/upe/index.js
+++ b/client/blocks/upe/index.js
@@ -61,8 +61,10 @@ if ( getBlocksConfiguration()?.isAmazonPayEnabled ) {
 // Not `isExpressCheckoutEnabled`: that aggregate is true when any wallet's locations
 // cover this page, which would register Apple/Google Pay on pages where only another
 // wallet (e.g. Amazon Pay) is enabled.
-if ( getBlocksConfiguration()?.isApplePayGooglePayEnabled ) {
+if ( getBlocksConfiguration()?.isApplePayEnabled ) {
 	registerExpressPaymentMethod( expressCheckoutElementApplePay( api ) );
+}
+if ( getBlocksConfiguration()?.isGooglePayEnabled ) {
 	registerExpressPaymentMethod( expressCheckoutElementGooglePay( api ) );
 }
 if ( getBlocksConfiguration()?.isLinkEnabled ) {

--- a/client/blocks/upe/index.js
+++ b/client/blocks/upe/index.js
@@ -58,7 +58,10 @@ Object.entries( paymentMethodsConfig )
 if ( getBlocksConfiguration()?.isAmazonPayEnabled ) {
 	registerExpressPaymentMethod( expressCheckoutElementAmazonPay( api ) );
 }
-if ( getBlocksConfiguration()?.isExpressCheckoutEnabled ) {
+// Not `isExpressCheckoutEnabled`: that aggregate is true when any wallet's locations
+// cover this page, which would register Apple/Google Pay on pages where only another
+// wallet (e.g. Amazon Pay) is enabled.
+if ( getBlocksConfiguration()?.isApplePayGooglePayEnabled ) {
 	registerExpressPaymentMethod( expressCheckoutElementApplePay( api ) );
 	registerExpressPaymentMethod( expressCheckoutElementGooglePay( api ) );
 }

--- a/client/entrypoints/express-checkout/__tests__/index.test.js
+++ b/client/entrypoints/express-checkout/__tests__/index.test.js
@@ -166,7 +166,8 @@ describe( 'Express Checkout product page variation breakdown', () => {
 			publishable_key: 'pk_test_123',
 			locale: 'en',
 			is_express_checkout_enabled: true,
-			is_apple_google_pay_enabled: true,
+			is_apple_pay_enabled: true,
+			is_google_pay_enabled: true,
 		},
 		product: {
 			total: { amount: 1000 },
@@ -413,7 +414,8 @@ describe( 'Express Checkout per-method location gating', () => {
 			// The aggregate is true because Amazon Pay covers this location —
 			// that alone must not surface Apple/Google Pay (STRIPE-1363).
 			is_express_checkout_enabled: true,
-			is_apple_google_pay_enabled: false,
+			is_apple_pay_enabled: false,
+			is_google_pay_enabled: false,
 			is_amazon_pay_enabled: true,
 		} );
 
@@ -425,12 +427,26 @@ describe( 'Express Checkout per-method location gating', () => {
 	it( 'creates Apple/Google Pay buttons when their own locations cover this page', () => {
 		global.wc_stripe_express_checkout_params = cartParamsWithFlags( {
 			is_express_checkout_enabled: true,
-			is_apple_google_pay_enabled: true,
+			is_apple_pay_enabled: true,
+			is_google_pay_enabled: true,
 			is_amazon_pay_enabled: false,
 		} );
 
 		loadEntrypoint();
 
 		expect( mountedTypes() ).toEqual( [ 'applePay', 'googlePay' ] );
+	} );
+
+	it( 'gates each wallet on its own flag, ready for a future settings split', () => {
+		global.wc_stripe_express_checkout_params = cartParamsWithFlags( {
+			is_express_checkout_enabled: true,
+			is_apple_pay_enabled: false,
+			is_google_pay_enabled: true,
+			is_amazon_pay_enabled: false,
+		} );
+
+		loadEntrypoint();
+
+		expect( mountedTypes() ).toEqual( [ 'googlePay' ] );
 	} );
 } );

--- a/client/entrypoints/express-checkout/__tests__/index.test.js
+++ b/client/entrypoints/express-checkout/__tests__/index.test.js
@@ -166,6 +166,7 @@ describe( 'Express Checkout product page variation breakdown', () => {
 			publishable_key: 'pk_test_123',
 			locale: 'en',
 			is_express_checkout_enabled: true,
+			is_apple_google_pay_enabled: true,
 		},
 		product: {
 			total: { amount: 1000 },
@@ -350,5 +351,86 @@ describe( 'Express Checkout product page variation breakdown', () => {
 		elementsList.forEach( ( elements ) => {
 			expect( elements.update ).toHaveBeenCalledWith( { amount: 2000 } );
 		} );
+	} );
+} );
+
+describe( 'Express Checkout per-method location gating', () => {
+	// Each created express button mounts into its own
+	// `#wc-stripe-express-checkout-element-<type>` container, so the container ids
+	// are the observable record of which wallets were actually created.
+	const mountedTypes = () =>
+		Array.from(
+			document.querySelectorAll(
+				'#wc-stripe-express-checkout-element > div'
+			)
+		).map( ( el ) =>
+			el.id.replace( 'wc-stripe-express-checkout-element-', '' )
+		);
+
+	const stubStripe = () => {
+		const button = {
+			on: () => button,
+			mount: jest.fn(),
+		};
+		mockGetStripe.mockReturnValue( {
+			elements: jest.fn( () => ( {
+				create: jest.fn( () => button ),
+				update: jest.fn(),
+			} ) ),
+		} );
+	};
+
+	const cartParamsWithFlags = ( stripeFlags ) => ( {
+		...baseParams(),
+		stripe: {
+			publishable_key: 'pk_test_123',
+			locale: 'en',
+			...stripeFlags,
+		},
+		cart: {
+			total: 1500,
+			currency: 'usd',
+			requestShipping: false,
+			requestPhone: false,
+			displayItems: [],
+		},
+	} );
+
+	beforeEach( () => {
+		jest.resetModules();
+		mockGetStripe.mockReset();
+		stubStripe();
+		document.body.innerHTML =
+			'<div id="wc-stripe-express-checkout-element"></div>';
+	} );
+
+	afterEach( () => {
+		delete global.wc_stripe_express_checkout_params;
+	} );
+
+	it( 'does not create Apple/Google Pay buttons when only another wallet covers this page', () => {
+		global.wc_stripe_express_checkout_params = cartParamsWithFlags( {
+			// The aggregate is true because Amazon Pay covers this location —
+			// that alone must not surface Apple/Google Pay (STRIPE-1363).
+			is_express_checkout_enabled: true,
+			is_apple_google_pay_enabled: false,
+			is_amazon_pay_enabled: true,
+		} );
+
+		loadEntrypoint();
+
+		expect( mountedTypes() ).toEqual( [ 'amazonPay' ] );
+	} );
+
+	it( 'creates Apple/Google Pay buttons when their own locations cover this page', () => {
+		global.wc_stripe_express_checkout_params = cartParamsWithFlags( {
+			is_express_checkout_enabled: true,
+			is_apple_google_pay_enabled: true,
+			is_amazon_pay_enabled: false,
+		} );
+
+		loadEntrypoint();
+
+		expect( mountedTypes() ).toEqual( [ 'applePay', 'googlePay' ] );
 	} );
 } );

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -230,9 +230,11 @@ jQuery( function ( $ ) {
 			// Deliberately not `is_express_checkout_enabled`: that aggregate is true when
 			// any wallet's locations cover this page, which would render Apple/Google Pay
 			// on pages where only another wallet (e.g. Amazon Pay) is enabled.
-			const isApplePayGooglePayEnabled =
+			const isApplePayEnabled =
+				wc_stripe_express_checkout_params?.stripe?.is_apple_pay_enabled; // eslint-disable-line camelcase
+			const isGooglePayEnabled =
 				wc_stripe_express_checkout_params?.stripe // eslint-disable-line camelcase
-					?.is_apple_google_pay_enabled;
+					?.is_google_pay_enabled;
 			const isAmazonPayEnabled =
 				wc_stripe_express_checkout_params?.stripe // eslint-disable-line camelcase
 					?.is_amazon_pay_enabled;
@@ -253,10 +255,8 @@ jQuery( function ( $ ) {
 			// may require different options or configurations, e.g. Amazon Pay
 			// does not support paymentMethodCreation: 'manual'.
 			const expressPaymentTypes = [
-				isApplePayGooglePayEnabled &&
-					EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY,
-				isApplePayGooglePayEnabled &&
-					EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY,
+				isApplePayEnabled && EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY,
+				isGooglePayEnabled && EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY,
 				isAmazonPayEnabled &&
 					! areTaxesBasedOnBillingAddress &&
 					! isChangePaymentMethod &&

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -227,9 +227,12 @@ jQuery( function ( $ ) {
 
 			const shippingRates = getShippingRates();
 
-			const isExpressCheckoutEnabled =
+			// Deliberately not `is_express_checkout_enabled`: that aggregate is true when
+			// any wallet's locations cover this page, which would render Apple/Google Pay
+			// on pages where only another wallet (e.g. Amazon Pay) is enabled.
+			const isApplePayGooglePayEnabled =
 				wc_stripe_express_checkout_params?.stripe // eslint-disable-line camelcase
-					?.is_express_checkout_enabled;
+					?.is_apple_google_pay_enabled;
 			const isAmazonPayEnabled =
 				wc_stripe_express_checkout_params?.stripe // eslint-disable-line camelcase
 					?.is_amazon_pay_enabled;
@@ -250,9 +253,9 @@ jQuery( function ( $ ) {
 			// may require different options or configurations, e.g. Amazon Pay
 			// does not support paymentMethodCreation: 'manual'.
 			const expressPaymentTypes = [
-				isExpressCheckoutEnabled &&
+				isApplePayGooglePayEnabled &&
 					EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY,
-				isExpressCheckoutEnabled &&
+				isApplePayGooglePayEnabled &&
 					EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY,
 				isAmazonPayEnabled &&
 					! areTaxesBasedOnBillingAddress &&

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -222,12 +222,8 @@ class WC_Stripe_Express_Checkout_Element {
 				'is_link_enabled'             => $this->express_checkout_helper->is_link_enabled(),
 				'is_express_checkout_enabled' => $this->express_checkout_helper->is_express_checkout_enabled(),
 				'is_amazon_pay_enabled'       => $this->express_checkout_helper->is_amazon_pay_enabled(),
-				// Apple/Google Pay need their own flags: `is_express_checkout_enabled` is the
-				// any-method aggregate, so it stays true when only another wallet's locations
-				// cover this page and must not decide whether these two buttons render.
-				// Both flags are currently backed by the shared Apple/Google Pay setting, so
-				// they are always equal — per-wallet keys so a future settings split only has
-				// to change how each value is computed, not the frontend contract.
+				// `is_express_checkout_enabled` aggregates all methods, so Apple/Google Pay need their
+				// own flags; per-wallet keys keep the contract stable if the shared setting ever splits.
 				'is_apple_pay_enabled'        => $this->express_checkout_helper->is_apple_google_pay_enabled(),
 				'is_google_pay_enabled'       => $this->express_checkout_helper->is_apple_google_pay_enabled(),
 			],

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -222,10 +222,14 @@ class WC_Stripe_Express_Checkout_Element {
 				'is_link_enabled'             => $this->express_checkout_helper->is_link_enabled(),
 				'is_express_checkout_enabled' => $this->express_checkout_helper->is_express_checkout_enabled(),
 				'is_amazon_pay_enabled'       => $this->express_checkout_helper->is_amazon_pay_enabled(),
-				// Apple/Google Pay need their own flag: `is_express_checkout_enabled` is the
+				// Apple/Google Pay need their own flags: `is_express_checkout_enabled` is the
 				// any-method aggregate, so it stays true when only another wallet's locations
 				// cover this page and must not decide whether these two buttons render.
-				'is_apple_google_pay_enabled' => $this->express_checkout_helper->is_apple_google_pay_enabled(),
+				// Both flags are currently backed by the shared Apple/Google Pay setting, so
+				// they are always equal — per-wallet keys so a future settings split only has
+				// to change how each value is computed, not the frontend contract.
+				'is_apple_pay_enabled'        => $this->express_checkout_helper->is_apple_google_pay_enabled(),
+				'is_google_pay_enabled'       => $this->express_checkout_helper->is_apple_google_pay_enabled(),
 			],
 			'nonce'                      => [
 				'payment'                       => wp_create_nonce( 'wc-stripe-express-checkout' ),

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -222,6 +222,10 @@ class WC_Stripe_Express_Checkout_Element {
 				'is_link_enabled'             => $this->express_checkout_helper->is_link_enabled(),
 				'is_express_checkout_enabled' => $this->express_checkout_helper->is_express_checkout_enabled(),
 				'is_amazon_pay_enabled'       => $this->express_checkout_helper->is_amazon_pay_enabled(),
+				// Apple/Google Pay need their own flag: `is_express_checkout_enabled` is the
+				// any-method aggregate, so it stays true when only another wallet's locations
+				// cover this page and must not decide whether these two buttons render.
+				'is_apple_google_pay_enabled' => $this->express_checkout_helper->is_apple_google_pay_enabled(),
 			],
 			'nonce'                      => [
 				'payment'                       => wp_create_nonce( 'wc-stripe-express-checkout' ),

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -603,10 +603,14 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		$stripe_params['isExpressCheckoutEnabled']          = $express_checkout_helper->is_express_checkout_enabled();
 		$stripe_params['isAmazonPayEnabled']                = $express_checkout_helper->is_amazon_pay_enabled();
 		$stripe_params['isLinkEnabled']                     = $express_checkout_helper->is_link_enabled();
-		// Apple/Google Pay need their own flag: `isExpressCheckoutEnabled` is the any-method
+		// Apple/Google Pay need their own flags: `isExpressCheckoutEnabled` is the any-method
 		// aggregate, so it stays true when only another wallet's locations cover this page
-		// and must not decide whether the Apple/Google Pay buttons register.
-		$stripe_params['isApplePayGooglePayEnabled'] = $express_checkout_helper->is_apple_google_pay_enabled();
+		// and must not decide whether the Apple/Google Pay buttons register. Both flags are
+		// currently backed by the shared Apple/Google Pay setting, so they are always equal —
+		// per-wallet keys so a future settings split only has to change how each value is
+		// computed, not the frontend contract.
+		$stripe_params['isApplePayEnabled']  = $express_checkout_helper->is_apple_google_pay_enabled();
+		$stripe_params['isGooglePayEnabled'] = $express_checkout_helper->is_apple_google_pay_enabled();
 
 		if ( $this->testmode ) {
 			/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -568,7 +568,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			}
 		}
 
-		$express_checkout_helper = new WC_Stripe_Express_Checkout_Helper();
+		$express_checkout_helper = $this->get_express_checkout_helper();
 
 		$is_signup_on_checkout_allowed = 'yes' === get_option( 'woocommerce_enable_signup_and_login_from_checkout', 'no' )
 			|| ( $this->is_subscription_item_in_cart() && 'yes' === get_option( 'woocommerce_enable_signup_from_checkout_for_subscriptions', 'no' ) );
@@ -603,12 +603,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		$stripe_params['isExpressCheckoutEnabled']          = $express_checkout_helper->is_express_checkout_enabled();
 		$stripe_params['isAmazonPayEnabled']                = $express_checkout_helper->is_amazon_pay_enabled();
 		$stripe_params['isLinkEnabled']                     = $express_checkout_helper->is_link_enabled();
-		// Apple/Google Pay need their own flags: `isExpressCheckoutEnabled` is the any-method
-		// aggregate, so it stays true when only another wallet's locations cover this page
-		// and must not decide whether the Apple/Google Pay buttons register. Both flags are
-		// currently backed by the shared Apple/Google Pay setting, so they are always equal —
-		// per-wallet keys so a future settings split only has to change how each value is
-		// computed, not the frontend contract.
+		// `isExpressCheckoutEnabled` aggregates all methods, so Apple/Google Pay need their own
+		// flags; per-wallet keys keep the contract stable if the shared setting ever splits.
 		$stripe_params['isApplePayEnabled']  = $express_checkout_helper->is_apple_google_pay_enabled();
 		$stripe_params['isGooglePayEnabled'] = $express_checkout_helper->is_apple_google_pay_enabled();
 
@@ -764,6 +760,17 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		}
 
 		return array_merge( $stripe_params, WC_Stripe_Helper::get_localized_messages() );
+	}
+
+	/**
+	 * Returns the express checkout helper used to compute the per-method flags.
+	 *
+	 * Protected seam so tests can substitute the helper.
+	 *
+	 * @return WC_Stripe_Express_Checkout_Helper
+	 */
+	protected function get_express_checkout_helper() {
+		return new WC_Stripe_Express_Checkout_Helper();
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -603,6 +603,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		$stripe_params['isExpressCheckoutEnabled']          = $express_checkout_helper->is_express_checkout_enabled();
 		$stripe_params['isAmazonPayEnabled']                = $express_checkout_helper->is_amazon_pay_enabled();
 		$stripe_params['isLinkEnabled']                     = $express_checkout_helper->is_link_enabled();
+		// Apple/Google Pay need their own flag: `isExpressCheckoutEnabled` is the any-method
+		// aggregate, so it stays true when only another wallet's locations cover this page
+		// and must not decide whether the Apple/Google Pay buttons register.
+		$stripe_params['isApplePayGooglePayEnabled'] = $express_checkout_helper->is_apple_google_pay_enabled();
 
 		if ( $this->testmode ) {
 			/**

--- a/readme.txt
+++ b/readme.txt
@@ -174,5 +174,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
 * Fix - Exclude password-protected products and products hidden from the catalog from the Agentic Commerce feed
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
+* Fix - Hide the Apple Pay and Google Pay express buttons on pages unchecked in their own locations setting, instead of following other wallets' locations
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-element-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-element-test.php
@@ -79,6 +79,53 @@ class WC_Stripe_Express_Checkout_Element_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The Apple/Google Pay flag must come from the method-specific check, not the any-method
+	 * aggregate: when only another wallet's locations cover the page, the aggregate is true
+	 * but Apple/Google Pay must still be reported as disabled.
+	 *
+	 * @param bool $apple_google_enabled What the helper reports for Apple/Google Pay in this context.
+	 * @dataProvider provide_apple_google_pay_enabled
+	 */
+	public function test_javascript_params_exposes_method_specific_apple_google_pay_flag( $apple_google_enabled ) {
+		$ajax_handler = $this->getMockBuilder( WC_Stripe_Express_Checkout_Ajax_Handler::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$helper = $this->getMockBuilder( WC_Stripe_Express_Checkout_Helper::class )
+			->setConstructorArgs( [ $gateway ] )
+			->setMethods( [ 'is_apple_google_pay_enabled', 'is_amazon_pay_enabled', 'is_link_enabled', 'is_express_checkout_enabled' ] )
+			->getMock();
+		$helper->method( 'is_apple_google_pay_enabled' )->willReturn( $apple_google_enabled );
+		// Amazon Pay alone keeps the aggregate true regardless of Apple/Google Pay.
+		$helper->method( 'is_amazon_pay_enabled' )->willReturn( true );
+		$helper->method( 'is_link_enabled' )->willReturn( false );
+		$helper->method( 'is_express_checkout_enabled' )->willReturn( true );
+
+		$element = new WC_Stripe_Express_Checkout_Element( $ajax_handler, $helper );
+
+		$actual = $element->javascript_params();
+
+		$this->assertSame( $apple_google_enabled, $actual['stripe']['is_apple_google_pay_enabled'] );
+		$this->assertTrue( $actual['stripe']['is_express_checkout_enabled'] );
+	}
+
+	/**
+	 * Data provider for {@see test_javascript_params_exposes_method_specific_apple_google_pay_flag()}.
+	 *
+	 * @return array<string, array{0: bool}>
+	 */
+	public function provide_apple_google_pay_enabled() {
+		return [
+			'disabled for this location' => [ false ],
+			'enabled for this location'  => [ true ],
+		];
+	}
+
+	/**
 	 * Test for `scripts`.
 	 *
 	 * @return void

--- a/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-element-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-element-test.php
@@ -79,14 +79,14 @@ class WC_Stripe_Express_Checkout_Element_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The Apple/Google Pay flag must come from the method-specific check, not the any-method
-	 * aggregate: when only another wallet's locations cover the page, the aggregate is true
-	 * but Apple/Google Pay must still be reported as disabled.
+	 * The per-wallet Apple Pay and Google Pay flags must come from the method-specific check,
+	 * not the any-method aggregate: when only another wallet's locations cover the page, the
+	 * aggregate is true but Apple/Google Pay must still be reported as disabled.
 	 *
 	 * @param bool $apple_google_enabled What the helper reports for Apple/Google Pay in this context.
 	 * @dataProvider provide_apple_google_pay_enabled
 	 */
-	public function test_javascript_params_exposes_method_specific_apple_google_pay_flag( $apple_google_enabled ) {
+	public function test_javascript_params_exposes_method_specific_apple_google_pay_flags( $apple_google_enabled ) {
 		$ajax_handler = $this->getMockBuilder( WC_Stripe_Express_Checkout_Ajax_Handler::class )
 			->disableOriginalConstructor()
 			->getMock();
@@ -109,12 +109,14 @@ class WC_Stripe_Express_Checkout_Element_Test extends WP_UnitTestCase {
 
 		$actual = $element->javascript_params();
 
-		$this->assertSame( $apple_google_enabled, $actual['stripe']['is_apple_google_pay_enabled'] );
+		// Both wallets are backed by the shared setting today, so the flags move together.
+		$this->assertSame( $apple_google_enabled, $actual['stripe']['is_apple_pay_enabled'] );
+		$this->assertSame( $apple_google_enabled, $actual['stripe']['is_google_pay_enabled'] );
 		$this->assertTrue( $actual['stripe']['is_express_checkout_enabled'] );
 	}
 
 	/**
-	 * Data provider for {@see test_javascript_params_exposes_method_specific_apple_google_pay_flag()}.
+	 * Data provider for {@see test_javascript_params_exposes_method_specific_apple_google_pay_flags()}.
 	 *
 	 * @return array<string, array{0: bool}>
 	 */

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -641,6 +641,65 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * The per-wallet Apple Pay and Google Pay flags must come from the method-specific check,
+	 * not the any-method aggregate: when only another wallet's locations cover the page, the
+	 * aggregate is true but Apple/Google Pay must still be reported as disabled.
+	 *
+	 * @param bool $apple_google_enabled What the helper reports for Apple/Google Pay in this context.
+	 *
+	 * @dataProvider provide_apple_google_pay_enabled
+	 */
+	public function test_javascript_params_exposes_method_specific_apple_google_pay_flags( $apple_google_enabled ) {
+		$helper = $this->getMockBuilder( WC_Stripe_Express_Checkout_Helper::class )
+			->onlyMethods( [ 'is_apple_google_pay_enabled', 'is_amazon_pay_enabled', 'is_link_enabled', 'is_express_checkout_enabled' ] )
+			->getMock();
+		$helper->method( 'is_apple_google_pay_enabled' )->willReturn( $apple_google_enabled );
+		// Amazon Pay alone keeps the aggregate true regardless of Apple/Google Pay.
+		$helper->method( 'is_amazon_pay_enabled' )->willReturn( true );
+		$helper->method( 'is_link_enabled' )->willReturn( false );
+		$helper->method( 'is_express_checkout_enabled' )->willReturn( true );
+
+		$gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
+			->setConstructorArgs( [] )
+			->onlyMethods(
+				[
+					'get_return_url',
+					'get_stripe_return_url',
+					'is_changing_payment_method_for_subscription',
+					'is_subscription_item_in_cart',
+					'get_express_checkout_helper',
+				]
+			)
+			->getMock();
+		$gateway->method( 'get_return_url' )->willReturn( '' );
+		$gateway->method( 'get_stripe_return_url' )->willReturn( '' );
+		$gateway->method( 'is_changing_payment_method_for_subscription' )->willReturn( false );
+		$gateway->method( 'is_subscription_item_in_cart' )->willReturn( false );
+		$gateway->method( 'get_express_checkout_helper' )->willReturn( $helper );
+
+		$this->set_stripe_account_data( [ 'country' => 'US' ] );
+
+		$params = $gateway->javascript_params();
+
+		// Both wallets are backed by the shared setting today, so the flags move together.
+		$this->assertSame( $apple_google_enabled, $params['isApplePayEnabled'] );
+		$this->assertSame( $apple_google_enabled, $params['isGooglePayEnabled'] );
+		$this->assertTrue( $params['isExpressCheckoutEnabled'] );
+	}
+
+	/**
+	 * Data provider for {@see test_javascript_params_exposes_method_specific_apple_google_pay_flags()}.
+	 *
+	 * @return array<string, array{0: bool}>
+	 */
+	public function provide_apple_google_pay_enabled() {
+		return [
+			'disabled for this location' => [ false ],
+			'enabled for this location'  => [ true ],
+		];
+	}
+
+	/**
 	 * The billing source for the deferred-payment flows is selected all-or-nothing:
 	 * the order on a validated pay-for-order page (so guests still get full address
 	 * details), otherwise the customer, with a wholesale fallback to the customer when


### PR DESCRIPTION
Fixes STRIPE-1363

## Changes proposed in this Pull Request:

With multiple express wallets available, unchecking every location under Apple Pay & Google Pay's "Show express checkouts on" setting did not remove their buttons: they kept rendering on any page covered by *another* wallet's locations (e.g. Amazon Pay), and only unchecking that other wallet's locations made them disappear.

The root cause was on the client boundary. PHP already computes a per-method, location-aware answer (`WC_Stripe_Express_Checkout_Helper::is_apple_google_pay_enabled()`), but neither frontend ever received it:

- the classic entrypoint created the Apple Pay and Google Pay elements whenever the localized `is_express_checkout_enabled` aggregate (any wallet enabled for the page) was true, and the ECE options pin `applePay`/`googlePay` to `always`, so Stripe rendered them unconditionally;
- the Blocks integration registered both express payment methods off the same aggregate (`isExpressCheckoutEnabled`), and `canMakePayment` only checks wallet availability, not locations.

Both frontends now receive method-specific flags and gate each wallet's creation/registration on its own flag: `is_apple_pay_enabled` / `is_google_pay_enabled` in the express checkout params (classic/OC), `isApplePayEnabled` / `isGooglePayEnabled` in the Blocks config. Amazon Pay and Link already had their own flags and are unchanged.

### Why per-wallet flags when the settings are shared?

Apple Pay and Google Pay share one setting today, so the two flags are always equal — both are fed from the same `is_apple_google_pay_enabled()` helper. They are still shipped as separate keys deliberately: these localized params are new surface introduced by this PR, and external code can read them once released, so this is the one cheap moment to pick names. Stripe already models the two wallets separately (distinct payment method configuration IDs, per-wallet Express Checkout Element options), and a follow-up (STRIPE-1373) proposes splitting them in wp-admin. With per-wallet keys, that split only changes how PHP computes each value — the frontend contract and rendering path need no changes, and no combined key ever ships that would need a deprecation window afterwards.

### Backward compatibility

- Purely additive: four new localized config keys; the existing aggregate flags remain localized with unchanged values, so external readers of the params objects are unaffected.
- No hooks, options, or PHP signatures change.
- Location settings are read per site, as before; no multisite impact.

## Testing instructions

1. Connect a Stripe account with Apple Pay/Google Pay and Amazon Pay available.
2. Under **Payment methods → Apple Pay / Google Pay → Customize express checkouts**, untick Checkout, Product page, and Cart. Save.
3. Under **Amazon Pay**, tick all three locations. Save.
4. Visit a product page, the cart, and checkout (both shortcode and Blocks): only the Amazon Pay button should render.
5. Re-tick a location for Apple Pay / Google Pay: their buttons return on that page only.

Automated coverage: `WC_Stripe_Express_Checkout_Element_Test` asserts both localized flags carry the method-specific value while the aggregate stays true; Jest tests on the classic entrypoint assert Apple/Google elements are not created when only another wallet covers the page, are created when their own locations do, and that each wallet follows its own flag independently.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)