### PR TITLE
Replace the empty stripe_locale in the blocks Stripe loader with locale

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ xxxx-xx-xx - version 11.0.0
 * Dev - Make GITHUB_TOKEN optional for the local E2E Docker setup by falling back to the GitHub CLI and then to plugin zips placed in tests/e2e/deps
 * Fix - Reload the plugin's payment method settings when refreshing account details, so the settings screen no longer keeps showing stale values
 * Update - Fetch express checkout AJAX nonces on demand instead of embedding them in every page
+* Fix - Render the Adaptive Pricing payment element in the store's Stripe locale
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/client/blocks/__tests__/load-stripe.test.js
+++ b/client/blocks/__tests__/load-stripe.test.js
@@ -7,7 +7,7 @@ jest.mock( '@stripe/stripe-js', () => ( {
 } ) );
 jest.mock( '../utils', () => ( {
 	getApiKey: jest.fn( () => 'pk_test_123' ),
-	getBlocksConfiguration: jest.fn( () => ( { stripe_locale: 'en' } ) ),
+	getBlocksConfiguration: jest.fn( () => ( { locale: 'en' } ) ),
 } ) );
 jest.mock( 'wcstripe/stripe-utils', () => ( {
 	getStripeDevWidgetOptions: jest.fn( () => ( {} ) ),

--- a/client/blocks/load-stripe.js
+++ b/client/blocks/load-stripe.js
@@ -12,7 +12,7 @@ const stripePromise = () =>
 
 			// Default to the 'auto' locale so Stripe chooses the browser's locale
 			// if the store's locale is not available.
-			const locale = getBlocksConfiguration()?.stripe_locale ?? 'auto';
+			const locale = getBlocksConfiguration()?.locale ?? 'auto';
 			resolve(
 				loadStripe( getApiKey(), {
 					locale,

--- a/readme.txt
+++ b/readme.txt
@@ -177,5 +177,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Make GITHUB_TOKEN optional for the local E2E Docker setup by falling back to the GitHub CLI and then to plugin zips placed in tests/e2e/deps
 * Fix - Reload the plugin's payment method settings when refreshing account details, so the settings screen no longer keeps showing stale values
 * Update - Fetch express checkout AJAX nonces on demand instead of embedding them in every page
+* Fix - Render the Adaptive Pricing payment element in the store's Stripe locale
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-<linear_issue_id>
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:

The Stripe loader used by the Cart and Checkout blocks read its locale from a config key that the blocks payload has never contained. The lookup silently fell through to `auto`, so Stripe picked the shopper’s browser locale instead of the store’s.

This reads the key that is actually there. The `auto` fallback is unchanged — the store locale still resolves to auto on its own when Stripe doesn’t support it.

The only visible change is the Adaptive Pricing payment element, which now renders in the store locale (if supported by Stripe, if it's not then the browser locale is used). The express checkout buttons are unaffected: they already pass their own locale when creating their Elements group.

## Testing instructions

1. Enable Adaptive Pricing and set the Checkout page to the Checkout block.
2. Set the site language to one Stripe supports (e.g. French) and keep your browser in English.
3. Open the checkout.
4. On develop: the payment element renders in English (browser locale).
5. With this PR: it renders in French (store locale).
6. Confirm the express checkout buttons are unchanged, and that a card payment still completes.
7. Set the site language to one Stripe does not support (e.g. Hindi) and reload — the payment element should fall back to the browser locale.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
