### PR TITLE
ci: add job-level timeout-minutes to workflow jobs

### DIFF
--- a/.github/workflows/build-upload-zip.yml
+++ b/.github/workflows/build-upload-zip.yml
@@ -14,6 +14,7 @@ jobs:
   build_project:
     name: Build and upload
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     
     steps:
       - name: Checkout repository

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -17,6 +17,7 @@ jobs:
   changes:
     name: Check for code changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
@@ -32,6 +33,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -48,6 +50,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       BASE_REF: ${{ github.event_name == 'pull_request' && github.base_ref || inputs.base_ref || 'trunk' }}
     steps:
@@ -72,6 +75,7 @@ jobs:
     name: Compare & report
     needs: [measure-head, measure-base]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/ci-cron-qit.yml
+++ b/.github/workflows/ci-cron-qit.yml
@@ -37,6 +37,7 @@ jobs:
     needs: qit-tests
     name: Handle failure
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:

--- a/.github/workflows/ci-extension-compat.yml
+++ b/.github/workflows/ci-extension-compat.yml
@@ -26,6 +26,7 @@ jobs:
   setup-matrix:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -82,6 +83,7 @@ jobs:
     if: ${{ failure() }}
     needs: [build-project, activation-tests]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
@@ -97,6 +99,7 @@ jobs:
     if: ${{ cancelled() }}
     needs: [build-project, activation-tests]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:

--- a/.github/workflows/ci-manual.yml
+++ b/.github/workflows/ci-manual.yml
@@ -118,6 +118,7 @@ jobs:
     needs: [php-tests, e2e-tests, qit-tests]
     name: Handle success
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
@@ -134,6 +135,7 @@ jobs:
     needs: [php-tests, e2e-tests, qit-tests]
     name: Handle cancellation
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
@@ -150,6 +152,7 @@ jobs:
     needs: [php-tests, e2e-tests, qit-tests]
     name: Handle failure
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:

--- a/.github/workflows/ci-merge.yml
+++ b/.github/workflows/ci-merge.yml
@@ -39,6 +39,7 @@ jobs:
     needs: qit-tests
     name: Handle cancellation
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
@@ -55,6 +56,7 @@ jobs:
     needs: qit-tests
     name: Handle failure
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -7,6 +7,7 @@ jobs:
   changes:
     name: Check for code changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
@@ -21,6 +22,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,6 +11,7 @@ jobs:
   changes:
     name: Check for code changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
@@ -25,6 +26,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       max-parallel: 10

--- a/.github/workflows/format-release-notes.yml
+++ b/.github/workflows/format-release-notes.yml
@@ -13,6 +13,7 @@ run-name: Format release notes for ${{ inputs.branch }}
 jobs:
   format-release-notes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -7,6 +7,7 @@ on:
 jobs:
     generate-zip-file:
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         steps:
             - name: Checkout
               uses: actions/checkout@v7.0.1

--- a/.github/workflows/issue-gardening.yml
+++ b/.github/workflows/issue-gardening.yml
@@ -8,6 +8,7 @@ jobs:
   issue-gardening:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: ${{ github.repository == 'woocommerce/woocommerce-gateway-stripe' }}
     strategy:
       matrix:

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -7,6 +7,7 @@ jobs:
   changes:
     name: Check for code changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
@@ -22,6 +23,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       # clone the repository
       - uses: actions/checkout@v7.0.1

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,6 +11,7 @@ jobs:
   changes:
     name: Check for code changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
@@ -26,6 +27,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       # clone the repository
       - uses: actions/checkout@v7.0.1
@@ -47,6 +49,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       # clone the repository
       - uses: actions/checkout@v7.0.1

--- a/.github/workflows/php-code-coverage.yml
+++ b/.github/workflows/php-code-coverage.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   get-woocommerce-versions:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     outputs:
       woocommerce-versions-json: ${{ steps.get-released-woocommerce-versions.outputs.versions-json }}
     steps:
@@ -26,6 +27,7 @@ jobs:
           version-count: 1
   get-wordpress-versions:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     outputs:
       wordpress-versions-json: ${{ steps.get-wordpress-versions.outputs.versions-json }}
     steps:
@@ -41,6 +43,7 @@ jobs:
     if: ${{ ! contains( github.event.head_commit.message, 'Merge branch' ) }}
     needs: [ get-woocommerce-versions, get-wordpress-versions ]
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     name: PHP=8.1, WP=L, WC=L
     env:
       PHP_VERSION: '8.1'

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -11,6 +11,7 @@ jobs:
   changes:
     name: Check for code changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
@@ -25,6 +26,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     outputs:
         woocommerce-versions-json: ${{ steps.get-released-woocommerce-versions.outputs.versions-json }}
     steps:
@@ -41,6 +43,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     outputs:
       wordpress-versions-json: ${{ steps.get-wordpress-versions.outputs.versions-json }}
     steps:
@@ -55,6 +58,7 @@ jobs:
 
   test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     needs: [ get-woocommerce-versions, get-wordpress-versions ]
     strategy:
       fail-fast:    false

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -32,6 +32,7 @@ jobs:
     phpstan:
         name: 'PHPStan Analysis'
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         steps:
             - uses: 'actions/checkout@v7.0.1'
               name: 'Checkout'

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -15,6 +15,7 @@ jobs:
   changes:
     name: Check for code changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
@@ -30,6 +31,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v7.0.1

--- a/.github/workflows/pr-require-milestone.yml
+++ b/.github/workflows/pr-require-milestone.yml
@@ -22,6 +22,7 @@ jobs:
     name: 'Ensure milestone is assigned'
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: 'Validate milestone'
         uses: actions/github-script@v9

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       max-parallel: 10

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -86,6 +86,7 @@ jobs:
     
     name: Run QIT Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
 
       - name: Install QIT via composer

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -17,6 +17,7 @@ jobs:
   php-unit-tests:
     name: PHP Unit - WP=${{ inputs.wp-version }}, WC=${{ inputs.wc-version }}, PHP=${{ inputs.php-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       WP_VERSION: ${{ inputs.wp-version }}
       WC_VERSION: ${{ inputs.wc-version }}

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -11,6 +11,7 @@ jobs:
   check_changelog:
     name: 'Check for changelog updates'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.1


### PR DESCRIPTION
Add job timeouts so runs fail fast instead of hanging for up to 6 hours on GitHub's 360-minute default.

| Job | Median (30d) | Max (30d) | `timeout-minutes` |
| --- | --- | --- | --- |
| `build-upload-zip.yml` / `build_project` | 1.25 | 2.73 | 5 |
| `bundle-size.yml` / `changes` | 0.10 | 0.32 | 5 |
| `bundle-size.yml` / `measure-head` | 1.76 | 2.78 | 5 |
| `bundle-size.yml` / `measure-base` | 1.69 | 2.67 | 5 |
| `bundle-size.yml` / `compare` | 0.17 | 0.33 | 5 |
| `ci-cron-qit.yml` / `handle-error` | — | — | 5 |
| `ci-extension-compat.yml` / `setup-matrix` | 0.05 | 0.20 | 5 |
| `ci-extension-compat.yml` / `handle-error` | — | — | 5 |
| `ci-extension-compat.yml` / `handle-cancelled` | — | — | 5 |
| `ci-manual.yml` / `handle-success` | 0.05 | 0.05 | 5 |
| `ci-manual.yml` / `handle-cancelled` | — | — | 5 |
| `ci-manual.yml` / `handle-error` | — | — | 5 |
| `ci-merge.yml` / `handle-cancelled` | — | — | 5 |
| `ci-merge.yml` / `handle-error` | — | — | 5 |
| `compatibility.yml` / `changes` | 0.10 | 0.28 | 5 |
| `compatibility.yml` / `beta-compatibility` | 4.31 | 14.80 | 20 |
| `e2e-tests.yml` / `changes` | 0.10 | 0.17 | 5 |
| `e2e-tests.yml` / `test` | 4.98 | 16.03 | 20 |
| `format-release-notes.yml` / `format-release-notes` | 1.45 * | 2.27 * | 5 |
| `generate-zip.yml` / `generate-zip-file` | — | — | 5 |
| `issue-gardening.yml` / `issue-gardening` | 0.15 | 10.10 | 15 |
| `js-tests.yml` / `changes` | 0.10 | 0.22 | 5 |
| `js-tests.yml` / `test` | 1.87 | 2.47 | 5 |
| `linting.yml` / `changes` | 0.10 | 0.32 | 5 |
| `linting.yml` / `php_lint` | 0.62 | 0.85 | 5 |
| `linting.yml` / `js_css_lint` | 1.43 | 1.95 | 5 |
| `php-code-coverage.yml` / `get-woocommerce-versions` | 0.08 * | 0.15 * | 5 |
| `php-code-coverage.yml` / `get-wordpress-versions` | 0.08 * | 0.15 * | 5 |
| `php-code-coverage.yml` / `test` | 4.17 * | 4.25 * | 10 |
| `php-tests.yml` / `changes` | 0.10 | 0.25 | 5 |
| `php-tests.yml` / `get-woocommerce-versions` | 0.10 | 0.37 | 5 |
| `php-tests.yml` / `get-wordpress-versions` | 0.12 | 0.27 | 5 |
| `php-tests.yml` / `test` | 4.13 | 15.08 | 20 |
| `phpstan.yml` / `phpstan` | 0.78 | 1.63 | 5 |
| `pr-build-live-branch.yml` / `changes` | 0.10 | 0.33 | 5 |
| `pr-build-live-branch.yml` / `build-and-inform-zip-file` | 1.18 | 2.87 | 5 |
| `pr-require-milestone.yml` / `ensure-milestone` | 0.07 | 0.22 | 5 |
| `run-e2e-tests.yml` / `e2e-tests` | 5.36 | 13.37 | 20 |
| `run-qit.yml` / `qit-tests` | 2.60 | 24.30 | 30 |
| `run-unit-tests.yml` / `php-unit-tests` | 3.85 | 3.85 | 20 |
| `validate-changelog.yml` / `check_changelog` | 0.13 | 0.25 | 5 |


- [x] This Pull Request does not require a changelog entry


Part of TESTOPS-272