### PR TITLE
Stop defining WOOCOMMERCE_CART during full cart/checkout page renders

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -128,6 +128,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Ensure that manual Adaptive Pricing changes after upgrades get precedence
 * Fix - Treat an expired Stripe Checkout Session as an abandoned order and cancel it, instead of marking it failed
 * Fix - Hide the save payment method checkbox for Bancontact, iDEAL and Sofort in the Adaptive Pricing checkout on non-EUR stores whose currency excludes them
+* Fix - Stop flagging the checkout page as the cart page (is_cart() returning true) when express checkout buttons are enabled, which made analytics and other plugins misread the page
 
 2026-08-05 - version 10.8.5
 * Update - Improve webhook handling

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -352,6 +352,10 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 		check_ajax_referer( 'wc-stripe-express-checkout-shipping', 'security' );
 		_deprecated_function( __METHOD__, '10.9.0' );
 
+		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
+			define( 'WOOCOMMERCE_CART', true );
+		}
+
 		$shipping_address          = filter_input_array(
 			INPUT_POST,
 			[

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -1794,10 +1794,9 @@ class WC_Stripe_Express_Checkout_Helper {
 	 * }
 	 */
 	public function build_display_items( $itemized_display_items = false ) {
-		// Must not define WOOCOMMERCE_CART here: this also runs during full page
-		// renders (get_cart_render_data()), where the constant would make core's
-		// is_cart() return true on the checkout page for the rest of the request.
-		// The ECE AJAX entry points define it themselves.
+		// Don't define WOOCOMMERCE_CART here: this also runs on full checkout page
+		// renders, where the constant would flip is_cart() to true. The ECE AJAX
+		// entry points define it themselves.
 
 		/**
 		 * Filters whether Express Checkout itemization should be hidden.

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -1239,6 +1239,10 @@ class WC_Stripe_Express_Checkout_Helper {
 	/**
 	 * Gets shipping options available for specified shipping address
 	 *
+	 * Since 11.0.0, this method no longer defines the WOOCOMMERCE_CART constant;
+	 * callers are responsible for defining it when they need this to run in a
+	 * WooCommerce cart context.
+	 *
 	 * @param array   $shipping_address       Shipping address.
 	 * @param boolean $itemized_display_items Indicates whether to show subtotals or itemized views.
 	 *
@@ -1777,6 +1781,10 @@ class WC_Stripe_Express_Checkout_Helper {
 
 	/**
 	 * Builds the line items to pass to express checkout elements.
+	 *
+	 * Since 11.0.0, this method no longer defines the WOOCOMMERCE_CART constant;
+	 * callers are responsible for defining it when they need this to run in a
+	 * WooCommerce cart context.
 	 *
 	 * @param bool $itemized_display_items Whether to include itemized display items.
 	 *

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -1794,9 +1794,10 @@ class WC_Stripe_Express_Checkout_Helper {
 	 * }
 	 */
 	public function build_display_items( $itemized_display_items = false ) {
-		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
-			define( 'WOOCOMMERCE_CART', true );
-		}
+		// Must not define WOOCOMMERCE_CART here: this also runs during full page
+		// renders (get_cart_render_data()), where the constant would make core's
+		// is_cart() return true on the checkout page for the rest of the request.
+		// The ECE AJAX entry points define it themselves.
 
 		/**
 		 * Filters whether Express Checkout itemization should be hidden.

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,8 @@ Stripe is available for store owners and merchants in [46 countries worldwide](h
 
 The following items note specific versions that include important changes, features, or deprecations.
 
+* 11.0.0
+   - Some express checkout helpers now require the caller to specify whether they are in the WooCommerce Cart context
 * 10.9.0
    - Express checkout processes classic checkout custom fields by default (opt out via the wc_stripe_express_checkout_enable_classic_checkout_custom_fields filter)
 * 10.8.0

--- a/readme.txt
+++ b/readme.txt
@@ -186,5 +186,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Reject negative refund amounts with an explicit error instead of silently refunding the absolute value
 * Fix - Hide the Apple Pay and Google Pay express buttons on pages unchecked in their own locations setting, instead of following other wallets' locations
 * Fix - Hide the save payment method checkbox for Bancontact, iDEAL and Sofort in the Adaptive Pricing checkout on non-EUR stores whose currency excludes them
+* Fix - Stop flagging the checkout page as the cart page (is_cart() returning true) when express checkout buttons are enabled, which made analytics and other plugins misread the page
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-helper-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-helper-test.php
@@ -2491,4 +2491,33 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 
 		$this->assertNull( $data );
 	}
+
+	/**
+	 * Building the render-time cart snapshot must not define WOOCOMMERCE_CART: the
+	 * snapshot is built during full checkout page renders, and the constant makes
+	 * core's is_cart() return true for the rest of the request, breaking every
+	 * is_cart() consumer on the checkout page.
+	 *
+	 * @return void
+	 */
+	public function test_get_cart_render_data_does_not_define_woocommerce_cart(): void {
+		if ( defined( 'WOOCOMMERCE_CART' ) ) {
+			$this->markTestSkipped( 'WOOCOMMERCE_CART already defined by an earlier test in this process; cannot assert.' );
+		}
+
+		add_filter( 'woocommerce_is_checkout', '__return_true' );
+
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( WC_Helper_Product::create_simple_product()->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		$helper = new WC_Stripe_Express_Checkout_Helper();
+		$data   = $helper->get_cart_render_data();
+
+		remove_filter( 'woocommerce_is_checkout', '__return_true' );
+		WC()->cart->empty_cart();
+
+		$this->assertIsArray( $data );
+		$this->assertFalse( defined( 'WOOCOMMERCE_CART' ) );
+	}
 }


### PR DESCRIPTION
Fixes STRIPE-1414

## Changes proposed in this Pull Request:

Since 10.9.0, `get_cart_render_data()` (#5606) runs `build_display_items()` during full cart/checkout page renders, and its unconditional `define( 'WOOCOMMERCE_CART', true )` makes core's `is_cart()` return true on the checkout page for the rest of the request. Plugins branching on `is_cart()` misread checkout views as cart views (reported: GTM4WP firing `view_cart` instead of `begin_checkout`), and our own localized `is_cart_page` flag became `"1"` on checkout, making ECE init early instead of waiting for `updated_checkout`.

Fix:

- Remove the define from `build_display_items()`.
- Add it to the deprecated `ajax_get_shipping_options()`, the only AJAX entry point that relied on it transitively; the other ECE AJAX handlers already define it themselves, so all AJAX paths keep their behavior.

**Backward compatibility:** restores the constant's pre-10.9.0 scope (ECE AJAX requests only, never full page renders). No hooks, signatures, or option keys change.

## Testing instructions

1. Enable Apple Pay/Google Pay express checkout with the checkout button location enabled (default).
2. Add this snippet as a mu-plugin (or via a code snippets plugin):
   ```php
   add_action( 'wp_footer', function () {
       printf( '<!-- probe is_cart=%s const=%s -->', is_cart() ? 'YES' : 'no', defined( 'WOOCOMMERCE_CART' ) ? 'DEFINED' : 'undef' );
   }, PHP_INT_MAX );
   ```
3. Add a product to the cart, open the checkout page, and find the `probe` comment in the page source.
   - Without this PR: `is_cart=YES const=DEFINED`, and `wc_stripe_express_checkout_params` contains `"is_cart_page":"1"`.
   - With this PR: `is_cart=no const=undef`, and `"is_cart_page":""`.
4. On the cart page, the probe shows `is_cart=YES` and the express checkout button still renders with the correct total.
5. Pay for an order via Apple Pay or Google Pay from the cart or checkout page to confirm express checkout still works.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SExFbpGjvB7Eqw8JkNNhb