### PR TITLE
Prevent Classic Checkout submitting an empty payment_method when missing a required-field

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Record the charge-captured state for asynchronously confirmed payments (e.g. ACH) so refunds from wp-admin and the Stripe Dashboard behave correctly
 * Fix - Reject negative refund amounts with an explicit error instead of silently refunding the absolute value
 * Fix - Prevent classic checkout from processing an empty payment method when custom required fields are present
+* Fix - Explain that payment details were not submitted, instead of reporting the selected payment method as invalid, when checkout is submitted without them
 * Fix - Hide the Apple Pay and Google Pay express buttons on pages unchecked in their own locations setting, instead of following other wallets' locations
 * Fix - Leave the Expires column blank instead of showing "N/A" on My Account → Payment methods for saved payment methods that have no expiry date, such as Link, SEPA and Cash App Pay
 * Fix - Remove the empty box shown under "Use a new payment method" on classic checkout when the save-payment-method checkbox is hidden

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Stop sending Level 3 data when paying with a non-card payment method through express checkout (e.g. Amazon Pay), which Stripe rejects and can disable Level 3 data for card payments
 * Fix - Record the charge-captured state for asynchronously confirmed payments (e.g. ACH) so refunds from wp-admin and the Stripe Dashboard behave correctly
 * Fix - Reject negative refund amounts with an explicit error instead of silently refunding the absolute value
+* Fix - Prevent classic checkout from processing an empty payment method when custom required fields are present
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/client/classic/upe/__tests__/payment-processing.test.js
+++ b/client/classic/upe/__tests__/payment-processing.test.js
@@ -1779,13 +1779,24 @@ describe( 'payment-processing', () => {
 			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
 		} );
 
-		it( 'returns true when a required radio group has no selection', () => {
+		it( 'returns true when no checkbox in a required group is checked', () => {
+			form.innerHTML =
+				'<p class="validate-required">' +
+				'<input type="checkbox" />' +
+				'<input type="checkbox" />' +
+				'</p>';
+			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( true );
+		} );
+
+		// Radios stay outside the selector: blocking on an unselected group would stop
+		// checkout on stores whose radio fields have no server-side validation.
+		it( 'returns false for a required wrapper holding only unselected radios', () => {
 			form.innerHTML =
 				'<p class="validate-required">' +
 				'<input type="radio" name="option" />' +
 				'<input type="radio" name="option" />' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( true );
+			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
 		} );
 
 		it( 'returns false when a required radio group has a selection', () => {
@@ -1797,11 +1808,13 @@ describe( 'payment-processing', () => {
 			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
 		} );
 
-		it( 'returns false when a grouped field has a value after an empty placeholder', () => {
+		// The checkbox group check only applies when the group leads the wrapper, so a
+		// filled text field ahead of an unchecked checkbox still passes, as before.
+		it( 'returns false when a filled text input precedes an unchecked checkbox', () => {
 			form.innerHTML =
 				'<p class="validate-required">' +
-				'<select><option value="" selected>Select...</option></select>' +
-				'<input type="radio" name="option" value="yes" checked />' +
+				'<input type="text" class="input-text" value="John" />' +
+				'<input type="checkbox" />' +
 				'</p>';
 			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
 		} );

--- a/client/classic/upe/__tests__/payment-processing.test.js
+++ b/client/classic/upe/__tests__/payment-processing.test.js
@@ -1754,6 +1754,43 @@ describe( 'payment-processing', () => {
 			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
 		} );
 
+		// WooCommerce posts a multiselect as implode( ', ', $value ), so both of the
+		// cases below still arrive as '' and are rejected server-side. Blocking them
+		// costs nothing; the third case posts ', US' and is accepted, so blocking it
+		// would fail the checkout outright.
+		it( 'returns true when a required multiple select has nothing selected', () => {
+			form.innerHTML =
+				'<p class="validate-required">' +
+				'<select multiple>' +
+				'<option value="">Select...</option>' +
+				'<option value="US">US</option>' +
+				'</select>' +
+				'</p>';
+			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( true );
+		} );
+
+		it( 'returns true when a required multiple select has only an empty option selected', () => {
+			form.innerHTML =
+				'<p class="validate-required">' +
+				'<select multiple>' +
+				'<option value="" selected>Select...</option>' +
+				'<option value="US">US</option>' +
+				'</select>' +
+				'</p>';
+			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( true );
+		} );
+
+		it( 'returns false when a required multiple select has a value selected after an empty option', () => {
+			form.innerHTML =
+				'<p class="validate-required">' +
+				'<select multiple>' +
+				'<option value="" selected>Select...</option>' +
+				'<option value="US" selected>US</option>' +
+				'</select>' +
+				'</p>';
+			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
+		} );
+
 		it( 'returns true when a required checkbox is unchecked', () => {
 			form.innerHTML =
 				'<p class="validate-required">' +

--- a/client/classic/upe/__tests__/payment-processing.test.js
+++ b/client/classic/upe/__tests__/payment-processing.test.js
@@ -1705,10 +1705,13 @@ describe( 'payment-processing', () => {
 			document.body.appendChild( form );
 		} );
 
-		const getWrappers = () => form.querySelectorAll( '.validate-required' );
+		const getRequiredFieldWrappers = () =>
+			form.querySelectorAll( '.validate-required' );
 
 		it( 'returns false when there are no required fields', () => {
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				false
+			);
 		} );
 
 		it( 'returns true when a required text input is empty', () => {
@@ -1716,7 +1719,9 @@ describe( 'payment-processing', () => {
 				'<p class="validate-required">' +
 				'<input type="text" class="input-text" value="" />' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( true );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				true
+			);
 		} );
 
 		it( 'returns true when a required text input has only whitespace', () => {
@@ -1724,7 +1729,9 @@ describe( 'payment-processing', () => {
 				'<p class="validate-required">' +
 				'<input type="text" class="input-text" value="   " />' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( true );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				true
+			);
 		} );
 
 		it( 'returns false when all required text inputs have values', () => {
@@ -1735,7 +1742,9 @@ describe( 'payment-processing', () => {
 				'<p class="validate-required">' +
 				'<input type="text" class="input-text" value="john@example.com" />' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				false
+			);
 		} );
 
 		it( 'returns true when a required select has no value', () => {
@@ -1743,7 +1752,9 @@ describe( 'payment-processing', () => {
 				'<p class="validate-required">' +
 				'<select><option value="">Select...</option><option value="US">US</option></select>' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( true );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				true
+			);
 		} );
 
 		it( 'returns false when a required select has a value', () => {
@@ -1751,7 +1762,9 @@ describe( 'payment-processing', () => {
 				'<p class="validate-required">' +
 				'<select><option value="">Select...</option><option value="US" selected>US</option></select>' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				false
+			);
 		} );
 
 		// WooCommerce posts a multiselect as implode( ', ', $value ), so both of the
@@ -1766,7 +1779,9 @@ describe( 'payment-processing', () => {
 				'<option value="US">US</option>' +
 				'</select>' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( true );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				true
+			);
 		} );
 
 		it( 'returns true when a required multiple select has only an empty option selected', () => {
@@ -1777,7 +1792,9 @@ describe( 'payment-processing', () => {
 				'<option value="US">US</option>' +
 				'</select>' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( true );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				true
+			);
 		} );
 
 		it( 'returns false when a required multiple select has a value selected after an empty option', () => {
@@ -1788,7 +1805,9 @@ describe( 'payment-processing', () => {
 				'<option value="US" selected>US</option>' +
 				'</select>' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				false
+			);
 		} );
 
 		it( 'returns true when a required checkbox is unchecked', () => {
@@ -1796,7 +1815,9 @@ describe( 'payment-processing', () => {
 				'<p class="validate-required">' +
 				'<input type="checkbox" />' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( true );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				true
+			);
 		} );
 
 		it( 'returns false when a required checkbox is checked', () => {
@@ -1804,7 +1825,9 @@ describe( 'payment-processing', () => {
 				'<p class="validate-required">' +
 				'<input type="checkbox" checked />' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				false
+			);
 		} );
 
 		it( 'returns false when one checkbox in a required group is checked', () => {
@@ -1813,7 +1836,9 @@ describe( 'payment-processing', () => {
 				'<input type="checkbox" />' +
 				'<input type="checkbox" checked />' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				false
+			);
 		} );
 
 		it( 'returns true when no checkbox in a required group is checked', () => {
@@ -1822,7 +1847,9 @@ describe( 'payment-processing', () => {
 				'<input type="checkbox" />' +
 				'<input type="checkbox" />' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( true );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				true
+			);
 		} );
 
 		// Radios stay outside the selector: blocking on an unselected group would stop
@@ -1833,7 +1860,9 @@ describe( 'payment-processing', () => {
 				'<input type="radio" name="option" />' +
 				'<input type="radio" name="option" />' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				false
+			);
 		} );
 
 		it( 'returns false when a required radio group has a selection', () => {
@@ -1842,7 +1871,9 @@ describe( 'payment-processing', () => {
 				'<input type="radio" name="option" />' +
 				'<input type="radio" name="option" checked />' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				false
+			);
 		} );
 
 		it( 'returns false when a checked radio accompanies an empty placeholder select', () => {
@@ -1851,7 +1882,9 @@ describe( 'payment-processing', () => {
 				'<select><option value="" selected>Select...</option></select>' +
 				'<input type="radio" name="option" value="yes" checked />' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				false
+			);
 		} );
 
 		it( 'returns true when unchecked radios accompany an empty placeholder select', () => {
@@ -1860,7 +1893,9 @@ describe( 'payment-processing', () => {
 				'<select><option value="" selected>Select...</option></select>' +
 				'<input type="radio" name="option" value="yes" />' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( true );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				true
+			);
 		} );
 
 		// The checkbox group check only applies when the group leads the wrapper, so a
@@ -1871,7 +1906,9 @@ describe( 'payment-processing', () => {
 				'<input type="text" class="input-text" value="John" />' +
 				'<input type="checkbox" />' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				false
+			);
 		} );
 
 		it( 'returns true if any one of multiple fields is empty', () => {
@@ -1882,7 +1919,9 @@ describe( 'payment-processing', () => {
 				'<p class="validate-required">' +
 				'<input type="text" class="input-text" value="" />' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( true );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				true
+			);
 		} );
 
 		it( 'skips validate-required wrappers with no matching input', () => {
@@ -1890,7 +1929,9 @@ describe( 'payment-processing', () => {
 				'<p class="validate-required">' +
 				'<span>No input here</span>' +
 				'</p>';
-			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				false
+			);
 		} );
 	} );
 } );

--- a/client/classic/upe/__tests__/payment-processing.test.js
+++ b/client/classic/upe/__tests__/payment-processing.test.js
@@ -1770,6 +1770,42 @@ describe( 'payment-processing', () => {
 			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
 		} );
 
+		it( 'returns false when one checkbox in a required group is checked', () => {
+			form.innerHTML =
+				'<p class="validate-required">' +
+				'<input type="checkbox" />' +
+				'<input type="checkbox" checked />' +
+				'</p>';
+			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
+		} );
+
+		it( 'returns true when a required radio group has no selection', () => {
+			form.innerHTML =
+				'<p class="validate-required">' +
+				'<input type="radio" name="option" />' +
+				'<input type="radio" name="option" />' +
+				'</p>';
+			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( true );
+		} );
+
+		it( 'returns false when a required radio group has a selection', () => {
+			form.innerHTML =
+				'<p class="validate-required">' +
+				'<input type="radio" name="option" />' +
+				'<input type="radio" name="option" checked />' +
+				'</p>';
+			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
+		} );
+
+		it( 'returns false when a grouped field has a value after an empty placeholder', () => {
+			form.innerHTML =
+				'<p class="validate-required">' +
+				'<select><option value="" selected>Select...</option></select>' +
+				'<input type="radio" name="option" value="yes" checked />' +
+				'</p>';
+			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
+		} );
+
 		it( 'returns true if any one of multiple fields is empty', () => {
 			form.innerHTML =
 				'<p class="validate-required">' +

--- a/client/classic/upe/__tests__/payment-processing.test.js
+++ b/client/classic/upe/__tests__/payment-processing.test.js
@@ -1845,6 +1845,24 @@ describe( 'payment-processing', () => {
 			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
 		} );
 
+		it( 'returns false when a checked radio accompanies an empty placeholder select', () => {
+			form.innerHTML =
+				'<p class="validate-required">' +
+				'<select><option value="" selected>Select...</option></select>' +
+				'<input type="radio" name="option" value="yes" checked />' +
+				'</p>';
+			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( false );
+		} );
+
+		it( 'returns true when unchecked radios accompany an empty placeholder select', () => {
+			form.innerHTML =
+				'<p class="validate-required">' +
+				'<select><option value="" selected>Select...</option></select>' +
+				'<input type="radio" name="option" value="yes" />' +
+				'</p>';
+			expect( hasEmptyRequiredFields( getWrappers() ) ).toBe( true );
+		} );
+
 		// The checkbox group check only applies when the group leads the wrapper, so a
 		// filled text field ahead of an unchecked checkbox still passes, as before.
 		it( 'returns false when a filled text input precedes an unchecked checkbox', () => {

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -1719,7 +1719,14 @@ export const hasEmptyRequiredFields = ( requiredWrappers ) => {
 			isEmpty = first.value.trim() === '';
 		}
 
-		if ( isEmpty ) {
+		// Radios are outside the selector above, so a wrapper holding only radios is
+		// skipped entirely, as it is by WC core. They can still satisfy a wrapper
+		// though: a checked radio means the shopper filled the field in, and blocking
+		// on it would fail a checkout the server would have accepted.
+		if (
+			isEmpty &&
+			! wrapper.querySelector( 'input[type="radio"]:checked' )
+		) {
 			return true;
 		}
 	}

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -1726,6 +1726,10 @@ export const hasEmptyRequiredFields = ( requiredWrappers ) => {
 			hasValue = first.value.trim() !== '';
 		}
 
+		if ( hasValue ) {
+			continue;
+		}
+
 		// Radios are not matched by the selector above, so a wrapper holding only
 		// radios is skipped entirely, as it is by WooCommerce core. A checked radio can
 		// still satisfy a wrapper: it is not proof the other controls are filled, but
@@ -1735,7 +1739,7 @@ export const hasEmptyRequiredFields = ( requiredWrappers ) => {
 			'input[type="radio"]:checked'
 		);
 
-		if ( ! hasValue && ! hasCheckedRadio ) {
+		if ( ! hasCheckedRadio ) {
 			return true;
 		}
 	}

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -1702,12 +1702,22 @@ export const hasEmptyRequiredFields = ( requiredWrappers ) => {
 			continue;
 		}
 
-		// A required wrapper can hold a "tick at least one" checkbox group, so the first
-		// box being unchecked does not mean the group is incomplete.
-		const isEmpty =
-			inputs[ 0 ].type === 'checkbox'
-				? ! inputs.some( ( input ) => input.checked )
-				: inputs[ 0 ].value.trim() === '';
+		const first = inputs[ 0 ];
+		let isEmpty;
+
+		if ( first.type === 'checkbox' ) {
+			// A required wrapper can hold a "tick at least one" checkbox group, so the
+			// first box being unchecked does not mean the group is incomplete.
+			isEmpty = ! inputs.some( ( input ) => input.checked );
+		} else if ( first.type === 'select-multiple' ) {
+			// `value` is only the first selected option, so a selected empty placeholder
+			// would hide the real selections behind it.
+			isEmpty = ! [ ...first.selectedOptions ].some(
+				( option ) => option.value.trim() !== ''
+			);
+		} else {
+			isEmpty = first.value.trim() === '';
+		}
 
 		if ( isEmpty ) {
 			return true;

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -1680,6 +1680,14 @@ export const confirmWalletPayment = async ( api, jQueryForm ) => {
 };
 
 /**
+ * Checks if any required checkout fields in the given list are empty.
+ * Uses the same field selectors as WC core's checkout validation (checkout.js).
+ * This is a read-only DOM check with no side effects — it does not trigger
+ * validation events or add/remove CSS classes.
+ *
+ * Visibility filtering is handled by the caller (using jQuery :visible in
+ * deferred-intent.js) since jsdom cannot compute element visibility.
+ *
  * @param {NodeList|Array} requiredWrappers Required checkout field groups.
  * @return {boolean} Whether any field group lacks a value.
  */

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -1680,31 +1680,27 @@ export const confirmWalletPayment = async ( api, jQueryForm ) => {
 };
 
 /**
- * Checks if any required checkout fields in the given list are empty.
- * Uses the same field selectors as WC core's checkout validation (checkout.js).
- * This is a read-only DOM check with no side effects — it does not trigger
- * validation events or add/remove CSS classes.
- *
- * Visibility filtering is handled by the caller (using jQuery :visible in
- * deferred-intent.js) since jsdom cannot compute element visibility.
- *
- * @param {NodeList|Array} requiredWrappers List of .validate-required DOM elements to check.
- * @return {boolean} True if any required field is empty.
+ * @param {NodeList|Array} requiredWrappers Required checkout field groups.
+ * @return {boolean} Whether any field group lacks a value.
  */
 export const hasEmptyRequiredFields = ( requiredWrappers ) => {
 	for ( const wrapper of requiredWrappers ) {
-		const input = wrapper.querySelector(
-			'input.input-text, select, input[type="checkbox"]'
+		const inputs = wrapper.querySelectorAll(
+			'input.input-text, select, input[type="checkbox"], input[type="radio"]'
 		);
-		if ( ! input ) {
+		if ( ! inputs.length ) {
 			continue;
 		}
 
-		if ( input.type === 'checkbox' ) {
-			if ( ! input.checked ) {
-				return true;
+		const hasValue = [ ...inputs ].some( ( input ) => {
+			if ( input.type === 'checkbox' || input.type === 'radio' ) {
+				return input.checked;
 			}
-		} else if ( ! input.value || input.value.trim() === '' ) {
+
+			return input.value?.trim() !== '';
+		} );
+
+		if ( ! hasValue ) {
 			return true;
 		}
 	}

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -1688,27 +1688,28 @@ export const confirmWalletPayment = async ( api, jQueryForm ) => {
  * Visibility filtering is handled by the caller (using jQuery :visible in
  * deferred-intent.js) since jsdom cannot compute element visibility.
  *
- * @param {NodeList|Array} requiredWrappers Required checkout field groups.
- * @return {boolean} Whether any field group lacks a value.
+ * @param {NodeList|Array} requiredWrappers List of .validate-required DOM elements to check.
+ * @return {boolean} True if any required field is empty.
  */
 export const hasEmptyRequiredFields = ( requiredWrappers ) => {
 	for ( const wrapper of requiredWrappers ) {
-		const inputs = wrapper.querySelectorAll(
-			'input.input-text, select, input[type="checkbox"], input[type="radio"]'
-		);
+		const inputs = [
+			...wrapper.querySelectorAll(
+				'input.input-text, select, input[type="checkbox"]'
+			),
+		];
 		if ( ! inputs.length ) {
 			continue;
 		}
 
-		const hasValue = [ ...inputs ].some( ( input ) => {
-			if ( input.type === 'checkbox' || input.type === 'radio' ) {
-				return input.checked;
-			}
+		// A required wrapper can hold a "tick at least one" checkbox group, so the first
+		// box being unchecked does not mean the group is incomplete.
+		const isEmpty =
+			inputs[ 0 ].type === 'checkbox'
+				? ! inputs.some( ( input ) => input.checked )
+				: inputs[ 0 ].value.trim() === '';
 
-			return input.value?.trim() !== '';
-		} );
-
-		if ( ! hasValue ) {
+		if ( isEmpty ) {
 			return true;
 		}
 	}

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -1708,7 +1708,9 @@ export const hasEmptyRequiredFields = ( requiredWrappers ) => {
 		if ( first.type === 'checkbox' ) {
 			// A required wrapper can hold a "tick at least one" checkbox group, so the
 			// first box being unchecked does not mean the group is incomplete.
-			isEmpty = ! inputs.some( ( input ) => input.checked );
+			isEmpty = ! inputs.some(
+				( input ) => input.type === 'checkbox' && input.checked
+			);
 		} else if ( first.type === 'select-multiple' ) {
 			// `value` is only the first selected option, so a selected empty placeholder
 			// would hide the real selections behind it.

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -1703,32 +1703,34 @@ export const hasEmptyRequiredFields = ( requiredWrappers ) => {
 		}
 
 		const first = inputs[ 0 ];
-		let isEmpty;
+		let hasValue;
 
 		if ( first.type === 'checkbox' ) {
 			// A required wrapper can hold a "tick at least one" checkbox group, so the
 			// first box being unchecked does not mean the group is incomplete.
-			isEmpty = ! inputs.some(
+			hasValue = inputs.some(
 				( input ) => input.type === 'checkbox' && input.checked
 			);
 		} else if ( first.type === 'select-multiple' ) {
-			// `value` is only the first selected option, so a selected empty placeholder
-			// would hide the real selections behind it.
-			isEmpty = ! [ ...first.selectedOptions ].some(
+			// `first.value` is only the first selected option, so a selected empty
+			// placeholder would hide the real selections behind it.
+			hasValue = [ ...first.selectedOptions ].some(
 				( option ) => option.value.trim() !== ''
 			);
 		} else {
-			isEmpty = first.value.trim() === '';
+			hasValue = first.value.trim() !== '';
 		}
 
-		// Radios are outside the selector above, so a wrapper holding only radios is
-		// skipped entirely, as it is by WC core. They can still satisfy a wrapper
-		// though: a checked radio means the shopper filled the field in, and blocking
-		// on it would fail a checkout the server would have accepted.
-		if (
-			isEmpty &&
-			! wrapper.querySelector( 'input[type="radio"]:checked' )
-		) {
+		// Radios are not matched by the selector above, so a wrapper holding only
+		// radios is skipped entirely, as it is by WooCommerce core. A checked radio can
+		// still satisfy a wrapper: it is not proof the other controls are filled, but
+		// it is reason enough to let the server validate the submission rather than
+		// block it here.
+		const hasCheckedRadio = !! wrapper.querySelector(
+			'input[type="radio"]:checked'
+		);
+
+		if ( ! hasValue && ! hasCheckedRadio ) {
 			return true;
 		}
 	}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3517,6 +3517,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		} else {
 			$payment_method_id = sanitize_text_field( wp_unslash( $_POST['wc-stripe-payment-method'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
+			if ( '' === $payment_method_id && empty( $_POST['wc-stripe-confirmation-token'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+				throw new WC_Stripe_Exception(
+					'Payment method ID is missing from the request.',
+					__( "The selected payment method isn't valid.", 'woocommerce-gateway-stripe' )
+				);
+			}
+
 			// sanitize_text_field() leaves URL metacharacters intact, so validate the grammar before the
 			// value is concatenated into the Stripe API paths below, where it could retarget the request.
 			if ( '' !== $payment_method_id && ! WC_Stripe_Helper::is_valid_stripe_id( $payment_method_id, [ 'pm', 'src', 'card' ] ) ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3533,9 +3533,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			$payment_method_id = sanitize_text_field( wp_unslash( $_POST['wc-stripe-payment-method'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 			if ( '' === $payment_method_id && empty( $_POST['wc-stripe-confirmation-token'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+				// The gateway the shopper picked is fine; what is missing are the payment details the
+				// browser should have attached. This path is shared by every deferred-intent flow, so
+				// the message must not name a cause: it is also reached when Stripe.js fails to load,
+				// when the payment element is remounting, and on tampered requests.
 				throw new WC_Stripe_Exception(
 					'Payment method ID is missing from the request.',
-					__( "The selected payment method isn't valid.", 'woocommerce-gateway-stripe' )
+					__( 'Your payment details were not submitted. Please review the checkout form and try again.', 'woocommerce-gateway-stripe' )
 				);
 			}
 

--- a/readme.txt
+++ b/readme.txt
@@ -158,7 +158,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 11.0.0 - xxxx-xx-xx =
-* Fix - Prevent classic checkout from processing an empty payment method when custom required fields are present
 * Add - Show the fuller sync-eligibility verdict in the Products list Agentic Commerce column and link the excluded-products view from the settings page
 * Add - Bulk edit, quick edit, and a sync-status column and filter on the Products list for excluding products from the Agentic Commerce catalog sync
 * Add - Use Stripe Dynamic Payment Methods for on-session Optimized Checkout payments so eligible methods follow your Stripe Payment Method Configuration
@@ -182,5 +181,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Stop sending Level 3 data when paying with a non-card payment method through express checkout (e.g. Amazon Pay), which Stripe rejects and can disable Level 3 data for card payments
 * Fix - Record the charge-captured state for asynchronously confirmed payments (e.g. ACH) so refunds from wp-admin and the Stripe Dashboard behave correctly
 * Fix - Reject negative refund amounts with an explicit error instead of silently refunding the absolute value
+* Fix - Prevent classic checkout from processing an empty payment method when custom required fields are present
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -191,6 +191,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Record the charge-captured state for asynchronously confirmed payments (e.g. ACH) so refunds from wp-admin and the Stripe Dashboard behave correctly
 * Fix - Reject negative refund amounts with an explicit error instead of silently refunding the absolute value
 * Fix - Prevent classic checkout from processing an empty payment method when custom required fields are present
+* Fix - Explain that payment details were not submitted, instead of reporting the selected payment method as invalid, when checkout is submitted without them
 * Fix - Hide the Apple Pay and Google Pay express buttons on pages unchecked in their own locations setting, instead of following other wallets' locations
 * Fix - Hide the save payment method checkbox for Bancontact, iDEAL and Sofort in the Adaptive Pricing checkout on non-EUR stores whose currency excludes them
 * Fix - Stop flagging the checkout page as the cart page (is_cart() returning true) when express checkout buttons are enabled, which made analytics and other plugins misread the page

--- a/readme.txt
+++ b/readme.txt
@@ -158,6 +158,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 11.0.0 - xxxx-xx-xx =
+* Fix - Prevent classic checkout from processing an empty payment method when custom required fields are present
 * Add - Show the fuller sync-eligibility verdict in the Products list Agentic Commerce column and link the excluded-products view from the settings page
 * Add - Bulk edit, quick edit, and a sync-status column and filter on the Products list for excluding products from the Agentic Commerce catalog sync
 * Add - Use Stripe Dynamic Payment Methods for on-session Optimized Checkout payments so eligible methods follow your Stripe Payment Method Configuration

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -812,6 +812,31 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * An empty client payment method must fail before intent creation.
+	 */
+	public function test_process_payment_deferred_intent_rejects_empty_payment_method_before_intent_creation() {
+		$order = WC_Helper_Order::create_order();
+
+		$_POST = [
+			'payment_method'               => 'stripe',
+			'wc-stripe-payment-method'     => '',
+			'wc-stripe-confirmation-token' => '',
+		];
+
+		$this->mock_gateway->intent_controller
+			->expects( $this->never() )
+			->method( 'create_and_confirm_payment_intent' );
+
+		$this->mock_gateway
+			->expects( $this->never() )
+			->method( 'stripe_request' );
+
+		$response = $this->mock_gateway->process_payment( $order->get_id() );
+
+		$this->assertSame( 'failure', $response['result'] );
+	}
+
+	/**
 	 * Test SCA/3DS checkout process_payment flow with deferred intent.
 	 */
 	public function test_process_payment_deferred_intent_with_required_action_returns_valid_response() {

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -890,7 +890,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			->expects( $this->never() )
 			->method( 'stripe_request' );
 
-		$response = $this->mock_gateway->process_payment( $order->get_id() );
+		try {
+			$response = $this->mock_gateway->process_payment( $order->get_id() );
+		} finally {
+			$_POST = [];
+		}
 
 		$this->assertSame( 'failure', $response['result'] );
 	}

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -4645,6 +4645,41 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * The shopper-facing message must describe the missing payment details rather than blame the
+	 * selected gateway, and must not name a cause: this guard is shared by every deferred-intent
+	 * flow, so it also fires on Stripe.js failures, element remounts and tampered requests.
+	 */
+	public function test_prepare_payment_information_reports_missing_payment_details_without_naming_a_cause() {
+		$order     = WC_Helper_Order::create_order();
+		$exception = null;
+
+		$_POST = [
+			'payment_method'               => 'stripe',
+			'wc-stripe-payment-method'     => '',
+			'wc-stripe-confirmation-token' => '',
+		];
+
+		$reflection = new \ReflectionClass( WC_Stripe_UPE_Payment_Gateway::class );
+		$method     = $reflection->getMethod( 'prepare_payment_information_from_request' );
+		$method->setAccessible( true );
+
+		try {
+			$method->invoke( $this->mock_gateway, $order );
+		} catch ( WC_Stripe_Exception $caught_exception ) {
+			$exception = $caught_exception;
+		} finally {
+			$_POST = [];
+		}
+
+		$this->assertInstanceOf( WC_Stripe_Exception::class, $exception );
+		$this->assertStringContainsString( 'Payment method ID is missing from the request', $exception->getMessage() );
+		$this->assertSame(
+			'Your payment details were not submitted. Please review the checkout form and try again.',
+			$exception->getLocalizedMessage()
+		);
+	}
+
+	/**
 	 * Provides prefix-compatible IDs containing URL structural characters.
 	 *
 	 * @return array<string, array{string}>


### PR DESCRIPTION
Fixes STRIPE-1402

## Changes proposed in this Pull Request:

This PR changes the Classic Checkout to:

- Treat a required-field wrapper’s checkboxes as one group.
    A "tick at least one" group is complete when any box is ticked, instead of only the first. This is the reported bug: a populated custom field blocked Stripe PaymentMethod creation.
- Stop treating a `<select multiple>` as empty when a placeholder is selected alongside a real option.
    select.value returns only the first selected option, so a selected placeholder masked the real selection.
- Never block on radios.
    Radios stay outside the selector, matching WooCommerce core, so a radio-only wrapper is skipped. A checked radio can still satisfy a wrapper it shares with other controls.

- Reject requests with neither a payment method nor a confirmation token before any Stripe lookup or intent creation.

Compared to 10.9.0 the gate differs in exactly three cases, all of which now allow checkout where it previously blocked: the checkbox group, the multi-select, and the checked radio. Nothing became stricter.


## Testing instructions

_**NOTE:**_ The report mentions [FooEvents for WooCommerce](https://worldpressit.com/downloads/fooevents-for-woocommerce/), but that's a paid plugin not hosted by Woo, so we don't have access to it, so the next steps just simulate the extra fields it would add in the checkout using JS

1. Configure Stripe with a test account
2. Change the checkout to classic (or add a new page for Classic Checkout)
3. Add a product to the cart and go to the Classic Checkout
4. Add the extra checkbox fields
    Open the browser Dev Tools and use this JS snippet:
    ```
    const checkout = document.querySelector( 'form.checkout' );
    const field = document.createElement( 'p' );

    field.id = 'stripe-1402-reproducer';
    field.className = 'form-row form-row-wide validate-required';
    field.innerHTML = `
	    <label>
		    Choose at least one option
		    <abbr class="required" title="required">*</abbr>
	    </label>
	    <label>
		    <input type="checkbox" name="stripe_1402_choice[]" value="first">
		    First option
	    </label>
	    <label>
		    <input type="checkbox" name="stripe_1402_choice[]" value="second" checked>
		    Second option
	    </label>
    `;

    checkout.prepend( field );
    ```
5. Verify the fields were added to the checkout form:
    <img width="1103" height="598" alt="Screenshot 2026-08-24 at 21 32 11" src="https://github.com/user-attachments/assets/9bd153ed-21c2-44e7-9808-8e175092680a" />
6. Place the order using the the test CC 4242424242424242
    - In develop this results in an error:
        <img width="1139" height="682" alt="Screenshot 2026-08-24 at 21 32 00" src="https://github.com/user-attachments/assets/eae3dbfc-d04a-4452-817e-db653c008175" />
    - In this branch, the order succeeds (same as in `10.8.5`)
        And it redirects to the Order Received page
7. Repeat with both checkboxes left unchecked and verify that the order is not placed and checkout reports:
    `There was an error processing the payment: Your payment details were not submitted. Please review the checkout form and try again.`

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
