### PR TITLE
Add E2E coverage for agentic order creation from a completed session

### DIFF
--- a/tests/e2e/bin/run-tests.sh
+++ b/tests/e2e/bin/run-tests.sh
@@ -65,6 +65,10 @@ if [[ "agentic" == "$project" ]]; then
 	cli wp option update wc_stripe_agentic_commerce_enabled yes
 	cli wp option update wc_stripe_agentic_commerce_webhook_secret whsec_e2e_agentic
 	cli wp option update woocommerce_flat_rate_1_settings --format=json '{"title":"Flat rate","tax_status":"taxable","cost":"10.00"}'
+	# The order-creation spec forges checkout.session.completed webhooks; the
+	# handler retrieves the session back from Stripe before creating the order,
+	# so this mu-plugin answers that one retrieval with a local fixture.
+	cli sh -c "mkdir -p /var/www/html/wp-content/mu-plugins && cp /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/tests/e2e/env/mu-plugins/wc-stripe-e2e-agentic-session-stub.php /var/www/html/wp-content/mu-plugins/"
 fi
 
 cross-env $TEST_ENV playwright test --config=tests/e2e/config/playwright.config.js $TEST_ARGS ${project:+--project=$project}

--- a/tests/e2e/env/mu-plugins/wc-stripe-e2e-agentic-session-stub.php
+++ b/tests/e2e/env/mu-plugins/wc-stripe-e2e-agentic-session-stub.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Plugin Name: WC Stripe E2E Agentic Session Stub
+ * Description: Serves a fixture agentic checkout session for E2E tests. The order-creation flow retrieves the completed session back from Stripe before mapping it to an order; a forged webhook has no session on Stripe's side, so this stub answers that one retrieval locally.
+ *
+ * @package WooCommerce_Stripe/Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_filter(
+	'pre_http_request',
+	function ( $preempt, $parsed_args, $url ) {
+		// Guarded to the E2E environment: never stub outside it.
+		if ( ! filter_var( getenv( 'E2E_TESTING' ), FILTER_VALIDATE_BOOLEAN ) ) {
+			return $preempt;
+		}
+
+		// Session ids are minted per test run (unique suffix) so a stale order
+		// from a previous run can never satisfy the spec's assertions.
+		if ( ! preg_match( '#api\.stripe\.com/v1/checkout/sessions/(cs_test_e2e_agentic_[A-Za-z0-9_]+)#', $url, $matches ) ) {
+			return $preempt;
+		}
+
+		$session_id = $matches[1];
+
+		// Amounts must stay consistent with the E2E seeding: the mapper
+		// recalculates the order from catalog prices (24.99 USD product,
+		// 10.00 USD flat rate) and refuses a session whose totals differ.
+		$address = [
+			'line1'       => '123 Test Street',
+			'line2'       => '',
+			'city'        => 'Testville',
+			'state'       => 'CA',
+			'postal_code' => '94000',
+			'country'     => 'US',
+		];
+
+		$session = [
+			'id'               => $session_id,
+			'object'           => 'checkout.session',
+			'livemode'         => false,
+			'currency'         => 'usd',
+			'amount_subtotal'  => 2499,
+			'amount_total'     => 3499,
+			'total_details'    => [
+				'amount_tax'      => 0,
+				'amount_discount' => 0,
+				'amount_shipping' => 1000,
+			],
+			'payment_intent'   => [
+				'id'            => 'pi_e2e_agentic_order',
+				'object'        => 'payment_intent',
+				'agent_details' => [
+					'network_business_profile' => 'E2E Test Agent',
+				],
+			],
+			'customer'         => 'cus_e2e_agentic',
+			'customer_details' => [
+				'email'   => 'agentic-e2e-buyer@example.com',
+				'name'    => 'Agentic Buyer',
+				'phone'   => '+15551234567',
+				'address' => $address,
+			],
+			'shipping_details' => [
+				'name'    => 'Agentic Buyer',
+				'address' => $address,
+			],
+			'line_items'       => [
+				'object' => 'list',
+				'data'   => [
+					[
+						'id'              => 'li_e2e_order_1',
+						'object'          => 'item',
+						'quantity'        => 1,
+						'amount_subtotal' => 2499,
+						'amount_total'    => 2499,
+						'amount_tax'      => 0,
+						'amount_discount' => 0,
+						'price'           => [
+							'id'                 => 'price_e2e_agentic_1',
+							'currency'           => 'usd',
+							'unit_amount'        => 2499,
+							'external_reference' => 'E2E-AGENTIC-1',
+							'product'            => [
+								'id'   => 'prod_e2e_agentic_1',
+								'name' => 'Agentic E2E Product',
+							],
+						],
+					],
+				],
+			],
+			'shipping_cost'    => [
+				'amount_total'  => 1000,
+				'amount_tax'    => 0,
+				'shipping_rate' => [
+					'id'           => 'shr_e2e_agentic_flat',
+					'display_name' => 'Flat rate',
+					'metadata'     => [
+						'wc_rate_id' => 'flat_rate:1',
+					],
+				],
+			],
+			'metadata'         => [],
+		];
+
+		return [
+			'headers'  => [ 'content-type' => 'application/json' ],
+			'body'     => wp_json_encode( $session ),
+			'response' => [
+				'code'    => 200,
+				'message' => 'OK',
+			],
+			'cookies'  => [],
+			'filename' => null,
+		];
+	},
+	10,
+	3
+);

--- a/tests/e2e/tests/agentic-commerce/feed-cli.spec.js
+++ b/tests/e2e/tests/agentic-commerce/feed-cli.spec.js
@@ -2,22 +2,12 @@
 
 /* jshint node: true */
 
-import { execSync } from 'child_process';
 import { test, expect } from '@playwright/test';
 import {
 	AGENTIC_CLI_EXCLUDED_PRODUCT_SKU,
 	AGENTIC_PRODUCT_SKU,
+	wpCliDocker,
 } from '../../utils/agentic';
-
-// Mirrors the cli() helper in tests/e2e/bin/common.sh: a throwaway
-// wordpress:cli container sharing the E2E WordPress volumes and network.
-const wpCli = ( command ) =>
-	execSync(
-		`docker run -i --rm --user 33:33 --env-file "${ process.env.E2E_ROOT }/env/default.env" ` +
-			'--volumes-from wcstripe-e2e-wordpress --network container:wcstripe-e2e-wordpress ' +
-			`wordpress:cli ${ command }`,
-		{ encoding: 'utf8' }
-	);
 
 test.describe( 'Agentic Commerce feed CLI', () => {
 	// The commands run through docker, so they only work against the local
@@ -28,7 +18,7 @@ test.describe( 'Agentic Commerce feed CLI', () => {
 	);
 
 	test( 'preview reports included and excluded catalog counts', async () => {
-		const output = wpCli( 'wp stripe agentic-commerce preview' );
+		const output = wpCliDocker( 'wp stripe agentic-commerce preview' );
 
 		expect( output ).toContain( 'Preview generation complete.' );
 
@@ -49,7 +39,7 @@ test.describe( 'Agentic Commerce feed CLI', () => {
 		// The feed writes to the CLI container's private temp dir until
 		// delivery, so the file must be read in the same container run that
 		// generated it.
-		const output = wpCli(
+		const output = wpCliDocker(
 			`sh -c 'OUT=$(wp stripe agentic-commerce sync); echo "$OUT"; ` +
 				`FILE=$(echo "$OUT" | sed -n "s/.*File: *//p"); ` +
 				`echo "---CSV-START---"; cat "$FILE"'`

--- a/tests/e2e/tests/agentic-commerce/order-creation.spec.js
+++ b/tests/e2e/tests/agentic-commerce/order-creation.spec.js
@@ -1,0 +1,117 @@
+'use strict';
+
+/* jshint node: true */
+
+import { test, expect } from '@playwright/test';
+import {
+	AGENTIC_PRODUCT_SKU,
+	WEBHOOK_SECRET,
+	checkoutSessionCompletedEvent,
+	customizeCheckoutEvent,
+	getConnectedAccountId,
+	getOrdersBySessionId,
+	postAgenticHook,
+	runDeferredWebhookJobs,
+} from '../../utils/agentic';
+
+// Later tests assert on state the first one creates.
+test.describe.configure( { mode: 'serial' } );
+
+test.describe( 'Agentic order creation from a completed session', () => {
+	// The session-retrieval stub is a mu-plugin installed by run-tests.sh in
+	// the Docker environment only.
+	test.skip(
+		! process.env.DOCKER,
+		'The order-creation spec needs the session stub mu-plugin from the Docker E2E environment.'
+	);
+
+	let accountId;
+	// Unique per run so an order left behind by a previous run can never
+	// satisfy the assertions.
+	const sessionId = `cs_test_e2e_agentic_${ Date.now() }`;
+
+	test.beforeAll( async () => {
+		accountId = ( await getConnectedAccountId() ) || 'acct_e2e_unknown';
+	} );
+
+	test( 'a claimed completed session creates a paid order', async ( {
+		request,
+	} ) => {
+		// The customize hook claims the session for this site; without the
+		// claim, checkout.session.completed is treated as another site's.
+		const claim = await postAgenticHook(
+			request,
+			customizeCheckoutEvent( {
+				skuId: AGENTIC_PRODUCT_SKU,
+				accountId,
+				sessionId,
+			} ),
+			WEBHOOK_SECRET
+		);
+		expect( claim.status() ).toBe( 200 );
+
+		const completed = await postAgenticHook(
+			request,
+			checkoutSessionCompletedEvent( { sessionId, accountId } ),
+			WEBHOOK_SECRET
+		);
+		expect( completed.ok() ).toBe( true );
+
+		// With no matching order, the webhook defers order creation to a
+		// wc_stripe_deferred_webhook job two minutes out; run it now.
+		expect( runDeferredWebhookJobs() ).toBeGreaterThan( 0 );
+
+		const orders = await getOrdersBySessionId( sessionId );
+		expect( orders ).toHaveLength( 1 );
+
+		const [ order ] = orders;
+
+		expect( order.status ).toBe( 'processing' );
+		expect( order.total ).toBe( '34.99' );
+		expect( order.shipping_total ).toBe( '10.00' );
+		expect( order.billing.email ).toBe( 'agentic-e2e-buyer@example.com' );
+		expect( order.transaction_id ).toBe( 'pi_e2e_agentic_order' );
+		expect( order.line_items ).toHaveLength( 1 );
+		expect( order.line_items[ 0 ].sku ).toBe( AGENTIC_PRODUCT_SKU );
+		expect( order.line_items[ 0 ].quantity ).toBe( 1 );
+	} );
+
+	test( 'a duplicate completed event does not create a second order', async ( {
+		request,
+	} ) => {
+		const completed = await postAgenticHook(
+			request,
+			checkoutSessionCompletedEvent( { sessionId, accountId } ),
+			WEBHOOK_SECRET
+		);
+		expect( completed.ok() ).toBe( true );
+
+		// Process anything the duplicate event may have queued, then confirm
+		// no second order appeared.
+		runDeferredWebhookJobs();
+		expect( await getOrdersBySessionId( sessionId ) ).toHaveLength( 1 );
+	} );
+
+	test( 'an unclaimed session does not create an order', async ( {
+		request,
+	} ) => {
+		const unclaimedSessionId = `cs_test_e2e_agentic_unclaimed_${ Date.now() }`;
+
+		const completed = await postAgenticHook(
+			request,
+			checkoutSessionCompletedEvent( {
+				sessionId: unclaimedSessionId,
+				accountId,
+			} ),
+			WEBHOOK_SECRET
+		);
+		expect( completed.ok() ).toBe( true );
+
+		// The deferred job still runs — the claim check inside it is what
+		// must reject the session.
+		expect( runDeferredWebhookJobs() ).toBeGreaterThan( 0 );
+		expect( await getOrdersBySessionId( unclaimedSessionId ) ).toHaveLength(
+			0
+		);
+	} );
+} );

--- a/tests/e2e/utils/agentic.js
+++ b/tests/e2e/utils/agentic.js
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import { execSync } from 'child_process';
 import wcApi from '@woocommerce/woocommerce-rest-api';
 import playwrightConfig from '../config/playwright.config';
 
@@ -76,6 +77,95 @@ export const getProductIdBySku = async ( sku ) => {
 	return response.data[ 0 ]?.id ?? null;
 };
 
+/**
+ * Builds a checkout.session.completed event referencing a stubbed agentic
+ * session. The handler retrieves the full session from Stripe by id, so the
+ * event body itself stays minimal.
+ *
+ * @param {Object} args
+ * @param {string} args.sessionId The `cs_test_e2e_agentic_…` session id.
+ * @param {string} args.accountId The connected Stripe account id.
+ * @return {Object} The event payload.
+ */
+export const checkoutSessionCompletedEvent = ( { sessionId, accountId } ) => ( {
+	id: 'evt_e2e_agentic_completed',
+	type: 'checkout.session.completed',
+	livemode: false,
+	context: accountId,
+	data: {
+		object: {
+			id: sessionId,
+			object: 'checkout.session',
+			payment_intent: 'pi_e2e_agentic_order',
+			metadata: {},
+		},
+	},
+} );
+
+/**
+ * Returns the recent orders created from the given agentic checkout session.
+ *
+ * @param {string} sessionId The checkout session id.
+ * @return {Promise<Object[]>} Matching orders, newest first.
+ */
+export const getOrdersBySessionId = async ( sessionId ) => {
+	const response = await agenticApi().get( 'orders', {
+		per_page: 50,
+		orderby: 'date',
+		order: 'desc',
+	} );
+
+	return response.data.filter( ( order ) =>
+		( order.meta_data ?? [] ).some(
+			( meta ) =>
+				'_stripe_checkout_session_id' === meta.key &&
+				meta.value === sessionId
+		)
+	);
+};
+
+/**
+ * Runs a command in a throwaway wordpress:cli container sharing the E2E
+ * WordPress volumes and network, mirroring the cli() helper in
+ * tests/e2e/bin/common.sh. Docker-environment only.
+ *
+ * @param {string} command The command for the container entrypoint.
+ * @return {string} Combined stdout.
+ */
+export const wpCliDocker = ( command ) =>
+	execSync(
+		`docker run -i --rm --user 33:33 --env-file "${ process.env.E2E_ROOT }/env/default.env" ` +
+			// docker-compose sets E2E_TESTING on the WordPress container but
+			// default.env does not, and the session-stub mu-plugin (and any
+			// other E2E-only guard) must behave the same under wp-cli.
+			'-e E2E_TESTING=true ' +
+			'--volumes-from wcstripe-e2e-wordpress --network container:wcstripe-e2e-wordpress ' +
+			`wordpress:cli ${ command }`,
+		{ encoding: 'utf8' }
+	);
+
+/**
+ * Immediately executes every pending wc_stripe_deferred_webhook job.
+ *
+ * checkout.session.completed with no matching order defers order creation to
+ * Action Scheduler two minutes out; running the jobs through the real queue
+ * runner keeps the spec deterministic without waiting out the delay.
+ *
+ * @return {number} How many jobs were processed.
+ */
+export const runDeferredWebhookJobs = () => {
+	const output = wpCliDocker(
+		"wp eval '" +
+			'$store = ActionScheduler::store(); ' +
+			'$ids = $store->query_actions( [ "hook" => "wc_stripe_deferred_webhook", "status" => "pending", "per_page" => 25 ] ); ' +
+			'$runner = ActionScheduler_QueueRunner::instance(); ' +
+			'foreach ( $ids as $id ) { $runner->process_action( $id, "e2e" ); } ' +
+			"echo count( $ids );'"
+	);
+
+	return Number( output.trim().split( '\n' ).pop() );
+};
+
 // The API tokens come from global setup, so the client cannot be built at
 // module load time.
 const agenticApi = () =>
@@ -97,13 +187,17 @@ const agenticApi = () =>
  * @param {string} args.accountId The connected Stripe account id.
  * @return {Object} The event payload.
  */
-export const customizeCheckoutEvent = ( { skuId, accountId } ) => ( {
+export const customizeCheckoutEvent = ( {
+	skuId,
+	accountId,
+	sessionId = 'cs_test_e2e_agentic',
+} ) => ( {
 	id: 'evt_e2e_agentic_customize',
 	type: 'v1.delegated_checkout.customize_checkout',
 	livemode: false,
 	context: accountId,
 	data: {
-		checkout_session: 'cs_test_e2e_agentic',
+		checkout_session: sessionId,
 		currency: 'usd',
 		automatic_tax: { enabled: false },
 		amount_subtotal: AGENTIC_PRODUCT_AMOUNT,


### PR DESCRIPTION
Towards STRIPE-1398

Stacked on #5833 (base branch is `stripe-1398-agentic-e2e-feed-cli`); only the last commit is new here. Completes the E2E stack for STRIPE-1398.

## Changes proposed in this Pull Request:

Covers the last leg of the agentic flow: order creation from `checkout.session.completed`. The handler retrieves the completed session back from Stripe before mapping it to an order, and a forged webhook has no session on Stripe's side, so this is the hybrid approach discussed on the issue: exactly that one retrieval is answered by a fixture, and everything else runs for real.

- `tests/e2e/env/mu-plugins/wc-stripe-e2e-agentic-session-stub.php`: a `pre_http_request` filter, installed into the Docker environment by `run-tests.sh`, that serves a fixture session for ids matching `cs_test_e2e_agentic_*`. It is double-gated: only in the E2E environment (`E2E_TESTING`) and only for that id prefix. The fixture's amounts stay consistent with the seeded catalog (24.99 USD product, 10.00 USD flat rate), which matters because the order mapper recalculates from catalog prices and rejects mismatched totals.
- `tests/e2e/tests/agentic-commerce/order-creation.spec.js`: three tests. A claimed session (claimed via a real `customize_checkout` hook, as in production) produces a `processing` order with the right total, shipping, billing email, transaction id, and line item; a duplicate `completed` event does not create a second order; an unclaimed session (the sibling-site scenario from the session-claim guard) creates no order.
- The webhook defers order creation to a `wc_stripe_deferred_webhook` Action Scheduler job two minutes out, so the spec executes pending jobs through Action Scheduler's real queue runner via wp-cli instead of waiting. Session ids are minted per run, so stale orders from previous runs can never satisfy an assertion.
- The shared wp-cli helper moved into `utils/agentic.js` and now passes `E2E_TESTING=true` into the CLI container: docker-compose sets it only on the WordPress container, and the deferred job runs under wp-cli, where the stub must behave identically.

What this deliberately does not cover: the real Stripe round trip for the session retrieval (impossible without an actual AI agent creating a delegated checkout session) and Stripe-side payload changes to the session shape. The fixture documents the shape the mapper depends on; if Stripe changes it, the PHPUnit fixtures and this stub need the same update.

No runtime behavior changes: the mu-plugin ships under `tests/e2e/env/` and is only ever copied into the E2E container, so there is no backward-compatibility impact.

## Testing instructions

1. Check out this branch and start the E2E environment (`npm run test:e2e-setup`), making sure WooCommerce in the environment meets the plugin minimum (see #5830).
2. Run `npm run test:e2e-agentic`.
3. Expected: 14 passed, 1 skipped (the signature-mismatch test, bypassed in the Docker env).

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Test-only change: adds E2E specs and test-environment tooling, with no user-facing or runtime behavior changes.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
