### PR TITLE
Stop webhook auto-configuration from clobbering manual webhook setups

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ xxxx-xx-xx - version 11.0.0
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
 * Fix - Exclude password-protected products and products hidden from the catalog from the Agentic Commerce feed
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
+* Fix - Stop webhook auto-configuration from deleting webhook endpoints the plugin did not create, and warn instead of silently replacing a manually entered signing secret or displaying a webhook that no longer exists
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,7 +17,7 @@ xxxx-xx-xx - version 11.0.0
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
 * Fix - Exclude password-protected products and products hidden from the catalog from the Agentic Commerce feed
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
-* Fix - Stop webhook auto-configuration from deleting webhook endpoints the plugin did not create, and warn instead of silently replacing a manually entered signing secret or displaying a webhook that no longer exists
+* Fix - Preserve manually configured webhooks during automatic reconfiguration and warn when the configured webhook no longer exists
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -264,6 +264,28 @@ class WC_Stripe_Admin_Notices {
 				$this->add_admin_notice( '3ds', 'notice notice-warning', $message, true );
 			}
 
+			if ( 'yes' === get_option( WC_Stripe_Account::WEBHOOK_MISSING_NOTICE_OPTION ) ) {
+				$message = sprintf(
+					/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
+					__( 'WooCommerce Stripe - The webhook endpoint saved in your settings no longer exists in your Stripe account, so order updates from Stripe are not being received. Please %1$sre-configure your webhooks%2$s.', 'woocommerce-gateway-stripe' ),
+					'<a href="' . $this->get_setting_link() . '">',
+					'</a>'
+				);
+
+				$this->add_admin_notice( 'webhook_missing', 'notice notice-error', $message, true );
+			}
+
+			if ( 'yes' === get_option( WC_Stripe_Account::WEBHOOK_MANUAL_SECRET_NOTICE_OPTION ) ) {
+				$message = sprintf(
+					/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
+					__( 'WooCommerce Stripe - Automatic webhook reconfiguration was skipped because the webhook signing secret in your settings was set manually. Please verify your webhook configuration in the Stripe Dashboard, or %1$sre-configure your webhooks%2$s to let the plugin manage them.', 'woocommerce-gateway-stripe' ),
+					'<a href="' . $this->get_setting_link() . '">',
+					'</a>'
+				);
+
+				$this->add_admin_notice( 'webhook_manual_secret', 'notice notice-warning', $message, true );
+			}
+
 			if ( empty( $show_style_notice ) ) {
 				$message = sprintf(
 				/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
@@ -842,6 +864,12 @@ class WC_Stripe_Admin_Notices {
 					break;
 				case 'changed_keys':
 					update_option( 'wc_stripe_show_changed_keys_notice', 'no' );
+					break;
+				case 'webhook_missing':
+					delete_option( WC_Stripe_Account::WEBHOOK_MISSING_NOTICE_OPTION );
+					break;
+				case 'webhook_manual_secret':
+					delete_option( WC_Stripe_Account::WEBHOOK_MANUAL_SECRET_NOTICE_OPTION );
 					break;
 				case 'legacy_deprecation':
 					update_option( 'wc_stripe_show_legacy_deprecation_notice', 'no' );

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -83,6 +83,25 @@ class WC_Stripe_Account {
 	protected const WEBHOOK_STATUS_CACHE_KEY = 'webhook_status';
 
 	/**
+	 * Metadata key/value stamped on webhook endpoints this plugin creates, so cleanup can
+	 * tell them apart from endpoints the merchant created at the same URL by hand.
+	 */
+	public const WEBHOOK_METADATA_CREATED_BY_KEY   = 'created_by';
+	public const WEBHOOK_METADATA_CREATED_BY_VALUE = 'woocommerce_gateway_stripe';
+
+	/**
+	 * Option set when automatic reconfiguration is skipped because the stored signing
+	 * secret was entered manually; read by WC_Stripe_Admin_Notices.
+	 */
+	public const WEBHOOK_MANUAL_SECRET_NOTICE_OPTION = 'wc_stripe_show_webhook_manual_secret_notice';
+
+	/**
+	 * Option set when the stored webhook endpoint no longer exists in the connected
+	 * Stripe account; read by WC_Stripe_Admin_Notices.
+	 */
+	public const WEBHOOK_MISSING_NOTICE_OPTION = 'wc_stripe_show_webhook_missing_notice';
+
+	/**
 	 * The Stripe connect instance.
 	 *
 	 * @var WC_Stripe_Connect
@@ -336,6 +355,9 @@ class WC_Stripe_Account {
 			'enabled_events' => self::WEBHOOK_EVENTS,
 			'url'            => WC_Stripe_Helper::get_webhook_url(),
 			'api_version'    => self::get_webhooks_api_version(),
+			// Stamp the endpoint so later cleanup only ever deletes endpoints this plugin
+			// created, never ones the merchant added at the same URL by hand.
+			'metadata'       => [ self::WEBHOOK_METADATA_CREATED_BY_KEY => self::WEBHOOK_METADATA_CREATED_BY_VALUE ],
 		];
 
 		$response = WC_Stripe_API::request( $request, 'webhook_endpoints', 'POST' );
@@ -360,12 +382,20 @@ class WC_Stripe_Account {
 		// Save the Webhook secret and ID.
 		$settings[ $webhook_secret_setting ] = wc_clean( $response->secret );
 		$settings[ $webhook_data_setting ]   = [
-			'id'     => wc_clean( $response->id ),
-			'url'    => wc_clean( $response->url ),
-			'secret' => WC_Stripe_API::get_secret_key(),
+			'id'             => wc_clean( $response->id ),
+			'url'            => wc_clean( $response->url ),
+			'secret'         => WC_Stripe_API::get_secret_key(),
+			// Record the signing secret this configuration wrote, so automatic
+			// reconfiguration can tell a plugin-written secret from one the merchant
+			// pasted in manually and avoid clobbering the latter without warning.
+			'signing_secret' => wc_clean( $response->secret ),
 		];
 
 		WC_Stripe_Helper::update_main_stripe_settings( $settings );
+
+		// A successful (re)configuration resolves whatever the webhook notices were flagging.
+		delete_option( self::WEBHOOK_MANUAL_SECRET_NOTICE_OPTION );
+		delete_option( self::WEBHOOK_MISSING_NOTICE_OPTION );
 
 		// After reconfiguring webhooks, clear the webhook state.
 		WC_Stripe_Webhook_State::clear_state();
@@ -388,7 +418,17 @@ class WC_Stripe_Account {
 		$webhook_url = WC_Stripe_Helper::get_webhook_url();
 
 		WC_Stripe_Logger::info(
-			$exclude_webhook_id ? "Deleting all webhooks sent to {$webhook_url} except for {$exclude_webhook_id}" : "Deleting all webhooks sent to {$webhook_url}"
+			$exclude_webhook_id ? "Deleting this plugin's webhooks sent to {$webhook_url} except for {$exclude_webhook_id}" : "Deleting this plugin's webhooks sent to {$webhook_url}"
+		);
+
+		// Endpoints the plugin recorded in settings are plugin-created even when they predate
+		// the metadata stamp, so they stay eligible for cleanup.
+		$settings            = WC_Stripe_Helper::get_stripe_settings();
+		$plugin_recorded_ids = array_filter(
+			[
+				$settings['webhook_data']['id'] ?? '',
+				$settings['test_webhook_data']['id'] ?? '',
+			]
 		);
 
 		foreach ( $webhooks->data as $webhook ) {
@@ -401,15 +441,28 @@ class WC_Stripe_Account {
 				continue;
 			}
 
-			// Delete the webhook if it matches the current site's webhook URL.
-			if ( WC_Stripe_Helper::is_webhook_url( $webhook->url, $webhook_url ) ) {
-				$this->stripe_api::request(
-					[],
-					"webhook_endpoints/{$webhook->id}",
-					'DELETE'
-				);
-				WC_Stripe_Logger::info( "Deleted webhook {$webhook->id} because it was being sent to this site's webhook URL." );
+			if ( ! WC_Stripe_Helper::is_webhook_url( $webhook->url, $webhook_url ) ) {
+				continue;
 			}
+
+			// Only delete endpoints this plugin created. Merchants are instructed by the
+			// settings page and docs to create an endpoint at this exact URL when
+			// configuring webhooks manually, so an unrecognized endpoint here is likely
+			// theirs — deleting it silently breaks their manual configuration.
+			$is_plugin_created = in_array( $webhook->id, $plugin_recorded_ids, true )
+				|| self::WEBHOOK_METADATA_CREATED_BY_VALUE === ( $webhook->metadata->{self::WEBHOOK_METADATA_CREATED_BY_KEY} ?? '' );
+
+			if ( ! $is_plugin_created ) {
+				WC_Stripe_Logger::info( "Skipped deleting webhook {$webhook->id}: it points at this site's webhook URL but was not created by this plugin." );
+				continue;
+			}
+
+			$this->stripe_api::request(
+				[],
+				"webhook_endpoints/{$webhook->id}",
+				'DELETE'
+			);
+			WC_Stripe_Logger::info( "Deleted webhook {$webhook->id} because this plugin created it for this site's webhook URL." );
 		}
 	}
 
@@ -564,6 +617,30 @@ class WC_Stripe_Account {
 	}
 
 	/**
+	 * Whether a webhook endpoint still exists in the connected Stripe account.
+	 *
+	 * Only a definitive resource_missing answer counts as gone; transport or other API
+	 * errors report the endpoint as existing so a transient failure can't raise a false
+	 * "webhook missing" alarm.
+	 *
+	 * @param string $webhook_id The webhook endpoint ID to check.
+	 * @return bool
+	 */
+	public function webhook_endpoint_exists( string $webhook_id ): bool {
+		$response = $this->stripe_api::retrieve( "webhook_endpoints/{$webhook_id}" );
+
+		if ( is_wp_error( $response ) || ! is_object( $response ) ) {
+			return true;
+		}
+
+		if ( isset( $response->error ) ) {
+			return 'resource_missing' !== ( $response->error->code ?? '' );
+		}
+
+		return isset( $response->id );
+	}
+
+	/**
 	 * Reconfigures webhooks during plugin update or when admin enables Adaptive Pricing in the settings.
 	 * This ensures webhooks are updated with any new events that may have been added.
 	 * Only reconfigures if there's an existing webhook and its events differ from desired events.
@@ -591,8 +668,27 @@ class WC_Stripe_Account {
 				$previous_secret = WC_Stripe_API::get_secret_key();
 				WC_Stripe_API::set_secret_key( $secret_key );
 
+				$webhook_secret_setting = 'live' === $mode ? 'webhook_secret' : 'test_webhook_secret';
+				$webhook_data_setting   = 'live' === $mode ? 'webhook_data' : 'test_webhook_data';
+				$stored_secret          = $settings[ $webhook_secret_setting ] ?? '';
+				$webhook_data           = is_array( $settings[ $webhook_data_setting ] ?? null ) ? $settings[ $webhook_data_setting ] : [];
+				$stored_webhook_id      = $webhook_data['id'] ?? '';
+
 				// Check for existing webhook
 				$existing_webhook = $this->get_existing_webhook();
+
+				// The stored endpoint can vanish (deleted in the Dashboard, or created under a
+				// previously connected account). Without this check the settings keep displaying
+				// the ghost ID and validating against its dead secret with no signal to the
+				// merchant, so surface an actionable notice instead.
+				if (
+					'' !== $stored_webhook_id
+					&& ( ! $existing_webhook || ( $existing_webhook->id ?? '' ) !== $stored_webhook_id )
+					&& ! $this->webhook_endpoint_exists( $stored_webhook_id )
+				) {
+					update_option( self::WEBHOOK_MISSING_NOTICE_OPTION, 'yes' );
+					WC_Stripe_Logger::info( "Stored webhook {$stored_webhook_id} for {$mode} mode no longer exists in the Stripe account." );
+				}
 
 				if ( ! $existing_webhook ) {
 					continue;
@@ -603,6 +699,22 @@ class WC_Stripe_Account {
 					! $this->do_webhook_events_differ( $existing_webhook )
 					&& ! $this->does_webhooks_api_version_differ( $existing_webhook )
 				) {
+					continue;
+				}
+
+				// A secret the plugin didn't write means the merchant configured webhooks
+				// manually (the settings page instructs exactly that). Reconfiguring would
+				// silently replace it and break their endpoint's deliveries, so leave the
+				// configuration alone and tell them instead. Legacy webhook_data without a
+				// recorded signing_secret keeps the pre-existing reconfigure behavior.
+				$secret_is_manual = '' !== $stored_secret && (
+					'' === $stored_webhook_id
+					|| ( isset( $webhook_data['signing_secret'] ) && $webhook_data['signing_secret'] !== $stored_secret )
+				);
+
+				if ( $secret_is_manual ) {
+					update_option( self::WEBHOOK_MANUAL_SECRET_NOTICE_OPTION, 'yes' );
+					WC_Stripe_Logger::info( "Skipped automatic webhook reconfiguration for {$mode} mode: the stored signing secret was set manually." );
 					continue;
 				}
 

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -82,23 +82,14 @@ class WC_Stripe_Account {
 	 */
 	protected const WEBHOOK_STATUS_CACHE_KEY = 'webhook_status';
 
-	/**
-	 * Metadata key/value stamped on webhook endpoints this plugin creates, so cleanup can
-	 * tell them apart from endpoints the merchant created at the same URL by hand.
-	 */
+	/** Metadata stamped on endpoints this plugin creates, so cleanup can tell them from merchant-created ones. */
 	public const WEBHOOK_METADATA_CREATED_BY_KEY   = 'created_by';
 	public const WEBHOOK_METADATA_CREATED_BY_VALUE = 'woocommerce_gateway_stripe';
 
-	/**
-	 * Option set when automatic reconfiguration is skipped because the stored signing
-	 * secret was entered manually; read by WC_Stripe_Admin_Notices.
-	 */
+	/** Option flagging that reconfiguration was skipped over a manually set signing secret. */
 	public const WEBHOOK_MANUAL_SECRET_NOTICE_OPTION = 'wc_stripe_show_webhook_manual_secret_notice';
 
-	/**
-	 * Option set when the stored webhook endpoint no longer exists in the connected
-	 * Stripe account; read by WC_Stripe_Admin_Notices.
-	 */
+	/** Option flagging that the stored webhook endpoint no longer exists in Stripe. */
 	public const WEBHOOK_MISSING_NOTICE_OPTION = 'wc_stripe_show_webhook_missing_notice';
 
 	/**
@@ -355,8 +346,7 @@ class WC_Stripe_Account {
 			'enabled_events' => self::WEBHOOK_EVENTS,
 			'url'            => WC_Stripe_Helper::get_webhook_url(),
 			'api_version'    => self::get_webhooks_api_version(),
-			// Stamp the endpoint so later cleanup only ever deletes endpoints this plugin
-			// created, never ones the merchant added at the same URL by hand.
+			// Stamp the endpoint so cleanup only deletes endpoints this plugin created.
 			'metadata'       => [ self::WEBHOOK_METADATA_CREATED_BY_KEY => self::WEBHOOK_METADATA_CREATED_BY_VALUE ],
 		];
 
@@ -385,9 +375,7 @@ class WC_Stripe_Account {
 			'id'             => wc_clean( $response->id ),
 			'url'            => wc_clean( $response->url ),
 			'secret'         => WC_Stripe_API::get_secret_key(),
-			// Record the signing secret this configuration wrote, so automatic
-			// reconfiguration can tell a plugin-written secret from one the merchant
-			// pasted in manually and avoid clobbering the latter without warning.
+			// Lets reconfiguration tell a plugin-written secret from a manually pasted one.
 			'signing_secret' => wc_clean( $response->secret ),
 		];
 
@@ -421,8 +409,7 @@ class WC_Stripe_Account {
 			$exclude_webhook_id ? "Deleting this plugin's webhooks sent to {$webhook_url} except for {$exclude_webhook_id}" : "Deleting this plugin's webhooks sent to {$webhook_url}"
 		);
 
-		// Endpoints the plugin recorded in settings are plugin-created even when they predate
-		// the metadata stamp, so they stay eligible for cleanup.
+		// Settings-recorded endpoints are plugin-created even when they predate the metadata stamp.
 		$settings            = WC_Stripe_Helper::get_stripe_settings();
 		$plugin_recorded_ids = array_filter(
 			[
@@ -445,10 +432,8 @@ class WC_Stripe_Account {
 				continue;
 			}
 
-			// Only delete endpoints this plugin created. Merchants are instructed by the
-			// settings page and docs to create an endpoint at this exact URL when
-			// configuring webhooks manually, so an unrecognized endpoint here is likely
-			// theirs — deleting it silently breaks their manual configuration.
+			// The settings page instructs merchants to create an endpoint at this exact URL
+			// when configuring manually, so an unrecognized endpoint here is likely theirs.
 			$is_plugin_created = in_array( $webhook->id, $plugin_recorded_ids, true )
 				|| self::WEBHOOK_METADATA_CREATED_BY_VALUE === ( $webhook->metadata->{self::WEBHOOK_METADATA_CREATED_BY_KEY} ?? '' );
 
@@ -618,10 +603,7 @@ class WC_Stripe_Account {
 
 	/**
 	 * Whether a webhook endpoint still exists in the connected Stripe account.
-	 *
-	 * Only a definitive resource_missing answer counts as gone; transport or other API
-	 * errors report the endpoint as existing so a transient failure can't raise a false
-	 * "webhook missing" alarm.
+	 * Only resource_missing counts as gone, so a transient API failure can't raise a false alarm.
 	 *
 	 * @param string $webhook_id The webhook endpoint ID to check.
 	 * @return bool
@@ -678,9 +660,7 @@ class WC_Stripe_Account {
 				$existing_webhook = $this->get_existing_webhook();
 
 				// The stored endpoint can vanish (deleted in the Dashboard, or created under a
-				// previously connected account). Without this check the settings keep displaying
-				// the ghost ID and validating against its dead secret with no signal to the
-				// merchant, so surface an actionable notice instead.
+				// previously connected account); notice instead of displaying the ghost ID forever.
 				if (
 					'' !== $stored_webhook_id
 					&& ( ! $existing_webhook || ( $existing_webhook->id ?? '' ) !== $stored_webhook_id )
@@ -702,11 +682,9 @@ class WC_Stripe_Account {
 					continue;
 				}
 
-				// A secret the plugin didn't write means the merchant configured webhooks
-				// manually (the settings page instructs exactly that). Reconfiguring would
-				// silently replace it and break their endpoint's deliveries, so leave the
-				// configuration alone and tell them instead. Legacy webhook_data without a
-				// recorded signing_secret keeps the pre-existing reconfigure behavior.
+				// A secret the plugin didn't write was set manually; reconfiguring would silently
+				// replace it and break the merchant's endpoint, so notify instead. Legacy
+				// webhook_data without signing_secret keeps the pre-existing behavior.
 				$secret_is_manual = '' !== $stored_secret && (
 					'' === $stored_webhook_id
 					|| ( isset( $webhook_data['signing_secret'] ) && $webhook_data['signing_secret'] !== $stored_secret )

--- a/readme.txt
+++ b/readme.txt
@@ -174,5 +174,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
 * Fix - Exclude password-protected products and products hidden from the catalog from the Agentic Commerce feed
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
+* Fix - Stop webhook auto-configuration from deleting webhook endpoints the plugin did not create, and warn instead of silently replacing a manually entered signing secret or displaying a webhook that no longer exists
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -174,6 +174,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
 * Fix - Exclude password-protected products and products hidden from the catalog from the Agentic Commerce feed
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
-* Fix - Stop webhook auto-configuration from deleting webhook endpoints the plugin did not create, and warn instead of silently replacing a manually entered signing secret or displaying a webhook that no longer exists
+* Fix - Preserve manually configured webhooks during automatic reconfiguration and warn when the configured webhook no longer exists
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-account-test.php
+++ b/tests/phpunit/class-wc-stripe-account-test.php
@@ -50,6 +50,8 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 		WC_Stripe_Helper::delete_main_stripe_settings();
 
 		WC_Helper_Stripe_Api::reset();
+		delete_option( WC_Stripe_Account::WEBHOOK_MANUAL_SECRET_NOTICE_OPTION );
+		delete_option( WC_Stripe_Account::WEBHOOK_MISSING_NOTICE_OPTION );
 
 		parent::tear_down();
 	}
@@ -313,6 +315,7 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 	 */
 	public function test_delete_previously_configured_webhooks_with_exclusion() {
 		$webhook_url = WC_Stripe_Helper::get_webhook_url();
+		$plugin_meta = (object) [ WC_Stripe_Account::WEBHOOK_METADATA_CREATED_BY_KEY => WC_Stripe_Account::WEBHOOK_METADATA_CREATED_BY_VALUE ];
 
 		// Mock the API retrieve.
 		WC_Helper_Stripe_Api::$retrieve_response = (object) [
@@ -321,31 +324,41 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 					'id' => 'wh_000', // Invalid data - no URL.
 				],
 				(object) [
-					'id'  => 'wh_123',
-					'url' => $webhook_url, // Should be deleted.
+					'id'       => 'wh_123',
+					'url'      => $webhook_url, // Should be deleted.
+					'metadata' => $plugin_meta,
 				],
 				(object) [
-					'id'  => 'wh_456',
-					'url' => $webhook_url, // Should not be deleted - excluded.
+					'id'       => 'wh_456',
+					'url'      => $webhook_url, // Should not be deleted - excluded.
+					'metadata' => $plugin_meta,
 				],
 				(object) [
-					'id'  => 'wh_789',
-					'url' => 'https://some-other-site.com', // Should not be deleted - different URL.
+					'id'       => 'wh_789',
+					'url'      => 'https://some-other-site.com', // Should not be deleted - different URL.
+					'metadata' => $plugin_meta,
 				],
 				(object) [
-					'id'  => 'wh_101112',
-					'url' => $webhook_url . '&foo=bar', // Should be deleted.
+					'id'       => 'wh_101112',
+					'url'      => $webhook_url . '&foo=bar', // Should be deleted.
+					'metadata' => $plugin_meta,
 				],
 				(object) [
 					'url' => $webhook_url, // Invalid data - no ID.
 				],
 				(object) [
-					'id'  => 'wh_131415',
-					'url' => str_replace( 'https', 'http', $webhook_url ), // Should be deleted - different protocol.
+					'id'       => 'wh_131415',
+					'url'      => str_replace( 'https', 'http', $webhook_url ), // Should be deleted - different protocol.
+					'metadata' => $plugin_meta,
 				],
 				(object) [
-					'id'  => 'wh_161718',
-					'url' => explode( '?', $webhook_url )[0], // Should be deleted - matching host with empty path.
+					'id'       => 'wh_161718',
+					'url'      => explode( '?', $webhook_url )[0], // Should be deleted - matching host with empty path.
+					'metadata' => $plugin_meta,
+				],
+				(object) [
+					'id'  => 'wh_merchant',
+					'url' => $webhook_url, // Should not be deleted - not created by this plugin.
 				],
 			],
 		];
@@ -369,6 +382,16 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 	 */
 	public function test_delete_previously_configured_webhooks_without_exclusion() {
 		$webhook_url = WC_Stripe_Helper::get_webhook_url();
+		$plugin_meta = (object) [ WC_Stripe_Account::WEBHOOK_METADATA_CREATED_BY_KEY => WC_Stripe_Account::WEBHOOK_METADATA_CREATED_BY_VALUE ];
+
+		// An endpoint recorded in settings is plugin-created even without the metadata stamp
+		// (it predates the stamp), so it must stay eligible for cleanup.
+		$settings                 = WC_Stripe_Helper::get_stripe_settings();
+		$settings['webhook_data'] = [
+			'id'     => 'wh_456',
+			'secret' => 'sk_test_key',
+		];
+		WC_Stripe_Helper::update_main_stripe_settings( $settings );
 
 		// Mock the API retrieve.
 		WC_Helper_Stripe_Api::$retrieve_response = (object) [
@@ -377,12 +400,13 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 					'id' => 'wh_000', // Invalid data - no URL.
 				],
 				(object) [
-					'id'  => 'wh_123',
-					'url' => $webhook_url, // Should be deleted.
+					'id'       => 'wh_123',
+					'url'      => $webhook_url, // Should be deleted - metadata stamp.
+					'metadata' => $plugin_meta,
 				],
 				(object) [
 					'id'  => 'wh_456',
-					'url' => $webhook_url, // Should be deleted.
+					'url' => $webhook_url, // Should be deleted - recorded in settings.
 				],
 				(object) [
 					'id'  => 'wh_789',
@@ -390,7 +414,7 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 				],
 				(object) [
 					'id'  => 'wh_101112',
-					'url' => $webhook_url, // Should be deleted.
+					'url' => $webhook_url, // Should not be deleted - not created by this plugin.
 				],
 				(object) [
 					'url' => $webhook_url, // Invalid data - no ID.
@@ -402,7 +426,6 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 		WC_Helper_Stripe_Api::$expected_request_call_params = [
 			[ [], 'webhook_endpoints/wh_123', 'DELETE' ],
 			[ [], 'webhook_endpoints/wh_456', 'DELETE' ],
-			[ [], 'webhook_endpoints/wh_101112', 'DELETE' ],
 		];
 
 		$this->account->delete_previously_configured_webhooks();
@@ -579,6 +602,213 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 	 * Tests that webhook reconfiguration is triggered when the agentic flag
 	 * causes the desired API version to differ from the existing webhook.
 	 */
+	/**
+	 * Builds an outdated existing webhook so the reconfigure path is reached.
+	 *
+	 * @param string $id The webhook endpoint ID.
+	 * @return object
+	 */
+	private function build_outdated_webhook( $id = 'we_123' ) {
+		return (object) [
+			'id'             => $id,
+			'url'            => WC_Stripe_Helper::get_webhook_url(),
+			'enabled_events' => [ 'charge.succeeded', 'charge.failed' ],
+			'api_version'    => \WC_Stripe_API::STRIPE_API_VERSION,
+			'status'         => 'enabled',
+		];
+	}
+
+	/**
+	 * A signing secret the plugin didn't write means the merchant configured webhooks
+	 * manually; automatic reconfiguration must not clobber it, and must tell the merchant.
+	 *
+	 * @param array $webhook_data Stored test_webhook_data for the scenario.
+	 * @dataProvider provide_manually_configured_webhook_data
+	 */
+	public function test_reconfigure_webhooks_skips_and_notices_when_secret_was_set_manually( array $webhook_data ) {
+		$settings                        = WC_Stripe_Helper::get_stripe_settings();
+		$settings['test_webhook_secret'] = 'whsec_manual';
+		$settings['test_webhook_data']   = $webhook_data;
+		WC_Stripe_Helper::update_main_stripe_settings( $settings );
+
+		$this->account = $this->getMockBuilder( WC_Stripe_Account::class )
+			->setConstructorArgs( [ $this->mock_connect, WC_Helper_Stripe_Api::class ] )
+			->onlyMethods( [ 'get_existing_webhook', 'configure_webhooks', 'webhook_endpoint_exists' ] )
+			->getMock();
+		$this->account->method( 'get_existing_webhook' )->willReturn( $this->build_outdated_webhook() );
+		$this->account->method( 'webhook_endpoint_exists' )->willReturn( true );
+		$this->account->expects( $this->never() )->method( 'configure_webhooks' );
+
+		$this->account->maybe_reconfigure_webhooks_on_update();
+
+		$this->assertSame( 'yes', get_option( WC_Stripe_Account::WEBHOOK_MANUAL_SECRET_NOTICE_OPTION ) );
+	}
+
+	/**
+	 * Data provider for {@see test_reconfigure_webhooks_skips_and_notices_when_secret_was_set_manually()}.
+	 *
+	 * @return array<string, array{0: array}>
+	 */
+	public function provide_manually_configured_webhook_data() {
+		return [
+			'secret pasted over an auto-configured one' => [
+				[
+					'id'             => 'we_123',
+					'secret'         => 'sk_test_key',
+					'signing_secret' => 'whsec_auto',
+				],
+			],
+			'secret set with no plugin webhook at all'  => [ [] ],
+		];
+	}
+
+	/**
+	 * A signing secret the plugin wrote itself keeps the automatic reconfigure behavior.
+	 */
+	public function test_reconfigure_webhooks_proceeds_when_secret_was_written_by_plugin() {
+		$settings                        = WC_Stripe_Helper::get_stripe_settings();
+		$settings['test_webhook_secret'] = 'whsec_auto';
+		$settings['test_webhook_data']   = [
+			'id'             => 'we_123',
+			'secret'         => 'sk_test_key',
+			'signing_secret' => 'whsec_auto',
+		];
+		WC_Stripe_Helper::update_main_stripe_settings( $settings );
+
+		$this->account = $this->getMockBuilder( WC_Stripe_Account::class )
+			->setConstructorArgs( [ $this->mock_connect, WC_Helper_Stripe_Api::class ] )
+			->onlyMethods( [ 'get_existing_webhook', 'configure_webhooks', 'webhook_endpoint_exists' ] )
+			->getMock();
+		$this->account->method( 'get_existing_webhook' )->willReturn( $this->build_outdated_webhook() );
+		$this->account->method( 'webhook_endpoint_exists' )->willReturn( true );
+		$this->account->expects( $this->once() )->method( 'configure_webhooks' )->with( 'test' );
+
+		$this->account->maybe_reconfigure_webhooks_on_update();
+
+		$this->assertFalse( get_option( WC_Stripe_Account::WEBHOOK_MANUAL_SECRET_NOTICE_OPTION ) );
+	}
+
+	/**
+	 * Legacy webhook_data without a recorded signing_secret keeps the pre-existing
+	 * reconfigure behavior instead of treating every legacy store as manually configured.
+	 */
+	public function test_reconfigure_webhooks_proceeds_for_legacy_webhook_data() {
+		$settings                        = WC_Stripe_Helper::get_stripe_settings();
+		$settings['test_webhook_secret'] = 'whsec_legacy';
+		$settings['test_webhook_data']   = [
+			'id'     => 'we_123',
+			'secret' => 'sk_test_key',
+		];
+		WC_Stripe_Helper::update_main_stripe_settings( $settings );
+
+		$this->account = $this->getMockBuilder( WC_Stripe_Account::class )
+			->setConstructorArgs( [ $this->mock_connect, WC_Helper_Stripe_Api::class ] )
+			->onlyMethods( [ 'get_existing_webhook', 'configure_webhooks', 'webhook_endpoint_exists' ] )
+			->getMock();
+		$this->account->method( 'get_existing_webhook' )->willReturn( $this->build_outdated_webhook() );
+		$this->account->method( 'webhook_endpoint_exists' )->willReturn( true );
+		$this->account->expects( $this->once() )->method( 'configure_webhooks' )->with( 'test' );
+
+		$this->account->maybe_reconfigure_webhooks_on_update();
+
+		$this->assertFalse( get_option( WC_Stripe_Account::WEBHOOK_MANUAL_SECRET_NOTICE_OPTION ) );
+	}
+
+	/**
+	 * When the stored webhook endpoint no longer exists in the account, the merchant gets
+	 * an actionable notice instead of the settings displaying a ghost ID forever.
+	 */
+	public function test_reconfigure_webhooks_flags_missing_stored_webhook() {
+		$settings                        = WC_Stripe_Helper::get_stripe_settings();
+		$settings['test_webhook_secret'] = 'whsec_auto';
+		$settings['test_webhook_data']   = [
+			'id'             => 'we_ghost',
+			'secret'         => 'sk_test_key',
+			'signing_secret' => 'whsec_auto',
+		];
+		WC_Stripe_Helper::update_main_stripe_settings( $settings );
+
+		$api_version_method = new ReflectionMethod( WC_Stripe_Account::class, 'get_webhooks_api_version' );
+		$api_version_method->setAccessible( true );
+
+		// The URL-matched endpoint is someone else's; the stored one is gone.
+		$up_to_date_webhook = (object) [
+			'id'             => 'we_other',
+			'url'            => WC_Stripe_Helper::get_webhook_url(),
+			'enabled_events' => WC_Stripe_Account::WEBHOOK_EVENTS,
+			'api_version'    => $api_version_method->invoke( null ),
+			'status'         => 'enabled',
+		];
+
+		$this->account = $this->getMockBuilder( WC_Stripe_Account::class )
+			->setConstructorArgs( [ $this->mock_connect, WC_Helper_Stripe_Api::class ] )
+			->onlyMethods( [ 'get_existing_webhook', 'configure_webhooks', 'webhook_endpoint_exists' ] )
+			->getMock();
+		$this->account->method( 'get_existing_webhook' )->willReturn( $up_to_date_webhook );
+		$this->account->method( 'webhook_endpoint_exists' )->with( 'we_ghost' )->willReturn( false );
+		$this->account->expects( $this->never() )->method( 'configure_webhooks' );
+
+		$this->account->maybe_reconfigure_webhooks_on_update();
+
+		$this->assertSame( 'yes', get_option( WC_Stripe_Account::WEBHOOK_MISSING_NOTICE_OPTION ) );
+	}
+
+	/**
+	 * configure_webhooks() must stamp the endpoint as plugin-created, record the signing
+	 * secret it wrote, and clear any pending webhook notices.
+	 */
+	public function test_configure_webhooks_records_signing_secret_and_stamps_endpoint() {
+		update_option( WC_Stripe_Account::WEBHOOK_MANUAL_SECRET_NOTICE_OPTION, 'yes' );
+		update_option( WC_Stripe_Account::WEBHOOK_MISSING_NOTICE_OPTION, 'yes' );
+
+		// No pre-existing endpoints for the post-create cleanup pass.
+		WC_Helper_Stripe_Api::$retrieve_response = (object) [ 'data' => [] ];
+
+		$captured_body = null;
+		$mock_request  = static function ( $return_value, $parsed_args, $url ) use ( &$captured_body ) {
+			if ( 'https://api.stripe.com/v1/webhook_endpoints' !== $url ) {
+				return $return_value;
+			}
+
+			$captured_body = $parsed_args['body'];
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => wp_json_encode(
+					(object) [
+						'id'     => 'we_new',
+						'url'    => WC_Stripe_Helper::get_webhook_url(),
+						'secret' => 'whsec_new',
+					]
+				),
+			];
+		};
+		add_filter( 'pre_http_request', $mock_request, 10, 3 );
+
+		try {
+			$this->account->configure_webhooks( 'test' );
+		} finally {
+			remove_filter( 'pre_http_request', $mock_request, 10 );
+		}
+
+		if ( is_string( $captured_body ) ) {
+			parse_str( $captured_body, $captured_body );
+		}
+
+		$this->assertSame(
+			WC_Stripe_Account::WEBHOOK_METADATA_CREATED_BY_VALUE,
+			$captured_body['metadata'][ WC_Stripe_Account::WEBHOOK_METADATA_CREATED_BY_KEY ] ?? null
+		);
+
+		$settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertSame( 'whsec_new', $settings['test_webhook_secret'] );
+		$this->assertSame( 'whsec_new', $settings['test_webhook_data']['signing_secret'] );
+		$this->assertSame( 'we_new', $settings['test_webhook_data']['id'] );
+
+		$this->assertFalse( get_option( WC_Stripe_Account::WEBHOOK_MANUAL_SECRET_NOTICE_OPTION ) );
+		$this->assertFalse( get_option( WC_Stripe_Account::WEBHOOK_MISSING_NOTICE_OPTION ) );
+	}
+
 	public function test_reconfigure_webhooks_on_update_with_agentic_flag_enabled() {
 		add_filter( 'wc_stripe_is_agentic_commerce_enabled', '__return_true' );
 

--- a/tests/phpunit/class-wc-stripe-account-test.php
+++ b/tests/phpunit/class-wc-stripe-account-test.php
@@ -384,8 +384,7 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 		$webhook_url = WC_Stripe_Helper::get_webhook_url();
 		$plugin_meta = (object) [ WC_Stripe_Account::WEBHOOK_METADATA_CREATED_BY_KEY => WC_Stripe_Account::WEBHOOK_METADATA_CREATED_BY_VALUE ];
 
-		// An endpoint recorded in settings is plugin-created even without the metadata stamp
-		// (it predates the stamp), so it must stay eligible for cleanup.
+		// A settings-recorded endpoint predating the metadata stamp stays eligible for cleanup.
 		$settings                 = WC_Stripe_Helper::get_stripe_settings();
 		$settings['webhook_data'] = [
 			'id'     => 'wh_456',
@@ -619,8 +618,7 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A signing secret the plugin didn't write means the merchant configured webhooks
-	 * manually; automatic reconfiguration must not clobber it, and must tell the merchant.
+	 * A manually set signing secret must block silent reconfiguration and raise the notice.
 	 *
 	 * @param array $webhook_data Stored test_webhook_data for the scenario.
 	 * @dataProvider provide_manually_configured_webhook_data
@@ -689,8 +687,7 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Legacy webhook_data without a recorded signing_secret keeps the pre-existing
-	 * reconfigure behavior instead of treating every legacy store as manually configured.
+	 * Legacy webhook_data without a recorded signing_secret keeps the pre-existing behavior.
 	 */
 	public function test_reconfigure_webhooks_proceeds_for_legacy_webhook_data() {
 		$settings                        = WC_Stripe_Helper::get_stripe_settings();
@@ -715,8 +712,7 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * When the stored webhook endpoint no longer exists in the account, the merchant gets
-	 * an actionable notice instead of the settings displaying a ghost ID forever.
+	 * A stored webhook ID that no longer exists in the account must raise the missing notice.
 	 */
 	public function test_reconfigure_webhooks_flags_missing_stored_webhook() {
 		$settings                        = WC_Stripe_Helper::get_stripe_settings();
@@ -754,8 +750,7 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * configure_webhooks() must stamp the endpoint as plugin-created, record the signing
-	 * secret it wrote, and clear any pending webhook notices.
+	 * configure_webhooks() must stamp the endpoint, record the signing secret, and clear notices.
 	 */
 	public function test_configure_webhooks_records_signing_secret_and_stamps_endpoint() {
 		update_option( WC_Stripe_Account::WEBHOOK_MANUAL_SECRET_NOTICE_OPTION, 'yes' );


### PR DESCRIPTION
Fixes STRIPE-1356

## Changes proposed in this Pull Request:

Automatic webhook reconfiguration (triggered silently on plugin updates and when enabling Adaptive Pricing) destroyed manually configured webhook setups: it deleted **every** endpoint pointing at the site's webhook URL — including ones the merchant created by following the settings page's own instructions — and silently overwrote a manually pasted signing secret. A stored webhook ID whose endpoint no longer exists also kept being displayed with no warning.

The plugin now keeps full control of its **own** endpoint while leaving merchant configuration alone:

- New endpoints are stamped with `metadata[created_by]`; cleanup only deletes stamped or settings-recorded endpoints and skips the rest.
- `webhook_data` records the signing secret auto-configuration wrote. If the stored secret was set manually, silent reconfiguration is skipped with a dismissible admin notice; the explicit Configure webhooks flow still replaces it. Legacy data without the recorded secret keeps the old behavior.
- If the stored webhook ID 404s during the update check, an admin notice asks the merchant to re-configure instead of displaying a ghost ID.

### Backward compatibility

All additive: endpoint metadata, one new `webhook_data` key, two `wc_stripe_show_*` options, one new public method. Cleanup deletes strictly fewer endpoints; stores with plugin-written secrets reconfigure exactly as before.

## Testing instructions

1. Let the plugin configure webhooks; the endpoint gets `created_by` metadata in the Dashboard.
2. Manually create a second endpoint at the same URL and trigger a reconfiguration (e.g. toggle Adaptive Pricing): the manual endpoint survives.
3. Paste the manual endpoint's secret into settings and trigger the silent path (`do_action( 'woocommerce_stripe_updated' )`): the secret is untouched and a notice appears; Configure webhooks replaces it and clears the notice.
4. Delete the plugin's endpoint in the Dashboard and trigger the update check: a "webhook no longer exists" notice appears.

Covered in `WC_Stripe_Account_Test`: deletion scoping, manual-secret skip (data provider), plugin-written and legacy secrets proceeding, ghost-ID notice, and endpoint stamping/recording/notice-clearing.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @daledupreez 