### PR TITLE
Add 'payment_intents/search' to admin Stripe endpoints

### DIFF
--- a/includes/admin/class-wc-stripe-rest-payment-intents-controller.php
+++ b/includes/admin/class-wc-stripe-rest-payment-intents-controller.php
@@ -60,6 +60,26 @@ class WC_Stripe_REST_Payment_Intents_Controller extends WC_Stripe_REST_Base_Cont
 
 	protected const STRIPE_LIST_PARAMS_TO_FORWARD = [ 'limit', 'starting_after', 'ending_before', 'customer', 'customer_account', 'created' ];
 
+	protected const STRIPE_SEARCH_RESPONSE_ALLOWED_FIELDS = [
+		'object',
+		'has_more',
+		'next_page',
+		'data.id',
+		'data.created',
+		'data.amount',
+		'data.currency',
+		'data.status',
+		'data.description',
+		'data.latest_charge.billing_details.name',
+	];
+
+	protected const STRIPE_SEARCH_EXPAND_PARAM = [
+		'data.latest_charge',
+		'data.latest_charge.balance_transaction',
+	];
+
+	protected const STRIPE_SEARCH_PARAMS_TO_FORWARD = [ 'limit', 'query', 'page' ];
+
 	/**
 	 * Configure REST API routes.
 	 *
@@ -126,6 +146,39 @@ class WC_Stripe_REST_Payment_Intents_Controller extends WC_Stripe_REST_Base_Cont
 				],
 			],
 		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/search',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'search_payment_intents' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+				'args'                => [
+					'limit'            => [
+						'type'              => 'integer',
+						'required'          => false,
+						'default'           => 10,
+						'minimum'           => 1,
+						'maximum'           => 100,
+						'sanitize_callback' => 'absint',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
+					'query'   => [
+						'type'              => 'string',
+						'required'          => false,
+						'sanitize_callback' => 'sanitize_text_field',
+						'validate_callback' => [ self::class, 'validate_non_empty_string' ],
+					],
+					'page'    => [
+						'type'              => 'string',
+						'required'          => false,
+						'sanitize_callback' => 'sanitize_text_field',
+						'validate_callback' => [ self::class, 'validate_non_empty_string' ],
+					],
+				],
+			],
+		);
 	}
 
 	/**
@@ -188,6 +241,29 @@ class WC_Stripe_REST_Payment_Intents_Controller extends WC_Stripe_REST_Base_Cont
 
 		return rest_ensure_response( $filtered_response );
 	}
+
+	/**
+	 * Retrieves and filters records matching the search criteria.
+	 *
+	 * @param WP_REST_Request<array<string, mixed>> $request The incoming REST request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function search_payment_intents( $request ) {
+		$response = $this->fetch_from_stripe(
+			'payment_intents/search',
+			self::build_params_to_forward( $request, self::STRIPE_SEARCH_PARAMS_TO_FORWARD, self::STRIPE_SEARCH_EXPAND_PARAM ),
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$filtered_response = WC_Stripe_REST_Response_Filter::filter_response( $response, self::STRIPE_SEARCH_RESPONSE_ALLOWED_FIELDS );
+
+		return rest_ensure_response( $filtered_response );
+	}
+	
 
 	/**
 	 * Fetch data from an Stripe API endpoint and returns its raw data or a WP_Error if an error occurs.
@@ -376,5 +452,18 @@ class WC_Stripe_REST_Payment_Intents_Controller extends WC_Stripe_REST_Base_Cont
 		}
 
 		return ctype_digit( $value ) && ( (int) $value >= 0 );
+	}
+
+	/**
+	 * Validate that a parameter is a non-empty string.
+	 *
+	 * @param string $param_value The parameter value.
+	 * @param WP_REST_Request<array<string, mixed>> $request The incoming REST request.
+	 * @param string $param_name The parameter name.
+	 *
+	 * @return bool
+	 */
+	public static function validate_non_empty_string( $param_value, $request, $param_name ) {
+		return  '' !== trim( $param_value );
 	}
 }

--- a/tests/phpunit/admin/class-wc-stripe-rest-payment-intents-controller-test.php
+++ b/tests/phpunit/admin/class-wc-stripe-rest-payment-intents-controller-test.php
@@ -8,6 +8,7 @@
 class WC_Stripe_REST_Payment_Intents_Controller_Test extends WP_UnitTestCase {
 	private const SINGLE_INTENT_ENDPOINT_URL = '/wc/v3/wc_stripe/payment_intents/pi_test_9876543210';
 	private const ALL_INTENTS_ENDPOINT_URL   = '/wc/v3/wc_stripe/payment_intents';
+	private const SEARCH_INTENTS_ENDPOINT_URL   = '/wc/v3/wc_stripe/payment_intents/search';
 
 	/** Initialise REST API, make WC_Stripe_REST_Payment_Intents_Controller instance available for testing*/
 	public static function set_up_before_class() {
@@ -536,5 +537,29 @@ class WC_Stripe_REST_Payment_Intents_Controller_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals( $expected_response_data, $response->data );
+	}
+
+	public static function provide_intent_search_malformed_param(): array {
+		return [
+			[ 'query', '' ],
+			[ 'page', '' ],
+		];
+	}
+
+	/**
+	 * Create an admin user and send requests containing wrong format args.
+	 *
+	 * @dataProvider provide_intent_search_malformed_param
+	 *
+	 * @param string $param_name
+	 * @param mixed $param_value
+	*/
+	public function test_intent_search_malformed_param( string $param_name, $param_value ) {
+		$admin_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$response = $this->send_request( self::SEARCH_INTENTS_ENDPOINT_URL, [ $param_name => $param_value ] );
+
+		$this->assertSame( 400, $response->get_status() );
 	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:


Extends the admin Stripe REST Controller implemented by https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5786 PR by adding a search route  for querying payment intents endpoint of Stripe API. The controller acts as a proxy, forwarding the received parameters to the remote endpoint. The supported parameters are documented here: https://docs.stripe.com/api/payment_intents/search?api-version=2026-06-24.preview&rds=1

The response received from Stripe API is returned after being filtered against a whitelist.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Make sure you can send HTTP requests to the backend using a HTTP client. For example, you can do this by setting define( 'WP_ENVIRONMENT_TYPE', 'local' ); in wp-config.php and adding an application password from 'admin' user profile.

2. Using a HTTP client (for example Postman or a browser), 'admin' and the new created password as Basic Auth , send a GET request to:
[WordPress instance URL]/wp-json/wc/v3/wc_stripe/payment_intents
The response should look something like this:
```
{
    "object": "list",
    "has_more": true,
    "data": [
        {
            "id": "pi_3TtPY4JlUF0dQbSB0Jb3hqkX",
            "created": 1784109376,
            "amount": 7900,
            "currency": "usd",
            "status": "succeeded",
            "description": "WooCommerce Stripe Dev - Order 37",
            "latest_charge": {
                "billing_details": {
                    "name": "John Smith"
                },
                "payment_method_details": {
                    "card": {
                        "amount_authorized": 7900,
                        "authorization_code": "747254",
                        "brand": "visa",
                        "checks": {
                            "address_line1_check": "pass",
                            "address_postal_code_check": "pass",
                            "cvc_check": "pass"
                        },
                        "country": "US",
                        "exp_month": 12,
                        "exp_year": 2030,
                        "extended_authorization": {
                            "status": "disabled"
                        },
                        "fingerprint": "lt4nMrHlZlkzWWm1",
                        "funding": "credit",
                        "incremental_authorization": {
                            "status": "unavailable"
                        },
                        "installments": null,
                        "last4": "0259",
                        "mandate": null,
                        "multicapture": {
                            "status": "unavailable"
                        },
                        "network": "visa",
                        "network_token": {
                            "used": false
                        },
                        "network_transaction_id": "104738610711282",
                        "overcapture": {
                            "maximum_amount_capturable": 7900,
                            "status": "unavailable"
                        },
                        "regulated_status": "unregulated",
                        "three_d_secure": null,
                        "transaction_link_id": null,
                        "wallet": null
                    },
                    "type": "card"
                }
            }
        }
    ]
}
```
3. The endpoint supports the following parameters:

- limit
- query
- page

They are documented here: 
https://docs.stripe.com/api/payment_intents/search?api-version=2026-06-24.preview&rds=1
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Message
Add a Stripe REST proxy endpoint for querying payment intents endpoint of Stripe API.
<!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
