### PR TITLE
Add E2E coverage for the agentic delegated checkout hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,6 +186,8 @@
     "test:e2e-isk-debug": "npm run test:e2e-isk -- --debug",
     "test:e2e-adaptive-pricing": "./tests/e2e/bin/run-tests.sh --project=adaptive-pricing",
     "test:e2e-adaptive-pricing-debug": "npm run test:e2e-adaptive-pricing -- --debug",
+    "test:e2e-agentic": "./tests/e2e/bin/run-tests.sh --project=agentic",
+    "test:e2e-agentic-debug": "npm run test:e2e-agentic -- --debug",
     "changelog": "node bin/changelog.js",
     "doc:hooks": "cd tasks/hooks && composer install --quiet && composer run-script generate"
   },

--- a/tests/e2e/bin/run-tests.sh
+++ b/tests/e2e/bin/run-tests.sh
@@ -54,4 +54,14 @@ if [[ "adaptive-pricing" == "$project" ]]; then
 	cli sh -c "mkdir -p /var/www/html/wp-content/mu-plugins && cp /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/tests/e2e/env/mu-plugins/wc-stripe-e2e-location-simulation.php /var/www/html/wp-content/mu-plugins/"
 fi
 
+# The delegated-checkout hook specs POST signed events directly to the webhook
+# endpoint, so the store needs the feature enabled, a known signing secret, and
+# a deterministic flat-rate cost for the shipping-options assertions.
+if [[ "agentic" == "$project" ]]; then
+	echo "Seeding Agentic Commerce prerequisites"
+	cli wp option update _wcstripe_feature_agentic_commerce yes
+	cli wp option update wc_stripe_agentic_commerce_webhook_secret whsec_e2e_agentic
+	cli wp option update woocommerce_flat_rate_1_settings --format=json '{"title":"Flat rate","tax_status":"taxable","cost":"10.00"}'
+fi
+
 cross-env $TEST_ENV playwright test --config=tests/e2e/config/playwright.config.js $TEST_ARGS ${project:+--project=$project}

--- a/tests/e2e/config/playwright.config.js
+++ b/tests/e2e/config/playwright.config.js
@@ -92,6 +92,7 @@ const config = {
 				'**/blik.spec.js',
 				'**/becs.spec.js',
 				'**/isk.spec.js',
+				'**/agentic-commerce/*.spec.js',
 			],
 			dependencies: [ 'default-setup' ],
 			use: { ...devices[ 'Desktop Chrome' ] },
@@ -168,6 +169,19 @@ const config = {
 		{
 			name: 'reset account',
 			testMatch: '/lpm.teardown.js',
+			use: { ...devices[ 'Desktop Chrome' ] },
+		},
+		{
+			name: 'agentic-setup',
+			testMatch: '/agentic-commerce.setup.js',
+			use: { ...devices[ 'Desktop Chrome' ] },
+		},
+		// Mutates global store state (feature flag, webhook secret, shipping
+		// settings seeded in run-tests.sh), so it must not join `default`.
+		{
+			name: 'agentic',
+			testMatch: '**/agentic-commerce/*.spec.js',
+			dependencies: [ 'agentic-setup' ],
 			use: { ...devices[ 'Desktop Chrome' ] },
 		},
 	],

--- a/tests/e2e/tests/agentic-commerce.setup.js
+++ b/tests/e2e/tests/agentic-commerce.setup.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/* jshint node: true */
+
+import { test as setup } from '@playwright/test';
+import wcApi from '@woocommerce/woocommerce-rest-api';
+import playwrightConfig from '../config/playwright.config';
+import { AGENTIC_OOS_PRODUCT_SKU, AGENTIC_PRODUCT_SKU } from '../utils/agentic';
+
+setup( 'Seed products for agentic delegated checkout tests', async () => {
+	const api = new wcApi( {
+		url: playwrightConfig.use.baseURL,
+		consumerKey: process.env.CONSUMER_KEY,
+		consumerSecret: process.env.CONSUMER_SECRET,
+		version: 'wc/v3',
+	} );
+
+	// Product creation fails on a duplicate SKU, so this setup must stay
+	// idempotent across repeated runs against the same environment.
+	const ensureProduct = async ( params ) => {
+		const existing = await api.get( 'products', { sku: params.sku } );
+
+		if ( existing.data.length > 0 ) {
+			return existing.data[ 0 ].id;
+		}
+
+		const created = await api.post( 'products', params );
+		return created.data.id;
+	};
+
+	await ensureProduct( {
+		name: 'Agentic E2E Product',
+		type: 'simple',
+		regular_price: '24.99',
+		sku: AGENTIC_PRODUCT_SKU,
+	} );
+
+	await ensureProduct( {
+		name: 'Agentic E2E Out of Stock Product',
+		type: 'simple',
+		regular_price: '24.99',
+		sku: AGENTIC_OOS_PRODUCT_SKU,
+		stock_status: 'outofstock',
+	} );
+} );

--- a/tests/e2e/tests/agentic-commerce/delegated-checkout-hooks.spec.js
+++ b/tests/e2e/tests/agentic-commerce/delegated-checkout-hooks.spec.js
@@ -1,0 +1,139 @@
+'use strict';
+
+/* jshint node: true */
+
+import { test, expect } from '@playwright/test';
+import {
+	AGENTIC_OOS_PRODUCT_SKU,
+	AGENTIC_PRODUCT_SKU,
+	WEBHOOK_SECRET,
+	customizeCheckoutEvent,
+	finalizeCheckoutEvent,
+	getConnectedAccountId,
+	postAgenticHook,
+} from '../../utils/agentic';
+
+test.describe( 'Agentic delegated checkout hooks', () => {
+	let accountId;
+
+	test.beforeAll( async () => {
+		// The handler drops events whose `context` does not match the cached
+		// connected account, and passes everything through when the account is
+		// unknown — so read the real id, and only fall back to a dummy when
+		// the store has no cached account data.
+		accountId = ( await getConnectedAccountId() ) || 'acct_e2e_unknown';
+	} );
+
+	test( 'customize_checkout returns line item taxes and shipping options', async ( {
+		request,
+	} ) => {
+		const response = await postAgenticHook(
+			request,
+			customizeCheckoutEvent( {
+				skuId: AGENTIC_PRODUCT_SKU,
+				accountId,
+			} ),
+			WEBHOOK_SECRET
+		);
+
+		expect( response.status() ).toBe( 200 );
+		const body = await response.json();
+
+		expect( body.line_items ).toHaveLength( 1 );
+		expect( body.line_items[ 0 ].id ).toBe( 'li_e2e_1' );
+		expect( Array.isArray( body.line_items[ 0 ].tax_rates ) ).toBe( true );
+
+		expect( body.shipping_options.length ).toBeGreaterThan( 0 );
+		for ( const option of body.shipping_options ) {
+			expect( option.shipping_rate_data.fixed_amount.currency ).toBe(
+				'usd'
+			);
+			expect(
+				option.shipping_rate_data.metadata.wc_rate_id
+			).toBeTruthy();
+		}
+
+		const flatRate = body.shipping_options.find(
+			( option ) => 'Flat rate' === option.shipping_rate_data.display_name
+		);
+		expect( flatRate ).toBeTruthy();
+		expect( flatRate.shipping_rate_data.fixed_amount.amount ).toBe( 1000 );
+	} );
+
+	test( 'finalize_checkout approves a purchasable in-stock line item', async ( {
+		request,
+	} ) => {
+		const response = await postAgenticHook(
+			request,
+			finalizeCheckoutEvent( {
+				skuId: AGENTIC_PRODUCT_SKU,
+				accountId,
+			} ),
+			WEBHOOK_SECRET
+		);
+
+		expect( response.status() ).toBe( 200 );
+		const body = await response.json();
+		expect( body.manual_approval_details.type ).toBe( 'approved' );
+	} );
+
+	test( 'finalize_checkout declines an out-of-stock line item', async ( {
+		request,
+	} ) => {
+		const response = await postAgenticHook(
+			request,
+			finalizeCheckoutEvent( {
+				skuId: AGENTIC_OOS_PRODUCT_SKU,
+				accountId,
+			} ),
+			WEBHOOK_SECRET
+		);
+
+		expect( response.status() ).toBe( 200 );
+		const body = await response.json();
+		expect( body.manual_approval_details.type ).toBe( 'declined' );
+		expect( body.manual_approval_details.declined.reason ).toContain(
+			'out of stock'
+		);
+	} );
+
+	test( 'finalize_checkout rejects an unknown SKU with a 400', async ( {
+		request,
+	} ) => {
+		// Product resolution failure throws inside the handler, which converts
+		// any Throwable from hook processing into a 400 (not a decline).
+		const response = await postAgenticHook(
+			request,
+			finalizeCheckoutEvent( {
+				skuId: 'E2E-AGENTIC-NO-SUCH-SKU',
+				accountId,
+			} ),
+			WEBHOOK_SECRET
+		);
+
+		expect( response.status() ).toBe( 400 );
+	} );
+
+	test( 'a tampered signature is rejected', async ( { request } ) => {
+		// The Docker E2E environment sets E2E_TESTING=true, which makes
+		// validate_request() skip signature verification in test mode — this
+		// test only means something against an environment without the bypass.
+		test.skip(
+			!! process.env.DOCKER,
+			'Signature validation is bypassed when E2E_TESTING is set.'
+		);
+
+		const response = await postAgenticHook(
+			request,
+			customizeCheckoutEvent( {
+				skuId: AGENTIC_PRODUCT_SKU,
+				accountId,
+			} ),
+			'whsec_wrong_secret'
+		);
+
+		// Bad signatures are acked with a 204 so Stripe stops retrying; hook
+		// output must not be returned.
+		expect( response.status() ).toBe( 204 );
+	} );
+} );

--- a/tests/e2e/utils/agentic.js
+++ b/tests/e2e/utils/agentic.js
@@ -1,0 +1,138 @@
+import crypto from 'crypto';
+import wcApi from '@woocommerce/woocommerce-rest-api';
+import playwrightConfig from '../config/playwright.config';
+
+export const WEBHOOK_PATH = '/?wc-api=wc_stripe';
+export const WEBHOOK_SECRET = 'whsec_e2e_agentic';
+export const AGENTIC_PRODUCT_SKU = 'E2E-AGENTIC-1';
+export const AGENTIC_OOS_PRODUCT_SKU = 'E2E-AGENTIC-OOS';
+
+// Cents, matching the product price seeded in agentic-commerce.setup.js.
+export const AGENTIC_PRODUCT_AMOUNT = 2499;
+
+/**
+ * Builds a Stripe-Signature header value for a webhook body, matching the
+ * scheme verified by WC_Stripe_Webhook_Handler::validate_request().
+ *
+ * @param {string} body   The raw request body.
+ * @param {string} secret The signing secret.
+ * @return {string} The Stripe-Signature header value.
+ */
+export const stripeSignature = ( body, secret ) => {
+	const timestamp = Math.floor( Date.now() / 1000 );
+	const signature = crypto
+		.createHmac( 'sha256', secret )
+		.update( `${ timestamp }.${ body }` )
+		.digest( 'hex' );
+
+	return `t=${ timestamp },v1=${ signature }`;
+};
+
+/**
+ * POSTs a delegated-checkout event to the plugin's webhook endpoint.
+ *
+ * @param {Object} request Playwright APIRequestContext.
+ * @param {Object} event   The event payload.
+ * @param {string} secret  The signing secret.
+ * @return {Promise<Object>} The APIResponse.
+ */
+export const postAgenticHook = async ( request, event, secret ) => {
+	const body = JSON.stringify( event );
+
+	return request.post( WEBHOOK_PATH, {
+		data: body,
+		headers: {
+			'Content-Type': 'application/json',
+			'Stripe-Signature': stripeSignature( body, secret ),
+		},
+	} );
+};
+
+/**
+ * Returns the id of the Stripe account the store is connected to, or '' when
+ * the account data has not been cached yet. The webhook handler drops events
+ * whose `context` does not match this id (and passes everything through when
+ * it is unknown), so payloads must carry the real value.
+ *
+ * @return {Promise<string>} The `acct_…` id, or ''.
+ */
+export const getConnectedAccountId = async () => {
+	const api = new wcApi( {
+		url: playwrightConfig.use.baseURL,
+		consumerKey: process.env.CONSUMER_KEY,
+		consumerSecret: process.env.CONSUMER_SECRET,
+		version: 'wc/v3',
+	} );
+
+	const response = await api.get( 'wc_stripe/account' );
+
+	return response.data?.account?.id ?? '';
+};
+
+/**
+ * Builds a v1.delegated_checkout.customize_checkout event. The payload shape
+ * mirrors tests/phpunit/dummy-data/agentic_customize_checkout_event.json —
+ * keep the two in sync when Stripe's hook payloads change.
+ *
+ * @param {Object} args
+ * @param {string} args.skuId     The line item sku_id (a product SKU, with a
+ *                                product-id fallback in the resolver).
+ * @param {string} args.accountId The connected Stripe account id.
+ * @return {Object} The event payload.
+ */
+export const customizeCheckoutEvent = ( { skuId, accountId } ) => ( {
+	id: 'evt_e2e_agentic_customize',
+	type: 'v1.delegated_checkout.customize_checkout',
+	livemode: false,
+	context: accountId,
+	data: {
+		checkout_session: 'cs_test_e2e_agentic',
+		currency: 'usd',
+		automatic_tax: { enabled: false },
+		amount_subtotal: AGENTIC_PRODUCT_AMOUNT,
+		amount_total: AGENTIC_PRODUCT_AMOUNT,
+		total_details: {
+			amount_tax: 0,
+			amount_discount: 0,
+			amount_shipping: 0,
+		},
+		discounts: [],
+		line_item_details: [
+			{
+				id: 'li_e2e_1',
+				sku_id: skuId,
+				quantity: 1,
+				unit_amount: AGENTIC_PRODUCT_AMOUNT,
+				amount_subtotal: AGENTIC_PRODUCT_AMOUNT,
+				amount_total: AGENTIC_PRODUCT_AMOUNT,
+				amount_tax: 0,
+				amount_discount: 0,
+				tax_rates: [],
+			},
+		],
+		shipping_details: {
+			shipping_rates: [],
+			address: {
+				line1: '123 Test Street',
+				line2: '',
+				city: 'Testville',
+				state: 'CA',
+				postal_code: '94000',
+				country: 'US',
+			},
+		},
+		metadata: {},
+	},
+} );
+
+/**
+ * Builds a v1.delegated_checkout.finalize_checkout event.
+ *
+ * @param {Object} args Same as customizeCheckoutEvent().
+ * @return {Object} The event payload.
+ */
+export const finalizeCheckoutEvent = ( args ) => ( {
+	...customizeCheckoutEvent( args ),
+	id: 'evt_e2e_agentic_finalize',
+	type: 'v1.delegated_checkout.finalize_checkout',
+} );


### PR DESCRIPTION
Towards STRIPE-1398

## Changes proposed in this Pull Request:

Adds the first end-to-end coverage for Agentic Commerce, targeting the synchronous delegated checkout hooks (`v1.delegated_checkout.customize_checkout` and `finalize_checkout`). These hooks are processed entirely from the webhook payload, with no callback to Stripe, so a Playwright spec can POST correctly signed events straight to the `/?wc-api=wc_stripe` endpoint and assert on the JSON responses. This exercises the real HTTP entry point, event routing, and the tax/shipping/manual-approval calculators against real store configuration, which the PHPUnit suite cannot cover.

New pieces:

- `tests/e2e/utils/agentic.js`: a Stripe-Signature signer matching `WC_Stripe_Webhook_Handler::validate_request()`, a helper that POSTs signed events to the webhook endpoint, event builders mirroring the PHPUnit fixture shape (`tests/phpunit/dummy-data/agentic_customize_checkout_event.json`), and a helper that reads the connected account id from the `wc_stripe/account` REST route so payloads carry a valid `context`.
- `tests/e2e/tests/agentic-commerce.setup.js`: idempotently seeds an in-stock and an out-of-stock product by SKU.
- `tests/e2e/tests/agentic-commerce/delegated-checkout-hooks.spec.js`: five tests. `customize_checkout` returns line-item tax rates and shipping options (including the seeded flat rate as 1000 cents); `finalize_checkout` approves an in-stock item, declines an out-of-stock one, and returns a 400 for an unresolvable SKU (product resolution throws and the handler converts hook Throwables to 400); a tampered signature is acked with a 204.
- A dedicated `agentic` Playwright project plus `npm run test:e2e-agentic`. The specs are excluded from `default` because the seeding in `run-tests.sh` (feature flag, webhook signing secret, flat-rate cost) mutates global store state.

Notes:

- The Docker E2E env sets `E2E_TESTING=true`, which makes `validate_request()` skip signature verification in test mode, so the tampered-signature test skips itself there. It runs against environments without the bypass.
- Known gaps, planned as follow-ups under STRIPE-1398: seeding is wired only for the local Docker path of `run-tests.sh` (not the remote `--base_url` path), and there is no CI matrix job for the `agentic` project yet.

No runtime behavior changes: the diff touches only E2E tooling and specs, so there is no backward-compatibility impact.

## Testing instructions

1. Start the E2E environment: `npm run test:e2e-setup`.
2. Confirm the environment's WooCommerce meets the plugin minimum (`WC_STRIPE_MIN_WC_VER`, currently 10.8). A reused environment can hold an older WooCommerce, and the plugin then silently does not boot; update it inside the container with `wp plugin update woocommerce` if needed.
3. Run `npm run test:e2e-agentic`.
4. Expected: 5 passed, 1 skipped (the signature-mismatch test, bypassed in the Docker env as described above).

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Test-only change: adds E2E specs and tooling, with no user-facing or runtime behavior changes.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
