### PR TITLE
Stop offering Sofort at checkout while keeping refunds and subscription renewals working

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ xxxx-xx-xx - version 11.0.0
 * Dev - Make GITHUB_TOKEN optional for the local E2E Docker setup by falling back to the GitHub CLI and then to plugin zips placed in tests/e2e/deps
 * Fix - Reload the plugin's payment method settings when refreshing account details, so the settings screen no longer keeps showing stale values
 * Update - Stop offering Sofort at checkout (discontinued by Stripe on March 31, 2025); refunds and subscription renewals for existing Sofort orders keep working
+* Dev - Mark the Sofort and giropay payment method classes and constants as deprecated ahead of their removal
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
 * Dev - Make GITHUB_TOKEN optional for the local E2E Docker setup by falling back to the GitHub CLI and then to plugin zips placed in tests/e2e/deps
 * Fix - Reload the plugin's payment method settings when refreshing account details, so the settings screen no longer keeps showing stale values
+* Update - Stop offering Sofort at checkout (discontinued by Stripe on March 31, 2025); refunds and subscription renewals for existing Sofort orders keep working
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/includes/constants/class-wc-stripe-payment-methods.php
+++ b/includes/constants/class-wc-stripe-payment-methods.php
@@ -23,17 +23,27 @@ class WC_Stripe_Payment_Methods {
 	public const CARD_PRESENT      = 'card_present';
 	public const CASHAPP_PAY       = 'cashapp';
 	public const EPS               = 'eps';
-	public const GIROPAY           = 'giropay';
-	public const IDEAL             = 'ideal';
-	public const KLARNA            = 'klarna';
-	public const MULTIBANCO        = 'multibanco';
-	public const OXXO              = 'oxxo';
-	public const P24               = 'p24';
-	public const SEPA              = 'sepa';
-	public const SEPA_DEBIT        = 'sepa_debit';
-	public const SOFORT            = 'sofort';
-	public const WECHAT_PAY        = 'wechat_pay';
-	public const OC                = 'card'; // This is a special case for the Optimized Checkout
+	/**
+	 * The giropay method ID.
+	 *
+	 * @deprecated 11.0.0 giropay is discontinued; still needed to read historical order data.
+	 */
+	public const GIROPAY    = 'giropay';
+	public const IDEAL      = 'ideal';
+	public const KLARNA     = 'klarna';
+	public const MULTIBANCO = 'multibanco';
+	public const OXXO       = 'oxxo';
+	public const P24        = 'p24';
+	public const SEPA       = 'sepa';
+	public const SEPA_DEBIT = 'sepa_debit';
+	/**
+	 * The Sofort method ID.
+	 *
+	 * @deprecated 11.0.0 Sofort is discontinued; still needed to read historical order data.
+	 */
+	public const SOFORT     = 'sofort';
+	public const WECHAT_PAY = 'wechat_pay';
+	public const OC         = 'card'; // This is a special case for the Optimized Checkout
 
 	public const LEGACY_SEPA = 'stripe_sepa'; // Sepa method identifier for the legacy checkout (now removed)
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -232,14 +232,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 
 		$this->payment_methods = [];
 		foreach ( self::UPE_AVAILABLE_METHODS as $payment_method_class ) {
-			/**
-			 * Sofort was discontinued by Stripe on 2025-03-31 and is never offered at checkout
-			 * ({@see WC_Stripe_UPE_Payment_Method_Sofort::is_enabled_at_checkout()}). It is still
-			 * instantiated for stores that have it enabled, so existing Sofort-initiated
-			 * subscriptions keep their renewal hooks (they renew through a SEPA mandate that
-			 * Stripe keeps active), and on the order details page / refund requests so old
-			 * Sofort orders can be refunded.
-			 */
+			// Sofort is discontinued and never offered at checkout. Keep it instantiated for
+			// stores that still have it enabled (preserves subscription renewal hooks) and on
+			// the order details page / refund requests so old Sofort orders can be refunded.
 			if ( WC_Stripe_UPE_Payment_Method_Sofort::class === $payment_method_class && ! $is_sofort_enabled && ! $this->is_order_details_page() && ! $this->is_refund_request() ) {
 				continue;
 			}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -232,10 +232,15 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 
 		$this->payment_methods = [];
 		foreach ( self::UPE_AVAILABLE_METHODS as $payment_method_class ) {
-			/** Show Sofort if it's already enabled. Hide from the new merchants and keep it for the old ones who are already using this gateway, until we remove it completely.
-			 * Stripe is deprecating Sofort https://support.stripe.com/questions/sofort-is-being-deprecated-as-a-standalone-payment-method.
+			/**
+			 * Sofort was discontinued by Stripe on 2025-03-31 and is never offered at checkout
+			 * ({@see WC_Stripe_UPE_Payment_Method_Sofort::is_enabled_at_checkout()}). It is still
+			 * instantiated for stores that have it enabled, so existing Sofort-initiated
+			 * subscriptions keep their renewal hooks (they renew through a SEPA mandate that
+			 * Stripe keeps active), and on the order details page / refund requests so old
+			 * Sofort orders can be refunded.
 			 */
-			if ( WC_Stripe_UPE_Payment_Method_Sofort::class === $payment_method_class && ! $is_sofort_enabled ) {
+			if ( WC_Stripe_UPE_Payment_Method_Sofort::class === $payment_method_class && ! $is_sofort_enabled && ! $this->is_order_details_page() && ! $this->is_refund_request() ) {
 				continue;
 			}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-giropay.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-giropay.php
@@ -5,6 +5,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * The giropay Payment Method class extending UPE base class
+ *
+ * @deprecated 11.0.0 Discontinued by Stripe on 2024-06-30; kept only for refunds on existing orders.
  */
 class WC_Stripe_UPE_Payment_Method_Giropay extends WC_Stripe_UPE_Payment_Method {
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
@@ -46,4 +46,19 @@ class WC_Stripe_UPE_Payment_Method_Sofort extends WC_Stripe_UPE_Payment_Method {
 	public function get_retrievable_type() {
 		return WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID;
 	}
+
+	/**
+	 * Sofort was discontinued by Stripe on 2025-03-31, so new payments always fail
+	 * and the method must never be offered at checkout. The class is kept (still
+	 * reusable, with subscriptions initialized) because existing Sofort-initiated
+	 * subscriptions renew through their SEPA mandate, which Stripe keeps active,
+	 * and old Sofort orders remain refundable.
+	 *
+	 * @param int|null    $order_id
+	 * @param string|null $account_domestic_currency The account's default currency.
+	 * @return bool
+	 */
+	public function is_enabled_at_checkout( $order_id = null, $account_domestic_currency = null ) {
+		return false;
+	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
@@ -8,6 +8,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Sofort Payment Method class extending UPE base class
+ *
+ * @deprecated 11.0.0 Discontinued by Stripe on 2025-03-31; kept only for refunds and
+ * SEPA-mandate subscription renewals on existing orders.
  */
 class WC_Stripe_UPE_Payment_Method_Sofort extends WC_Stripe_UPE_Payment_Method {
 	use WC_Stripe_Subscriptions_Trait;
@@ -48,11 +51,7 @@ class WC_Stripe_UPE_Payment_Method_Sofort extends WC_Stripe_UPE_Payment_Method {
 	}
 
 	/**
-	 * Sofort was discontinued by Stripe on 2025-03-31, so new payments always fail
-	 * and the method must never be offered at checkout. The class is kept (still
-	 * reusable, with subscriptions initialized) because existing Sofort-initiated
-	 * subscriptions renew through their SEPA mandate, which Stripe keeps active,
-	 * and old Sofort orders remain refundable.
+	 * Sofort is discontinued, so it can never be offered at checkout.
 	 *
 	 * @param int|null    $order_id
 	 * @param string|null $account_domestic_currency The account's default currency.

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,8 @@ Stripe is available for store owners and merchants in [46 countries worldwide](h
 
 The following items note specific versions that include important changes, features, or deprecations.
 
+* 11.0.0
+   - Sofort is no longer offered at checkout, since Stripe discontinued it on March 31, 2025; existing Sofort orders can still be refunded and Sofort-initiated subscriptions keep renewing
 * 10.9.0
    - Express checkout processes classic checkout custom fields by default (opt out via the wc_stripe_express_checkout_enable_classic_checkout_custom_fields filter)
 * 10.8.0
@@ -176,5 +178,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
 * Dev - Make GITHUB_TOKEN optional for the local E2E Docker setup by falling back to the GitHub CLI and then to plugin zips placed in tests/e2e/deps
 * Fix - Reload the plugin's payment method settings when refreshing account details, so the settings screen no longer keeps showing stale values
+* Update - Stop offering Sofort at checkout (discontinued by Stripe on March 31, 2025); refunds and subscription renewals for existing Sofort orders keep working
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -179,5 +179,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Make GITHUB_TOKEN optional for the local E2E Docker setup by falling back to the GitHub CLI and then to plugin zips placed in tests/e2e/deps
 * Fix - Reload the plugin's payment method settings when refreshing account details, so the settings screen no longer keeps showing stale values
 * Update - Stop offering Sofort at checkout (discontinued by Stripe on March 31, 2025); refunds and subscription renewals for existing Sofort orders keep working
+* Dev - Mark the Sofort and giropay payment method classes and constants as deprecated ahead of their removal
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-test.php
@@ -573,6 +573,20 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 	}
 
 	/**
+	 * Sofort was discontinued by Stripe, so it must stay disabled at checkout even
+	 * with an active capability and a supported store currency.
+	 */
+	public function test_sofort_is_never_enabled_at_checkout() {
+		$this->set_mock_payment_method_return_value( 'get_capabilities_response', self::MOCK_ACTIVE_CAPABILITIES_RESPONSE, true );
+		$this->set_mock_payment_method_return_value( 'get_woocommerce_currency', WC_Stripe_Currency_Code::EURO );
+		$this->set_mock_payment_method_return_value( 'is_subscription_item_in_cart', false );
+
+		$sofort_method = $this->mock_payment_methods[ WC_Stripe_Payment_Methods::SOFORT ];
+
+		$this->assertFalse( $sofort_method->is_enabled_at_checkout( null, WC_Stripe_Currency_Code::EURO ) );
+	}
+
+	/**
 	 * Payment method is only enabled when capability response contains active for payment method.
 	 */
 	public function test_payment_methods_are_only_enabled_when_capability_is_active() {
@@ -585,7 +599,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 
 		$payment_method_ids = array_map( [ $this, 'get_id' ], $this->mock_payment_methods );
 		foreach ( $payment_method_ids as $id ) {
-			if ( WC_Stripe_Payment_Methods::CARD === $id || WC_Stripe_Payment_Methods::BOLETO === $id || WC_Stripe_Payment_Methods::OXXO === $id || WC_Stripe_Payment_Methods::GIROPAY === $id ) {
+			if ( WC_Stripe_Payment_Methods::CARD === $id || WC_Stripe_Payment_Methods::BOLETO === $id || WC_Stripe_Payment_Methods::OXXO === $id || WC_Stripe_Payment_Methods::GIROPAY === $id || WC_Stripe_Payment_Methods::SOFORT === $id ) {
 				continue;
 			}
 
@@ -630,7 +644,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 
 		$payment_method_ids = array_map( [ $this, 'get_id' ], $this->mock_payment_methods );
 		foreach ( $payment_method_ids as $id ) {
-			if ( WC_Stripe_Payment_Methods::GIROPAY === $id ) {
+			if ( WC_Stripe_Payment_Methods::GIROPAY === $id || WC_Stripe_Payment_Methods::SOFORT === $id ) {
 				continue;
 			}
 
@@ -760,6 +774,11 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 		$this->set_mock_payment_method_return_value( 'get_capabilities_response', self::MOCK_ACTIVE_CAPABILITIES_RESPONSE );
 
 		foreach ( $this->mock_payment_methods as $payment_method_id => $payment_method ) {
+			// Sofort is reusable but discontinued, so it's never enabled at checkout.
+			if ( WC_Stripe_UPE_Payment_Method_Sofort::STRIPE_ID === $payment_method_id ) {
+				continue;
+			}
+
 			$store_currency = 'EUR';
 			if ( in_array(
 				$payment_method_id,

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-method-test.php
@@ -573,8 +573,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 	}
 
 	/**
-	 * Sofort was discontinued by Stripe, so it must stay disabled at checkout even
-	 * with an active capability and a supported store currency.
+	 * Sofort is discontinued: disabled even with an active capability and supported currency.
 	 */
 	public function test_sofort_is_never_enabled_at_checkout() {
 		$this->set_mock_payment_method_return_value( 'get_capabilities_response', self::MOCK_ACTIVE_CAPABILITIES_RESPONSE, true );


### PR DESCRIPTION
Fixes #5828

### Changes proposed in this Pull Request

Stripe [discontinued Sofort on March 31, 2025](https://docs.stripe.com/payments/sofort), so new Sofort payments now fail. The plugin already hid Sofort from merchants who never enabled it, but those who had it enabled before the deprecation still got it offered at checkout.

- `WC_Stripe_UPE_Payment_Method_Sofort::is_enabled_at_checkout()` now always returns `false`, the single choke point for classic checkout, Blocks, Optimized Checkout, and the add-payment-method page, so Sofort disappears from every checkout surface.
- Refunds and renewals for existing Sofort orders keep working: the gateway is still instantiated on the order-details and refund paths (mirroring giropay), stores that still have Sofort enabled keep their renewal hooks, and tokenization and the SEPA-typed token mapping are untouched.
- The Sofort and giropay classes and their `WC_Stripe_Payment_Methods` constants are tagged `@deprecated 11.0.0` (PHPDoc only, since both still run on refund/renewal paths and the constant strings read historical order and webhook data).

Full removal is deferred to a follow-up once the refund/renewal window is over.

### Backward compatibility

- `WC_Stripe_UPE_Payment_Method_Sofort::is_enabled_at_checkout()` changes behavior (always `false`). Any third-party code calling it will now see Sofort reported as unavailable at checkout — which matches reality at Stripe, where these payments fail.
- No hooks, option keys, or public symbols are renamed or removed. The `stripe_sofort` gateway remains registered in the same contexts as before, plus the order-details/refund contexts for stores that disabled Sofort.
- Settings are read/written through the existing site-scoped helpers; no multisite behavior changes. Not explicitly tested under multisite.

### Testing instructions

Sofort can no longer be created at checkout, which is what this PR enforces, so a fresh store has no Sofort orders or subscriptions to test refunds and renewals against. Sofort settles as a SEPA Direct Debit on Stripe, so seed the test data from SEPA. Testers who already have historical Sofort orders or subscriptions can use those and skip the setup.

**Setup**

1. On a store connected to Stripe, set the store currency to EUR and enable both SEPA Direct Debit and Sofort. The UI no longer offers Sofort, so add it to `woocommerce_stripe_settings` > `upe_checkout_experience_accepted_payments` in the DB. Keep Sofort enabled for the whole test, so its gateway stays instantiated and the refund and renewal hooks stay registered.
2. Place a SEPA Direct Debit order. For the renewal test, also start a SEPA Direct Debit subscription with WooCommerce Subscriptions active.
3. Change the payment method of that order (and subscription) to `stripe_sofort` by setting the `_payment_method` post meta in the DB. They now look like Sofort-initiated records.

**Checks**

4. Visit classic checkout and Blocks checkout: Sofort must not be offered. Before this change it was, and paying with it failed at Stripe.
5. Open the seeded Sofort order in wp-admin and issue a partial refund: it must succeed. SEPA charges settle asynchronously, so the charge must be settled before it can be refunded.
6. Trigger a renewal for the seeded Sofort subscription (scheduled action `woocommerce_scheduled_subscription_payment_stripe_sofort`): the renewal must process against the saved SEPA-typed token.

`npm run test:php -- --filter WC_Stripe_UPE_Payment_Method_Test` → 118 tests OK; `--filter WC_Stripe_UPE_Payment_Gateway_Test` → 241 tests OK. PHPStan clean; PHPCS unchanged.

### Changelog entry

> Update - Stop offering Sofort at checkout (discontinued by Stripe on March 31, 2025); refunds and subscription renewals for existing Sofort orders keep working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

