### PR TITLE
Keep express checkout addresses when normalization fails

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ xxxx-xx-xx - version 11.0.0
 * Dev - Make GITHUB_TOKEN optional for the local E2E Docker setup by falling back to the GitHub CLI and then to plugin zips placed in tests/e2e/deps
 * Fix - Reload the plugin's payment method settings when refreshing account details, so the settings screen no longer keeps showing stale values
 * Update - Fetch express checkout AJAX nonces on demand instead of embedding them in every page
+* Fix - Keep the wallet billing and shipping addresses on express checkout orders when the address normalization request returns an unusable response
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/client/express-checkout/__tests__/payment-flow.test.js
+++ b/client/express-checkout/__tests__/payment-flow.test.js
@@ -656,8 +656,22 @@ describe( 'address normalization', () => {
 				{ billing_address: '', shipping_address: null },
 			],
 			[
+				'addresses encoded as non-empty strings',
+				{
+					billing_address: 'invalid',
+					shipping_address: 'invalid',
+				},
+			],
+			[
 				'addresses encoded as empty PHP arrays',
 				{ billing_address: [], shipping_address: [] },
+			],
+			[
+				'addresses encoded as non-empty arrays',
+				{
+					billing_address: [ 'invalid' ],
+					shipping_address: [ 'invalid' ],
+				},
 			],
 			[
 				'empty addresses',

--- a/client/express-checkout/__tests__/payment-flow.test.js
+++ b/client/express-checkout/__tests__/payment-flow.test.js
@@ -524,3 +524,221 @@ describe( 'handleConfirmationTokenFlow', () => {
 		expect( abortPayment ).not.toHaveBeenCalled();
 	} );
 } );
+
+describe( 'address normalization', () => {
+	let api;
+	let stripe;
+	let elements;
+	let completePayment;
+	let abortPayment;
+	let event;
+
+	// What normalizeOrderData() builds from the wallet event below.
+	const walletBillingAddress = {
+		first_name: 'Jane',
+		last_name: 'Doe',
+		company: '',
+		email: 'jane@example.com',
+		phone: '',
+		country: 'US',
+		address_1: '456 Oak Ave',
+		address_2: '',
+		city: 'San Juan',
+		state: 'PR',
+		postcode: '00901',
+	};
+	const walletShippingAddress = {
+		first_name: 'Jane',
+		last_name: 'Doe',
+		company: '',
+		phone: '',
+		country: 'US',
+		address_1: '456 Oak Ave',
+		address_2: '',
+		city: 'San Juan',
+		state: 'PR',
+		postcode: '00901',
+		method: [ 'flat_rate:1' ],
+	};
+
+	const getCreateOrderPayload = () =>
+		api.expressCheckoutECECreateOrder.mock.calls[ 0 ][ 0 ];
+
+	beforeEach( () => {
+		const paymentResult = {
+			payment_result: {
+				payment_status: 'success',
+				redirect_url: 'https://example.com/order-received',
+			},
+		};
+		api = {
+			expressCheckoutECECreateOrder: jest
+				.fn()
+				.mockResolvedValue( paymentResult ),
+			expressCheckoutECEPayForOrder: jest
+				.fn()
+				.mockResolvedValue( paymentResult ),
+			expressCheckoutNormalizeAddress: jest.fn(),
+			confirmIntent: jest.fn().mockReturnValue( true ),
+		};
+		stripe = {
+			createPaymentMethod: jest
+				.fn()
+				.mockResolvedValue( { paymentMethod: { id: 'pm_test_123' } } ),
+			createConfirmationToken: jest.fn().mockResolvedValue( {
+				confirmationToken: { id: 'ct_test_456' },
+			} ),
+		};
+		elements = {};
+		completePayment = jest.fn();
+		abortPayment = jest.fn();
+		event = {
+			billingDetails: {
+				name: 'Jane Doe',
+				email: 'jane@example.com',
+				address: {
+					city: 'San Juan',
+					country: 'US',
+					line1: '456 Oak Ave',
+					postal_code: '00901',
+					state: 'PR',
+				},
+			},
+			shippingAddress: {
+				name: 'Jane Doe',
+				address: {
+					city: 'San Juan',
+					country: 'US',
+					line1: '456 Oak Ave',
+					postal_code: '00901',
+					state: 'PR',
+				},
+			},
+			shippingRate: { id: 'flat_rate:1' },
+		};
+	} );
+
+	// Apple Pay and Google Pay run through the manual flow; Amazon Pay runs through the
+	// confirmation token flow unless the cart has a free trial. Both share processOrder.
+	describe.each( [
+		[
+			'handleManualPaymentMethodFlow',
+			handleManualPaymentMethodFlow,
+			'apple_pay',
+		],
+		[
+			'handleConfirmationTokenFlow',
+			handleConfirmationTokenFlow,
+			'amazon_pay',
+		],
+	] )( '%s', ( _name, runFlow, expressPaymentType ) => {
+		const flow = ( params = {} ) =>
+			runFlow( {
+				api,
+				stripe,
+				elements,
+				completePayment,
+				abortPayment,
+				event: { ...event, expressPaymentType },
+				...params,
+			} );
+
+		test.each( [
+			[ 'null', null ],
+			[
+				'an HTML page served by a cache or a redirect',
+				'<!DOCTYPE html>',
+			],
+			[ 'an empty array', [] ],
+			[ 'a body without the address keys', { success: true } ],
+			[
+				'addresses that are not objects',
+				{ billing_address: '', shipping_address: null },
+			],
+			[
+				'addresses encoded as empty PHP arrays',
+				{ billing_address: [], shipping_address: [] },
+			],
+			[
+				'empty addresses',
+				{ billing_address: {}, shipping_address: {} },
+			],
+		] )(
+			'keeps the wallet addresses when normalization responds with %s',
+			async ( _label, response ) => {
+				api.expressCheckoutNormalizeAddress.mockResolvedValue(
+					response
+				);
+
+				await flow();
+
+				const payload = getCreateOrderPayload();
+				expect( payload.billing_address ).toEqual(
+					walletBillingAddress
+				);
+				expect( payload.shipping_address ).toEqual(
+					walletShippingAddress
+				);
+				expect( completePayment ).toHaveBeenCalled();
+				expect( abortPayment ).not.toHaveBeenCalled();
+			}
+		);
+
+		test( 'applies the normalized addresses when the response provides them', async () => {
+			// Puerto Rico: the wallet reports it as a US state, and normalization
+			// promotes it to a country.
+			api.expressCheckoutNormalizeAddress.mockResolvedValue( {
+				billing_address: { country: 'PR', state: '' },
+				shipping_address: { country: 'PR', state: '' },
+			} );
+
+			await flow();
+
+			const payload = getCreateOrderPayload();
+			expect( payload.billing_address ).toEqual( {
+				...walletBillingAddress,
+				country: 'PR',
+				state: '',
+			} );
+			expect( payload.shipping_address ).toEqual( {
+				...walletShippingAddress,
+				country: 'PR',
+				state: '',
+			} );
+		} );
+
+		test( 'keeps the wallet fields the response omits', async () => {
+			api.expressCheckoutNormalizeAddress.mockResolvedValue( {
+				billing_address: { country: 'PR' },
+			} );
+
+			await flow();
+
+			const payload = getCreateOrderPayload();
+			expect( payload.billing_address ).toEqual( {
+				...walletBillingAddress,
+				country: 'PR',
+			} );
+			expect( payload.shipping_address ).toEqual( walletShippingAddress );
+		} );
+
+		test( 'keeps the wallet billing address when paying for an existing order', async () => {
+			api.expressCheckoutNormalizeAddress.mockResolvedValue(
+				'<!DOCTYPE html>'
+			);
+
+			await flow( {
+				order: 123,
+				orderDetails: {
+					orderKey: 'wc_order_abc',
+					billingEmail: 'jane@example.com',
+					shippingAddress: walletShippingAddress,
+				},
+			} );
+
+			const payload =
+				api.expressCheckoutECEPayForOrder.mock.calls[ 0 ][ 2 ];
+			expect( payload.billing_address ).toEqual( walletBillingAddress );
+		} );
+	} );
+} );

--- a/client/express-checkout/__tests__/payment-flow.test.js
+++ b/client/express-checkout/__tests__/payment-flow.test.js
@@ -622,12 +622,17 @@ describe( 'address normalization', () => {
 	// confirmation token flow unless the cart has a free trial. Both share processOrder.
 	describe.each( [
 		[
-			'handleManualPaymentMethodFlow',
+			'handleManualPaymentMethodFlow - Apple Pay',
 			handleManualPaymentMethodFlow,
 			'apple_pay',
 		],
 		[
-			'handleConfirmationTokenFlow',
+			'handleManualPaymentMethodFlow - Google Pay',
+			handleManualPaymentMethodFlow,
+			'google_pay',
+		],
+		[
+			'handleConfirmationTokenFlow - Amazon Pay',
 			handleConfirmationTokenFlow,
 			'amazon_pay',
 		],
@@ -650,9 +655,12 @@ describe( 'address normalization', () => {
 				'<!DOCTYPE html>',
 			],
 			[ 'an empty array', [] ],
-			[ 'a body without the address keys', { success: true } ],
 			[
-				'addresses that are not objects',
+				'a body without the address keys (undefined addresses)',
+				{ success: true },
+			],
+			[
+				'an empty string and a null address',
 				{ billing_address: '', shipping_address: null },
 			],
 			[
@@ -661,6 +669,10 @@ describe( 'address normalization', () => {
 					billing_address: 'invalid',
 					shipping_address: 'invalid',
 				},
+			],
+			[
+				'addresses encoded as scalars',
+				{ billing_address: 1, shipping_address: true },
 			],
 			[
 				'addresses encoded as empty PHP arrays',

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -43,6 +43,13 @@ const handlePaymentFlowException = ( event, exception, abortPayment ) => {
 	);
 };
 
+const getUsableAddress = ( address ) =>
+	address !== null &&
+	typeof address === 'object' &&
+	! Array.isArray( address )
+		? address
+		: {};
+
 /**
  * Creates or pays for an order using the Express Checkout payment data,
  * normalizing addresses before submission.
@@ -83,11 +90,11 @@ const processOrder = async ( {
 	// drops the keys from the Store API request entirely.
 	normalizedOrderData.billing_address = {
 		...normalizedOrderData.billing_address,
-		...normalizedAddress?.billing_address,
+		...getUsableAddress( normalizedAddress?.billing_address ),
 	};
 	normalizedOrderData.shipping_address = {
 		...normalizedOrderData.shipping_address,
-		...normalizedAddress?.shipping_address,
+		...getUsableAddress( normalizedAddress?.shipping_address ),
 	};
 
 	if ( order ) {

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -85,7 +85,7 @@ const processOrder = async ( {
 	);
 
 	// Merge rather than replace: the response can carry no usable address at all, 
-	// and replacing with `undefined` would drop the keys from the Store API request.
+	// and replacing with `undefined` would drop the keys from the Store API request
 	normalizedOrderData.billing_address = {
 		...normalizedOrderData.billing_address,
 		...getUsableAddress( normalizedAddress?.billing_address ),

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -84,10 +84,8 @@ const processOrder = async ( {
 		normalizedOrderData.shipping_address
 	);
 
-	// Merge rather than replace: the response can carry no usable address at all (a page cache
-	// or canonical redirect answering the wc-ajax POST, a third-party
-	// `wc_stripe_express_checkout_normalize_address` filter), and replacing with `undefined`
-	// drops the keys from the Store API request entirely.
+	// Merge rather than replace: the response can carry no usable address at all, 
+	// and replacing with `undefined` would drop the keys from the Store API request.
 	normalizedOrderData.billing_address = {
 		...normalizedOrderData.billing_address,
 		...getUsableAddress( normalizedAddress?.billing_address ),

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -84,7 +84,7 @@ const processOrder = async ( {
 		normalizedOrderData.shipping_address
 	);
 
-	// Merge rather than replace: the response can carry no usable address at all, 
+	// Merge rather than replace: the response can carry no usable address at all,
 	// and replacing with `undefined` would drop the keys from the Store API request
 	normalizedOrderData.billing_address = {
 		...normalizedOrderData.billing_address,

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -77,11 +77,18 @@ const processOrder = async ( {
 		normalizedOrderData.shipping_address
 	);
 
-	if ( normalizedAddress ) {
-		normalizedOrderData.billing_address = normalizedAddress.billing_address;
-		normalizedOrderData.shipping_address =
-			normalizedAddress.shipping_address;
-	}
+	// Merge rather than replace: the response can carry no usable address at all (a page cache
+	// or canonical redirect answering the wc-ajax POST, a third-party
+	// `wc_stripe_express_checkout_normalize_address` filter), and replacing with `undefined`
+	// drops the keys from the Store API request entirely.
+	normalizedOrderData.billing_address = {
+		...normalizedOrderData.billing_address,
+		...normalizedAddress?.billing_address,
+	};
+	normalizedOrderData.shipping_address = {
+		...normalizedOrderData.shipping_address,
+		...normalizedAddress?.shipping_address,
+	};
 
 	if ( order ) {
 		orderResponse = await api.expressCheckoutECEPayForOrder(

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -327,6 +327,9 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 		 * as it can cause issues for express checkout flows. Also ensure that data is correctly sanitized and checked
 		 * as it will be visible to shoppers.
 		 *
+		 * Since 11.0.0 the client merges the returned addresses over the ones it sent, so removing a field
+		 * from an address no longer clears it. Return an empty string to clear a field.
+		 *
 		 * @since 10.2.0
 		 *
 		 * @param array $normalized_data The normalized address data.

--- a/readme.txt
+++ b/readme.txt
@@ -177,5 +177,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Make GITHUB_TOKEN optional for the local E2E Docker setup by falling back to the GitHub CLI and then to plugin zips placed in tests/e2e/deps
 * Fix - Reload the plugin's payment method settings when refreshing account details, so the settings screen no longer keeps showing stale values
 * Update - Fetch express checkout AJAX nonces on demand instead of embedding them in every page
+* Fix - Keep the wallet billing and shipping addresses on express checkout orders when the address normalization request returns an unusable response
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -37,6 +37,7 @@ The following items note specific versions that include important changes, featu
 
 * 11.0.0
    - Some express checkout helpers now require the caller to specify whether they are in the WooCommerce Cart context
+   - Express checkout merges the wc_stripe_express_checkout_normalize_address filter result over the address it sent; removing a field no longer clears it, return an empty string instead
 * 10.9.0
    - Express checkout processes classic checkout custom fields by default (opt out via the wc_stripe_express_checkout_enable_classic_checkout_custom_fields filter)
 * 10.8.0


### PR DESCRIPTION
Fixes STRIPE-1401
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/5838

## Changes proposed in this Pull Request:

Apple Pay / Google Pay orders intermittently failed with `rest_missing_callback_param: billing_address` from `POST /wc/store/v1/checkout`. No order was created and no charge was made, but the sale was lost and the shopper saw a message they could not act on.

`processOrder()` submitted the addresses it built from the wallet event to `wc_ajax_wc_stripe_normalize_address`, then overwrote both with the response:

```js
if ( normalizedAddress ) {
	normalizedOrderData.billing_address = normalizedAddress.billing_address;
	normalizedOrderData.shipping_address = normalizedAddress.shipping_address;
}
```

The fix merges the response over the wallet-derived addresses instead of replacing them:

```js
normalizedOrderData.billing_address = {
	...normalizedOrderData.billing_address,
	...getUsableAddress( normalizedAddress?.billing_address ),
};
```

## Testing instructions

`npm run test:js -- client/express-checkout/__tests__/payment-flow.test.js`

Manual:

1. On a store with the Blocks checkout and Apple Pay or Google Pay enabled, add a virtual product to the cart and go to the checkout page.
2. Open the browser developer tools Network tab and filter for `wc-ajax=wc_stripe_normalize_address`.
3. Complete a payment through the wallet sheet.
4. Verify the order is created, and the `POST /wc/store/v1/checkout` request body contains a populated `billing_address`.
5. To simulate the failure, block or stub the normalize-address request so it returns `200` with a non-JSON body (e.g.: using devtools request blocking/request conditions), then pay again.
    - In develop the checkout fails with "Missing parameter(s): billing_address" and no order is created
    - In this branch, the order is created using the address the wallet supplied.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)