### PR TITLE
Reconcile stale saved payment tokens when the Stripe customer is missing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ xxxx-xx-xx - version 11.0.0
 * Dev - Make GITHUB_TOKEN optional for the local E2E Docker setup by falling back to the GitHub CLI and then to plugin zips placed in tests/e2e/deps
 * Fix - Reload the plugin's payment method settings when refreshing account details, so the settings screen no longer keeps showing stale values
 * Update - Fetch express checkout AJAX nonces on demand instead of embedding them in every page
+* Fix - Remove stale saved payment methods at checkout when the Stripe customer no longer exists, and keep valid ones when Stripe returns a transient API error
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -880,9 +880,9 @@ class WC_Stripe_Customer {
 	 *
 	 * @param string[] $payment_method_types The payment method types to look for using Stripe method IDs. If the array is empty, it implies all payment method types.
 	 * @param int      $limit                The maximum number of payment methods to return. If the value is -1, no limit is applied.
-	 * @param bool     $throw_on_error       Whether to throw on a generic API error instead of returning an empty array. A missing customer still returns an empty array.
+	 * @param bool     $throw_on_error       Throw on generic API errors instead of returning []. A missing customer still returns [].
 	 * @return array
-	 * @throws WC_Stripe_Exception When $throw_on_error is true and the API returns an error other than a missing customer.
+	 * @throws WC_Stripe_Exception When $throw_on_error is true and the error is not a missing customer.
 	 */
 	public function get_all_payment_methods( array $payment_method_types = [], int $limit = -1, bool $throw_on_error = false ) {
 		if ( ! $this->get_id() ) {
@@ -919,9 +919,8 @@ class WC_Stripe_Customer {
 						return [];
 					}
 
-					// A generic API error is not proof the payment methods are gone. Callers that
-					// reconcile local tokens against this list need to distinguish that from a
-					// genuinely empty list, otherwise a transient failure would wipe valid tokens.
+					// A generic error is not proof the payment methods are gone; callers reconciling
+					// local tokens must be able to tell it apart from a genuinely empty list.
 					if ( $throw_on_error ) {
 						throw new WC_Stripe_Exception(
 							print_r( $response->error, true ),

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -659,11 +659,22 @@ class WC_Stripe_Customer {
 	 * error and it is no such customer.
 	 *
 	 * @since 4.1.2
-	 * @param array $error
+	 * @param \stdClass|null $error The error object from a Stripe API response.
+	 * @return bool
 	 */
 	public function is_no_such_customer_error( $error ) {
+		if ( ! $error ) {
+			return false;
+		}
+
+		// Some endpoints reference the customer as a request param and return the
+		// code/param pair; others only carry the message, so both shapes identify
+		// a missing customer.
+		if ( isset( $error->code, $error->param ) && 'resource_missing' === $error->code && 'customer' === $error->param ) {
+			return true;
+		}
+
 		return (
-			$error &&
 			'invalid_request_error' === $error->type &&
 			preg_match( '/No such customer/i', $error->message )
 		);
@@ -674,7 +685,7 @@ class WC_Stripe_Customer {
 	 * error and it is no such customer.
 	 *
 	 * @since 4.5.6
-	 * @param array $error
+	 * @param \stdClass|null $error The error object from a Stripe API response.
 	 * @return bool
 	 */
 	public function is_source_already_attached_error( $error ) {
@@ -909,11 +920,7 @@ class WC_Stripe_Customer {
 				$response = WC_Stripe_API::request( $request_params, 'payment_methods?expand[]=data.sepa_debit.generated_from.charge&expand[]=data.sepa_debit.generated_from.setup_attempt', 'GET' );
 
 				if ( ! empty( $response->error ) ) {
-					if (
-						isset( $response->error->param, $response->error->code )
-						&& 'customer' === $response->error->param
-						&& 'resource_missing' === $response->error->code
-					) {
+					if ( $this->is_no_such_customer_error( $response->error ) ) {
 						// If the customer doesn't exist, cache an empty array.
 						set_transient( $cache_key, [], DAY_IN_SECONDS );
 						return [];

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -880,9 +880,11 @@ class WC_Stripe_Customer {
 	 *
 	 * @param string[] $payment_method_types The payment method types to look for using Stripe method IDs. If the array is empty, it implies all payment method types.
 	 * @param int      $limit                The maximum number of payment methods to return. If the value is -1, no limit is applied.
+	 * @param bool     $throw_on_error       Whether to throw on a generic API error instead of returning an empty array. A missing customer still returns an empty array.
 	 * @return array
+	 * @throws WC_Stripe_Exception When $throw_on_error is true and the API returns an error other than a missing customer.
 	 */
-	public function get_all_payment_methods( array $payment_method_types = [], int $limit = -1 ) {
+	public function get_all_payment_methods( array $payment_method_types = [], int $limit = -1, bool $throw_on_error = false ) {
 		if ( ! $this->get_id() ) {
 			return [];
 		}
@@ -914,7 +916,19 @@ class WC_Stripe_Customer {
 					) {
 						// If the customer doesn't exist, cache an empty array.
 						set_transient( $cache_key, [], DAY_IN_SECONDS );
+						return [];
 					}
+
+					// A generic API error is not proof the payment methods are gone. Callers that
+					// reconcile local tokens against this list need to distinguish that from a
+					// genuinely empty list, otherwise a transient failure would wipe valid tokens.
+					if ( $throw_on_error ) {
+						throw new WC_Stripe_Exception(
+							print_r( $response->error, true ),
+							__( 'There was a problem retrieving data from the Stripe API endpoint.', 'woocommerce-gateway-stripe' )
+						);
+					}
+
 					return [];
 				}
 

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -207,11 +207,11 @@ class WC_Stripe_Payment_Tokens {
 			return $tokens;
 		}
 
-		if ( count( $tokens ) >= get_option( 'posts_per_page' ) ) {
-			// The tokens data store is not paginated and only the first "post_per_page" (defaults to 10) tokens are retrieved.
-			// Having 10 saved credit cards is considered an unsupported edge case, new ones that have been stored in Stripe won't be added.
-			return $tokens;
-		}
+		// The tokens data store is not paginated and only the first "posts_per_page" (defaults to 10) tokens are retrieved.
+		// At or beyond that cap, new payment methods stored in Stripe won't be added as tokens (an unsupported edge case),
+		// but the retrieved tokens are still verified against Stripe below, so stale tokens (e.g. ones left behind by a
+		// deleted Stripe customer) are cleaned up instead of being displayed as usable payment methods.
+		$can_add_new_tokens = count( $tokens ) < (int) get_option( 'posts_per_page' );
 
 		$gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
 
@@ -224,7 +224,11 @@ class WC_Stripe_Payment_Tokens {
 			// Prevent unnecessary recursion, WC_Payment_Token::save() ends up calling 'woocommerce_get_customer_payment_tokens' in some cases.
 			remove_filter( 'woocommerce_get_customer_payment_tokens', [ $this, 'woocommerce_get_customer_payment_tokens' ], 10 );
 
-			$payment_methods    = $customer->get_all_payment_methods( $active_reusable_types );
+			// Throw on generic API errors so a transient Stripe failure bails out below and keeps
+			// the local tokens, instead of being mistaken for "the customer has no payment methods"
+			// and wiping them in cleanup_invalid_tokens(). A missing customer still returns an empty
+			// list, which is the authoritative signal that every local token is stale.
+			$payment_methods    = $customer->get_all_payment_methods( $active_reusable_types, -1, true );
 			$payment_method_ids = array_map( fn ( $payment_method ) => $payment_method->id, $payment_methods );
 
 			foreach ( $payment_methods as $payment_method ) {
@@ -266,9 +270,11 @@ class WC_Stripe_Payment_Tokens {
 				}
 
 				// Create a new token when:
+				// - The token count is below the data store's retrieval cap.
 				// - The payment method is a valid PaymentMethodID (i.e. only support IDs starting with "src_" when using the card payment method type).
 				// - The payment method belongs to the gateway ID being retrieved or the gateway ID is empty (meaning we're looking for all payment methods).
 				if (
+					$can_add_new_tokens &&
 					$this->is_valid_payment_method_id( $payment_method->id, $payment_method_type ) &&
 					( empty( $gateway_id ) || $this->is_valid_payment_method_type_for_gateway( $payment_method_type, $gateway_id ) )
 				) {
@@ -304,7 +310,11 @@ class WC_Stripe_Payment_Tokens {
 				}
 			}
 		} catch ( WC_Stripe_Exception $e ) {
-			wc_add_notice( $e->getLocalizedMessage(), 'error' );
+			// This filter also runs where no WC session exists (admin, REST, CLI), and
+			// wc_add_notice() only guards against that itself since WC 10.5.
+			if ( WC()->session ) {
+				wc_add_notice( $e->getLocalizedMessage(), 'error' );
+			}
 			WC_Stripe_Logger::error( 'Error getting customer payment tokens (upe) for customer: ' . $customer_id, [ 'error_message' => $e->getMessage() ] );
 
 			return $tokens;

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -545,7 +545,9 @@ class WC_Stripe_Payment_Tokens {
 					$active_reusable_payment_method_types[] = WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID;
 				}
 			}
-			$payment_methods = $customer->get_all_payment_methods( $active_reusable_payment_method_types );
+			// Throw on generic API errors (caught below) so a transient failure keeps the
+			// local tokens instead of deleting them against an empty list.
+			$payment_methods = $customer->get_all_payment_methods( $active_reusable_payment_method_types, -1, true );
 
 			$payment_method_ids = array_map(
 				function ( $payment_method ) {

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -316,7 +316,7 @@ class WC_Stripe_Payment_Tokens {
 				}
 			}
 		} catch ( WC_Stripe_Exception $e ) {
-			// wc_add_notice() only guards against a missing session (admin, REST, CLI) since WC 10.5.
+			// No shopper sees notices in sessionless contexts (admin, REST, CLI), so only queue one when a session exists.
 			if ( WC()->session ) {
 				wc_add_notice( $e->getLocalizedMessage(), 'error' );
 			}

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -207,10 +207,8 @@ class WC_Stripe_Payment_Tokens {
 			return $tokens;
 		}
 
-		// The tokens data store is not paginated and only the first "posts_per_page" (defaults to 10) tokens are retrieved.
-		// At or beyond that cap, new payment methods stored in Stripe won't be added as tokens (an unsupported edge case),
-		// but the retrieved tokens are still verified against Stripe below, so stale tokens (e.g. ones left behind by a
-		// deleted Stripe customer) are cleaned up instead of being displayed as usable payment methods.
+		// The unpaginated tokens data store only returns the first "posts_per_page" (default 10) tokens, so at
+		// that cap new tokens are not added; verification and cleanup below still run on the retrieved ones.
 		$can_add_new_tokens = count( $tokens ) < (int) get_option( 'posts_per_page' );
 
 		$gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
@@ -224,10 +222,8 @@ class WC_Stripe_Payment_Tokens {
 			// Prevent unnecessary recursion, WC_Payment_Token::save() ends up calling 'woocommerce_get_customer_payment_tokens' in some cases.
 			remove_filter( 'woocommerce_get_customer_payment_tokens', [ $this, 'woocommerce_get_customer_payment_tokens' ], 10 );
 
-			// Throw on generic API errors so a transient Stripe failure bails out below and keeps
-			// the local tokens, instead of being mistaken for "the customer has no payment methods"
-			// and wiping them in cleanup_invalid_tokens(). A missing customer still returns an empty
-			// list, which is the authoritative signal that every local token is stale.
+			// Throw on generic API errors so a transient failure bails out and keeps the local tokens;
+			// only a missing customer returns the empty list that authorizes cleanup below.
 			$payment_methods    = $customer->get_all_payment_methods( $active_reusable_types, -1, true );
 			$payment_method_ids = array_map( fn ( $payment_method ) => $payment_method->id, $payment_methods );
 
@@ -270,7 +266,7 @@ class WC_Stripe_Payment_Tokens {
 				}
 
 				// Create a new token when:
-				// - The token count is below the data store's retrieval cap.
+				// - The token count is below the retrieval cap.
 				// - The payment method is a valid PaymentMethodID (i.e. only support IDs starting with "src_" when using the card payment method type).
 				// - The payment method belongs to the gateway ID being retrieved or the gateway ID is empty (meaning we're looking for all payment methods).
 				if (
@@ -310,8 +306,7 @@ class WC_Stripe_Payment_Tokens {
 				}
 			}
 		} catch ( WC_Stripe_Exception $e ) {
-			// This filter also runs where no WC session exists (admin, REST, CLI), and
-			// wc_add_notice() only guards against that itself since WC 10.5.
+			// wc_add_notice() only guards against a missing session (admin, REST, CLI) since WC 10.5.
 			if ( WC()->session ) {
 				wc_add_notice( $e->getLocalizedMessage(), 'error' );
 			}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1645,18 +1645,6 @@ parameters:
 			path: includes/class-wc-stripe-customer.php
 
 		-
-			message: '#^Cannot access property \$message on array\.$#'
-			identifier: property.nonObject
-			count: 2
-			path: includes/class-wc-stripe-customer.php
-
-		-
-			message: '#^Cannot access property \$type on array\.$#'
-			identifier: property.nonObject
-			count: 2
-			path: includes/class-wc-stripe-customer.php
-
-		-
 			message: '#^Cannot call method save\(\) on WC_Payment_Token_SEPA\|WC_Stripe_Payment_Token_CC\|false\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -1707,12 +1695,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Customer\:\:get_user\(\) should return WP_User but returns WP_User\|false\.$#'
 			identifier: return.type
-			count: 1
-			path: includes/class-wc-stripe-customer.php
-
-		-
-			message: '#^Method WC_Stripe_Customer\:\:is_no_such_customer_error\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/class-wc-stripe-customer.php
 

--- a/readme.txt
+++ b/readme.txt
@@ -177,5 +177,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Make GITHUB_TOKEN optional for the local E2E Docker setup by falling back to the GitHub CLI and then to plugin zips placed in tests/e2e/deps
 * Fix - Reload the plugin's payment method settings when refreshing account details, so the settings screen no longer keeps showing stale values
 * Update - Fetch express checkout AJAX nonces on demand instead of embedding them in every page
+* Fix - Remove stale saved payment methods at checkout when the Stripe customer no longer exists, and keep valid ones when Stripe returns a transient API error
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-customer-test.php
+++ b/tests/phpunit/class-wc-stripe-customer-test.php
@@ -801,8 +801,7 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * A generic API error must throw when $throw_on_error is requested, and must not
-	 * poison the payment methods cache with an empty list.
+	 * A generic API error throws when requested and does not cache an empty list.
 	 */
 	public function test_get_all_payment_methods_throws_on_generic_error_when_requested() {
 		$user_id = $this->factory->user->create();
@@ -834,8 +833,7 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * A missing Stripe customer is an authoritative empty result: it must return an
-	 * empty array (not throw, even with $throw_on_error) and cache it.
+	 * A missing customer returns and caches an empty list even with $throw_on_error.
 	 */
 	public function test_get_all_payment_methods_returns_empty_when_customer_missing_even_with_throw_on_error() {
 		$user_id = $this->factory->user->create();
@@ -870,8 +868,7 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Without $throw_on_error, a generic API error must keep the historical behavior
-	 * of returning an empty array.
+	 * By default a generic API error still returns an empty array.
 	 */
 	public function test_get_all_payment_methods_returns_empty_on_generic_error_by_default() {
 		$user_id = $this->factory->user->create();

--- a/tests/phpunit/class-wc-stripe-customer-test.php
+++ b/tests/phpunit/class-wc-stripe-customer-test.php
@@ -895,4 +895,53 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 
 		$this->assertSame( [], $result );
 	}
+
+	/**
+	 * is_no_such_customer_error() must recognize both error shapes Stripe returns for a
+	 * missing customer and reject unrelated errors.
+	 *
+	 * @param object|null $error    The error object under test.
+	 * @param bool        $expected Whether the error identifies a missing customer.
+	 *
+	 * @dataProvider provide_is_no_such_customer_error_cases
+	 */
+	public function test_is_no_such_customer_error( ?object $error, bool $expected ) {
+		$customer = new \WC_Stripe_Customer();
+
+		$this->assertSame( $expected, (bool) $customer->is_no_such_customer_error( $error ) );
+	}
+
+	/**
+	 * Cases for test_is_no_such_customer_error.
+	 *
+	 * @return array[]
+	 */
+	public function provide_is_no_such_customer_error_cases(): array {
+		return [
+			'code and param pair' => [
+				(object) [
+					'code'  => 'resource_missing',
+					'param' => 'customer',
+				],
+				true,
+			],
+			'message only'        => [
+				(object) [
+					'type'    => 'invalid_request_error',
+					'message' => "No such customer: 'cus_123'",
+				],
+				true,
+			],
+			'unrelated error'     => [
+				(object) [
+					'code'    => 'card_declined',
+					'param'   => 'card',
+					'type'    => 'card_error',
+					'message' => 'Your card was declined.',
+				],
+				false,
+			],
+			'no error'            => [ null, false ],
+		];
+	}
 }

--- a/tests/phpunit/class-wc-stripe-customer-test.php
+++ b/tests/phpunit/class-wc-stripe-customer-test.php
@@ -776,4 +776,126 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 			remove_filter( 'pre_http_request', $spy, 10 );
 		}
 	}
+
+	/**
+	 * Builds a pre_http_request callback that answers Stripe payment_methods requests with the given body.
+	 *
+	 * @param array $body        The decoded response body to return.
+	 * @param int   $status_code The HTTP status code to return.
+	 * @return callable
+	 */
+	private function mock_payment_methods_http_response( array $body, int $status_code ): callable {
+		return function ( $preempt, $parsed_args, $url ) use ( $body, $status_code ) {
+			if ( false === strpos( $url, 'payment_methods' ) ) {
+				return $preempt;
+			}
+			return [
+				'headers'  => [],
+				'body'     => wp_json_encode( $body ),
+				'response' => [
+					'code'    => $status_code,
+					'message' => 'OK',
+				],
+			];
+		};
+	}
+
+	/**
+	 * A generic API error must throw when $throw_on_error is requested, and must not
+	 * poison the payment methods cache with an empty list.
+	 */
+	public function test_get_all_payment_methods_throws_on_generic_error_when_requested() {
+		$user_id = $this->factory->user->create();
+		update_user_option( $user_id, '_stripe_customer_id', 'cus_generic_error_' . $user_id, false );
+		$customer = new \WC_Stripe_Customer( $user_id );
+
+		$mock_http = $this->mock_payment_methods_http_response(
+			[
+				'error' => [
+					'code'    => 'rate_limit',
+					'message' => 'Too many requests.',
+					'type'    => 'api_error',
+				],
+			],
+			429
+		);
+		add_filter( 'pre_http_request', $mock_http, 10, 3 );
+
+		try {
+			$this->expectException( \WC_Stripe_Exception::class );
+			$customer->get_all_payment_methods( [], -1, true );
+		} finally {
+			remove_filter( 'pre_http_request', $mock_http, 10 );
+			$this->assertFalse(
+				get_transient( \WC_Stripe_Customer::PAYMENT_METHODS_TRANSIENT_KEY . '__all_cus_generic_error_' . $user_id ),
+				'A generic API error must not cache an empty payment methods list.'
+			);
+		}
+	}
+
+	/**
+	 * A missing Stripe customer is an authoritative empty result: it must return an
+	 * empty array (not throw, even with $throw_on_error) and cache it.
+	 */
+	public function test_get_all_payment_methods_returns_empty_when_customer_missing_even_with_throw_on_error() {
+		$user_id = $this->factory->user->create();
+		update_user_option( $user_id, '_stripe_customer_id', 'cus_gone_' . $user_id, false );
+		$customer = new \WC_Stripe_Customer( $user_id );
+
+		$mock_http = $this->mock_payment_methods_http_response(
+			[
+				'error' => [
+					'code'    => 'resource_missing',
+					'message' => 'No such customer',
+					'param'   => 'customer',
+					'type'    => 'invalid_request_error',
+				],
+			],
+			404
+		);
+		add_filter( 'pre_http_request', $mock_http, 10, 3 );
+
+		try {
+			$result = $customer->get_all_payment_methods( [], -1, true );
+		} finally {
+			remove_filter( 'pre_http_request', $mock_http, 10 );
+		}
+
+		$this->assertSame( [], $result );
+		$this->assertSame(
+			[],
+			get_transient( \WC_Stripe_Customer::PAYMENT_METHODS_TRANSIENT_KEY . '__all_cus_gone_' . $user_id ),
+			'A missing customer must cache the empty payment methods list.'
+		);
+	}
+
+	/**
+	 * Without $throw_on_error, a generic API error must keep the historical behavior
+	 * of returning an empty array.
+	 */
+	public function test_get_all_payment_methods_returns_empty_on_generic_error_by_default() {
+		$user_id = $this->factory->user->create();
+		update_user_option( $user_id, '_stripe_customer_id', 'cus_default_error_' . $user_id, false );
+		$customer = new \WC_Stripe_Customer( $user_id );
+
+		$mock_http = $this->mock_payment_methods_http_response(
+			[
+				'error' => [
+					'code'    => 'rate_limit',
+					'message' => 'Too many requests.',
+					'type'    => 'api_error',
+				],
+			],
+			429
+		);
+		add_filter( 'pre_http_request', $mock_http, 10, 3 );
+
+		try {
+			$result = $customer->get_all_payment_methods();
+		} finally {
+			remove_filter( 'pre_http_request', $mock_http, 10 );
+		}
+
+		$this->assertSame( [], $result );
+	}
 }

--- a/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
+++ b/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
@@ -787,10 +787,8 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * When Stripe reports the stored customer no longer exists, every local token is
-	 * stale and must be deleted — including when the customer is at the posts_per_page
-	 * token cap, which previously skipped the sync entirely and left unusable saved
-	 * cards visible at checkout.
+	 * Tokens for a missing Stripe customer are deleted, below and at the
+	 * posts_per_page cap (which previously skipped the sync entirely).
 	 *
 	 * @param bool $at_limit Whether the customer has posts_per_page saved tokens.
 	 * @dataProvider provide_test_deletes_stale_tokens_when_stripe_customer_missing
@@ -854,8 +852,7 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A generic Stripe API error (e.g. rate limiting) is not proof the payment methods
-	 * are gone: the local tokens must be kept, not treated as orphaned and deleted.
+	 * A generic Stripe API error keeps local tokens instead of deleting them as orphaned.
 	 */
 	public function test_woocommerce_get_customer_payment_tokens_keeps_tokens_on_generic_api_error(): void {
 		$user_id = $this->factory->user->create();
@@ -899,9 +896,7 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * At the posts_per_page token cap, the sync must still verify tokens against Stripe
-	 * (deleting stale ones) but must not add new tokens beyond the data store's
-	 * unpaginated retrieval window.
+	 * At the token cap the sync still deletes stale tokens but adds no new ones.
 	 */
 	public function test_woocommerce_get_customer_payment_tokens_verifies_but_does_not_add_tokens_at_token_limit(): void {
 		$user_id = $this->factory->user->create();

--- a/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
+++ b/tests/phpunit/payment-tokens/class-wc-stripe-payment-tokens-test.php
@@ -787,19 +787,249 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * When the number of existing tokens has reached the posts_per_page limit the
-	 * tokens array must be returned unchanged (no sync happens).
+	 * When Stripe reports the stored customer no longer exists, every local token is
+	 * stale and must be deleted — including when the customer is at the posts_per_page
+	 * token cap, which previously skipped the sync entirely and left unusable saved
+	 * cards visible at checkout.
+	 *
+	 * @param bool $at_limit Whether the customer has posts_per_page saved tokens.
+	 * @dataProvider provide_test_deletes_stale_tokens_when_stripe_customer_missing
 	 */
-	public function test_woocommerce_get_customer_payment_tokens_returns_unchanged_when_at_token_limit(): void {
+	public function test_woocommerce_get_customer_payment_tokens_deletes_stale_tokens_when_stripe_customer_missing( bool $at_limit ): void {
 		$user_id = $this->factory->user->create();
 		wp_set_current_user( $user_id );
+		update_user_option( $user_id, '_stripe_customer_id', 'cus_missing_' . ( $at_limit ? 'at_limit_' : 'below_limit_' ) . $user_id, false );
 
-		$limit          = (int) get_option( 'posts_per_page', 10 );
-		$initial_tokens = array_fill( 0, $limit, new WC_Payment_Token_CC() );
+		$token_count = $at_limit ? (int) get_option( 'posts_per_page', 10 ) : 1;
+		$tokens      = [];
+		for ( $i = 0; $i < $token_count; $i++ ) {
+			$token                      = $this->create_saved_cc_token( $user_id, "pm_stale_{$i}" );
+			$tokens[ $token->get_id() ] = $token;
+		}
 
-		$result = $this->stripe_payment_tokens->woocommerce_get_customer_payment_tokens( $initial_tokens, $user_id, WC_Stripe_UPE_Payment_Gateway::ID );
+		$mock_http = $this->mock_stripe_payment_methods_http_response(
+			[
+				'error' => [
+					'code'    => 'resource_missing',
+					'message' => 'No such customer',
+					'param'   => 'customer',
+					'type'    => 'invalid_request_error',
+				],
+			],
+			404
+		);
+		add_filter( 'pre_http_request', $mock_http, 10, 3 );
 
-		$this->assertSame( $initial_tokens, $result );
+		$this->set_main_gateway( $this->get_mock_gateway( false ) );
+
+		try {
+			$result = $this->stripe_payment_tokens->woocommerce_get_customer_payment_tokens( $tokens, $user_id, WC_Stripe_UPE_Payment_Gateway::ID );
+		} finally {
+			remove_filter( 'pre_http_request', $mock_http, 10 );
+		}
+
+		$this->assertSame( [], $result );
+		$this->assertSame(
+			[],
+			WC_Payment_Tokens::get_tokens(
+				[
+					'user_id'    => $user_id,
+					'gateway_id' => WC_Stripe_UPE_Payment_Gateway::ID,
+				]
+			),
+			'Stale tokens for a missing Stripe customer must be deleted from the data store.'
+		);
+	}
+
+	/**
+	 * Data provider for `test_woocommerce_get_customer_payment_tokens_deletes_stale_tokens_when_stripe_customer_missing`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_deletes_stale_tokens_when_stripe_customer_missing(): array {
+		return [
+			'below the token cap' => [ false ],
+			'at the token cap'    => [ true ],
+		];
+	}
+
+	/**
+	 * A generic Stripe API error (e.g. rate limiting) is not proof the payment methods
+	 * are gone: the local tokens must be kept, not treated as orphaned and deleted.
+	 */
+	public function test_woocommerce_get_customer_payment_tokens_keeps_tokens_on_generic_api_error(): void {
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+		update_user_option( $user_id, '_stripe_customer_id', 'cus_api_error_' . $user_id, false );
+
+		$token  = $this->create_saved_cc_token( $user_id, 'pm_kept_on_error' );
+		$tokens = [ $token->get_id() => $token ];
+
+		$mock_http = $this->mock_stripe_payment_methods_http_response(
+			[
+				'error' => [
+					'code'    => 'rate_limit',
+					'message' => 'Too many requests.',
+					'type'    => 'api_error',
+				],
+			],
+			429
+		);
+		add_filter( 'pre_http_request', $mock_http, 10, 3 );
+
+		$this->set_main_gateway( $this->get_mock_gateway( false ) );
+
+		try {
+			$result = $this->stripe_payment_tokens->woocommerce_get_customer_payment_tokens( $tokens, $user_id, WC_Stripe_UPE_Payment_Gateway::ID );
+		} finally {
+			remove_filter( 'pre_http_request', $mock_http, 10 );
+		}
+
+		$this->assertSame( $tokens, $result );
+		$this->assertCount(
+			1,
+			WC_Payment_Tokens::get_tokens(
+				[
+					'user_id'    => $user_id,
+					'gateway_id' => WC_Stripe_UPE_Payment_Gateway::ID,
+				]
+			),
+			'Tokens must survive a transient Stripe API failure.'
+		);
+	}
+
+	/**
+	 * At the posts_per_page token cap, the sync must still verify tokens against Stripe
+	 * (deleting stale ones) but must not add new tokens beyond the data store's
+	 * unpaginated retrieval window.
+	 */
+	public function test_woocommerce_get_customer_payment_tokens_verifies_but_does_not_add_tokens_at_token_limit(): void {
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+		update_user_option( $user_id, '_stripe_customer_id', 'cus_at_limit_' . $user_id, false );
+
+		$limit  = (int) get_option( 'posts_per_page', 10 );
+		$tokens = [];
+		for ( $i = 0; $i < $limit - 1; $i++ ) {
+			$token                      = $this->create_saved_cc_token( $user_id, "pm_kept_{$i}" );
+			$tokens[ $token->get_id() ] = $token;
+		}
+		$stale_token                      = $this->create_saved_cc_token( $user_id, 'pm_stale_at_limit' );
+		$tokens[ $stale_token->get_id() ] = $stale_token;
+
+		// Stripe still has every kept payment method plus one the store has never seen,
+		// but not the stale one.
+		$stripe_payment_methods = [];
+		for ( $i = 0; $i < $limit - 1; $i++ ) {
+			$stripe_payment_methods[] = $this->get_stripe_card_payment_method_data( "pm_kept_{$i}" );
+		}
+		$stripe_payment_methods[] = $this->get_stripe_card_payment_method_data( 'pm_new_beyond_cap' );
+
+		$mock_http = $this->mock_stripe_payment_methods_http_response(
+			[
+				'data'     => $stripe_payment_methods,
+				'has_more' => false,
+			]
+		);
+		add_filter( 'pre_http_request', $mock_http, 10, 3 );
+
+		$mock_cc_pm = $this->getMockBuilder( WC_Stripe_UPE_Payment_Method_CC::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'is_enabled', 'is_enabled_at_checkout' ] )
+			->getMock();
+		$mock_cc_pm->method( 'is_enabled' )->willReturn( true );
+		$mock_cc_pm->method( 'is_enabled_at_checkout' )->willReturn( true );
+
+		$mock_gateway = $this->get_mock_gateway( false );
+		$mock_gateway->payment_methods[ WC_Stripe_Payment_Methods::CARD ] = $mock_cc_pm;
+		$this->set_main_gateway( $mock_gateway );
+
+		try {
+			$result = $this->stripe_payment_tokens->woocommerce_get_customer_payment_tokens( $tokens, $user_id, WC_Stripe_UPE_Payment_Gateway::ID );
+		} finally {
+			remove_filter( 'pre_http_request', $mock_http, 10 );
+		}
+
+		$result_token_ids = array_map( fn( $token ) => $token->get_token(), $result );
+		$this->assertNotContains( 'pm_stale_at_limit', $result_token_ids, 'A stale token must be removed even at the token cap.' );
+		$this->assertNotContains( 'pm_new_beyond_cap', $result_token_ids, 'New Stripe payment methods must not be added at the token cap.' );
+		$this->assertCount( $limit - 1, $result );
+
+		$db_token_ids = array_map(
+			fn( $token ) => $token->get_token(),
+			WC_Payment_Tokens::get_tokens(
+				[
+					'user_id'    => $user_id,
+					'gateway_id' => WC_Stripe_UPE_Payment_Gateway::ID,
+				]
+			)
+		);
+		$this->assertNotContains( 'pm_stale_at_limit', $db_token_ids );
+		$this->assertNotContains( 'pm_new_beyond_cap', $db_token_ids );
+	}
+
+	/**
+	 * Creates and saves a card token for a user under the main Stripe gateway.
+	 *
+	 * @param int    $user_id The user ID.
+	 * @param string $pm_id   The Stripe payment method ID.
+	 * @return WC_Stripe_Payment_Token_CC
+	 */
+	private function create_saved_cc_token( int $user_id, string $pm_id ): WC_Stripe_Payment_Token_CC {
+		$token = new WC_Stripe_Payment_Token_CC();
+		$token->set_token( $pm_id );
+		$token->set_gateway_id( WC_Stripe_UPE_Payment_Gateway::ID );
+		$token->set_card_type( 'visa' );
+		$token->set_last4( '4242' );
+		$token->set_expiry_month( 4 );
+		$token->set_expiry_year( 2050 );
+		$token->set_fingerprint( 'fingerprint_' . $pm_id );
+		$token->set_user_id( $user_id );
+		$token->save();
+		return $token;
+	}
+
+	/**
+	 * Returns Stripe API response data for a card payment method.
+	 *
+	 * @param string $pm_id The Stripe payment method ID.
+	 * @return array
+	 */
+	private function get_stripe_card_payment_method_data( string $pm_id ): array {
+		return [
+			'id'   => $pm_id,
+			'type' => WC_Stripe_Payment_Methods::CARD,
+			'card' => [
+				'brand'       => 'visa',
+				'exp_month'   => 4,
+				'exp_year'    => 2050,
+				'last4'       => '4242',
+				'fingerprint' => 'fingerprint_' . $pm_id,
+			],
+		];
+	}
+
+	/**
+	 * Builds a pre_http_request callback that intercepts Stripe payment_methods requests.
+	 *
+	 * @param array $body        The decoded response body to return.
+	 * @param int   $status_code The HTTP status code to return.
+	 * @return callable
+	 */
+	private function mock_stripe_payment_methods_http_response( array $body, int $status_code = 200 ): callable {
+		return function ( $preempt, $request_args, $url ) use ( $body, $status_code ) {
+			if ( false === strpos( $url, 'payment_methods' ) ) {
+				return $preempt;
+			}
+			return [
+				'headers'  => [],
+				'body'     => wp_json_encode( $body ),
+				'response' => [
+					'code'    => $status_code,
+					'message' => 'OK',
+				],
+			];
+		};
 	}
 
 	/**


### PR DESCRIPTION
Fixes STRIPE-882

## Changes proposed in this Pull Request:

When a customer's Stripe customer object is deleted (or their stored `_stripe_customer_id` is gone), their locally saved payment tokens become unusable, but they could still be displayed at checkout as if they were valid. The token sync (`WC_Stripe_Payment_Tokens::sync_and_retrieve_customer_payment_tokens()`) already reconciles local tokens against Stripe and cleans up stale ones, so for most customers this resolves itself on the first checkout or account view. Two gaps remained, and this PR closes both at the reconciliation layer rather than adding a per-render Stripe call to the display layer (the approach explored and closed in #5590):

1. **Customers at the token cap were never reconciled.** With `posts_per_page` (default 10) or more saved tokens, the sync returned early and skipped verification entirely, so stale cards stayed visible and selectable indefinitely. The cap exists only because the token data store is unpaginated, so it should only prevent *adding* tokens beyond that window. Verification and cleanup of the retrieved tokens now always run; adding new tokens is still skipped at the cap.

2. **A transient Stripe API error could wipe valid tokens.** `WC_Stripe_Customer::get_all_payment_methods()` returned an empty array for both "this customer does not exist" and "the API request failed", and the sync treats an empty list as proof that every local token is stale. A rate limit or auth error at the wrong moment would therefore delete all of a customer's valid saved tokens. The method now accepts an opt-in `$throw_on_error` parameter: a missing customer still returns (and caches) an empty list, which is the authoritative cleanup signal, while generic errors throw so the sync bails out and keeps the local tokens. This becomes more important now that reconciliation also runs for at-cap customers.

Since the sync runs on the `woocommerce_get_customer_payment_tokens` filter, the fix covers every surface that lists saved methods (classic checkout, Blocks checkout, optimized checkout, and My Account), unlike a display-layer check on one gateway hook.

Also guards the error-notice call in the sync's catch block behind a session check: the filter also runs in admin/REST/CLI contexts, where no shopper would see the notice.

**Backward compatibility:** the new `get_all_payment_methods()` parameter is optional and defaults to the existing behavior, so external callers are unaffected. No hooks were added, removed, or re-ordered. The behavior change for at-cap customers is that stale tokens are now deleted (the same cleanup that already applied below the cap); token deletion in this path deliberately skips detaching the payment method from Stripe, as before. Settings and tokens are site-scoped; no multisite behavior changes (not tested under multisite).

## Testing instructions

1. In test mode, as a logged-in customer, save a card at checkout (check "Save payment information to my account").
2. In the Stripe dashboard (test mode), delete that customer object (Customers > select the customer > Actions > Delete).
3. On the store, clear the cached payment methods, e.g. with WP-CLI: `wp transient delete --all` (or wait for the 1-day cache to expire).
4. Visit checkout again as that customer: the saved card must no longer be offered, and the new-card fields must show. The stale token is also gone from My Account > Payment methods.
5. Repeat steps 1–4 with 10 saved cards (save 10 different test cards, e.g. 4242424242424242, 4000056655665556, 5555555555554444, ...). Before this PR the 10 stale cards remained visible; now they are removed as well.
6. Regression check: with a valid customer and saved cards, confirm the cards still display and are usable on classic checkout and Blocks checkout, and that deleting a card from My Account > Payment methods still works.

The transient-API-error path (tokens are kept when Stripe returns e.g. a rate-limit error) is covered by unit tests, as it is impractical to reproduce manually.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply): server-side token reconciliation, does not apply.

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

Added changelog entries to `changelog.txt` and `readme.txt`.

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

> *Drafted with AI; reviewed by me.*

