### PR TITLE
Retry failed remote-config syncs with backoff and surface cache staleness

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ xxxx-xx-xx - version 11.0.0
 * Dev - Make GITHUB_TOKEN optional for the local E2E Docker setup by falling back to the GitHub CLI and then to plugin zips placed in tests/e2e/deps
 * Fix - Reload the plugin's payment method settings when refreshing account details, so the settings screen no longer keeps showing stale values
 * Add - Remote configuration system for managing feature availability during incidents
+* Update - Retry failed remote-config syncs with backoff and log a warning when the cached configuration goes stale
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/includes/remote-config/class-wc-stripe-remote-config-scheduler.php
+++ b/includes/remote-config/class-wc-stripe-remote-config-scheduler.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * - Daily Action Scheduler job (`wc_stripe_remote_config_sync`).
  * - Immediate single-action enqueue on plugin upgrade
  * - Immediate single-action enqueue when API keys or the test/live mode change
+ * - In-cycle retries with backoff after a failed fetch (see RETRY_DELAYS)
  *
  * On each run (skipped entirely when no mode has keys), makes one combined
  * Client::fetch_all call and applies each mode's payload.
@@ -17,6 +18,26 @@ class WC_Stripe_Remote_Config_Scheduler {
 
 	public const SYNC_ACTION     = 'wc_stripe_remote_config_sync';
 	public const SCHEDULER_GROUP = 'woocommerce-gateway-stripe';
+
+	/**
+	 * Option tracking consecutive failed fetches. Reset on the first
+	 * successful fetch; never autoloaded.
+	 */
+	public const FAILURE_COUNT_OPTION = '_wcstripe_remote_config_sync_failures';
+
+	/**
+	 * Delays (seconds) before each in-cycle retry after a failed fetch: a run
+	 * at attempt N that fails schedules attempt N+1 after RETRY_DELAYS[N].
+	 * Past the end of the list, the sync waits for the next daily run, so a
+	 * fully failed cycle contacts the endpoint three times per day.
+	 */
+	protected const RETRY_DELAYS = [ HOUR_IN_SECONDS, 4 * HOUR_IN_SECONDS ];
+
+	/**
+	 * Cache age (seconds) past which a failed fetch logs at warning level:
+	 * remote flag changes have not reached this site for this long.
+	 */
+	protected const STALENESS_WARNING_SECONDS = 7 * DAY_IN_SECONDS;
 
 	/**
 	 * Outbound HTTP client used to fetch remote-config payloads.
@@ -77,8 +98,12 @@ class WC_Stripe_Remote_Config_Scheduler {
 	 * One combined fetch covers both modes, and both payloads are cached even
 	 * when only one mode has keys, so a later mode switch or go-live starts
 	 * from a warm cache instead of local fallbacks.
+	 *
+	 * @param int $attempt In-cycle attempt number; 0 for scheduled/immediate
+	 *                     syncs, incremented by the retry chain.
+	 * @return void
 	 */
-	public function run(): void {
+	public function run( $attempt = 0 ): void {
 		if ( ! WC_Stripe_Remote_Config_Flags::is_remote_config_enabled() ) {
 			return;
 		}
@@ -90,16 +115,7 @@ class WC_Stripe_Remote_Config_Scheduler {
 
 		$response = $this->client->fetch_all();
 		if ( is_wp_error( $response ) ) {
-			WC_Stripe_Logger::debug(
-				'Stripe remote-config: fetch failed; keeping previous cache.',
-				[
-					'error'          => $response->get_error_code(),
-					'previous_cache' => [
-						'live' => $this->remote_config->get_cache_snapshot( 'live' ),
-						'test' => $this->remote_config->get_cache_snapshot( 'test' ),
-					],
-				]
-			);
+			$this->handle_failed_fetch( $response, (int) $attempt );
 			return;
 		}
 
@@ -108,6 +124,99 @@ class WC_Stripe_Remote_Config_Scheduler {
 				$this->remote_config->apply( $mode, $response['modes'][ $mode ] );
 			}
 		}
+
+		if ( 0 !== (int) get_option( self::FAILURE_COUNT_OPTION, 0 ) ) {
+			delete_option( self::FAILURE_COUNT_OPTION );
+		}
+	}
+
+	/**
+	 * Records a failed fetch and schedules the next in-cycle retry.
+	 *
+	 * The cache is deliberately left untouched: last-known-good wins until a
+	 * fetch succeeds, however stale it gets. Expiring values back to local
+	 * defaults would re-enable a remotely disabled feature on exactly the
+	 * sites the disable can no longer reach.
+	 *
+	 * @param WP_Error $error   The fetch failure.
+	 * @param int      $attempt In-cycle attempt number of the failed run.
+	 * @return void
+	 */
+	private function handle_failed_fetch( WP_Error $error, int $attempt ): void {
+		$failures = (int) get_option( self::FAILURE_COUNT_OPTION, 0 ) + 1;
+		update_option( self::FAILURE_COUNT_OPTION, $failures, false );
+
+		$ages = [
+			'live' => $this->remote_config->get_cache_age( 'live' ),
+			'test' => $this->remote_config->get_cache_age( 'test' ),
+		];
+
+		$context = [
+			'error'                => $error->get_error_code(),
+			'attempt'              => $attempt,
+			'consecutive_failures' => $failures,
+			'cache_age_seconds'    => $ages,
+			'previous_cache'       => [
+				'live' => $this->remote_config->get_cache_snapshot( 'live' ),
+				'test' => $this->remote_config->get_cache_snapshot( 'test' ),
+			],
+		];
+
+		// A long-unreachable endpoint means remote flag changes are no longer
+		// arriving; escalate so the staleness is visible in the logs.
+		if ( $this->is_cache_stale( $ages ) ) {
+			WC_Stripe_Logger::warning( 'Stripe remote-config: fetch failed and cache is stale; keeping last-known-good values.', $context );
+		} else {
+			WC_Stripe_Logger::debug( 'Stripe remote-config: fetch failed; keeping previous cache.', $context );
+		}
+
+		$this->maybe_schedule_retry( $error, $attempt );
+	}
+
+	/**
+	 * Whether a connected mode's cached config is older than the warning threshold.
+	 *
+	 * A mode with no cache at all is not stale: it holds no remote overrides,
+	 * so the site already runs on local defaults.
+	 *
+	 * @param array<string, int|null> $ages Cache age per mode, null when uncached.
+	 * @return bool
+	 */
+	private function is_cache_stale( array $ages ): bool {
+		foreach ( $this->connected_modes() as $mode ) {
+			$age = $ages[ $mode ] ?? null;
+			if ( null !== $age && $age > self::STALENESS_WARNING_SECONDS ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Schedules the next retry attempt after a failed fetch, with backoff.
+	 *
+	 * Only transport-level failures are retried: a disabled channel is a
+	 * deliberate state, and retrying it sooner cannot change the outcome.
+	 *
+	 * @param WP_Error $error   The fetch failure.
+	 * @param int      $attempt In-cycle attempt number of the failed run.
+	 * @return void
+	 */
+	private function maybe_schedule_retry( WP_Error $error, int $attempt ): void {
+		if ( 'wc_stripe_remote_config_disabled' === $error->get_error_code() ) {
+			return;
+		}
+
+		if ( ! isset( self::RETRY_DELAYS[ $attempt ] ) || ! function_exists( 'as_schedule_single_action' ) ) {
+			return;
+		}
+
+		$next_attempt = $attempt + 1;
+		if ( as_has_scheduled_action( self::SYNC_ACTION, [ $next_attempt ], self::SCHEDULER_GROUP ) ) {
+			return;
+		}
+
+		as_schedule_single_action( time() + self::RETRY_DELAYS[ $attempt ], self::SYNC_ACTION, [ $next_attempt ], self::SCHEDULER_GROUP );
 	}
 
 	/**

--- a/includes/remote-config/class-wc-stripe-remote-config-scheduler.php
+++ b/includes/remote-config/class-wc-stripe-remote-config-scheduler.php
@@ -20,22 +20,18 @@ class WC_Stripe_Remote_Config_Scheduler {
 	public const SCHEDULER_GROUP = 'woocommerce-gateway-stripe';
 
 	/**
-	 * Option tracking consecutive failed fetches. Reset on the first
-	 * successful fetch; never autoloaded.
+	 * Consecutive failed fetches; reset on the first success. Never autoloaded.
 	 */
 	public const FAILURE_COUNT_OPTION = '_wcstripe_remote_config_sync_failures';
 
 	/**
-	 * Delays (seconds) before each in-cycle retry after a failed fetch: a run
-	 * at attempt N that fails schedules attempt N+1 after RETRY_DELAYS[N].
-	 * Past the end of the list, the sync waits for the next daily run, so a
-	 * fully failed cycle contacts the endpoint three times per day.
+	 * Backoff delays: a failed run at attempt N schedules attempt N+1 after
+	 * RETRY_DELAYS[N]; past the end, the next contact is the daily run.
 	 */
 	protected const RETRY_DELAYS = [ HOUR_IN_SECONDS, 4 * HOUR_IN_SECONDS ];
 
 	/**
-	 * Cache age (seconds) past which a failed fetch logs at warning level:
-	 * remote flag changes have not reached this site for this long.
+	 * Cache age (seconds) past which a failed fetch logs at warning level.
 	 */
 	protected const STALENESS_WARNING_SECONDS = 7 * DAY_IN_SECONDS;
 
@@ -131,12 +127,8 @@ class WC_Stripe_Remote_Config_Scheduler {
 	}
 
 	/**
-	 * Records a failed fetch and schedules the next in-cycle retry.
-	 *
-	 * The cache is deliberately left untouched: last-known-good wins until a
-	 * fetch succeeds, however stale it gets. Expiring values back to local
-	 * defaults would re-enable a remotely disabled feature on exactly the
-	 * sites the disable can no longer reach.
+	 * Records a failed fetch and schedules the next in-cycle retry. The cache
+	 * is left untouched: last-known-good wins (see WC_Stripe_Remote_Config).
 	 *
 	 * @param WP_Error $error   The fetch failure.
 	 * @param int      $attempt In-cycle attempt number of the failed run.
@@ -162,8 +154,6 @@ class WC_Stripe_Remote_Config_Scheduler {
 			],
 		];
 
-		// A long-unreachable endpoint means remote flag changes are no longer
-		// arriving; escalate so the staleness is visible in the logs.
 		if ( $this->is_cache_stale( $ages ) ) {
 			WC_Stripe_Logger::warning( 'Stripe remote-config: fetch failed and cache is stale; keeping last-known-good values.', $context );
 		} else {
@@ -174,10 +164,8 @@ class WC_Stripe_Remote_Config_Scheduler {
 	}
 
 	/**
-	 * Whether a connected mode's cached config is older than the warning threshold.
-	 *
-	 * A mode with no cache at all is not stale: it holds no remote overrides,
-	 * so the site already runs on local defaults.
+	 * Whether a connected mode's cached config is older than the warning
+	 * threshold. An uncached mode is not stale: it holds no remote overrides.
 	 *
 	 * @param array<string, int|null> $ages Cache age per mode, null when uncached.
 	 * @return bool
@@ -193,10 +181,8 @@ class WC_Stripe_Remote_Config_Scheduler {
 	}
 
 	/**
-	 * Schedules the next retry attempt after a failed fetch, with backoff.
-	 *
-	 * Only transport-level failures are retried: a disabled channel is a
-	 * deliberate state, and retrying it sooner cannot change the outcome.
+	 * Schedules the next retry attempt with backoff. The deliberate
+	 * disabled-channel error is not retried.
 	 *
 	 * @param WP_Error $error   The fetch failure.
 	 * @param int      $attempt In-cycle attempt number of the failed run.

--- a/includes/remote-config/class-wc-stripe-remote-config.php
+++ b/includes/remote-config/class-wc-stripe-remote-config.php
@@ -17,11 +17,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * Last-known-good wins indefinitely: there is no TTL-based expiry of the cache
  * itself. A schema or HTTP failure discards the new payload and keeps the
- * existing cache (circuit breaker). This is deliberate: expiring stale values
- * back to local defaults would re-enable a remotely disabled feature on
- * exactly the sites the disable can no longer reach. Recovery from a
- * permanently unreachable endpoint is therefore manual: delete the per-mode
- * option (e.g. via wp-cli) or disable the channel via the internal override.
+ * existing cache (circuit breaker). Deliberate: expiring stale values back to
+ * local defaults would re-enable a remotely disabled feature on exactly the
+ * sites the disable can no longer reach. Recovery from a permanently
+ * unreachable endpoint is manual (delete the per-mode option via wp-cli, or
+ * the internal channel override).
  */
 class WC_Stripe_Remote_Config {
 
@@ -211,11 +211,10 @@ class WC_Stripe_Remote_Config {
 	}
 
 	/**
-	 * Age of the cached config for the given mode, in seconds.
+	 * Seconds since the last successful fetch for the given mode.
 	 *
 	 * @param string $mode 'live' or 'test'.
-	 * @return int|null Seconds since the last successful fetch, or null when
-	 *                  no cache is stored or it carries no usable timestamp.
+	 * @return int|null Null when no cache (or no usable timestamp) is stored.
 	 */
 	public function get_cache_age( string $mode ): ?int {
 		$cache = $this->get_cache( $mode );

--- a/includes/remote-config/class-wc-stripe-remote-config.php
+++ b/includes/remote-config/class-wc-stripe-remote-config.php
@@ -17,7 +17,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * Last-known-good wins indefinitely: there is no TTL-based expiry of the cache
  * itself. A schema or HTTP failure discards the new payload and keeps the
- * existing cache (circuit breaker).
+ * existing cache (circuit breaker). This is deliberate: expiring stale values
+ * back to local defaults would re-enable a remotely disabled feature on
+ * exactly the sites the disable can no longer reach. Recovery from a
+ * permanently unreachable endpoint is therefore manual: delete the per-mode
+ * option (e.g. via wp-cli) or disable the channel via the internal override.
  */
 class WC_Stripe_Remote_Config {
 
@@ -204,6 +208,21 @@ class WC_Stripe_Remote_Config {
 			'fetched_at' => (int) $cache['fetched_at'],
 			'flags'      => $cache['flags'],
 		];
+	}
+
+	/**
+	 * Age of the cached config for the given mode, in seconds.
+	 *
+	 * @param string $mode 'live' or 'test'.
+	 * @return int|null Seconds since the last successful fetch, or null when
+	 *                  no cache is stored or it carries no usable timestamp.
+	 */
+	public function get_cache_age( string $mode ): ?int {
+		$cache = $this->get_cache( $mode );
+		if ( null === $cache || empty( $cache['fetched_at'] ) ) {
+			return null;
+		}
+		return max( 0, time() - (int) $cache['fetched_at'] );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -177,5 +177,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Make GITHUB_TOKEN optional for the local E2E Docker setup by falling back to the GitHub CLI and then to plugin zips placed in tests/e2e/deps
 * Fix - Reload the plugin's payment method settings when refreshing account details, so the settings screen no longer keeps showing stale values
 * Add - Remote configuration system for managing feature availability during incidents
+* Update - Retry failed remote-config syncs with backoff and log a warning when the cached configuration goes stale
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/remote-config/class-wc-stripe-remote-config-scheduler-test.php
+++ b/tests/phpunit/remote-config/class-wc-stripe-remote-config-scheduler-test.php
@@ -254,8 +254,8 @@ class WC_Stripe_Remote_Config_Scheduler_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The last in-cycle retry failing must not schedule another attempt; the
-	 * next contact is the daily run. The failure is still counted.
+	 * The last in-cycle retry failing must not schedule another attempt but
+	 * must still count the failure.
 	 */
 	public function test_last_retry_failure_schedules_no_further_attempt(): void {
 		if ( ! function_exists( 'as_next_scheduled_action' ) ) {
@@ -286,8 +286,7 @@ class WC_Stripe_Remote_Config_Scheduler_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A successful fetch must reset the consecutive-failure counter so the
-	 * count always reflects the current outage, not history.
+	 * A successful fetch must reset the consecutive-failure counter.
 	 */
 	public function test_successful_fetch_resets_failure_counter(): void {
 		$this->configure_modes( true, false );

--- a/tests/phpunit/remote-config/class-wc-stripe-remote-config-scheduler-test.php
+++ b/tests/phpunit/remote-config/class-wc-stripe-remote-config-scheduler-test.php
@@ -19,6 +19,7 @@ class WC_Stripe_Remote_Config_Scheduler_Test extends WP_UnitTestCase {
 		WC_Stripe_Remote_Config::reset_in_memory_cache();
 		delete_option( '_wcstripe_remote_config_live' );
 		delete_option( '_wcstripe_remote_config_test' );
+		delete_option( WC_Stripe_Remote_Config_Scheduler::FAILURE_COUNT_OPTION );
 		if ( function_exists( 'as_unschedule_all_actions' ) ) {
 			as_unschedule_all_actions( WC_Stripe_Remote_Config_Scheduler::SYNC_ACTION, [], 'woocommerce-gateway-stripe' );
 		}
@@ -26,6 +27,7 @@ class WC_Stripe_Remote_Config_Scheduler_Test extends WP_UnitTestCase {
 
 	public function tear_down(): void {
 		delete_option( WC_Stripe_Remote_Config_Flags::ENABLED_OVERRIDE_OPTION );
+		delete_option( WC_Stripe_Remote_Config_Scheduler::FAILURE_COUNT_OPTION );
 		if ( function_exists( 'as_unschedule_all_actions' ) ) {
 			as_unschedule_all_actions( WC_Stripe_Remote_Config_Scheduler::SYNC_ACTION, [], 'woocommerce-gateway-stripe' );
 		}
@@ -198,6 +200,105 @@ class WC_Stripe_Remote_Config_Scheduler_Test extends WP_UnitTestCase {
 		$rc = new WC_Stripe_Remote_Config();
 		( new WC_Stripe_Remote_Config_Scheduler( $err_client, $rc ) )->run();
 		$this->assertNull( $rc->get_flag( 'optimized_checkout', 'live' ) );
+	}
+
+	/**
+	 * Builds a scheduler whose client always fails with the given error code.
+	 *
+	 * @param string $error_code WP_Error code the client returns.
+	 * @return WC_Stripe_Remote_Config_Scheduler
+	 */
+	private function get_failing_scheduler( string $error_code = 'wc_stripe_remote_config_http_error' ): WC_Stripe_Remote_Config_Scheduler {
+		$client = $this->createMock( WC_Stripe_Remote_Config_Client::class );
+		$client->method( 'fetch_all' )->willReturn( new WP_Error( $error_code, 'boom' ) );
+
+		return new WC_Stripe_Remote_Config_Scheduler( $client, new WC_Stripe_Remote_Config() );
+	}
+
+	/**
+	 * A failed fetch must schedule the next backoff retry at the delay for its
+	 * attempt number and increment the consecutive-failure counter.
+	 *
+	 * @param int $attempt        In-cycle attempt number of the failing run.
+	 * @param int $expected_delay Expected seconds until the scheduled retry.
+	 *
+	 * @dataProvider provide_retry_attempts
+	 */
+	public function test_failed_fetch_schedules_backoff_retry( int $attempt, int $expected_delay ): void {
+		if ( ! function_exists( 'as_next_scheduled_action' ) ) {
+			$this->markTestSkipped( 'Action Scheduler not available.' );
+		}
+
+		$this->configure_modes( true, false );
+
+		$before = time();
+		$this->get_failing_scheduler()->run( $attempt );
+
+		$timestamp = as_next_scheduled_action( WC_Stripe_Remote_Config_Scheduler::SYNC_ACTION, [ $attempt + 1 ], WC_Stripe_Remote_Config_Scheduler::SCHEDULER_GROUP );
+		$this->assertIsInt( $timestamp, 'A retry must be scheduled for the next attempt.' );
+		$this->assertGreaterThanOrEqual( $before + $expected_delay, $timestamp );
+		$this->assertLessThanOrEqual( time() + $expected_delay, $timestamp );
+		$this->assertSame( 1, (int) get_option( WC_Stripe_Remote_Config_Scheduler::FAILURE_COUNT_OPTION ) );
+	}
+
+	/**
+	 * Data provider for {@see test_failed_fetch_schedules_backoff_retry()}.
+	 *
+	 * @return array
+	 */
+	public function provide_retry_attempts(): array {
+		return [
+			'first failure retries in 1h'  => [ 0, HOUR_IN_SECONDS ],
+			'second failure retries in 4h' => [ 1, 4 * HOUR_IN_SECONDS ],
+		];
+	}
+
+	/**
+	 * The last in-cycle retry failing must not schedule another attempt; the
+	 * next contact is the daily run. The failure is still counted.
+	 */
+	public function test_last_retry_failure_schedules_no_further_attempt(): void {
+		if ( ! function_exists( 'as_next_scheduled_action' ) ) {
+			$this->markTestSkipped( 'Action Scheduler not available.' );
+		}
+
+		$this->configure_modes( true, false );
+
+		$this->get_failing_scheduler()->run( 2 );
+
+		$this->assertFalse( as_next_scheduled_action( WC_Stripe_Remote_Config_Scheduler::SYNC_ACTION, [ 3 ], WC_Stripe_Remote_Config_Scheduler::SCHEDULER_GROUP ) );
+		$this->assertSame( 1, (int) get_option( WC_Stripe_Remote_Config_Scheduler::FAILURE_COUNT_OPTION ) );
+	}
+
+	/**
+	 * The deliberate disabled-channel error must not spawn a retry chain.
+	 */
+	public function test_disabled_error_is_not_retried(): void {
+		if ( ! function_exists( 'as_next_scheduled_action' ) ) {
+			$this->markTestSkipped( 'Action Scheduler not available.' );
+		}
+
+		$this->configure_modes( true, false );
+
+		$this->get_failing_scheduler( 'wc_stripe_remote_config_disabled' )->run();
+
+		$this->assertFalse( as_next_scheduled_action( WC_Stripe_Remote_Config_Scheduler::SYNC_ACTION, [ 1 ], WC_Stripe_Remote_Config_Scheduler::SCHEDULER_GROUP ) );
+	}
+
+	/**
+	 * A successful fetch must reset the consecutive-failure counter so the
+	 * count always reflects the current outage, not history.
+	 */
+	public function test_successful_fetch_resets_failure_counter(): void {
+		$this->configure_modes( true, false );
+		update_option( WC_Stripe_Remote_Config_Scheduler::FAILURE_COUNT_OPTION, 5, false );
+
+		$client = $this->createMock( WC_Stripe_Remote_Config_Client::class );
+		$client->method( 'fetch_all' )->willReturn( $this->get_mock_combined_payload( false, true ) );
+
+		( new WC_Stripe_Remote_Config_Scheduler( $client, new WC_Stripe_Remote_Config() ) )->run();
+
+		$this->assertSame( 0, (int) get_option( WC_Stripe_Remote_Config_Scheduler::FAILURE_COUNT_OPTION, 0 ) );
 	}
 
 	/**

--- a/tests/phpunit/remote-config/class-wc-stripe-remote-config-test.php
+++ b/tests/phpunit/remote-config/class-wc-stripe-remote-config-test.php
@@ -76,6 +76,22 @@ class WC_Stripe_Remote_Config_Test extends WP_UnitTestCase {
 		];
 	}
 
+	/**
+	 * get_cache_age() must report seconds since the last successful fetch and
+	 * null for a mode that has never been fetched.
+	 */
+	public function test_get_cache_age_reflects_fetched_at(): void {
+		$rc = new WC_Stripe_Remote_Config();
+
+		$this->assertNull( $rc->get_cache_age( 'live' ) );
+
+		$rc->apply( 'live', $this->get_valid_payload() );
+		$age = $rc->get_cache_age( 'live' );
+		$this->assertIsInt( $age );
+		$this->assertLessThanOrEqual( 5, $age, 'A just-applied payload must have an age of ~0 seconds.' );
+		$this->assertNull( $rc->get_cache_age( 'test' ) );
+	}
+
 	public function test_apply_drops_unknown_flag_names_silently(): void {
 		$rc                               = new WC_Stripe_Remote_Config();
 		$payload                          = $this->get_valid_payload();


### PR DESCRIPTION
Fixes STRIPE-1381

## Changes proposed in this Pull Request:

Hardens the remote-config cache lifecycle against endpoint unreachability:

- **Retry with backoff.** A failed fetch previously waited ~24h for the next daily run. It now schedules in-cycle retries at +1h and +4h, with the attempt number as the action arg and duplicates guarded. The deliberate disabled-channel error is not retried.
- **Staleness observability.** Failure logs include a consecutive-failure counter (`_wcstripe_remote_config_sync_failures`, reset on first success) and per-mode cache age (new `get_cache_age()`), escalating to warning once a connected mode's cache is older than 7 days.
- **No TTL expiry, recorded as a decision.** Expiring stale overrides back to local defaults would re-enable a remotely disabled feature on exactly the sites the disable can no longer reach. Rationale and the manual recovery path (delete the per-mode option, or the internal override) are now in the `WC_Stripe_Remote_Config` docblock.

BC impact: no public surface changes. The `wc_stripe_remote_config_sync` action gains an optional attempt arg (default 0), so existing schedules keep working.

## Testing instructions

1. `wp option update _wcstripe_remote_config_enabled yes`, then block reach to `public-api.wordpress.com` (e.g. /etc/hosts).
2. Run the sync action; confirm a pending `wc_stripe_remote_config_sync` action with args `[1]` ~1h out and `_wcstripe_remote_config_sync_failures` = 1.
3. Restore connectivity, run the pending action; confirm the failure option is deleted and `_wcstripe_remote_config_{mode}` has a fresh `fetched_at`.

Covered by PHPUnit: backoff per attempt, chain cap, no retry on the disabled error, counter reset on success, `get_cache_age()`.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)