### PR TITLE
Recreate the Checkout Session when the shopper's login state changes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,7 +23,7 @@ xxxx-xx-xx - version 11.0.0
 * Dev - Make GITHUB_TOKEN optional for the local E2E Docker setup by falling back to the GitHub CLI and then to plugin zips placed in tests/e2e/deps
 * Fix - Reload the plugin's payment method settings when refreshing account details, so the settings screen no longer keeps showing stale values
 * Update - Fetch express checkout AJAX nonces on demand instead of embedding them in every page
-* Fix - Recreate the Adaptive Pricing Checkout Session when a shopper logs in or out mid-checkout, so card payments with "Save payment method" no longer fail after a guest logs in
+* Fix - Recreate the Adaptive Pricing Checkout Session when a shopper logs in or out mid-checkout, so payment methods can be saved correctly
 * Fix - Keep the wallet billing and shipping addresses on express checkout orders when the address normalization request returns an unusable response
 * Fix - Render the Adaptive Pricing payment element in the store's Stripe locale
 * Fix - Stop sending Level 3 data when paying with a non-card payment method through express checkout (e.g. Amazon Pay), which Stripe rejects and can disable Level 3 data for card payments

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ xxxx-xx-xx - version 11.0.0
 * Dev - Make GITHUB_TOKEN optional for the local E2E Docker setup by falling back to the GitHub CLI and then to plugin zips placed in tests/e2e/deps
 * Fix - Reload the plugin's payment method settings when refreshing account details, so the settings screen no longer keeps showing stale values
 * Update - Fetch express checkout AJAX nonces on demand instead of embedding them in every page
+* Fix - Recreate the Adaptive Pricing Checkout Session when a shopper logs in or out mid-checkout, so card payments with "Save payment method" no longer fail after a guest logs in
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/client/blocks/checkout-sessions/__tests__/hooks.test.js
+++ b/client/blocks/checkout-sessions/__tests__/hooks.test.js
@@ -647,10 +647,9 @@ describe( 'CheckoutSessions hook tests', () => {
 				shippingData
 			);
 			await onCheckoutSuccessResultPromise;
-			expect( confirm ).toHaveBeenCalledWith(
-				expect.not.objectContaining( {
-					savePaymentMethod: expect.anything(),
-				} )
+			expect( confirm ).toHaveBeenCalledTimes( 1 );
+			expect( confirm.mock.calls[ 0 ][ 0 ] ).not.toHaveProperty(
+				'savePaymentMethod'
 			);
 		} );
 	} );

--- a/client/blocks/checkout-sessions/__tests__/hooks.test.js
+++ b/client/blocks/checkout-sessions/__tests__/hooks.test.js
@@ -624,6 +624,35 @@ describe( 'CheckoutSessions hook tests', () => {
 				} )
 			);
 		} );
+
+		it( 'omits savePaymentMethod when the session does not support saving, even with the checkbox checked', async () => {
+			document.body.innerHTML = `
+				<div class="wc-block-components-payment-methods__save-card-info">
+					<input type="checkbox" checked />
+				</div>
+			`;
+			const confirm = jest.fn().mockResolvedValue( {
+				type: 'success',
+			} );
+			const checkoutState = {
+				type: 'success',
+				checkout: { email: '', confirm },
+			};
+			useCheckoutSuccessHandler(
+				checkoutState,
+				onCheckoutSuccess,
+				billing,
+				false,
+				false,
+				shippingData
+			);
+			await onCheckoutSuccessResultPromise;
+			expect( confirm ).toHaveBeenCalledWith(
+				expect.not.objectContaining( {
+					savePaymentMethod: expect.anything(),
+				} )
+			);
+		} );
 	} );
 
 	describe( 'usePaymentFailHandler hook', () => {

--- a/client/blocks/checkout-sessions/checkout-form.js
+++ b/client/blocks/checkout-sessions/checkout-form.js
@@ -32,7 +32,6 @@ import {
  * @param {string}                 props.errorMessage                Error message to display if loading the checkout session fails.
  * @param {EventRegistrationProps} props.eventRegistration           Object containing event registration functions for payment setup, checkout success, and checkout failure.
  * @param {Object}                 props.billing                     Billing information for the checkout session.
- * @param {boolean}                props.isLoggedIn                  Whether the customer is logged-in.
  * @param {boolean}                props.isPayerPhoneRequired        Whether the payer phone information is required.
  * @param {Object}                 props.shippingData                Shipping information for the checkout session.
  * @param {Object}                 props.cartData                    Cart data containing Store API extensions.
@@ -47,7 +46,6 @@ const CheckoutForm = ( {
 	errorMessage,
 	eventRegistration: { onPaymentSetup, onCheckoutSuccess, onCheckoutFail },
 	billing,
-	isLoggedIn,
 	isPayerPhoneRequired,
 	shippingData,
 	cartData,
@@ -89,7 +87,7 @@ const CheckoutForm = ( {
 		checkoutState,
 		onCheckoutSuccess,
 		billing,
-		isLoggedIn,
+		!! checkoutSessionData?.save_payment_method_enabled,
 		isPayerPhoneRequired,
 		shippingData
 	);

--- a/client/blocks/checkout-sessions/hooks.js
+++ b/client/blocks/checkout-sessions/hooks.js
@@ -143,18 +143,18 @@ export const usePaymentSetupHandler = (
 /**
  * Handles the Block Checkout onCheckoutSuccess event for the Checkout Sessions integration.
  *
- * @param {*}       checkoutState        The checkout state.
- * @param {*}       onCheckoutSuccess    The onCheckoutSuccess event.
- * @param {Object}  billing              The billing data from WooCommerce Blocks, containing billingAddress.
- * @param {boolean} isLoggedIn           Whether the customer is logged-in.
- * @param {boolean} isPayerPhoneRequired Whether the payer phone information is required.
- * @param {Object}  shippingData         The shipping data from WooCommerce Blocks, containing shippingAddress.
+ * @param {*}       checkoutState            The checkout state.
+ * @param {*}       onCheckoutSuccess        The onCheckoutSuccess event.
+ * @param {Object}  billing                  The billing data from WooCommerce Blocks, containing billingAddress.
+ * @param {boolean} savePaymentMethodEnabled Whether the Checkout Session was created with payment method saving enabled.
+ * @param {boolean} isPayerPhoneRequired     Whether the payer phone information is required.
+ * @param {Object}  shippingData             The shipping data from WooCommerce Blocks, containing shippingAddress.
  */
 export const useCheckoutSuccessHandler = (
 	checkoutState,
 	onCheckoutSuccess,
 	billing,
-	isLoggedIn,
+	savePaymentMethodEnabled,
 	isPayerPhoneRequired,
 	shippingData
 ) => {
@@ -196,7 +196,9 @@ export const useCheckoutSuccessHandler = (
 						redirect: 'if_required',
 					};
 
-					if ( isLoggedIn ) {
+					// Stripe rejects savePaymentMethod when the session was created
+					// without save support (e.g. as a guest).
+					if ( savePaymentMethodEnabled ) {
 						confirmArgs.savePaymentMethod =
 							isSavePaymentMethodCheckboxChecked();
 					}
@@ -285,7 +287,7 @@ export const useCheckoutSuccessHandler = (
 			onCheckoutSuccess,
 			checkoutState,
 			billing,
-			isLoggedIn,
+			savePaymentMethodEnabled,
 			isPayerPhoneRequired,
 			shippingData,
 		]

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
@@ -244,7 +244,6 @@ const PaymentElements = ( {
 		containerComponent = (
 			<CheckoutContainer
 				api={ api }
-				isLoggedIn={ stripeServerData?.isLoggedIn }
 				isPayerPhoneRequired={ stripeServerData?.isPayerPhoneRequired }
 				setPaymentProcessorLoadErrorMessage={
 					setPaymentProcessorLoadErrorMessage

--- a/client/classic/upe/__tests__/payment-processing.test.js
+++ b/client/classic/upe/__tests__/payment-processing.test.js
@@ -942,7 +942,7 @@ describe( 'payment-processing', () => {
 				} );
 			} );
 
-			it( 'passes savePaymentMethod true when logged in and the save card checkbox is checked', async () => {
+			it( 'passes savePaymentMethod true when the session supports saving and the save card checkbox is checked', async () => {
 				const orderReceivedUrl =
 					'https://shop.com/checkout/order-received/123/';
 				const mockActions = {
@@ -964,10 +964,8 @@ describe( 'payment-processing', () => {
 					actions: mockActions,
 				} );
 
-				stripeUtils.getStripeServerData.mockReturnValue( {
-					...BASE_SERVER_DATA,
-					isAdaptivePricingEnabled: true,
-					isLoggedIn: true,
+				setNativeCheckoutSessionData( {
+					save_payment_method_enabled: true,
 				} );
 
 				const form = createMockForm( {
@@ -983,7 +981,7 @@ describe( 'payment-processing', () => {
 				} );
 			} );
 
-			it( 'does not pass savePaymentMethod for guests even when the save card checkbox is checked', async () => {
+			it( 'does not pass savePaymentMethod when the session does not support saving, even when logged in with the save card checkbox checked', async () => {
 				const orderReceivedUrl =
 					'https://shop.com/checkout/order-received/123/';
 				const mockActions = {
@@ -1005,10 +1003,14 @@ describe( 'payment-processing', () => {
 					actions: mockActions,
 				} );
 
+				// A guest-created session reused after login.
 				stripeUtils.getStripeServerData.mockReturnValue( {
 					...BASE_SERVER_DATA,
 					isAdaptivePricingEnabled: true,
-					isLoggedIn: false,
+					isLoggedIn: true,
+				} );
+				setNativeCheckoutSessionData( {
+					save_payment_method_enabled: false,
 				} );
 
 				const form = createMockForm( {

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -1309,7 +1309,12 @@ export const processPayment = (
 					redirect: 'if_required',
 				};
 
-				if ( getStripeServerData()?.isLoggedIn ) {
+				// Stripe rejects savePaymentMethod when the session was created
+				// without save support (e.g. as a guest), so gate on the session,
+				// not the login state.
+				if (
+					getNativeCheckoutSessionData()?.save_payment_method_enabled
+				) {
 					confirmArgs.savePaymentMethod = jQueryForm
 						.find( '#wc-stripe-new-payment-method' )
 						.is( ':checked' );

--- a/includes/class-wc-stripe-checkout-session-lifecycle.php
+++ b/includes/class-wc-stripe-checkout-session-lifecycle.php
@@ -128,29 +128,34 @@ class WC_Stripe_Checkout_Session_Lifecycle {
 	 */
 	public static function get_store_api_schema(): array {
 		return [
-			'session_id'    => [
+			'session_id'                  => [
 				'description' => __( 'Stripe Checkout Session ID.', 'woocommerce-gateway-stripe' ),
 				'type'        => 'string',
 				'readonly'    => true,
 			],
-			'client_secret' => [
+			'client_secret'               => [
 				'description' => __( 'Stripe Checkout Session client secret.', 'woocommerce-gateway-stripe' ),
 				'type'        => 'string',
 				'readonly'    => true,
 			],
-			'revision'      => [
+			'revision'                    => [
 				'description' => __( 'Checkout Session revision token.', 'woocommerce-gateway-stripe' ),
 				'type'        => 'string',
 				'readonly'    => true,
 			],
-			'status'        => [
+			'status'                      => [
 				'description' => __( 'Checkout Session synchronization status.', 'woocommerce-gateway-stripe' ),
 				'type'        => 'string',
 				'readonly'    => true,
 			],
-			'message'       => [
+			'message'                     => [
 				'description' => __( 'Checkout Session synchronization message.', 'woocommerce-gateway-stripe' ),
 				'type'        => 'string',
+				'readonly'    => true,
+			],
+			'save_payment_method_enabled' => [
+				'description' => __( 'Whether the Checkout Session was created with payment method saving enabled.', 'woocommerce-gateway-stripe' ),
+				'type'        => 'boolean',
 				'readonly'    => true,
 			],
 		];

--- a/includes/class-wc-stripe-checkout-session-manager.php
+++ b/includes/class-wc-stripe-checkout-session-manager.php
@@ -79,7 +79,8 @@ class WC_Stripe_Checkout_Session_Manager {
 			$request['phone_number_collection'] = [ 'enabled' => 'true' ];
 		}
 
-		if ( is_user_logged_in() && WC()->customer instanceof WC_Customer ) {
+		$save_payment_method_enabled = $this->can_enable_save_payment_method();
+		if ( $save_payment_method_enabled ) {
 			try {
 				// Creation happens before checkout fields are complete, so only the saved account identity can be used here.
 				$stripe_customer = new WC_Stripe_Customer( WC()->customer->get_id() );
@@ -119,11 +120,12 @@ class WC_Stripe_Checkout_Session_Manager {
 		// the source of truth for the amount and currency. That code controls the data sent
 		// to Stripe and is used to validate amounts later.
 		$record = [
-			'session_id'    => (string) $checkout_session->id,
-			'client_secret' => (string) $checkout_session->client_secret,
-			'revision'      => $this->generate_revision_token(),
-			'status'        => 'success',
-			'message'       => '',
+			'session_id'                  => (string) $checkout_session->id,
+			'client_secret'               => (string) $checkout_session->client_secret,
+			'revision'                    => $this->generate_revision_token(),
+			'status'                      => 'success',
+			'message'                     => '',
+			'save_payment_method_enabled' => $save_payment_method_enabled,
 		];
 		$this->set_record( $record );
 
@@ -203,6 +205,12 @@ class WC_Stripe_Checkout_Session_Manager {
 			return $this->create_session();
 		}
 
+		// Stripe cannot add or remove saved_payment_method_options after creation, so a
+		// login-state change (e.g. a migrated guest session) requires a new session.
+		if ( ! empty( $record['save_payment_method_enabled'] ) !== $this->can_enable_save_payment_method() ) {
+			return $this->create_session();
+		}
+
 		// The context is the source of truth for amount and currency, so we need to compare
 		// against the data that was pushed to Stripe.
 		if (
@@ -238,6 +246,16 @@ class WC_Stripe_Checkout_Session_Manager {
 		$this->set_record( $record );
 
 		return $this->get_public_data( $record );
+	}
+
+	/**
+	 * Whether create_session() would attach a customer and saved_payment_method_options
+	 * for the current request.
+	 *
+	 * @return bool
+	 */
+	private function can_enable_save_payment_method(): bool {
+		return is_user_logged_in() && WC()->customer instanceof WC_Customer;
 	}
 
 	/**
@@ -354,11 +372,12 @@ class WC_Stripe_Checkout_Session_Manager {
 	 */
 	private function get_public_data( ?array $record ): array {
 		return [
-			'session_id'    => (string) ( $record['session_id'] ?? '' ),
-			'client_secret' => (string) ( $record['client_secret'] ?? '' ),
-			'revision'      => (string) ( $record['revision'] ?? '' ),
-			'status'        => (string) ( $record['status'] ?? 'uninitialized' ),
-			'message'       => (string) ( $record['message'] ?? '' ),
+			'session_id'                  => (string) ( $record['session_id'] ?? '' ),
+			'client_secret'               => (string) ( $record['client_secret'] ?? '' ),
+			'revision'                    => (string) ( $record['revision'] ?? '' ),
+			'status'                      => (string) ( $record['status'] ?? 'uninitialized' ),
+			'message'                     => (string) ( $record['message'] ?? '' ),
+			'save_payment_method_enabled' => ! empty( $record['save_payment_method_enabled'] ),
 		];
 	}
 }

--- a/includes/class-wc-stripe-checkout-session-manager.php
+++ b/includes/class-wc-stripe-checkout-session-manager.php
@@ -207,7 +207,16 @@ class WC_Stripe_Checkout_Session_Manager {
 
 		// Stripe cannot add or remove saved_payment_method_options after creation, so a
 		// login-state change (e.g. a migrated guest session) requires a new session.
-		if ( ! empty( $record['save_payment_method_enabled'] ) !== $this->can_enable_save_payment_method() ) {
+		$can_save_payment_method = $this->can_enable_save_payment_method();
+		if ( ! empty( $record['save_payment_method_enabled'] ) !== $can_save_payment_method ) {
+			WC_Stripe_Logger::info(
+				'Recreating the Checkout Session after a login-state change.',
+				[
+					'checkout_session_id'         => (string) $record['session_id'],
+					'save_payment_method_enabled' => $can_save_payment_method,
+				]
+			);
+
 			return $this->create_session();
 		}
 

--- a/includes/class-wc-stripe-checkout-session-manager.php
+++ b/includes/class-wc-stripe-checkout-session-manager.php
@@ -249,8 +249,9 @@ class WC_Stripe_Checkout_Session_Manager {
 	}
 
 	/**
-	 * Whether create_session() would attach a customer and saved_payment_method_options
-	 * for the current request.
+	 * Will a newly created session allow a saved payment method to be created.
+	 * This is only available for a logged-in user with an existing WC_Customer definition
+	 * at the start of a session.
 	 *
 	 * @return bool
 	 */

--- a/readme.txt
+++ b/readme.txt
@@ -177,5 +177,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Make GITHUB_TOKEN optional for the local E2E Docker setup by falling back to the GitHub CLI and then to plugin zips placed in tests/e2e/deps
 * Fix - Reload the plugin's payment method settings when refreshing account details, so the settings screen no longer keeps showing stale values
 * Update - Fetch express checkout AJAX nonces on demand instead of embedding them in every page
+* Fix - Recreate the Adaptive Pricing Checkout Session when a shopper logs in or out mid-checkout, so card payments with "Save payment method" no longer fail after a guest logs in
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -184,7 +184,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Make GITHUB_TOKEN optional for the local E2E Docker setup by falling back to the GitHub CLI and then to plugin zips placed in tests/e2e/deps
 * Fix - Reload the plugin's payment method settings when refreshing account details, so the settings screen no longer keeps showing stale values
 * Update - Fetch express checkout AJAX nonces on demand instead of embedding them in every page
-* Fix - Recreate the Adaptive Pricing Checkout Session when a shopper logs in or out mid-checkout, so card payments with "Save payment method" no longer fail after a guest logs in
+* Fix - Recreate the Adaptive Pricing Checkout Session when a shopper logs in or out mid-checkout, so payment methods can be saved correctly
 * Fix - Keep the wallet billing and shipping addresses on express checkout orders when the address normalization request returns an unusable response
 * Fix - Render the Adaptive Pricing payment element in the store's Stripe locale
 * Fix - Stop sending Level 3 data when paying with a non-card payment method through express checkout (e.g. Amazon Pay), which Stripe rejects and can disable Level 3 data for card payments

--- a/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
+++ b/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
@@ -305,14 +305,22 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A guest-created session cannot accept savePaymentMethod, so a login must recreate it
-	 * rather than reuse the migrated guest one.
+	 * Run synchronize() across a login-state transition with the Stripe API mocked.
+	 *
+	 * Synchronizes once in the starting state, flips the login state (using a
+	 * freshly created user), then synchronizes twice more to cover both the
+	 * recreation and the subsequent reuse of the new session.
+	 *
+	 * @param bool   $start_logged_in Whether the first synchronization happens while logged in.
+	 * @param string $prefix          Fixture prefix for the mocked Stripe identifiers.
+	 * @return array The three synchronize() results, the captured create requests, and the create count.
 	 */
-	public function test_synchronize_recreates_session_when_guest_logs_in(): void {
+	private function run_synchronize_login_transition( bool $start_logged_in, string $prefix ): array {
 		$product = WC_Helper_Product::create_simple_product( true, [ 'regular_price' => 42 ] );
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
 		WC()->cart->calculate_totals();
 
+		$user_id           = self::factory()->user->create();
 		$create_count      = 0;
 		$captured_creates  = [];
 		$original_customer = WC()->customer;
@@ -322,12 +330,12 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 			}
 			return $request;
 		};
-		$mock_request      = static function ( $return_value, $parsed_args, $url ) use ( &$create_count ) {
+		$mock_request      = static function ( $return_value, $parsed_args, $url ) use ( &$create_count, $prefix ) {
 			if ( false !== strpos( $url, '/v1/customers' ) ) {
 				return [
 					'response' => 200,
 					'headers'  => [ 'Content-Type' => 'application/json' ],
-					'body'     => wp_json_encode( (object) [ 'id' => 'cus_login_transition' ] ),
+					'body'     => wp_json_encode( (object) [ 'id' => "cus_{$prefix}" ] ),
 				];
 			}
 
@@ -341,32 +349,54 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 				'headers'  => [ 'Content-Type' => 'application/json' ],
 				'body'     => wp_json_encode(
 					(object) [
-						'id'            => "cs_test_login_transition_$create_count",
-						'client_secret' => "cs_test_login_transition_secret_$create_count",
+						'id'            => "cs_test_{$prefix}_{$create_count}",
+						'client_secret' => "cs_test_{$prefix}_secret_{$create_count}",
 					]
 				),
 			];
 		};
+
+		$log_in  = static function () use ( $user_id ) {
+			wp_set_current_user( $user_id );
+			WC()->customer = new WC_Customer( $user_id );
+		};
+		$log_out = static function () use ( $original_customer ) {
+			wp_set_current_user( 0 );
+			WC()->customer = $original_customer;
+		};
+
 		add_filter( 'wc_stripe_request_body', $capture_body, 10, 2 );
 		add_filter( 'pre_http_request', $mock_request, 10, 3 );
 
 		try {
-			$manager  = new WC_Stripe_Checkout_Session_Manager();
-			$as_guest = $manager->synchronize();
+			$start_logged_in ? $log_in() : $log_out();
 
-			wp_set_current_user( 1 );
-			WC()->customer = new WC_Customer( 1 );
+			$manager = new WC_Stripe_Checkout_Session_Manager();
+			$before  = $manager->synchronize();
 
-			$after_login  = $manager->synchronize();
+			$start_logged_in ? $log_out() : $log_in();
+
+			$after        = $manager->synchronize();
 			$still_reused = $manager->synchronize();
 		} finally {
 			remove_filter( 'wc_stripe_request_body', $capture_body, 10 );
 			remove_filter( 'pre_http_request', $mock_request, 10 );
 			wp_set_current_user( 0 );
 			WC()->customer = $original_customer;
-			WC_Stripe_Checkout_Session_Context::delete_context( 'cs_test_login_transition_1' );
-			WC_Stripe_Checkout_Session_Context::delete_context( 'cs_test_login_transition_2' );
+			WC_Stripe_Checkout_Session_Context::delete_context( "cs_test_{$prefix}_1" );
+			WC_Stripe_Checkout_Session_Context::delete_context( "cs_test_{$prefix}_2" );
 		}
+
+		return [ $before, $after, $still_reused, $captured_creates, $create_count ];
+	}
+
+	/**
+	 * A guest-created session cannot accept savePaymentMethod, so a login must recreate it
+	 * rather than reuse the migrated guest one.
+	 */
+	public function test_synchronize_recreates_session_when_guest_logs_in(): void {
+		[ $as_guest, $after_login, $still_reused, $captured_creates, $create_count ] =
+			$this->run_synchronize_login_transition( false, 'login_transition' );
 
 		$this->assertSame( 2, $create_count, 'The login must trigger exactly one session recreation.' );
 		$this->assertCount( 2, $captured_creates );
@@ -387,66 +417,8 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 	 * The inverse transition: logging out must also recreate the session.
 	 */
 	public function test_synchronize_recreates_session_when_user_logs_out(): void {
-		$product = WC_Helper_Product::create_simple_product( true, [ 'regular_price' => 42 ] );
-		WC()->cart->add_to_cart( $product->get_id(), 1 );
-		WC()->cart->calculate_totals();
-
-		$create_count      = 0;
-		$captured_creates  = [];
-		$original_customer = WC()->customer;
-		$capture_body      = static function ( $request, $api ) use ( &$captured_creates ) {
-			if ( 'checkout/sessions' === $api ) {
-				$captured_creates[] = $request;
-			}
-			return $request;
-		};
-		$mock_request      = static function ( $return_value, $parsed_args, $url ) use ( &$create_count ) {
-			if ( false !== strpos( $url, '/v1/customers' ) ) {
-				return [
-					'response' => 200,
-					'headers'  => [ 'Content-Type' => 'application/json' ],
-					'body'     => wp_json_encode( (object) [ 'id' => 'cus_logout_transition' ] ),
-				];
-			}
-
-			if ( 'https://api.stripe.com/v1/checkout/sessions' !== $url ) {
-				return $return_value;
-			}
-
-			++$create_count;
-			return [
-				'response' => 200,
-				'headers'  => [ 'Content-Type' => 'application/json' ],
-				'body'     => wp_json_encode(
-					(object) [
-						'id'            => "cs_test_logout_transition_$create_count",
-						'client_secret' => "cs_test_logout_transition_secret_$create_count",
-					]
-				),
-			];
-		};
-		add_filter( 'wc_stripe_request_body', $capture_body, 10, 2 );
-		add_filter( 'pre_http_request', $mock_request, 10, 3 );
-
-		try {
-			wp_set_current_user( 1 );
-			WC()->customer = new WC_Customer( 1 );
-
-			$manager         = new WC_Stripe_Checkout_Session_Manager();
-			$while_logged_in = $manager->synchronize();
-
-			wp_set_current_user( 0 );
-			WC()->customer = $original_customer;
-
-			$after_logout = $manager->synchronize();
-		} finally {
-			remove_filter( 'wc_stripe_request_body', $capture_body, 10 );
-			remove_filter( 'pre_http_request', $mock_request, 10 );
-			wp_set_current_user( 0 );
-			WC()->customer = $original_customer;
-			WC_Stripe_Checkout_Session_Context::delete_context( 'cs_test_logout_transition_1' );
-			WC_Stripe_Checkout_Session_Context::delete_context( 'cs_test_logout_transition_2' );
-		}
+		[ $while_logged_in, $after_logout, $still_reused, $captured_creates, $create_count ] =
+			$this->run_synchronize_login_transition( true, 'logout_transition' );
 
 		$this->assertSame( 2, $create_count, 'The logout must trigger exactly one session recreation.' );
 		$this->assertTrue( $while_logged_in['save_payment_method_enabled'] );
@@ -454,6 +426,8 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'customer', $captured_creates[1] );
 		$this->assertSame( 'cs_test_logout_transition_2', $after_logout['session_id'] );
 		$this->assertFalse( $after_logout['save_payment_method_enabled'] );
+
+		$this->assertSame( $after_logout, $still_reused, 'An unchanged logged-out state must keep reusing the recreated session.' );
 	}
 
 	/**

--- a/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
+++ b/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
@@ -305,6 +305,158 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A guest-created session cannot accept savePaymentMethod, so a login must recreate it
+	 * rather than reuse the migrated guest one.
+	 */
+	public function test_synchronize_recreates_session_when_guest_logs_in(): void {
+		$product = WC_Helper_Product::create_simple_product( true, [ 'regular_price' => 42 ] );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		$create_count      = 0;
+		$captured_creates  = [];
+		$original_customer = WC()->customer;
+		$capture_body      = static function ( $request, $api ) use ( &$captured_creates ) {
+			if ( 'checkout/sessions' === $api ) {
+				$captured_creates[] = $request;
+			}
+			return $request;
+		};
+		$mock_request      = static function ( $return_value, $parsed_args, $url ) use ( &$create_count ) {
+			if ( false !== strpos( $url, '/v1/customers' ) ) {
+				return [
+					'response' => 200,
+					'headers'  => [ 'Content-Type' => 'application/json' ],
+					'body'     => wp_json_encode( (object) [ 'id' => 'cus_login_transition' ] ),
+				];
+			}
+
+			if ( 'https://api.stripe.com/v1/checkout/sessions' !== $url ) {
+				return $return_value;
+			}
+
+			++$create_count;
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => wp_json_encode(
+					(object) [
+						'id'            => "cs_test_login_transition_$create_count",
+						'client_secret' => "cs_test_login_transition_secret_$create_count",
+					]
+				),
+			];
+		};
+		add_filter( 'wc_stripe_request_body', $capture_body, 10, 2 );
+		add_filter( 'pre_http_request', $mock_request, 10, 3 );
+
+		try {
+			$manager  = new WC_Stripe_Checkout_Session_Manager();
+			$as_guest = $manager->synchronize();
+
+			wp_set_current_user( 1 );
+			WC()->customer = new WC_Customer( 1 );
+
+			$after_login  = $manager->synchronize();
+			$still_reused = $manager->synchronize();
+		} finally {
+			remove_filter( 'wc_stripe_request_body', $capture_body, 10 );
+			remove_filter( 'pre_http_request', $mock_request, 10 );
+			wp_set_current_user( 0 );
+			WC()->customer = $original_customer;
+			WC_Stripe_Checkout_Session_Context::delete_context( 'cs_test_login_transition_1' );
+			WC_Stripe_Checkout_Session_Context::delete_context( 'cs_test_login_transition_2' );
+		}
+
+		$this->assertSame( 2, $create_count, 'The login must trigger exactly one session recreation.' );
+		$this->assertCount( 2, $captured_creates );
+
+		$this->assertArrayNotHasKey( 'saved_payment_method_options', $captured_creates[0] );
+		$this->assertArrayNotHasKey( 'customer', $captured_creates[0] );
+		$this->assertFalse( $as_guest['save_payment_method_enabled'] );
+
+		$this->assertSame( [ 'payment_method_save' => 'enabled' ], $captured_creates[1]['saved_payment_method_options'] );
+		$this->assertSame( 'cus_login_transition', $captured_creates[1]['customer'] );
+		$this->assertSame( 'cs_test_login_transition_2', $after_login['session_id'] );
+		$this->assertTrue( $after_login['save_payment_method_enabled'] );
+
+		$this->assertSame( $after_login, $still_reused, 'An unchanged login state must keep reusing the recreated session.' );
+	}
+
+	/**
+	 * The inverse transition: logging out must also recreate the session.
+	 */
+	public function test_synchronize_recreates_session_when_user_logs_out(): void {
+		$product = WC_Helper_Product::create_simple_product( true, [ 'regular_price' => 42 ] );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		$create_count      = 0;
+		$captured_creates  = [];
+		$original_customer = WC()->customer;
+		$capture_body      = static function ( $request, $api ) use ( &$captured_creates ) {
+			if ( 'checkout/sessions' === $api ) {
+				$captured_creates[] = $request;
+			}
+			return $request;
+		};
+		$mock_request      = static function ( $return_value, $parsed_args, $url ) use ( &$create_count ) {
+			if ( false !== strpos( $url, '/v1/customers' ) ) {
+				return [
+					'response' => 200,
+					'headers'  => [ 'Content-Type' => 'application/json' ],
+					'body'     => wp_json_encode( (object) [ 'id' => 'cus_logout_transition' ] ),
+				];
+			}
+
+			if ( 'https://api.stripe.com/v1/checkout/sessions' !== $url ) {
+				return $return_value;
+			}
+
+			++$create_count;
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => wp_json_encode(
+					(object) [
+						'id'            => "cs_test_logout_transition_$create_count",
+						'client_secret' => "cs_test_logout_transition_secret_$create_count",
+					]
+				),
+			];
+		};
+		add_filter( 'wc_stripe_request_body', $capture_body, 10, 2 );
+		add_filter( 'pre_http_request', $mock_request, 10, 3 );
+
+		try {
+			wp_set_current_user( 1 );
+			WC()->customer = new WC_Customer( 1 );
+
+			$manager         = new WC_Stripe_Checkout_Session_Manager();
+			$while_logged_in = $manager->synchronize();
+
+			wp_set_current_user( 0 );
+			WC()->customer = $original_customer;
+
+			$after_logout = $manager->synchronize();
+		} finally {
+			remove_filter( 'wc_stripe_request_body', $capture_body, 10 );
+			remove_filter( 'pre_http_request', $mock_request, 10 );
+			wp_set_current_user( 0 );
+			WC()->customer = $original_customer;
+			WC_Stripe_Checkout_Session_Context::delete_context( 'cs_test_logout_transition_1' );
+			WC_Stripe_Checkout_Session_Context::delete_context( 'cs_test_logout_transition_2' );
+		}
+
+		$this->assertSame( 2, $create_count, 'The logout must trigger exactly one session recreation.' );
+		$this->assertTrue( $while_logged_in['save_payment_method_enabled'] );
+		$this->assertArrayNotHasKey( 'saved_payment_method_options', $captured_creates[1] );
+		$this->assertArrayNotHasKey( 'customer', $captured_creates[1] );
+		$this->assertSame( 'cs_test_logout_transition_2', $after_logout['session_id'] );
+		$this->assertFalse( $after_logout['save_payment_method_enabled'] );
+	}
+
+	/**
 	 * Classic checkout refreshes arrive as wc-ajax requests against the home URL, so is_checkout()
 	 * is false. Eligibility must still resolve or the fragment never carries a usable session.
 	 */
@@ -384,7 +536,7 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 		$this->assertNotFalse( has_filter( 'woocommerce_update_order_review_fragments', [ $lifecycle, 'add_classic_fragment' ] ) );
 
 		$schema = WC_Stripe_Checkout_Session_Lifecycle::get_store_api_schema();
-		$this->assertSame( [ 'session_id', 'client_secret', 'revision', 'status', 'message' ], array_keys( $schema ) );
+		$this->assertSame( [ 'session_id', 'client_secret', 'revision', 'status', 'message', 'save_payment_method_enabled' ], array_keys( $schema ) );
 
 		remove_action( 'woocommerce_review_order_after_payment', [ $lifecycle, 'render_classic_placeholder' ] );
 		remove_filter( 'woocommerce_update_order_review_fragments', [ $lifecycle, 'add_classic_fragment' ], 20 );

--- a/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
+++ b/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
@@ -434,6 +434,7 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 			$this->run_synchronize_login_transition( true, 'logout_transition' );
 
 		$this->assertSame( 2, $create_count, 'The logout must trigger exactly one session recreation.' );
+		$this->assertCount( 2, $captured_creates );
 		$this->assertTrue( $while_logged_in['save_payment_method_enabled'] );
 		$this->assertArrayNotHasKey( 'saved_payment_method_options', $captured_creates[1] );
 		$this->assertArrayNotHasKey( 'customer', $captured_creates[1] );

--- a/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
+++ b/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
@@ -311,14 +311,19 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 	 * freshly created user), then synchronizes twice more to cover both the
 	 * recreation and the subsequent reuse of the new session.
 	 *
-	 * @param bool   $start_logged_in Whether the first synchronization happens while logged in.
-	 * @param string $prefix          Fixture prefix for the mocked Stripe identifiers.
+	 * @param bool          $start_logged_in Whether the first synchronization happens while logged in.
+	 * @param string        $prefix          Fixture prefix for the mocked Stripe identifiers.
+	 * @param callable|null $seed            Optional callback to seed a pre-existing record once the cart totals are known.
 	 * @return array The three synchronize() results, the captured create requests, and the create count.
 	 */
-	private function run_synchronize_login_transition( bool $start_logged_in, string $prefix ): array {
+	private function run_synchronize_login_transition( bool $start_logged_in, string $prefix, ?callable $seed = null ): array {
 		$product = WC_Helper_Product::create_simple_product( true, [ 'regular_price' => 42 ] );
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
 		WC()->cart->calculate_totals();
+
+		if ( null !== $seed ) {
+			$seed();
+		}
 
 		$user_id           = self::factory()->user->create();
 		$create_count      = 0;
@@ -428,6 +433,52 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 		$this->assertFalse( $after_logout['save_payment_method_enabled'] );
 
 		$this->assertSame( $after_logout, $still_reused, 'An unchanged logged-out state must keep reusing the recreated session.' );
+	}
+
+	/**
+	 * A record written before the save flag existed omits the key entirely. A guest must
+	 * keep reusing it, and a login must recreate it rather than reuse it in a state that
+	 * cannot save a payment method.
+	 */
+	public function test_synchronize_self_heals_legacy_record_without_save_flag(): void {
+		$seed = static function (): void {
+			WC()->session->set(
+				'wc_stripe_checkout_session',
+				[
+					'session_id'    => 'cs_test_legacy_record',
+					'client_secret' => 'cs_test_legacy_secret',
+					'revision'      => 'legacy-revision',
+					'status'        => 'success',
+					'message'       => '',
+				]
+			);
+
+			$currency = get_woocommerce_currency();
+			WC_Stripe_Checkout_Session_Context::set_context(
+				'cs_test_legacy_record',
+				[
+					'amount'   => WC_Stripe_Helper::get_stripe_amount( (float) WC()->cart->get_total( 'edit' ), $currency ),
+					'currency' => strtolower( $currency ),
+				]
+			);
+		};
+
+		try {
+			[ $as_guest, $after_login, $still_reused, $captured_creates, $create_count ] =
+				$this->run_synchronize_login_transition( false, 'legacy_heal', $seed );
+		} finally {
+			WC_Stripe_Checkout_Session_Context::delete_context( 'cs_test_legacy_record' );
+		}
+
+		$this->assertSame( 'cs_test_legacy_record', $as_guest['session_id'], 'A guest must keep reusing the legacy record.' );
+		$this->assertFalse( $as_guest['save_payment_method_enabled'] );
+
+		$this->assertSame( 1, $create_count, 'The login must recreate the legacy session exactly once.' );
+		$this->assertSame( [ 'payment_method_save' => 'enabled' ], $captured_creates[0]['saved_payment_method_options'] );
+		$this->assertSame( 'cs_test_legacy_heal_1', $after_login['session_id'] );
+		$this->assertTrue( $after_login['save_payment_method_enabled'] );
+
+		$this->assertSame( $after_login, $still_reused, 'An unchanged login state must keep reusing the recreated session.' );
 	}
 
 	/**

--- a/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
+++ b/tests/phpunit/class-wc-stripe-checkout-session-manager-test.php
@@ -374,12 +374,20 @@ class WC_Stripe_Checkout_Session_Manager_Test extends WP_UnitTestCase {
 		add_filter( 'pre_http_request', $mock_request, 10, 3 );
 
 		try {
-			$start_logged_in ? $log_in() : $log_out();
+			if ( $start_logged_in ) {
+				$log_in();
+			} else {
+				$log_out();
+			}
 
 			$manager = new WC_Stripe_Checkout_Session_Manager();
 			$before  = $manager->synchronize();
 
-			$start_logged_in ? $log_out() : $log_in();
+			if ( $start_logged_in ) {
+				$log_out();
+			} else {
+				$log_in();
+			}
 
 			$after        = $manager->synchronize();
 			$still_reused = $manager->synchronize();


### PR DESCRIPTION
Fixes STRIPE-1400
Fixes #5836

## Changes proposed in this Pull Request:

With Adaptive Pricing enabled, a Stripe Checkout Session created while the shopper is logged out is created without a `customer` and without `saved_payment_method_options`, and Stripe does not allow adding them after creation. When the shopper then logs in mid-checkout, the session's ownership is deliberately migrated with the WooCommerce session and `synchronize()` keeps reusing it as long as the cart amount and currency are unchanged. Meanwhile both confirm paths (classic and Blocks) sent `savePaymentMethod` based purely on `isLoggedIn`, so Stripe rejected the confirm with `savePaymentMethod cannot be used unless the Checkout Session was created with saved_payment_method_options[payment_method_save]=enabled` — and the shopper could not pay by card at all until the cart total changed.

Two complementary layers:

1. **Recreate on login-state change (the actual fix).** The session record now stores whether the session was created with payment method saving enabled, and `synchronize()` recreates the session whenever that no longer matches the current login state. This covers both directions (guest → logged in, logged in → guest) and restores the ability to actually save the card, since the recreated session carries the Stripe customer. Records persisted before this change lack the flag, so a logged-in shopper's first sync after updating recreates the session once — which also self-heals any store currently stuck in the broken state.
2. **Gate the client on session capability (defense in depth).** The session's public data (classic fragment + Store API extension) now includes `save_payment_method_enabled`, and both confirm paths gate `savePaymentMethod` on it instead of on `isLoggedIn`, so the parameter can never be sent to a session that cannot accept it.

**Backward compatibility impact:** additive only — a new `save_payment_method_enabled` boolean field on the classic `#wc-stripe-checkout-session-data` fragment payload and the `wc-stripe/checkout-session` Store API extension schema, and a new key in the session record stored in the WooCommerce session. No hooks, option keys, or PHP signatures changed; no existing fields were renamed, removed, or reordered. Session records written by previous versions are handled gracefully (missing flag reads as `false`, triggering at most one extra session creation for logged-in shoppers). Site-scoped state only; not tested under multisite, but no state crosses sites.

## Testing instructions

1. Enable the Optimized Checkout Element and Adaptive Pricing (requires an eligible account), disable Link, and enable saved cards. Use classic (shortcode) checkout.
2. As a logged-out guest, add a product to the cart and open the checkout page. A Checkout Session is created (visible in the Stripe dashboard as unpaid, with no customer).
3. Log in (or create an account) without changing the cart contents, and return to the checkout page.
4. Choose card, tick **Save payment method**, and place the order.
5. Before this change: checkout fails with the `savePaymentMethod cannot be used…` error and no payment is taken. After this change: a new Checkout Session is created on the post-login page load, the payment succeeds, and the card is saved to the account.
6. Repeat on Blocks checkout (steps 2–5).
7. Regression check while logged in throughout: place an order with the save box ticked (card saved) and unticked (card not saved), on both classic and Blocks checkout.

Automated coverage: new PHPUnit tests for `synchronize()` recreating the session on login and logout transitions (including the request payload with/without `saved_payment_method_options`), and Jest tests for both confirm paths verifying `savePaymentMethod` is gated on the session capability flag.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry added to `changelog.txt` and `readme.txt` in this PR:

> Fix - Recreate the Adaptive Pricing Checkout Session when a shopper logs in or out mid-checkout, so card payments with "Save payment method" no longer fail after a guest logs in

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
