### PR TITLE
Remove Klarna's dead static supported-currencies list

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
 * Dev - Make GITHUB_TOKEN optional for the local E2E Docker setup by falling back to the GitHub CLI and then to plugin zips placed in tests/e2e/deps
 * Fix - Reload the plugin's payment method settings when refreshing account details, so the settings screen no longer keeps showing stale values
+* Dev - Remove Klarna's unused static supported-currencies list; supported currencies are computed from the Stripe account
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
@@ -91,27 +91,12 @@ class WC_Stripe_UPE_Payment_Method_Klarna extends WC_Stripe_UPE_Payment_Method {
 	 */
 	public function __construct() {
 		parent::__construct();
-		$this->stripe_id            = self::STRIPE_ID;
-		$this->title                = __( 'Klarna', 'woocommerce-gateway-stripe' );
-		$this->is_reusable          = true;
-		$this->supports[]           = PaymentGatewayFeature::TOKENIZATION;
-		$this->supported_currencies = [
-			WC_Stripe_Currency_Code::AUSTRALIAN_DOLLAR,
-			WC_Stripe_Currency_Code::CANADIAN_DOLLAR,
-			WC_Stripe_Currency_Code::SWISS_FRANC,
-			WC_Stripe_Currency_Code::CZECH_KORUNA,
-			WC_Stripe_Currency_Code::DANISH_KRONE,
-			WC_Stripe_Currency_Code::EURO,
-			WC_Stripe_Currency_Code::POUND_STERLING,
-			WC_Stripe_Currency_Code::NORWEGIAN_KRONE,
-			WC_Stripe_Currency_Code::NEW_ZEALAND_DOLLAR,
-			WC_Stripe_Currency_Code::POLISH_ZLOTY,
-			WC_Stripe_Currency_Code::ROMANIAN_LEU,
-			WC_Stripe_Currency_Code::SWEDISH_KRONA,
-			WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR,
-		];
-		$this->label                = __( 'Klarna', 'woocommerce-gateway-stripe' );
-		$this->description          = __(
+		$this->stripe_id   = self::STRIPE_ID;
+		$this->title       = __( 'Klarna', 'woocommerce-gateway-stripe' );
+		$this->is_reusable = true;
+		$this->supports[]  = PaymentGatewayFeature::TOKENIZATION;
+		$this->label       = __( 'Klarna', 'woocommerce-gateway-stripe' );
+		$this->description = __(
 			'Allow customers to pay over time with Klarna.',
 			'woocommerce-gateway-stripe'
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -176,5 +176,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Name password protection and hidden visibility as their own reasons in the Agentic Commerce feed preview
 * Dev - Make GITHUB_TOKEN optional for the local E2E Docker setup by falling back to the GitHub CLI and then to plugin zips placed in tests/e2e/deps
 * Fix - Reload the plugin's payment method settings when refreshing account details, so the settings screen no longer keeps showing stale values
+* Dev - Remove Klarna's unused static supported-currencies list; supported currencies are computed from the Stripe account
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
### Changes proposed in this Pull Request

Remove the static `$this->supported_currencies` array from the `WC_Stripe_UPE_Payment_Method_Klarna` constructor. It was dead code: the property is only ever read through the base `WC_Stripe_UPE_Payment_Method::get_supported_currencies()`, which Klarna fully overrides with an account-derived list, so the 13-currency array was assigned and never used.

### Backward compatibility

- No public method, hook, or option changes. `get_supported_currencies()` output is unchanged.
- The protected `$supported_currencies` property is no longer pre-populated for Klarna (it stays at the base default). A third-party subclass reading the property directly would now see the default instead of the stale list — the overridden getter has been the authoritative source for a long time.
- Pre-existing quirk, unchanged by this PR: because Klarna's override doesn't call the base getter, the `wc_stripe_klarna_upe_supported_currencies` filter does not fire for Klarna.

### Testing instructions

Klarna availability at checkout is unaffected; `npm run test:php -- --filter 'WC_Stripe_UPE_Payment_Method_Klarna_Test|WC_Stripe_UPE_Payment_Method_Test'` → 126 tests OK, PHPStan clean.

### Changelog entry

> Dev - Remove Klarna's unused static supported-currencies list; supported currencies are computed from the Stripe account

🤖 Generated with [Claude Code](https://claude.com/claude-code)
