### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/actions/ci-tests-with-coverage/action.yml
+++ b/.github/actions/ci-tests-with-coverage/action.yml
@@ -11,16 +11,16 @@ runs:
   using: "composite"
   steps:
     - name: Checking out
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
 
     - name: Set up dependencies caching
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.cache/composer/
         key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
 
     - name: Cache WordPress core and test suite
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: |
           /tmp/wordpress

--- a/.github/actions/get-wordpress-versions/action.yaml
+++ b/.github/actions/get-wordpress-versions/action.yaml
@@ -27,7 +27,7 @@ runs:
 
     - name: Check WordPress version cache
       id: check-wordpress-version-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: wordpress-versions-${{ steps.build-cache-key.outputs.cache-timestamp }}
         path: .wp-version-cache

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -20,7 +20,7 @@ runs:
 
     - name: Cache Composer dependencies
       id: composer-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ./vendor
         key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
@@ -32,14 +32,14 @@ runs:
         
     # Node
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version-file: '.nvmrc'
         cache: 'npm'
 
     - name: Cache Node dependencies
       id: node-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: |
           ./node_modules

--- a/.github/workflows/build-upload-zip.yml
+++ b/.github/workflows/build-upload-zip.yml
@@ -17,7 +17,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup PHP and Node
         uses: ./.github/actions/setup-env
@@ -28,7 +28,7 @@ jobs:
         run: npm run build
 
       - name: Upload package
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ inputs.artifact }}
           path: ${{ github.workspace }}/woocommerce-gateway-stripe.zip

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       code: ${{ steps.detect.outputs.code }}
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - id: detect
         uses: ./.github/actions/detect-code-changes
 

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       code: ${{ steps.detect.outputs.code }}
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - id: detect
         uses: ./.github/actions/detect-code-changes
 
@@ -39,10 +39,10 @@ jobs:
       WC_VERSION:  ${{ matrix.woocommerce }}
     steps:
       - name: Testing with PHP=${{ matrix.php }}, WP=${{ matrix.wordpress }}, WC=${{ matrix.woocommerce }}
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up dependencies caching
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       code: ${{ steps.detect.outputs.code }}
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - id: detect
         uses: ./.github/actions/detect-code-changes
 
@@ -34,7 +34,7 @@ jobs:
     name: E2E - ${{ matrix.project }} WP=latest, WC=latest, PHP=7.4
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # PHP
 
@@ -47,7 +47,7 @@ jobs:
 
       - name: Cache Composer deps
         id: composer-cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ./vendor
           key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
@@ -60,13 +60,13 @@ jobs:
       # Node
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: '.nvmrc'
 
       - name: Cache Node deps
         id: node-cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ./node_modules
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload e2e setup logs
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: E2E-${{ matrix.project }}-WP_latest-WC_latest-setup-logs
           path: tests/e2e/e2e-setup.log
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload E2E-${{ matrix.project }}-WP_latest-WC_latest-results
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: E2E-${{ matrix.project }}-WP_latest-WC_latest-results
           path: tests/e2e/test-results

--- a/.github/workflows/format-release-notes.yml
+++ b/.github/workflows/format-release-notes.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.branch }}
 

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -9,10 +9,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v7.0.1
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Setup node version
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version-file: '.nvmrc'
 
@@ -20,7 +20,7 @@ jobs:
               run: npm run build && rm -rf ./woocommerce-gateway-stripe && unzip woocommerce-gateway-stripe.zip -d ./woocommerce-gateway-stripe
 
             - name: Use the Upload Artifact GitHub Action
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: woocommerce-gateway-stripe
                   path: woocommerce-gateway-stripe/

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       code: ${{ steps.detect.outputs.code }}
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - id: detect
         uses: ./.github/actions/detect-code-changes
 
@@ -24,13 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # clone the repository
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # use the node version defined in nvmrc
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: '.nvmrc'
       # enable dependencies caching
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.npm/
           key:  ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       code: ${{ steps.detect.outputs.code }}
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - id: detect
         uses: ./.github/actions/detect-code-changes
 
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # clone the repository
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # enable dependencies caching
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
@@ -49,17 +49,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # clone the repository
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # use the node version defined in nvmrc
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: '.nvmrc'
       # enable dependencies caching
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/composer/
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.npm/
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/php-code-coverage.yml
+++ b/.github/workflows/php-code-coverage.yml
@@ -16,7 +16,7 @@ jobs:
       woocommerce-versions-json: ${{ steps.get-released-woocommerce-versions.outputs.versions-json }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Get WooCommerce plugin versions
         id: get-released-woocommerce-versions
@@ -30,7 +30,7 @@ jobs:
       wordpress-versions-json: ${{ steps.get-wordpress-versions.outputs.versions-json }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Get WordPress versions
         id: get-wordpress-versions

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       code: ${{ steps.detect.outputs.code }}
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - id: detect
         uses: ./.github/actions/detect-code-changes
 
@@ -29,7 +29,7 @@ jobs:
         woocommerce-versions-json: ${{ steps.get-released-woocommerce-versions.outputs.versions-json }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Get WooCommerce plugin versions
         id: get-released-woocommerce-versions
@@ -45,7 +45,7 @@ jobs:
       wordpress-versions-json: ${{ steps.get-wordpress-versions.outputs.versions-json }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Get WordPress versions
         id: get-wordpress-versions
@@ -90,16 +90,16 @@ jobs:
       WC_VERSION:  ${{ matrix.woocommerce }}
     steps:
       - name: Testing with PHP=${{ matrix.php }}, WP=${{ matrix.wordpress }}, WC=${{ matrix.woocommerce }}
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up dependencies caching
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
 
       - name: Cache WordPress core and test suite
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             /tmp/wordpress

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -33,7 +33,7 @@ jobs:
         name: 'PHPStan Analysis'
         runs-on: ubuntu-latest
         steps:
-            - uses: 'actions/checkout@v7.0.1'
+            - uses: 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1' # v7.0.1
               name: 'Checkout'
 
             - name: Setup PHP
@@ -45,7 +45,7 @@ jobs:
 
             - name: Cache Composer deps
               id: composer-cache
-              uses: actions/cache@v6
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
               with:
                 path: ./vendor
                 key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
@@ -59,7 +59,7 @@ jobs:
               run: mkdir -p phpstan-tmp
 
             - name: 'Restore PHPStan result cache'
-              uses: actions/cache/restore@v6
+              uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
               with:
                   path: phpstan-tmp
                   key: phpstan-result-cache-${{ github.run_id }}
@@ -70,7 +70,7 @@ jobs:
               run: npm run phpstan
 
             - name: 'Save PHPStan result cache'
-              uses: actions/cache/save@v6
+              uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
               if: ${{ !cancelled() }}
               with:
                   path: phpstan-tmp

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       code: ${{ steps.detect.outputs.code }}
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - id: detect
         uses: ./.github/actions/detect-code-changes
 
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: "Get current version"
         id: current-version

--- a/.github/workflows/pr-require-milestone.yml
+++ b/.github/workflows/pr-require-milestone.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Validate milestone'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const prNumber = context.payload.pull_request.number;

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -28,7 +28,7 @@ jobs:
     name: E2E - ${{ matrix.project }} (WP=${{ inputs.wp-version }}, WC=${{ inputs.wc-version }}, PHP=${{ inputs.php-version }})
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.branch }}
 
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload E2E test results
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.project }}-WP_${{ inputs.wp-version }}-WC_${{ inputs.wc-version }}-results
           path: tests/e2e/test-results

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -108,7 +108,7 @@ jobs:
           mkdir ${{ github.workspace }}/qit-results
 
       - name: Download the zip
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ inputs.artifact }}
           path: ${{ github.workspace }}
@@ -352,7 +352,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ inputs.results-artifact }}
           path: ${{ github.workspace }}/qit-results/

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
       PHP_VERSION: ${{ inputs.php-version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup PHP and Node
         uses: ./.github/actions/setup-env

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check PR description for changelog exemption
         id: check_exemption
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const prBody = context.payload.pull_request.body || '';
@@ -30,7 +30,7 @@ jobs:
       - name: Check for changelog updates
         id: has_changelog_entries
         if: steps.check_exemption.outputs.is_exempt != 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             // Paginate: a PR can change more files than a single listFiles page


### PR DESCRIPTION
## Changes proposed in this pull request

Pin every third-party GitHub Action used by this repository to a full 40-character commit SHA. The prior human-readable tag or branch is retained in an inline comment so future updates remain understandable.

The WooCommerce organization intends to enforce full-length commit SHA pinning for Actions at the organization level. Landing this change first avoids disrupting this repository when enforcement is enabled. Immutable action revisions reduce the risk that a moved or compromised upstream tag can be used for a CI/CD supply-chain exploit.

## How to test

- Confirm each external `uses:` reference ends in a 40-character commit SHA.
- Confirm the prior version or branch appears in the inline comment.
- Parse all changed workflow and action metadata files as YAML.
- Re-run the repository audit and confirm it reports zero unpinned external action references.

## Changelog

No changelog entry is needed because this only hardens CI configuration and does not change the shipped product.

_Drafted with AI assistance._
