### PR TITLE
Add E2E coverage for the Agentic Commerce admin surfaces

### DIFF
--- a/tests/e2e/bin/run-tests.sh
+++ b/tests/e2e/bin/run-tests.sh
@@ -60,6 +60,9 @@ fi
 if [[ "agentic" == "$project" ]]; then
 	echo "Seeding Agentic Commerce prerequisites"
 	cli wp option update _wcstripe_feature_agentic_commerce yes
+	# The admin surfaces (meta box, list table, feed preview) are additionally
+	# gated on the merchant-level enable toggle, not just the feature flag.
+	cli wp option update wc_stripe_agentic_commerce_enabled yes
 	cli wp option update wc_stripe_agentic_commerce_webhook_secret whsec_e2e_agentic
 	cli wp option update woocommerce_flat_rate_1_settings --format=json '{"title":"Flat rate","tax_status":"taxable","cost":"10.00"}'
 fi

--- a/tests/e2e/tests/agentic-commerce.setup.js
+++ b/tests/e2e/tests/agentic-commerce.setup.js
@@ -5,7 +5,11 @@
 import { test as setup } from '@playwright/test';
 import wcApi from '@woocommerce/woocommerce-rest-api';
 import playwrightConfig from '../config/playwright.config';
-import { AGENTIC_OOS_PRODUCT_SKU, AGENTIC_PRODUCT_SKU } from '../utils/agentic';
+import {
+	AGENTIC_EXCLUDED_PRODUCT_SKU,
+	AGENTIC_OOS_PRODUCT_SKU,
+	AGENTIC_PRODUCT_SKU,
+} from '../utils/agentic';
 
 setup( 'Seed products for agentic delegated checkout tests', async () => {
 	const api = new wcApi( {
@@ -41,5 +45,19 @@ setup( 'Seed products for agentic delegated checkout tests', async () => {
 		regular_price: '24.99',
 		sku: AGENTIC_OOS_PRODUCT_SKU,
 		stock_status: 'outofstock',
+	} );
+
+	// The admin-ui spec excludes this one through the product-edit UI, so it
+	// must start each run without the exclusion flag.
+	const excludedId = await ensureProduct( {
+		name: 'Agentic E2E Excludable Product',
+		type: 'simple',
+		regular_price: '24.99',
+		sku: AGENTIC_EXCLUDED_PRODUCT_SKU,
+	} );
+	await api.put( `products/${ excludedId }`, {
+		meta_data: [
+			{ key: '_wc_stripe_agentic_commerce_exclude', value: '' },
+		],
 	} );
 } );

--- a/tests/e2e/tests/agentic-commerce/admin-ui.spec.js
+++ b/tests/e2e/tests/agentic-commerce/admin-ui.spec.js
@@ -1,0 +1,134 @@
+'use strict';
+
+/* jshint node: true */
+
+import { test, expect } from '@playwright/test';
+import {
+	AGENTIC_EXCLUDED_PRODUCT_SKU,
+	AGENTIC_PRODUCT_SKU,
+	getProductIdBySku,
+} from '../../utils/agentic';
+
+const EXCLUDE_CHECKBOX_ID = '_wc_stripe_agentic_commerce_exclude';
+
+// The exclusion test writes state the list-table filter test asserts on, so
+// the file must run in order within one worker.
+test.describe.configure( { mode: 'serial' } );
+
+test.describe( 'Agentic Commerce admin surfaces', () => {
+	let adminPage;
+
+	test.beforeAll( async ( { browser } ) => {
+		const adminContext = await browser.newContext( {
+			storageState: process.env.ADMINSTATE,
+		} );
+		adminPage = await adminContext.newPage();
+	} );
+
+	test( 'settings tab renders and the feed preview reports catalog counts', async () => {
+		await adminPage.goto(
+			'/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=agentic-commerce'
+		);
+
+		await expect(
+			adminPage.getByRole( 'heading', { name: 'Agentic Commerce' } )
+		).toBeVisible();
+
+		await adminPage.getByRole( 'button', { name: 'Preview feed' } ).click();
+
+		// The preview walks the catalog through the same mapper + validator
+		// pipeline as the sync, synchronously, so allow it a moment.
+		const stats = adminPage.locator(
+			'.wc-stripe-agentic-preview__stat-label'
+		);
+		await expect( stats.filter( { hasText: 'Included' } ) ).toBeVisible();
+		await expect(
+			stats.filter( { hasText: 'With errors' } )
+		).toBeVisible();
+		await expect( stats.filter( { hasText: 'Excluded' } ) ).toBeVisible();
+
+		// At minimum the seeded agentic products are included.
+		const includedValue = adminPage
+			.locator( '.is-included .wc-stripe-agentic-preview__stat-value' )
+			.first();
+		const included = Number(
+			( await includedValue.textContent() ).replace( /[^0-9]/g, '' )
+		);
+		expect( included ).toBeGreaterThan( 0 );
+	} );
+
+	test( 'a product can be excluded from the sync on the product edit page', async () => {
+		const productId = await getProductIdBySku(
+			AGENTIC_EXCLUDED_PRODUCT_SKU
+		);
+		expect( productId ).not.toBeNull();
+
+		await adminPage.goto(
+			`/wp-admin/post.php?post=${ productId }&action=edit`
+		);
+
+		await adminPage.locator( '.inventory_options' ).click();
+		const checkbox = adminPage.locator( `#${ EXCLUDE_CHECKBOX_ID }` );
+		await expect( checkbox ).toBeVisible();
+		await checkbox.check();
+
+		await adminPage.locator( '#publish' ).click();
+		await expect(
+			adminPage.locator( '.notice-success' ).first()
+		).toBeVisible();
+
+		// Re-open the Inventory tab: persistence, not DOM state.
+		await adminPage.locator( '.inventory_options' ).click();
+		await expect(
+			adminPage.locator( `#${ EXCLUDE_CHECKBOX_ID }` )
+		).toBeChecked();
+	} );
+
+	test( 'the products list shows sync status and filters excluded products', async () => {
+		await adminPage.goto( '/wp-admin/edit.php?post_type=product' );
+
+		await expect(
+			adminPage.locator( 'th#wc_stripe_agentic_sync' )
+		).toHaveCount( 1 );
+
+		// Filter down to excluded products only.
+		const filter = adminPage.locator(
+			'select[name="wc_stripe_agentic_sync_status"]'
+		);
+		await filter.selectOption( 'excluded' );
+		await adminPage.locator( '#post-query-submit' ).click();
+
+		await expect(
+			adminPage.getByRole( 'link', {
+				name: 'Agentic E2E Excludable Product',
+				exact: true,
+			} )
+		).toBeVisible();
+		await expect(
+			adminPage.getByRole( 'link', {
+				name: 'Agentic E2E Product',
+				exact: true,
+			} )
+		).toHaveCount( 0 );
+	} );
+
+	test( 'the excluded product row is labeled Excluded in the sync column', async () => {
+		const productId = await getProductIdBySku(
+			AGENTIC_EXCLUDED_PRODUCT_SKU
+		);
+		const includedId = await getProductIdBySku( AGENTIC_PRODUCT_SKU );
+
+		await adminPage.goto( '/wp-admin/edit.php?post_type=product' );
+
+		await expect(
+			adminPage.locator(
+				`#post-${ productId } .column-wc_stripe_agentic_sync`
+			)
+		).toContainText( 'Excluded' );
+		await expect(
+			adminPage.locator(
+				`#post-${ includedId } .column-wc_stripe_agentic_sync`
+			)
+		).toContainText( 'Synced' );
+	} );
+} );

--- a/tests/e2e/utils/agentic.js
+++ b/tests/e2e/utils/agentic.js
@@ -6,6 +6,7 @@ export const WEBHOOK_PATH = '/?wc-api=wc_stripe';
 export const WEBHOOK_SECRET = 'whsec_e2e_agentic';
 export const AGENTIC_PRODUCT_SKU = 'E2E-AGENTIC-1';
 export const AGENTIC_OOS_PRODUCT_SKU = 'E2E-AGENTIC-OOS';
+export const AGENTIC_EXCLUDED_PRODUCT_SKU = 'E2E-AGENTIC-EXCL';
 
 // Cents, matching the product price seeded in agentic-commerce.setup.js.
 export const AGENTIC_PRODUCT_AMOUNT = 2499;
@@ -57,17 +58,32 @@ export const postAgenticHook = async ( request, event, secret ) => {
  * @return {Promise<string>} The `acct_…` id, or ''.
  */
 export const getConnectedAccountId = async () => {
-	const api = new wcApi( {
+	const response = await agenticApi().get( 'wc_stripe/account' );
+
+	return response.data?.account?.id ?? '';
+};
+
+/**
+ * Returns the id of the product with the given SKU, or null when absent.
+ *
+ * @param {string} sku The product SKU.
+ * @return {Promise<number|null>} The product id, or null.
+ */
+export const getProductIdBySku = async ( sku ) => {
+	const response = await agenticApi().get( 'products', { sku } );
+
+	return response.data[ 0 ]?.id ?? null;
+};
+
+// The API tokens come from global setup, so the client cannot be built at
+// module load time.
+const agenticApi = () =>
+	new wcApi( {
 		url: playwrightConfig.use.baseURL,
 		consumerKey: process.env.CONSUMER_KEY,
 		consumerSecret: process.env.CONSUMER_SECRET,
 		version: 'wc/v3',
 	} );
-
-	const response = await api.get( 'wc_stripe/account' );
-
-	return response.data?.account?.id ?? '';
-};
 
 /**
  * Builds a v1.delegated_checkout.customize_checkout event. The payload shape


### PR DESCRIPTION
Towards STRIPE-1398

Stacked on #5830 (base branch is `stripe-1398-add-e2e-test-coverage-for-agentic-commerce`); only the last commit is new here.

## Changes proposed in this Pull Request:

Adds the admin-UI leg of the Agentic Commerce E2E coverage, in the same `agentic` Playwright project introduced by #5830:

- `tests/e2e/tests/agentic-commerce/admin-ui.spec.js`: four tests. The Stripe settings "Agentic Commerce" tab renders and its "Preview feed" button reports catalog counts (Included / With errors / Excluded) computed by the real mapper + validator pipeline; the product-edit Inventory tab's exclusion checkbox persists across a save and reload; the products list table exposes the sync-status column and the "Excluded products" filter shows only excluded products; the column labels the excluded product "Excluded" and the included one "Synced".
- Setup seeds a dedicated excludable product whose exclusion flag is cleared at the start of each run, since the spec exercises the exclusion flow through the UI itself.
- `run-tests.sh` seeding now also enables the merchant-level toggle (`wc_stripe_agentic_commerce_enabled`): the admin surfaces are gated on it in addition to the feature flag.
- Small util additions: a shared REST client factory and a product-id-by-SKU lookup.

The spec file runs in serial mode because the exclusion test writes state the list-table tests assert on.

No runtime behavior changes: the diff touches only E2E tooling and specs, so there is no backward-compatibility impact.

## Testing instructions

1. Check out this branch and start the E2E environment (`npm run test:e2e-setup`), making sure WooCommerce in the environment meets the plugin minimum (see #5830).
2. Run `npm run test:e2e-agentic`.
3. Expected: 9 passed, 1 skipped (the signature-mismatch test, bypassed in the Docker env).

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Test-only change: adds E2E specs and tooling, with no user-facing or runtime behavior changes.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
