### PR TITLE
Seed the store name as the Checkout Session intent description

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ xxxx-xx-xx - version 11.0.0
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
 * Fix - Exclude password-protected products and products hidden from the catalog from the Agentic Commerce feed
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
+* Fix - Show the store name instead of a raw payment ID in Stripe receipt emails for Adaptive Pricing payments, until the order reference is backfilled
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/includes/class-wc-stripe-checkout-session-manager.php
+++ b/includes/class-wc-stripe-checkout-session-manager.php
@@ -288,8 +288,16 @@ class WC_Stripe_Checkout_Session_Manager {
 			'checkout_type' => self::ADAPTIVE_PRICING_CHECKOUT_TYPE,
 		];
 
-		/** Documented in includes/abstracts/abstract-wc-stripe-payment-gateway.php */
-		return [ 'metadata' => apply_filters( 'wc_stripe_payment_metadata', $metadata, null, null ) ];
+		return [
+			// The session is created from the cart, before an order exists, so the order
+			// reference can't be included yet. Stripe's automatic receipt email renders the
+			// intent description at charge time — before the post-payment backfill can land —
+			// so seed the store name here; the backfill later replaces it with the full
+			// "store - Order N" description.
+			'description' => wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ),
+			/** Documented in includes/abstracts/abstract-wc-stripe-payment-gateway.php */
+			'metadata'    => apply_filters( 'wc_stripe_payment_metadata', $metadata, null, null ),
+		];
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -174,5 +174,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
 * Fix - Exclude password-protected products and products hidden from the catalog from the Agentic Commerce feed
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
+* Fix - Show the store name instead of a raw payment ID in Stripe receipt emails for Adaptive Pricing payments, until the order reference is backfilled
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
+++ b/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
@@ -191,6 +191,52 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Session creation must seed the store name as the intent description: Stripe's automatic
+	 * receipt email renders the description at charge time, before the post-payment backfill
+	 * can replace it with the full order reference.
+	 */
+	public function test_create_session_seeds_the_store_name_as_intent_description(): void {
+		$product = WC_Helper_Product::create_simple_product( true, [ 'regular_price' => 12.34 ] );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		$captured_body = null;
+		$mock_request  = static function ( $return_value, $parsed_args, $url ) use ( &$captured_body ) {
+			if ( 'https://api.stripe.com/v1/checkout/sessions' !== $url ) {
+				return $return_value;
+			}
+
+			$captured_body = $parsed_args['body'];
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => wp_json_encode(
+					(object) [
+						'id'            => 'cs_test_description_seed',
+						'client_secret' => 'cs_test_description_secret',
+					]
+				),
+			];
+		};
+		add_filter( 'pre_http_request', $mock_request, 10, 3 );
+
+		try {
+			( new WC_Stripe_Checkout_Session_Manager() )->synchronize();
+		} finally {
+			remove_filter( 'pre_http_request', $mock_request, 10 );
+		}
+
+		if ( is_string( $captured_body ) ) {
+			parse_str( $captured_body, $captured_body );
+		}
+
+		$this->assertSame(
+			wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ),
+			$captured_body['payment_intent_data']['description'] ?? null
+		);
+	}
+
+	/**
 	 * A later native cart total updates the server-owned session and increments its embedded revision.
 	 */
 	public function test_synchronize_updates_existing_session_after_cart_total_changes(): void {


### PR DESCRIPTION
Related to STRIPE-1359

## Changes proposed in this Pull Request:

With Adaptive Pricing / Optimized Checkout Suite, the Checkout Session (and its future PaymentIntent) is created from the cart, before a WooCommerce order exists, so the intent starts with no description. The existing post-payment backfill adds the full order reference, but Stripe's automatic customer receipt email renders the description at charge time — before any backfill can land — so customers with Stripe receipts enabled see a raw payment ID.

A complete fix isn't possible with the current Stripe API: the PaymentIntent only comes into existence at client-side confirmation, and the [Checkout Session update API](https://docs.stripe.com/api/checkout/sessions/update) doesn't accept `payment_intent_data` (creation-only). That makes session creation the only window, so this PR seeds the store name (`payment_intent_data[description]`) there. Receipt emails now show the store name instead of a raw payment ID; the existing delayed backfill still replaces it with the full "store - Order N" reference for the Dashboard.

### Backward compatibility

- Additive request field on session creation only; no hooks, options, or signatures change.
- `get_bloginfo( 'name' )` is site-scoped, so multisite networks get each site's own name.

## Testing instructions

1. Enable Optimized Checkout / Adaptive Pricing and, in the Stripe Dashboard, enable successful-payment receipt emails.
2. Check out via the Checkout Sessions flow with a test card and a test email address.
3. The receipt email should show the store name as the description instead of a raw `pi_…`/`py_…` ID.
4. After ~2 minutes, the payment in the Stripe Dashboard should show the full "store - Order N" description (existing backfill, unchanged).

Automated coverage: `WC_Stripe_Checkout_Session_Manager_Test` asserts the session-creation request carries the store name as `payment_intent_data[description]`.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @daledupreez 