### PR TITLE
Stop sending Level 3 data for non-card express checkout payments

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ xxxx-xx-xx - version 11.0.0
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
 * Fix - Exclude password-protected products and products hidden from the catalog from the Agentic Commerce feed
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
+* Fix - Stop sending Level 3 data when paying with a non-card payment method through express checkout (e.g. Amazon Pay), which Stripe rejects and can disable Level 3 data for card payments
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -974,7 +974,7 @@ class WC_Stripe_Intent_Controller {
 		$this->validate_payment_intent_required_params( $required_params, $non_empty_params, $instance_params, $payment_information );
 
 		$order                 = $payment_information['order'];
-		$selected_payment_type = $payment_information['selected_payment_type'] ?? '';
+		$selected_payment_type = $payment_information['selected_payment_type'];
 		$payment_method_types  = $payment_information['payment_method_types'];
 		$is_using_saved_token  = $payment_information['is_using_saved_payment_method'] ?? false;
 

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1049,9 +1049,11 @@ class WC_Stripe_Intent_Controller {
 
 		// Only update the payment_type if we have a reference to the payment type the customer selected.
 		// Must happen before the API request: request_with_level3_data() reads this meta to exclude
-		// non-card methods from level3 data.
+		// non-card methods from level3 data. Saved immediately so parallel requests (e.g. webhooks
+		// fired by the confirmation) read the type from the database rather than an empty value.
 		if ( '' !== $selected_payment_type ) {
 			WC_Stripe_Order_Helper::get_instance()->update_stripe_upe_payment_type( $order, $selected_payment_type );
+			$order->save_meta_data();
 		}
 
 		return WC_Stripe_API::request_with_level3_data(
@@ -1155,10 +1157,13 @@ class WC_Stripe_Intent_Controller {
 		);
 
 		// Persist the selected payment type before the API request: request_with_level3_data()
-		// reads this meta to exclude non-card methods from level3 data.
+		// reads this meta to exclude non-card methods from level3 data. Saved immediately so
+		// parallel requests (e.g. webhooks fired by the confirmation) read the type from the
+		// database rather than an empty value.
 		$selected_payment_type = $payment_information['selected_payment_type'];
 		if ( '' !== $selected_payment_type ) {
 			WC_Stripe_Order_Helper::get_instance()->update_stripe_upe_payment_type( $order, $selected_payment_type );
+			$order->save_meta_data();
 		}
 
 		return WC_Stripe_API::request_with_level3_data(

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1047,14 +1047,7 @@ class WC_Stripe_Intent_Controller {
 			null // $prepared_source parameter is not necessary for adding mandate information.
 		);
 
-		// Only update the payment_type if we have a reference to the payment type the customer selected.
-		// Must happen before the API request: request_with_level3_data() reads this meta to exclude
-		// non-card methods from level3 data. Saved immediately so parallel requests (e.g. webhooks
-		// fired by the confirmation) read the type from the database rather than an empty value.
-		if ( '' !== $selected_payment_type ) {
-			WC_Stripe_Order_Helper::get_instance()->update_stripe_upe_payment_type( $order, $selected_payment_type );
-			$order->save_meta_data();
-		}
+		$this->set_selected_payment_type_for_order( $order, $selected_payment_type );
 
 		return WC_Stripe_API::request_with_level3_data(
 			$request,
@@ -1156,15 +1149,7 @@ class WC_Stripe_Intent_Controller {
 			null // $prepared_source parameter is not necessary for adding mandate information.
 		);
 
-		// Persist the selected payment type before the API request: request_with_level3_data()
-		// reads this meta to exclude non-card methods from level3 data. Saved immediately so
-		// parallel requests (e.g. webhooks fired by the confirmation) read the type from the
-		// database rather than an empty value.
-		$selected_payment_type = $payment_information['selected_payment_type'];
-		if ( '' !== $selected_payment_type ) {
-			WC_Stripe_Order_Helper::get_instance()->update_stripe_upe_payment_type( $order, $selected_payment_type );
-			$order->save_meta_data();
-		}
+		$this->set_selected_payment_type_for_order( $order, $payment_information['selected_payment_type'] );
 
 		return WC_Stripe_API::request_with_level3_data(
 			$request,
@@ -1172,6 +1157,26 @@ class WC_Stripe_Intent_Controller {
 			$payment_information['level3'],
 			$order
 		);
+	}
+
+	/**
+	 * Persists the payment type the customer selected to the order, if there is one.
+	 *
+	 * Must be called before the intent request: WC_Stripe_API::request_with_level3_data() reads
+	 * this meta to exclude non-card methods from level3 data. Saved immediately so parallel
+	 * requests (e.g. webhooks fired by the confirmation) read the type from the database rather
+	 * than an empty value.
+	 *
+	 * @param WC_Order $order                 The order being paid.
+	 * @param string   $selected_payment_type The payment type the customer selected, or '' if unknown.
+	 */
+	private function set_selected_payment_type_for_order( WC_Order $order, string $selected_payment_type ) {
+		if ( '' === $selected_payment_type ) {
+			return;
+		}
+
+		WC_Stripe_Order_Helper::get_instance()->update_stripe_upe_payment_type( $order, $selected_payment_type );
+		$order->save_meta_data();
 	}
 
 	/**

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1047,19 +1047,19 @@ class WC_Stripe_Intent_Controller {
 			null // $prepared_source parameter is not necessary for adding mandate information.
 		);
 
-		$payment_intent = WC_Stripe_API::request_with_level3_data(
+		// Only update the payment_type if we have a reference to the payment type the customer selected.
+		// Must happen before the API request: request_with_level3_data() reads this meta to exclude
+		// non-card methods from level3 data.
+		if ( '' !== $selected_payment_type ) {
+			WC_Stripe_Order_Helper::get_instance()->update_stripe_upe_payment_type( $order, $selected_payment_type );
+		}
+
+		return WC_Stripe_API::request_with_level3_data(
 			$request,
 			'payment_intents',
 			$payment_information['level3'],
 			$order
 		);
-
-		// Only update the payment_type if we have a reference to the payment type the customer selected.
-		if ( '' !== $selected_payment_type ) {
-			WC_Stripe_Order_Helper::get_instance()->update_stripe_upe_payment_type( $order, $selected_payment_type );
-		}
-
-		return $payment_intent;
 	}
 
 	/**
@@ -1153,6 +1153,13 @@ class WC_Stripe_Intent_Controller {
 			$order,
 			null // $prepared_source parameter is not necessary for adding mandate information.
 		);
+
+		// Persist the selected payment type before the API request: request_with_level3_data()
+		// reads this meta to exclude non-card methods from level3 data.
+		$selected_payment_type = $payment_information['selected_payment_type'];
+		if ( '' !== $selected_payment_type ) {
+			WC_Stripe_Order_Helper::get_instance()->update_stripe_upe_payment_type( $order, $selected_payment_type );
+		}
 
 		return WC_Stripe_API::request_with_level3_data(
 			$request,

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -974,7 +974,7 @@ class WC_Stripe_Intent_Controller {
 		$this->validate_payment_intent_required_params( $required_params, $non_empty_params, $instance_params, $payment_information );
 
 		$order                 = $payment_information['order'];
-		$selected_payment_type = $payment_information['selected_payment_type'];
+		$selected_payment_type = $payment_information['selected_payment_type'] ?? '';
 		$payment_method_types  = $payment_information['payment_method_types'];
 		$is_using_saved_token  = $payment_information['is_using_saved_payment_method'] ?? false;
 
@@ -1168,10 +1168,11 @@ class WC_Stripe_Intent_Controller {
 	 * than an empty value.
 	 *
 	 * @param WC_Order $order                 The order being paid.
-	 * @param string   $selected_payment_type The payment type the customer selected, or '' if unknown.
+	 * @param mixed    $selected_payment_type The payment type the customer selected, or '' if unknown.
+	 * @return void
 	 */
-	private function set_selected_payment_type_for_order( WC_Order $order, string $selected_payment_type ) {
-		if ( '' === $selected_payment_type ) {
+	private function set_selected_payment_type_for_order( WC_Order $order, $selected_payment_type ) {
+		if ( ! is_string( $selected_payment_type ) || '' === $selected_payment_type ) {
 			return;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -174,5 +174,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Remove the deprecated @woocommerce/settings npm package; settings are still read from the wc-settings script WooCommerce provides at runtime
 * Fix - Exclude password-protected products and products hidden from the catalog from the Agentic Commerce feed
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
+* Fix - Stop sending Level 3 data when paying with a non-card payment method through express checkout (e.g. Amazon Pay), which Stripe rejects and can disable Level 3 data for card payments
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-intent-controller-test.php
+++ b/tests/phpunit/class-wc-stripe-intent-controller-test.php
@@ -666,8 +666,8 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	 * Level3 data is card-only: the controller must persist the selected payment type to the
 	 * order before the intent request so the level3 gate can exclude non-card methods.
 	 *
-	 * @param string $selected_payment_type The selected payment type posted with the confirmation token.
-	 * @param bool   $expect_level3         Whether the outgoing request should carry level3 data.
+	 * @param string|null $selected_payment_type The selected payment type posted with the confirmation token.
+	 * @param bool        $expect_level3         Whether the outgoing request should carry level3 data.
 	 * @dataProvider provide_test_confirmation_token_level3
 	 */
 	public function test_create_and_confirm_payment_intent_with_confirmation_token_gates_level3( $selected_payment_type, $expect_level3 ) {
@@ -701,16 +701,18 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		}
 		// The in-memory order is what the level3 gate reads during this request; the freshly
 		// loaded instance proves the type was also persisted for parallel requests (e.g. webhooks).
-		$this->assertSame( $selected_payment_type, $this->order->get_meta( '_stripe_upe_payment_type' ) );
-		$this->assertSame( $selected_payment_type, wc_get_order( $this->order->get_id() )->get_meta( '_stripe_upe_payment_type' ) );
+		// A null/empty selected type must not be written (nor fatal), leaving the meta empty.
+		$expected_meta = is_string( $selected_payment_type ) ? $selected_payment_type : '';
+		$this->assertSame( $expected_meta, $this->order->get_meta( '_stripe_upe_payment_type' ) );
+		$this->assertSame( $expected_meta, wc_get_order( $this->order->get_id() )->get_meta( '_stripe_upe_payment_type' ) );
 	}
 
 	/**
 	 * Same as the create case: the confirm call on an existing intent must not carry level3
 	 * data for non-card methods.
 	 *
-	 * @param string $selected_payment_type The selected payment type posted with the confirmation token.
-	 * @param bool   $expect_level3         Whether the outgoing request should carry level3 data.
+	 * @param string|null $selected_payment_type The selected payment type posted with the confirmation token.
+	 * @param bool        $expect_level3         Whether the outgoing request should carry level3 data.
 	 * @dataProvider provide_test_confirmation_token_level3
 	 */
 	public function test_update_and_confirm_payment_intent_with_confirmation_token_gates_level3( $selected_payment_type, $expect_level3 ) {
@@ -745,8 +747,10 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		}
 		// The in-memory order is what the level3 gate reads during this request; the freshly
 		// loaded instance proves the type was also persisted for parallel requests (e.g. webhooks).
-		$this->assertSame( $selected_payment_type, $this->order->get_meta( '_stripe_upe_payment_type' ) );
-		$this->assertSame( $selected_payment_type, wc_get_order( $this->order->get_id() )->get_meta( '_stripe_upe_payment_type' ) );
+		// A null/empty selected type must not be written (nor fatal), leaving the meta empty.
+		$expected_meta = is_string( $selected_payment_type ) ? $selected_payment_type : '';
+		$this->assertSame( $expected_meta, $this->order->get_meta( '_stripe_upe_payment_type' ) );
+		$this->assertSame( $expected_meta, wc_get_order( $this->order->get_id() )->get_meta( '_stripe_upe_payment_type' ) );
 	}
 
 	/**
@@ -758,6 +762,9 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		return [
 			'amazon_pay does not get level3' => [ WC_Stripe_Payment_Methods::AMAZON_PAY, false ],
 			'card keeps level3'              => [ WC_Stripe_Payment_Methods::CARD, true ],
+			// Unknown types must not fatal; the gate then falls back to its legacy card default.
+			'empty type keeps level3'        => [ '', true ],
+			'null type keeps level3'         => [ null, true ],
 		];
 	}
 
@@ -765,7 +772,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	 * Payment information mirroring what the ECE confirmation-token flow prepares: a confirmation
 	 * token instead of a payment method ID, and no UPE payment type persisted on the order yet.
 	 *
-	 * @param string $selected_payment_type The selected payment type.
+	 * @param string|null $selected_payment_type The selected payment type.
 	 * @return array
 	 */
 	private function get_confirmation_token_payment_information( $selected_payment_type ) {

--- a/tests/phpunit/class-wc-stripe-intent-controller-test.php
+++ b/tests/phpunit/class-wc-stripe-intent-controller-test.php
@@ -699,7 +699,9 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		} else {
 			$this->assertArrayNotHasKey( 'level3', $requests_seen[0] );
 		}
-		$this->assertSame( $selected_payment_type, $this->order->get_meta( '_stripe_upe_payment_type' ) );
+		// Read through a fresh order instance: the type must be persisted to the database,
+		// not just set on the in-memory object, so parallel requests (e.g. webhooks) see it.
+		$this->assertSame( $selected_payment_type, wc_get_order( $this->order->get_id() )->get_meta( '_stripe_upe_payment_type' ) );
 	}
 
 	/**
@@ -740,7 +742,9 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		} else {
 			$this->assertArrayNotHasKey( 'level3', $requests_seen[0] );
 		}
-		$this->assertSame( $selected_payment_type, $this->order->get_meta( '_stripe_upe_payment_type' ) );
+		// Read through a fresh order instance: the type must be persisted to the database,
+		// not just set on the in-memory object, so parallel requests (e.g. webhooks) see it.
+		$this->assertSame( $selected_payment_type, wc_get_order( $this->order->get_id() )->get_meta( '_stripe_upe_payment_type' ) );
 	}
 
 	/**

--- a/tests/phpunit/class-wc-stripe-intent-controller-test.php
+++ b/tests/phpunit/class-wc-stripe-intent-controller-test.php
@@ -675,10 +675,15 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		update_option( 'woocommerce_default_country', 'US:CA' );
 
 		$payment_information = $this->get_confirmation_token_payment_information( $selected_payment_type );
+		// A null/empty selected type must not be written (nor fatal), leaving the meta empty.
+		$expected_meta = is_string( $selected_payment_type ) ? $selected_payment_type : '';
 
 		$requests_seen = [];
-		$test_request  = function ( $preempt, $parsed_args, $url ) use ( &$requests_seen ) {
+		$test_request  = function ( $preempt, $parsed_args, $url ) use ( &$requests_seen, $expected_meta ) {
 			if ( false !== strpos( $url, 'payment_intents' ) ) {
+				// The save must precede the request: webhooks triggered by the confirmation can
+				// arrive while this call is still in flight and read the order from the database.
+				$this->assertSame( $expected_meta, wc_get_order( $this->order->get_id() )->get_meta( '_stripe_upe_payment_type' ) );
 				$requests_seen[] = $parsed_args['body'];
 			}
 
@@ -701,8 +706,6 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		}
 		// The in-memory order is what the level3 gate reads during this request; the freshly
 		// loaded instance proves the type was also persisted for parallel requests (e.g. webhooks).
-		// A null/empty selected type must not be written (nor fatal), leaving the meta empty.
-		$expected_meta = is_string( $selected_payment_type ) ? $selected_payment_type : '';
 		$this->assertSame( $expected_meta, $this->order->get_meta( '_stripe_upe_payment_type' ) );
 		$this->assertSame( $expected_meta, wc_get_order( $this->order->get_id() )->get_meta( '_stripe_upe_payment_type' ) );
 	}
@@ -721,10 +724,15 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 
 		$payment_information = $this->get_confirmation_token_payment_information( $selected_payment_type );
 		$payment_intent      = (object) [ 'id' => 'pi_mock' ];
+		// A null/empty selected type must not be written (nor fatal), leaving the meta empty.
+		$expected_meta = is_string( $selected_payment_type ) ? $selected_payment_type : '';
 
 		$requests_seen = [];
-		$test_request  = function ( $preempt, $parsed_args, $url ) use ( &$requests_seen ) {
+		$test_request  = function ( $preempt, $parsed_args, $url ) use ( &$requests_seen, $expected_meta ) {
 			if ( false !== strpos( $url, 'payment_intents/pi_mock/confirm' ) ) {
+				// The save must precede the request: webhooks triggered by the confirmation can
+				// arrive while this call is still in flight and read the order from the database.
+				$this->assertSame( $expected_meta, wc_get_order( $this->order->get_id() )->get_meta( '_stripe_upe_payment_type' ) );
 				$requests_seen[] = $parsed_args['body'];
 			}
 
@@ -747,8 +755,6 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		}
 		// The in-memory order is what the level3 gate reads during this request; the freshly
 		// loaded instance proves the type was also persisted for parallel requests (e.g. webhooks).
-		// A null/empty selected type must not be written (nor fatal), leaving the meta empty.
-		$expected_meta = is_string( $selected_payment_type ) ? $selected_payment_type : '';
 		$this->assertSame( $expected_meta, $this->order->get_meta( '_stripe_upe_payment_type' ) );
 		$this->assertSame( $expected_meta, wc_get_order( $this->order->get_id() )->get_meta( '_stripe_upe_payment_type' ) );
 	}
@@ -761,6 +767,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	public function provide_test_confirmation_token_level3() {
 		return [
 			'amazon_pay does not get level3' => [ WC_Stripe_Payment_Methods::AMAZON_PAY, false ],
+			'link does not get level3'       => [ WC_Stripe_Payment_Methods::LINK, false ],
 			'card keeps level3'              => [ WC_Stripe_Payment_Methods::CARD, true ],
 			// Unknown types must not fatal; the gate then falls back to its legacy card default.
 			'empty type keeps level3'        => [ '', true ],

--- a/tests/phpunit/class-wc-stripe-intent-controller-test.php
+++ b/tests/phpunit/class-wc-stripe-intent-controller-test.php
@@ -776,6 +776,12 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	private function get_confirmation_token_payment_information( $selected_payment_type ) {
+		// Real requests always carry concrete method strings in payment_method_types; a null/empty
+		// *selected* type is passed through raw so the meta fallback is still what gets exercised.
+		$payment_method_types = is_string( $selected_payment_type ) && '' !== $selected_payment_type
+			? [ $selected_payment_type ]
+			: [ WC_Stripe_Payment_Methods::CARD ];
+
 		return [
 			'amount'                        => 100,
 			'confirmation_token'            => 'ctoken_mock',
@@ -795,7 +801,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 			'order'                         => $this->order,
 			'shipping'                      => [],
 			'selected_payment_type'         => $selected_payment_type,
-			'payment_method_types'          => [ $selected_payment_type ],
+			'payment_method_types'          => $payment_method_types,
 			'return_url'                    => 'https://example.com/return',
 			'is_using_saved_payment_method' => false,
 			'save_payment_method_to_store'  => false,

--- a/tests/phpunit/class-wc-stripe-intent-controller-test.php
+++ b/tests/phpunit/class-wc-stripe-intent-controller-test.php
@@ -663,6 +663,134 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Level3 data is card-only: the controller must persist the selected payment type to the
+	 * order before the intent request so the level3 gate can exclude non-card methods.
+	 *
+	 * @param string $selected_payment_type The selected payment type posted with the confirmation token.
+	 * @param bool   $expect_level3         Whether the outgoing request should carry level3 data.
+	 * @dataProvider provide_test_confirmation_token_level3
+	 */
+	public function test_create_and_confirm_payment_intent_with_confirmation_token_gates_level3( $selected_payment_type, $expect_level3 ) {
+		// The level3 gate only applies to US-based stores.
+		update_option( 'woocommerce_default_country', 'US:CA' );
+
+		$payment_information = $this->get_confirmation_token_payment_information( $selected_payment_type );
+
+		$requests_seen = [];
+		$test_request  = function ( $preempt, $parsed_args, $url ) use ( &$requests_seen ) {
+			if ( false !== strpos( $url, 'payment_intents' ) ) {
+				$requests_seen[] = $parsed_args['body'];
+			}
+
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => json_encode( [ 'id' => 'pi_mock' ] ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		$this->mock_controller->create_and_confirm_payment_intent( $payment_information );
+
+		$this->assertCount( 1, $requests_seen );
+		if ( $expect_level3 ) {
+			$this->assertArrayHasKey( 'level3', $requests_seen[0] );
+		} else {
+			$this->assertArrayNotHasKey( 'level3', $requests_seen[0] );
+		}
+		$this->assertSame( $selected_payment_type, $this->order->get_meta( '_stripe_upe_payment_type' ) );
+	}
+
+	/**
+	 * Same as the create case: the confirm call on an existing intent must not carry level3
+	 * data for non-card methods.
+	 *
+	 * @param string $selected_payment_type The selected payment type posted with the confirmation token.
+	 * @param bool   $expect_level3         Whether the outgoing request should carry level3 data.
+	 * @dataProvider provide_test_confirmation_token_level3
+	 */
+	public function test_update_and_confirm_payment_intent_with_confirmation_token_gates_level3( $selected_payment_type, $expect_level3 ) {
+		// The level3 gate only applies to US-based stores.
+		update_option( 'woocommerce_default_country', 'US:CA' );
+
+		$payment_information = $this->get_confirmation_token_payment_information( $selected_payment_type );
+		$payment_intent      = (object) [ 'id' => 'pi_mock' ];
+
+		$requests_seen = [];
+		$test_request  = function ( $preempt, $parsed_args, $url ) use ( &$requests_seen ) {
+			if ( false !== strpos( $url, 'payment_intents/pi_mock/confirm' ) ) {
+				$requests_seen[] = $parsed_args['body'];
+			}
+
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => json_encode( [ 'id' => 'pi_mock' ] ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		$this->mock_controller->update_and_confirm_payment_intent( $payment_intent, $payment_information );
+
+		$this->assertCount( 1, $requests_seen );
+		if ( $expect_level3 ) {
+			$this->assertArrayHasKey( 'level3', $requests_seen[0] );
+		} else {
+			$this->assertArrayNotHasKey( 'level3', $requests_seen[0] );
+		}
+		$this->assertSame( $selected_payment_type, $this->order->get_meta( '_stripe_upe_payment_type' ) );
+	}
+
+	/**
+	 * Provider for the confirmation-token level3 gating tests.
+	 *
+	 * @return array
+	 */
+	public function provide_test_confirmation_token_level3() {
+		return [
+			'amazon_pay does not get level3' => [ WC_Stripe_Payment_Methods::AMAZON_PAY, false ],
+			'card keeps level3'              => [ WC_Stripe_Payment_Methods::CARD, true ],
+		];
+	}
+
+	/**
+	 * Payment information mirroring what the ECE confirmation-token flow prepares: a confirmation
+	 * token instead of a payment method ID, and no UPE payment type persisted on the order yet.
+	 *
+	 * @param string $selected_payment_type The selected payment type.
+	 * @return array
+	 */
+	private function get_confirmation_token_payment_information( $selected_payment_type ) {
+		return [
+			'amount'                        => 100,
+			'confirmation_token'            => 'ctoken_mock',
+			'currency'                      => WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR,
+			'customer'                      => 'cus_mock',
+			'level3'                        => [
+				'line_items' => [
+					[
+						'product_code'        => 'ABC123',
+						'product_description' => 'Test Product',
+						'unit_cost'           => 100,
+						'quantity'            => 1,
+					],
+				],
+			],
+			'metadata'                      => [ '_stripe_metadata' => '123' ],
+			'order'                         => $this->order,
+			'shipping'                      => [],
+			'selected_payment_type'         => $selected_payment_type,
+			'payment_method_types'          => [ $selected_payment_type ],
+			'return_url'                    => 'https://example.com/return',
+			'is_using_saved_payment_method' => false,
+			'save_payment_method_to_store'  => false,
+			'has_subscription'              => false,
+		];
+	}
+
+	/**
 	 * Test for setting the `setup_future_usage` parameter in the
 	 *  create_and_confirm_payment_intent intent creation request.
 	 */

--- a/tests/phpunit/class-wc-stripe-intent-controller-test.php
+++ b/tests/phpunit/class-wc-stripe-intent-controller-test.php
@@ -667,14 +667,15 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	 * order before the intent request so the level3 gate can exclude non-card methods.
 	 *
 	 * @param string|null $selected_payment_type The selected payment type posted with the confirmation token.
+	 * @param string[]    $payment_method_types  The payment method types the request carries.
 	 * @param bool        $expect_level3         Whether the outgoing request should carry level3 data.
 	 * @dataProvider provide_test_confirmation_token_level3
 	 */
-	public function test_create_and_confirm_payment_intent_with_confirmation_token_gates_level3( $selected_payment_type, $expect_level3 ) {
+	public function test_create_and_confirm_payment_intent_with_confirmation_token_gates_level3( $selected_payment_type, $payment_method_types, $expect_level3 ) {
 		// The level3 gate only applies to US-based stores.
 		update_option( 'woocommerce_default_country', 'US:CA' );
 
-		$payment_information = $this->get_confirmation_token_payment_information( $selected_payment_type );
+		$payment_information = $this->get_confirmation_token_payment_information( $selected_payment_type, $payment_method_types );
 		// A null/empty selected type must not be written (nor fatal), leaving the meta empty.
 		$expected_meta = is_string( $selected_payment_type ) ? $selected_payment_type : '';
 
@@ -715,14 +716,15 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	 * data for non-card methods.
 	 *
 	 * @param string|null $selected_payment_type The selected payment type posted with the confirmation token.
+	 * @param string[]    $payment_method_types  The payment method types the request carries.
 	 * @param bool        $expect_level3         Whether the outgoing request should carry level3 data.
 	 * @dataProvider provide_test_confirmation_token_level3
 	 */
-	public function test_update_and_confirm_payment_intent_with_confirmation_token_gates_level3( $selected_payment_type, $expect_level3 ) {
+	public function test_update_and_confirm_payment_intent_with_confirmation_token_gates_level3( $selected_payment_type, $payment_method_types, $expect_level3 ) {
 		// The level3 gate only applies to US-based stores.
 		update_option( 'woocommerce_default_country', 'US:CA' );
 
-		$payment_information = $this->get_confirmation_token_payment_information( $selected_payment_type );
+		$payment_information = $this->get_confirmation_token_payment_information( $selected_payment_type, $payment_method_types );
 		$payment_intent      = (object) [ 'id' => 'pi_mock' ];
 		// A null/empty selected type must not be written (nor fatal), leaving the meta empty.
 		$expected_meta = is_string( $selected_payment_type ) ? $selected_payment_type : '';
@@ -766,12 +768,17 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	 */
 	public function provide_test_confirmation_token_level3() {
 		return [
-			'amazon_pay does not get level3' => [ WC_Stripe_Payment_Methods::AMAZON_PAY, false ],
-			'link does not get level3'       => [ WC_Stripe_Payment_Methods::LINK, false ],
-			'card keeps level3'              => [ WC_Stripe_Payment_Methods::CARD, true ],
-			// Unknown types must not fatal; the gate then falls back to its legacy card default.
-			'empty type keeps level3'        => [ '', true ],
-			'null type keeps level3'         => [ null, true ],
+			'amazon_pay does not get level3'       => [ WC_Stripe_Payment_Methods::AMAZON_PAY, [ WC_Stripe_Payment_Methods::AMAZON_PAY ], false ],
+			// Link's selected type depends on the gateway: OCS resolves it from the payment method
+			// object as 'link', while base UPE maps ECE Link submissions to 'card' (the intent then
+			// carries [card, link], which Stripe accepts level3 for).
+			'link (OCS) does not get level3'       => [ WC_Stripe_Payment_Methods::LINK, [ WC_Stripe_Payment_Methods::LINK ], false ],
+			'link (base UPE) keeps level3 as card' => [ WC_Stripe_Payment_Methods::CARD, [ WC_Stripe_Payment_Methods::CARD, WC_Stripe_Payment_Methods::LINK ], true ],
+			'card keeps level3'                    => [ WC_Stripe_Payment_Methods::CARD, [ WC_Stripe_Payment_Methods::CARD ], true ],
+			// Unknown selected types must not fatal; the gate then falls back to its legacy card
+			// default. The request still carries a concrete type, as real payloads always do.
+			'empty type keeps level3'              => [ '', [ WC_Stripe_Payment_Methods::CARD ], true ],
+			'null type keeps level3'               => [ null, [ WC_Stripe_Payment_Methods::CARD ], true ],
 		];
 	}
 
@@ -780,15 +787,10 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	 * token instead of a payment method ID, and no UPE payment type persisted on the order yet.
 	 *
 	 * @param string|null $selected_payment_type The selected payment type.
+	 * @param string[]    $payment_method_types  The payment method types for the request.
 	 * @return array
 	 */
-	private function get_confirmation_token_payment_information( $selected_payment_type ) {
-		// Real requests always carry concrete method strings in payment_method_types; a null/empty
-		// *selected* type is passed through raw so the meta fallback is still what gets exercised.
-		$payment_method_types = is_string( $selected_payment_type ) && '' !== $selected_payment_type
-			? [ $selected_payment_type ]
-			: [ WC_Stripe_Payment_Methods::CARD ];
-
+	private function get_confirmation_token_payment_information( $selected_payment_type, $payment_method_types ) {
 		return [
 			'amount'                        => 100,
 			'confirmation_token'            => 'ctoken_mock',

--- a/tests/phpunit/class-wc-stripe-intent-controller-test.php
+++ b/tests/phpunit/class-wc-stripe-intent-controller-test.php
@@ -699,8 +699,9 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		} else {
 			$this->assertArrayNotHasKey( 'level3', $requests_seen[0] );
 		}
-		// Read through a fresh order instance: the type must be persisted to the database,
-		// not just set on the in-memory object, so parallel requests (e.g. webhooks) see it.
+		// The in-memory order is what the level3 gate reads during this request; the freshly
+		// loaded instance proves the type was also persisted for parallel requests (e.g. webhooks).
+		$this->assertSame( $selected_payment_type, $this->order->get_meta( '_stripe_upe_payment_type' ) );
 		$this->assertSame( $selected_payment_type, wc_get_order( $this->order->get_id() )->get_meta( '_stripe_upe_payment_type' ) );
 	}
 
@@ -742,8 +743,9 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		} else {
 			$this->assertArrayNotHasKey( 'level3', $requests_seen[0] );
 		}
-		// Read through a fresh order instance: the type must be persisted to the database,
-		// not just set on the in-memory object, so parallel requests (e.g. webhooks) see it.
+		// The in-memory order is what the level3 gate reads during this request; the freshly
+		// loaded instance proves the type was also persisted for parallel requests (e.g. webhooks).
+		$this->assertSame( $selected_payment_type, $this->order->get_meta( '_stripe_upe_payment_type' ) );
 		$this->assertSame( $selected_payment_type, wc_get_order( $this->order->get_id() )->get_meta( '_stripe_upe_payment_type' ) );
 	}
 


### PR DESCRIPTION
Fixes #5734
Fixes STRIPE-1293

## Changes proposed in this Pull Request:

Level 3 data is card-only, and `WC_Stripe_API::request_with_level3_data()` gates it on the `_stripe_upe_payment_type` order meta. The confirmation-token flow (express checkout) wrote that meta **after** the intent request in `create_and_confirm_payment_intent()` — and never on the confirm path — so the gate fell back to its "unset means card" default and attached Level 3 data to non-card intents (e.g. Amazon Pay). Stripe rejects those with `parameter_unknown: level3`, which sets the account-wide `wc_stripe_level3_not_allowed` transient for 3 months, silently disabling Level 3 for legitimate card payments too.

The fix persists the selected payment type **before** the API request in both methods, via a shared helper that saves immediately (so parallel requests like webhooks read it from the DB) and tolerates null/non-string types. Apple Pay and Google Pay are unaffected — they produce `card`-type payment methods.

**BC impact:** no public signatures, hooks, or option keys change; the meta is just written earlier.

**Follow-up hardening (next PR):** make the gate read `payment_method_types` from the request itself (order meta stays as the fallback for capture-time calls), and only set the `wc_stripe_level3_not_allowed` transient for card requests so one mismatched request can't disable Level 3 account-wide.

## Testing instructions

Prerequisites: US-based store (Level 3 is US-only), Stripe test mode, express checkout with Amazon Pay enabled.

1. Enable Stripe debug logging (**Settings → Payments → Stripe → Settings → Advanced settings → Debug mode**).
2. Buy a product using the **Amazon Pay** express checkout button.
3. In the logs, verify the `payment_intents` request carries no `level3` parameter and the payment succeeds.
4. Verify `wp_options` has no `_transient_wc_stripe_level3_not_allowed` row.
5. Verify the order meta contains `_stripe_upe_payment_type = amazon_pay`.
6. Regression: a regular card payment still succeeds (and still carries `level3` on Level 3–gated accounts).

Covered by new PHPUnit tests in `tests/phpunit/class-wc-stripe-intent-controller-test.php`: create and confirm paths, Level 3 stripped for Amazon Pay / kept for card, meta persisted, null/empty types tolerated.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

> *Drafted with AI (Claude Code); reviewed by me.*
