### PR TITLE
Refund the shopper when a discounted agentic checkout session is rejected

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ xxxx-xx-xx - version 11.0.0
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
 * Fix - Exclude password-protected products and products hidden from the catalog from the Agentic Commerce feed
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
+* Fix - Automatically refund the shopper when a discounted agentic checkout session is rejected, instead of leaving the captured payment for manual resolution
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
@@ -150,15 +150,15 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 			);
 		}
 
-		// WooCommerce coupons don't participate in delegated checkout, so a
-		// Stripe-side discount can't be represented on the order — WC
-		// recalculates full catalog prices, and the total verification would
-		// reject the order anyway after it was built. Fail fast with an
-		// explicit reason instead of an opaque total mismatch.
+		// WooCommerce coupons don't participate in delegated checkout, so a Stripe-side
+		// discount can't be represented on the order. Rejection is deferred to the amount
+		// checks below: the discount field alone must not trigger a rejection (and the
+		// refund that follows) — only a charged amount actually below catalog price,
+		// corroborating the field, does. A discount flag on a full-price charge proceeds.
 		if ( $session->get_amount_discount() > 0 ) {
-			throw new WC_Stripe_Agentic_Order_Rejected_Exception(
+			WC_Stripe_Logger::info(
 				sprintf(
-					'Checkout session %s includes a discount (%d): discounts are not supported for agentic checkout orders.',
+					'Checkout session %s reports a discount (%d); deferring to amount verification.',
 					$session->get_id(),
 					$session->get_amount_discount()
 				)
@@ -286,6 +286,22 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 			// Verify WC-calculated total matches Stripe's pre-tax line total.
 			$wc_line_total = (float) $item->get_total();
 			if ( abs( $wc_line_total - $line_total ) > 0.001 ) {
+				// A line charged below catalog price while the session reports a discount is
+				// a corroborated discount: permanently rejected (refund path). Any other
+				// mismatch keeps the generic exception and the retry path.
+				if ( $session->get_amount_discount() > 0 && $wc_line_total - $line_total > 0.001 ) {
+					throw new WC_Stripe_Agentic_Order_Rejected_Exception(
+						sprintf(
+							'Checkout session %s charged product %d below catalog price (%s vs %s) with a reported discount (%d): discounts are not supported for agentic checkout orders.',
+							$session->get_id(),
+							$product_id,
+							wc_format_decimal( $line_total ),
+							wc_format_decimal( $wc_line_total ),
+							$session->get_amount_discount()
+						)
+					);
+				}
+
 				throw new Exception(
 					sprintf(
 						'Line item price mismatch for product %d: WC calculated %s, Stripe expected %s.',
@@ -690,6 +706,21 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 		$order_total    = (float) $order->get_total();
 
 		if ( abs( $order_total - $expected_total ) > 0.001 ) {
+			// A charge below the catalog-derived order total while the session reports a
+			// discount is a corroborated discount: permanently rejected (refund path).
+			// Any other mismatch keeps the generic exception and the retry path.
+			if ( $session->get_amount_discount() > 0 && $order_total - $expected_total > 0.001 ) {
+				throw new WC_Stripe_Agentic_Order_Rejected_Exception(
+					sprintf(
+						'Checkout session %s charged %s against a catalog total of %s with a reported discount (%d): discounts are not supported for agentic checkout orders.',
+						$session->get_id(),
+						wc_format_decimal( $expected_total ),
+						wc_format_decimal( $order_total ),
+						$session->get_amount_discount()
+					)
+				);
+			}
+
 			throw new Exception(
 				sprintf(
 					'Order total mismatch for session %s: WC total %s, Stripe total %s.',

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
@@ -156,7 +156,7 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 		// reject the order anyway after it was built. Fail fast with an
 		// explicit reason instead of an opaque total mismatch.
 		if ( $session->get_amount_discount() > 0 ) {
-			throw new Exception(
+			throw new WC_Stripe_Agentic_Order_Rejected_Exception(
 				sprintf(
 					'Checkout session %s includes a discount (%d): discounts are not supported for agentic checkout orders.',
 					$session->get_id(),

--- a/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper.php
@@ -150,11 +150,8 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 			);
 		}
 
-		// WooCommerce coupons don't participate in delegated checkout, so a Stripe-side
-		// discount can't be represented on the order. Rejection is deferred to the amount
-		// checks below: the discount field alone must not trigger a rejection (and the
-		// refund that follows) — only a charged amount actually below catalog price,
-		// corroborating the field, does. A discount flag on a full-price charge proceeds.
+		// Rejection is deferred to the amount checks: the discount field alone must not
+		// trigger a refund — only a charge actually below catalog price corroborates it.
 		if ( $session->get_amount_discount() > 0 ) {
 			WC_Stripe_Logger::info(
 				sprintf(
@@ -286,9 +283,8 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 			// Verify WC-calculated total matches Stripe's pre-tax line total.
 			$wc_line_total = (float) $item->get_total();
 			if ( abs( $wc_line_total - $line_total ) > 0.001 ) {
-				// A line charged below catalog price while the session reports a discount is
-				// a corroborated discount: permanently rejected (refund path). Any other
-				// mismatch keeps the generic exception and the retry path.
+				// Charged below catalog price with a reported discount = corroborated
+				// discount: permanent rejection (refund path). Other mismatches retry.
 				if ( $session->get_amount_discount() > 0 && $wc_line_total - $line_total > 0.001 ) {
 					throw new WC_Stripe_Agentic_Order_Rejected_Exception(
 						sprintf(
@@ -706,9 +702,8 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper {
 		$order_total    = (float) $order->get_total();
 
 		if ( abs( $order_total - $expected_total ) > 0.001 ) {
-			// A charge below the catalog-derived order total while the session reports a
-			// discount is a corroborated discount: permanently rejected (refund path).
-			// Any other mismatch keeps the generic exception and the retry path.
+			// Same corroboration as the line-level check: only a charge below the
+			// catalog total with a reported discount takes the refund path.
 			if ( $session->get_amount_discount() > 0 && $order_total - $expected_total > 0.001 ) {
 				throw new WC_Stripe_Agentic_Order_Rejected_Exception(
 					sprintf(

--- a/includes/agentic-commerce/class-wc-stripe-agentic-order-rejected-exception.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-order-rejected-exception.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Class WC_Stripe_Agentic_Order_Rejected_Exception
+ *
+ * @package WooCommerce_Stripe/Agentic_Commerce
+ * @since   11.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Signals that an agentic checkout session was permanently rejected during order
+ * creation — no retry can succeed. The webhook handler treats it differently from a
+ * transient failure: the shopper was already charged (payment is captured before the
+ * webhook fires), so the payment is refunded and the job is not retried.
+ *
+ * @since 11.0.0
+ */
+class WC_Stripe_Agentic_Order_Rejected_Exception extends Exception {}

--- a/includes/agentic-commerce/class-wc-stripe-agentic-order-rejected-exception.php
+++ b/includes/agentic-commerce/class-wc-stripe-agentic-order-rejected-exception.php
@@ -12,9 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Signals that an agentic checkout session was permanently rejected during order
- * creation — no retry can succeed. The webhook handler treats it differently from a
- * transient failure: the shopper was already charged (payment is captured before the
- * webhook fires), so the payment is refunded and the job is not retried.
+ * creation. The shopper was already charged, so the webhook handler refunds the
+ * payment instead of retrying.
  *
  * @since 11.0.0
  */

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -3087,6 +3087,24 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				 * @param WC_Stripe_Agentic_Checkout_Session $session The checkout session wrapper.
 				 */
 				do_action( 'wc_stripe_agentic_order_created', $order, $session );
+			} catch ( WC_Stripe_Agentic_Order_Rejected_Exception $e ) {
+				// A permanent rejection (e.g. a discounted session): retrying can never
+				// succeed, and Stripe captured the payment before this webhook fired, so
+				// refund the shopper instead of leaving a charge with no order behind it.
+				WC_Stripe_Logger::error(
+					'Agentic checkout session was rejected; refunding the captured payment.',
+					[
+						'session_id' => $session->get_id(),
+						'error'      => $e->getMessage(),
+					]
+				);
+
+				/** This action is documented below in the generic failure catch. */
+				do_action( 'wc_stripe_agentic_order_creation_failed', $e, $session );
+
+				$this->refund_rejected_agentic_payment( (string) $payment_intent_id, (string) $session->get_id() );
+
+				// Deliberately not re-thrown: the job must not retry a permanent rejection.
 			} catch ( Throwable $e ) {
 				// Cap trace length to avoid overwhelming log handlers that may
 				// truncate or reject very large context fields.
@@ -3124,6 +3142,44 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		} finally {
 			remove_filter( 'wc_stripe_request_headers', $override_version );
 		}
+	}
+
+	/**
+	 * Refunds the captured payment of a permanently rejected agentic checkout session.
+	 * There is no WooCommerce order to route through process_refund(), so the refund
+	 * goes straight to the Stripe API by payment intent. A redelivered webhook may
+	 * retry an already-refunded charge, which Stripe reports as an error we treat
+	 * as success.
+	 *
+	 * @param string $payment_intent_id The captured PaymentIntent to refund.
+	 * @param string $session_id        The rejected checkout session, for logging.
+	 * @return void
+	 */
+	protected function refund_rejected_agentic_payment( string $payment_intent_id, string $session_id ): void {
+		try {
+			$response = WC_Stripe_API::request( [ 'payment_intent' => $payment_intent_id ], 'refunds' );
+		} catch ( Exception $e ) {
+			WC_Stripe_Logger::error(
+				"Failed to refund rejected agentic payment {$payment_intent_id} (session {$session_id}); please refund it manually in the Stripe dashboard.",
+				[ 'error' => $e->getMessage() ]
+			);
+			return;
+		}
+
+		if ( ! empty( $response->error ) ) {
+			if ( 'charge_already_refunded' === ( $response->error->code ?? '' ) ) {
+				WC_Stripe_Logger::info( "Rejected agentic payment {$payment_intent_id} (session {$session_id}) was already refunded." );
+				return;
+			}
+
+			WC_Stripe_Logger::error(
+				"Failed to refund rejected agentic payment {$payment_intent_id} (session {$session_id}); please refund it manually in the Stripe dashboard.",
+				[ 'error' => $response->error->message ?? '(no message)' ]
+			);
+			return;
+		}
+
+		WC_Stripe_Logger::info( "Refunded rejected agentic payment {$payment_intent_id} (session {$session_id})." );
 	}
 
 	/**

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -3156,6 +3156,22 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @return void
 	 */
 	protected function refund_rejected_agentic_payment( string $payment_intent_id, string $session_id ): void {
+		/**
+		 * Filters whether the captured payment of a permanently rejected agentic checkout
+		 * session is refunded automatically. Return false to fall back to log-only, leaving
+		 * the refund to be issued manually.
+		 *
+		 * @since 11.0.0
+		 *
+		 * @param bool   $auto_refund       Whether to refund automatically. Default true.
+		 * @param string $payment_intent_id The captured PaymentIntent.
+		 * @param string $session_id        The rejected checkout session.
+		 */
+		if ( ! apply_filters( 'wc_stripe_agentic_auto_refund_rejected_session', true, $payment_intent_id, $session_id ) ) {
+			WC_Stripe_Logger::info( "Automatic refund disabled by filter for rejected agentic payment {$payment_intent_id} (session {$session_id}); please refund it manually in the Stripe dashboard." );
+			return;
+		}
+
 		try {
 			$response = WC_Stripe_API::request( [ 'payment_intent' => $payment_intent_id ], 'refunds' );
 		} catch ( Exception $e ) {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -3088,9 +3088,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				 */
 				do_action( 'wc_stripe_agentic_order_created', $order, $session );
 			} catch ( WC_Stripe_Agentic_Order_Rejected_Exception $e ) {
-				// A permanent rejection (e.g. a discounted session): retrying can never
-				// succeed, and Stripe captured the payment before this webhook fired, so
-				// refund the shopper instead of leaving a charge with no order behind it.
+				// Permanent rejection: retrying can never succeed and the payment is
+				// already captured, so refund the shopper instead of retrying.
 				WC_Stripe_Logger::error(
 					'Agentic checkout session was rejected; refunding the captured payment.',
 					[
@@ -3146,10 +3145,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 	/**
 	 * Refunds the captured payment of a permanently rejected agentic checkout session.
-	 * There is no WooCommerce order to route through process_refund(), so the refund
-	 * goes straight to the Stripe API by payment intent. A redelivered webhook may
-	 * retry an already-refunded charge, which Stripe reports as an error we treat
-	 * as success.
+	 * No order exists to route through process_refund(), so the refund goes straight to
+	 * the Stripe API; an already-refunded charge (webhook redelivery) counts as success.
 	 *
 	 * @param string $payment_intent_id The captured PaymentIntent to refund.
 	 * @param string $session_id        The rejected checkout session, for logging.
@@ -3157,9 +3154,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	protected function refund_rejected_agentic_payment( string $payment_intent_id, string $session_id ): void {
 		/**
-		 * Filters whether the captured payment of a permanently rejected agentic checkout
-		 * session is refunded automatically. Return false to fall back to log-only, leaving
-		 * the refund to be issued manually.
+		 * Filters whether the captured payment of a rejected agentic checkout session is
+		 * refunded automatically. Return false to log only and refund manually.
 		 *
 		 * @since 11.0.0
 		 *

--- a/readme.txt
+++ b/readme.txt
@@ -174,5 +174,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
 * Fix - Exclude password-protected products and products hidden from the catalog from the Agentic Commerce feed
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
+* Fix - Automatically refund the shopper when a discounted agentic checkout session is rejected, instead of leaving the captured payment for manual resolution
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
@@ -137,16 +137,19 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A discounted session is a permanent rejection, signalled with the dedicated
-	 * exception type so the webhook handler refunds instead of retrying.
+	 * A session-level discount corroborated by a charge below the catalog total is a
+	 * permanent rejection, signalled with the dedicated exception type so the webhook
+	 * handler refunds instead of retrying.
 	 */
-	public function test_discounted_session_throws_the_rejected_exception() {
+	public function test_discounted_session_charged_below_catalog_total_throws_the_rejected_exception() {
 		$session = $this->build_checkout_session(
 			[
-				'total_details' => (object) [
+				'amount_total'    => 800,
+				'amount_subtotal' => 1000,
+				'total_details'   => (object) [
 					'amount_shipping' => 0,
 					'amount_tax'      => 0,
-					'amount_discount' => 500,
+					'amount_discount' => 200,
 				],
 			]
 		);
@@ -155,6 +158,80 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 		$this->expectExceptionMessage( 'discounts are not supported' );
 
 		$this->mapper->create_order_from_checkout_session( $session );
+	}
+
+	/**
+	 * A per-line discount (line charged below catalog price) is also a corroborated,
+	 * permanent rejection.
+	 */
+	public function test_discounted_line_item_throws_the_rejected_exception() {
+		$session = $this->build_checkout_session(
+			[
+				'amount_total'    => 800,
+				'amount_subtotal' => 800,
+				'line_items'      => $this->build_line_items(
+					[
+						[
+							'lookup_key'   => (string) $this->default_product->get_sku(),
+							'quantity'     => 1,
+							'unit_amount'  => 800,
+							'amount_total' => 800,
+						],
+					]
+				),
+				'total_details'   => (object) [
+					'amount_shipping' => 0,
+					'amount_tax'      => 0,
+					'amount_discount' => 200,
+				],
+			]
+		);
+
+		$this->expectException( WC_Stripe_Agentic_Order_Rejected_Exception::class );
+		$this->expectExceptionMessage( 'discounts are not supported' );
+
+		$this->mapper->create_order_from_checkout_session( $session );
+	}
+
+	/**
+	 * An uncorroborated discount field — the shopper paid full catalog price — must not
+	 * reject the session (and trigger a refund); the order proceeds.
+	 */
+	public function test_discount_field_without_reduced_charge_still_creates_the_order() {
+		$session = $this->build_checkout_session(
+			[
+				'total_details' => (object) [
+					'amount_shipping' => 0,
+					'amount_tax'      => 0,
+					'amount_discount' => 200,
+				],
+			]
+		);
+
+		$order = $this->mapper->create_order_from_checkout_session( $session );
+
+		$this->assertInstanceOf( 'WC_Order', $order );
+		$order->delete( true );
+	}
+
+	/**
+	 * A total mismatch without a discount keeps the generic exception, so the webhook
+	 * handler retries instead of refunding.
+	 */
+	public function test_total_mismatch_without_discount_keeps_the_generic_exception() {
+		$session = $this->build_checkout_session(
+			[
+				'amount_total' => 800,
+			]
+		);
+
+		try {
+			$this->mapper->create_order_from_checkout_session( $session );
+			$this->fail( 'Expected an exception for the total mismatch.' );
+		} catch ( Exception $e ) {
+			$this->assertNotInstanceOf( WC_Stripe_Agentic_Order_Rejected_Exception::class, $e );
+			$this->assertStringContainsString( 'total mismatch', $e->getMessage() );
+		}
 	}
 
 	/**
@@ -1074,27 +1151,6 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 
 		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'has no line items' );
-
-		$this->mapper->create_order_from_checkout_session( $session );
-	}
-
-	/**
-	 * Test that a session carrying a Stripe-side discount is rejected with an
-	 * explicit error before the order is built.
-	 */
-	public function test_exception_thrown_for_discounted_session() {
-		$session = $this->build_checkout_session(
-			[
-				'total_details' => (object) [
-					'amount_shipping' => 0,
-					'amount_tax'      => 0,
-					'amount_discount' => 500,
-				],
-			]
-		);
-
-		$this->expectException( Exception::class );
-		$this->expectExceptionMessage( 'discounts are not supported' );
 
 		$this->mapper->create_order_from_checkout_session( $session );
 	}

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
@@ -137,9 +137,7 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A session-level discount corroborated by a charge below the catalog total is a
-	 * permanent rejection, signalled with the dedicated exception type so the webhook
-	 * handler refunds instead of retrying.
+	 * A discount corroborated by a charge below the catalog total is a permanent rejection.
 	 */
 	public function test_discounted_session_charged_below_catalog_total_throws_the_rejected_exception() {
 		$session = $this->build_checkout_session(
@@ -194,8 +192,7 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * An uncorroborated discount field — the shopper paid full catalog price — must not
-	 * reject the session (and trigger a refund); the order proceeds.
+	 * An uncorroborated discount field (full catalog price charged) must not reject.
 	 */
 	public function test_discount_field_without_reduced_charge_still_creates_the_order() {
 		$session = $this->build_checkout_session(

--- a/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
+++ b/tests/phpunit/agentic-commerce/class-wc-stripe-agentic-commerce-order-mapper-test.php
@@ -137,6 +137,27 @@ class WC_Stripe_Agentic_Commerce_Order_Mapper_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A discounted session is a permanent rejection, signalled with the dedicated
+	 * exception type so the webhook handler refunds instead of retrying.
+	 */
+	public function test_discounted_session_throws_the_rejected_exception() {
+		$session = $this->build_checkout_session(
+			[
+				'total_details' => (object) [
+					'amount_shipping' => 0,
+					'amount_tax'      => 0,
+					'amount_discount' => 500,
+				],
+			]
+		);
+
+		$this->expectException( WC_Stripe_Agentic_Order_Rejected_Exception::class );
+		$this->expectExceptionMessage( 'discounts are not supported' );
+
+		$this->mapper->create_order_from_checkout_session( $session );
+	}
+
+	/**
 	 * Integration guard for the legacy product-ID fallback: a SKU-less product
 	 * synced under the old "external_reference = product_id" contract still
 	 * resolves end-to-end through `map_line_items() → resolve_product()` and

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -4261,6 +4261,32 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The escape-hatch filter disables the automatic refund entirely.
+	 */
+	public function test_refund_rejected_agentic_payment_respects_the_disable_filter() {
+		$refund_requested = false;
+		$mock_request     = static function ( $return_value, $parsed_args, $url ) use ( &$refund_requested ) {
+			if ( 'https://api.stripe.com/v1/refunds' === $url ) {
+				$refund_requested = true;
+			}
+			return $return_value;
+		};
+		add_filter( 'pre_http_request', $mock_request, 10, 3 );
+		add_filter( 'wc_stripe_agentic_auto_refund_rejected_session', '__return_false' );
+
+		try {
+			$method = new ReflectionMethod( WC_Stripe_Webhook_Handler::class, 'refund_rejected_agentic_payment' );
+			$method->setAccessible( true );
+			$method->invoke( new WC_Stripe_Webhook_Handler(), 'pi_rejected_123', 'cs_rejected_456' );
+		} finally {
+			remove_filter( 'pre_http_request', $mock_request, 10 );
+			remove_filter( 'wc_stripe_agentic_auto_refund_rejected_session', '__return_false' );
+		}
+
+		$this->assertFalse( $refund_requested );
+	}
+
+	/**
 	 * Data provider for {@see test_refund_rejected_agentic_payment()}.
 	 *
 	 * @return array<string, array{0: object}>

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -4219,4 +4219,76 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 
 		return $combined_test_cases;
 	}
+
+	/**
+	 * The refund helper for rejected agentic payments posts the payment intent to the
+	 * refunds API, and treats an already-refunded charge as success (webhook redelivery).
+	 *
+	 * @param object $refund_response  Stripe response for the refunds call.
+	 * @dataProvider provide_rejected_agentic_refund_responses
+	 */
+	public function test_refund_rejected_agentic_payment( $refund_response ) {
+		$captured_body = null;
+		$mock_request  = static function ( $return_value, $parsed_args, $url ) use ( &$captured_body, $refund_response ) {
+			if ( 'https://api.stripe.com/v1/refunds' !== $url ) {
+				return $return_value;
+			}
+
+			$captured_body = $parsed_args['body'];
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => wp_json_encode( $refund_response ),
+			];
+		};
+		add_filter( 'pre_http_request', $mock_request, 10, 3 );
+
+		try {
+			$method = new ReflectionMethod( WC_Stripe_Webhook_Handler::class, 'refund_rejected_agentic_payment' );
+			$method->setAccessible( true );
+			$method->invoke( new WC_Stripe_Webhook_Handler(), 'pi_rejected_123', 'cs_rejected_456' );
+		} finally {
+			remove_filter( 'pre_http_request', $mock_request, 10 );
+		}
+
+		if ( is_string( $captured_body ) ) {
+			parse_str( $captured_body, $captured_body );
+		}
+
+		// Never throws — a failed refund must not crash webhook processing — and always
+		// targets the rejected session's payment intent.
+		$this->assertSame( 'pi_rejected_123', $captured_body['payment_intent'] ?? null );
+	}
+
+	/**
+	 * Data provider for {@see test_refund_rejected_agentic_payment()}.
+	 *
+	 * @return array<string, array{0: object}>
+	 */
+	public function provide_rejected_agentic_refund_responses() {
+		return [
+			'refund succeeds'  => [
+				(object) [
+					'id'     => 're_1',
+					'status' => 'succeeded',
+				],
+			],
+			'already refunded' => [
+				(object) [
+					'error' => (object) [
+						'code'    => 'charge_already_refunded',
+						'message' => 'Charge has already been refunded.',
+					],
+				],
+			],
+			'other API error'  => [
+				(object) [
+					'error' => (object) [
+						'code'    => 'processing_error',
+						'message' => 'Try again later.',
+					],
+				],
+			],
+		];
+	}
 }


### PR DESCRIPTION
Fixes STRIPE-1375 (Layer 2 — the pre-charge decline is tracked separately in the same issue)

## Changes proposed in this Pull Request:

When an AI agent presents a discounted price, the order mapper rejects the session — but that runs on the `checkout.session.completed` webhook, after Stripe has captured the payment. The shopper stayed charged with no order behind it, the failure only surfaced in logs for a manual refund, and the generic failure handling re-threw so Action Scheduler kept retrying a rejection that can never succeed.

- New `WC_Stripe_Agentic_Order_Rejected_Exception` signals a permanent rejection.
- **The rejection requires two independent signals.** The discount field alone no longer rejects: the mapper throws the rejected exception only when the session reports a discount **and** the charged amount is actually below the catalog-derived total (checked at both line and order level). An erroneous `amount_discount` on a full-price charge proceeds with the order instead of refunding a legitimate payment; any mismatch without a discount keeps the generic exception and the retry path.
- The webhook handler catches the rejection specifically: logs, fires the existing `wc_stripe_agentic_order_creation_failed` action, refunds the payment intent directly via the `refunds` API (no order exists to route through `process_refund()`), and does not re-throw, so the job isn't retried. Follows the #5703 precedent of refunding shoppers charged for orders that can't proceed.
- A redelivered webhook that retries an already-refunded charge (`charge_already_refunded`) is treated as success; any other refund failure is logged with a "refund manually" pointer and never crashes webhook processing.
- **Escape hatch:** the automatic refund is gated behind the new `wc_stripe_agentic_auto_refund_rejected_session` filter (default `true`), so support can drop a store back to log-only without a release.

### Backward compatibility

Additive: one new exception class (subclass of `Exception`, so external listeners on the failure action are unaffected), one new protected method, one new filter. One behavior change: a session whose `amount_discount` is non-zero but whose charge equals the full catalog total now creates the order (previously rejected) — the charge was correct, so this is the desired outcome. Transient failures keep the existing log-and-retry behavior.

## Testing instructions

1. With Adaptive Pricing/agentic commerce enabled, complete an agentic checkout whose session carries a non-zero `total_details.amount_discount` and a correspondingly reduced total (or simulate the `checkout.session.completed` event).
2. No order is created; the payment intent is refunded automatically, with log entries for the rejection and the refund.
3. Re-deliver the same event: the already-refunded charge is logged as such, no duplicate refund, no failed/retrying Action Scheduler job.
4. With `add_filter( 'wc_stripe_agentic_auto_refund_rejected_session', '__return_false' )`, step 2 logs the rejection but issues no refund.

Covered by `WC_Stripe_Agentic_Commerce_Order_Mapper_Test` (corroborated order-level and line-level discounts throw the rejected exception; an uncorroborated discount field still creates the order; a mismatch without a discount keeps the generic exception) and `WC_Stripe_Webhook_Handler_Test` (refund helper posts the payment intent and never throws across success/already-refunded/error responses; the disable filter suppresses the refund call).

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)