### PR TITLE
Reuse the express checkout Elements group on cart and checkout updates

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Record the charge-captured state for asynchronously confirmed payments (e.g. ACH) so refunds from wp-admin and the Stripe Dashboard behave correctly
 * Fix - Reject negative refund amounts with an explicit error instead of silently refunding the absolute value
 * Fix - Hide the Apple Pay and Google Pay express buttons on pages unchecked in their own locations setting, instead of following other wallets' locations
+* Update - Reuse the mounted express checkout buttons on cart and checkout updates instead of re-creating them on every totals refresh, and defer refreshes while the wallet sheet is open
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/client/entrypoints/express-checkout/__tests__/index.test.js
+++ b/client/entrypoints/express-checkout/__tests__/index.test.js
@@ -450,3 +450,155 @@ describe( 'Express Checkout per-method location gating', () => {
 		expect( mountedTypes() ).toEqual( [ 'googlePay' ] );
 	} );
 } );
+
+describe( 'Express Checkout group reuse on cart/checkout updates', () => {
+	// One stub per Elements group so tests can tell "reused in place" (no new
+	// elements() call, update() received the new amount) from "rebuilt".
+	let elementsGroups;
+	let buttons;
+
+	const stubStripe = () => {
+		elementsGroups = [];
+		buttons = [];
+		mockGetStripe.mockReturnValue( {
+			elements: jest.fn( () => {
+				const handlers = {};
+				const button = {
+					handlers,
+					on: jest.fn( ( eventName, callback ) => {
+						handlers[ eventName ] = callback;
+						return button;
+					} ),
+					mount: jest.fn(),
+					unmount: jest.fn(),
+					destroy: jest.fn(),
+				};
+				buttons.push( button );
+				const group = {
+					create: jest.fn( () => button ),
+					update: jest.fn(),
+				};
+				elementsGroups.push( group );
+				return group;
+			} ),
+		} );
+	};
+
+	const cartParams = () => ( {
+		...baseParams(),
+		stripe: {
+			publishable_key: 'pk_test_123',
+			locale: 'en',
+			is_google_pay_enabled: true,
+		},
+		cart: {
+			total: 1500,
+			currency: 'usd',
+			requestShipping: false,
+			requestPhone: false,
+			displayItems: [],
+		},
+	} );
+
+	// The debounced refresh handler fires its leading call synchronously, but a
+	// second trigger within the wait window is swallowed; step past it.
+	const waitOutDebounce = () =>
+		new Promise( ( resolve ) => setTimeout( resolve, 350 ) );
+
+	beforeEach( () => {
+		jest.resetModules();
+		mockGetStripe.mockReset();
+		mockGetCartDetails.mockReset();
+		mockGetCartDetails.mockResolvedValue( {
+			totals: { total_price: '1500', total_refund: '0' },
+			needs_shipping: false,
+		} );
+		stubStripe();
+		// blockUI is a jQuery plugin the click handler calls via the global;
+		// absent in jsdom.
+		global.jQuery = require( 'jquery' );
+		global.jQuery.blockUI = jest.fn();
+		global.jQuery.unblockUI = jest.fn();
+		document.body.innerHTML =
+			'<div id="wc-stripe-express-checkout-element"></div>';
+	} );
+
+	afterEach( () => {
+		delete global.wc_stripe_express_checkout_params;
+	} );
+
+	it( 'refreshes the mounted group in place when only the amount changed', async () => {
+		global.wc_stripe_express_checkout_params = cartParams();
+		loadEntrypoint();
+		expect( elementsGroups ).toHaveLength( 1 );
+
+		require( 'jquery' )( document.body ).trigger( 'updated_cart_totals' );
+		await flushPromises();
+
+		// Same structure: no second Elements group (and no second
+		// /v1/elements/sessions), no teardown; the amount was pushed in place.
+		expect( elementsGroups ).toHaveLength( 1 );
+		expect( buttons[ 0 ].destroy ).not.toHaveBeenCalled();
+		expect( elementsGroups[ 0 ].update ).toHaveBeenCalledWith( {
+			amount: 1500,
+		} );
+	} );
+
+	it( 'rebuilds the group when the shipping requirement changes', async () => {
+		global.wc_stripe_express_checkout_params = cartParams();
+		loadEntrypoint();
+		expect( elementsGroups ).toHaveLength( 1 );
+
+		mockGetCartDetails.mockResolvedValue( {
+			totals: { total_price: '1500', total_refund: '0' },
+			needs_shipping: true,
+		} );
+		require( 'jquery' )( document.body ).trigger( 'updated_cart_totals' );
+		await flushPromises();
+
+		// Structural change: the old button is torn down and a new group built.
+		expect( buttons[ 0 ].destroy ).toHaveBeenCalled();
+		expect( elementsGroups ).toHaveLength( 2 );
+	} );
+
+	it( 'remounts the existing button when WooCommerce discarded the markup', async () => {
+		global.wc_stripe_express_checkout_params = cartParams();
+		loadEntrypoint();
+
+		// updated_cart_totals re-renders the cart totals wholesale, discarding
+		// the button containers WooCommerce knows nothing about.
+		document.getElementById(
+			'wc-stripe-express-checkout-element'
+		).innerHTML = '';
+		require( 'jquery' )( document.body ).trigger( 'updated_cart_totals' );
+		await flushPromises();
+
+		expect( elementsGroups ).toHaveLength( 1 );
+		expect( buttons[ 0 ].unmount ).toHaveBeenCalled();
+		expect( buttons[ 0 ].mount ).toHaveBeenCalledTimes( 2 );
+		expect(
+			document.getElementById(
+				'wc-stripe-express-checkout-element-googlePay'
+			)
+		).not.toBeNull();
+	} );
+
+	it( 'defers the refresh while the wallet sheet is open and applies it on cancel', async () => {
+		global.wc_stripe_express_checkout_params = cartParams();
+		loadEntrypoint();
+
+		// Open the sheet: the click handler resolves the event, marking a
+		// payment in flight.
+		await buttons[ 0 ].handlers.click( { resolve: jest.fn() } );
+
+		require( 'jquery' )( document.body ).trigger( 'updated_cart_totals' );
+		await flushPromises();
+		expect( mockGetCartDetails ).not.toHaveBeenCalled();
+
+		// Closing the sheet applies the deferred refresh.
+		buttons[ 0 ].handlers.cancel();
+		await waitOutDebounce();
+		await flushPromises();
+		expect( mockGetCartDetails ).toHaveBeenCalled();
+	} );
+} );

--- a/client/entrypoints/express-checkout/__tests__/index.test.js
+++ b/client/entrypoints/express-checkout/__tests__/index.test.js
@@ -452,8 +452,7 @@ describe( 'Express Checkout per-method location gating', () => {
 } );
 
 describe( 'Express Checkout group reuse on cart/checkout updates', () => {
-	// One stub per Elements group so tests can tell "reused in place" (no new
-	// elements() call, update() received the new amount) from "rebuilt".
+	// One stub per Elements group so tests can tell reuse from rebuild.
 	let elementsGroups;
 	let buttons;
 
@@ -500,8 +499,7 @@ describe( 'Express Checkout group reuse on cart/checkout updates', () => {
 		},
 	} );
 
-	// The debounced refresh handler fires its leading call synchronously, but a
-	// second trigger within the wait window is swallowed; step past it.
+	// Step past the debounce window so a follow-up trigger isn't swallowed.
 	const waitOutDebounce = () =>
 		new Promise( ( resolve ) => setTimeout( resolve, 350 ) );
 
@@ -514,8 +512,7 @@ describe( 'Express Checkout group reuse on cart/checkout updates', () => {
 			needs_shipping: false,
 		} );
 		stubStripe();
-		// blockUI is a jQuery plugin the click handler calls via the global;
-		// absent in jsdom.
+		// The click handler calls the global jQuery.blockUI, absent in jsdom.
 		global.jQuery = require( 'jquery' );
 		global.jQuery.blockUI = jest.fn();
 		global.jQuery.unblockUI = jest.fn();
@@ -535,8 +532,8 @@ describe( 'Express Checkout group reuse on cart/checkout updates', () => {
 		require( 'jquery' )( document.body ).trigger( 'updated_cart_totals' );
 		await flushPromises();
 
-		// Same structure: no second Elements group (and no second
-		// /v1/elements/sessions), no teardown; the amount was pushed in place.
+		// Same structure: no new group/session, no teardown, amount pushed
+		// in place.
 		expect( elementsGroups ).toHaveLength( 1 );
 		expect( buttons[ 0 ].destroy ).not.toHaveBeenCalled();
 		expect( elementsGroups[ 0 ].update ).toHaveBeenCalledWith( {
@@ -565,8 +562,7 @@ describe( 'Express Checkout group reuse on cart/checkout updates', () => {
 		global.wc_stripe_express_checkout_params = cartParams();
 		loadEntrypoint();
 
-		// updated_cart_totals re-renders the cart totals wholesale, discarding
-		// the button containers WooCommerce knows nothing about.
+		// Simulate WC re-rendering the totals and discarding the markup.
 		document.getElementById(
 			'wc-stripe-express-checkout-element'
 		).innerHTML = '';
@@ -587,8 +583,7 @@ describe( 'Express Checkout group reuse on cart/checkout updates', () => {
 		global.wc_stripe_express_checkout_params = cartParams();
 		loadEntrypoint();
 
-		// Open the sheet: the click handler resolves the event, marking a
-		// payment in flight.
+		// Resolving the click marks a payment in flight (sheet open).
 		await buttons[ 0 ].handlers.click( { resolve: jest.fn() } );
 
 		require( 'jquery' )( document.body ).trigger( 'updated_cart_totals' );

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -131,7 +131,31 @@ jQuery( function ( $ ) {
 				} ),
 		};
 
+		// The wallet sheet opens once this resolves; cart/checkout refreshes
+		// must not tear the buttons down underneath it (see the update-event
+		// guard at the bottom of this file).
+		wcStripeECE.paymentInFlight = true;
 		return event.resolve( clickOptions );
+	};
+
+	// Shared between the initial render and in-place refreshes so a refreshed
+	// wallet sheet derives its rates from the same items as the first paint.
+	const getShippingRatesForOptions = ( options ) => {
+		if ( ! options.requestShipping ) {
+			return [];
+		}
+
+		if ( getExpressCheckoutData( 'is_product_page' ) ) {
+			return getExpressCheckoutData( 'product' )?.shippingOptions;
+		}
+
+		return options.displayItems
+			.filter( ( i ) => i.key && i.key === 'total_shipping' )
+			.map( ( i ) => ( {
+				id: 'rate-shipping',
+				amount: i.amount,
+				displayName: useLegacyDisplayItems ? i.label ?? i.name : i.name,
+			} ) );
 	};
 
 	// Check if the product is waiting for a variation to be selected.
@@ -199,33 +223,116 @@ jQuery( function ( $ ) {
 			).length;
 		},
 
+		// Mounted Elements groups, with the inputs that decide whether they can
+		// be refreshed in place on a cart/checkout update.
+		mountedGroups: [],
+
+		// True while the wallet sheet is open (set when a click resolves,
+		// cleared on cancel/abort/complete); refreshes are deferred meanwhile.
+		paymentInFlight: false,
+		pendingRefresh: false,
+
+		// Only currency and the shipping requirement can't be changed through
+		// elements.update(); anything else refreshes in place.
+		getStructuralSignature: ( options ) =>
+			JSON.stringify( {
+				currency: options.currency,
+				requestShipping: !! options.requestShipping,
+			} ),
+
+		teardownExpressCheckout: () => {
+			wcStripeECE.mountedGroups.forEach( ( group ) => {
+				try {
+					group.button?.destroy();
+				} catch ( error ) {
+					// The button may already be gone (e.g. WooCommerce replaced
+					// the surrounding markup); a stale reference must not block
+					// the rebuild.
+				}
+				$(
+					`#wc-stripe-express-checkout-element-${ group.type }`
+				).remove();
+			} );
+			wcStripeECE.mountedGroups = [];
+		},
+
+		/**
+		 * Refreshes the mounted buttons in place when only amounts/items
+		 * changed, falling back to a full rebuild when a structural input
+		 * changed or nothing is mounted. Reuse skips the /v1/elements/sessions
+		 * call and the wallet availability re-probe a rebuild would repeat on
+		 * every cart/checkout update.
+		 *
+		 * @param {Object} options ECE options (same shape as startExpressCheckout).
+		 */
+		refreshOrStartExpressCheckout: ( options ) => {
+			const signature = wcStripeECE.getStructuralSignature( options );
+			const groups = wcStripeECE.mountedGroups;
+			const canReuse =
+				groups.length > 0 &&
+				groups.every(
+					( group ) => group.button && group.signature === signature
+				);
+
+			if ( ! canReuse ) {
+				wcStripeECE.startExpressCheckout( options );
+				return;
+			}
+
+			const shippingRates = getShippingRatesForOptions( options );
+			groups.forEach( ( group ) => {
+				// The click/confirm closures read this same options object, so
+				// mutate it in place to keep the wallet sheet contents in sync
+				// with the refreshed cart.
+				Object.assign( group.options, options, { shippingRates } );
+				group.elements.update( { amount: options.total } );
+
+				// WooCommerce re-renders the cart totals wholesale on
+				// updated_cart_totals, discarding the button markup; remount
+				// the existing button instead of paying for a new group.
+				const container = document.getElementById(
+					`wc-stripe-express-checkout-element-${ group.type }`
+				);
+				if (
+					( ! container || ! container.childElementCount ) &&
+					group.available !== false
+				) {
+					wcStripeECE.remountGroupButton( group );
+				}
+			} );
+
+			// A zero-total update may have hidden the buttons; only groups that
+			// reported availability justify re-showing the section.
+			if ( groups.some( ( group ) => group.available ) ) {
+				wcStripeECE.show();
+				wcStripeECE.getButtonSeparator().show();
+			}
+		},
+
+		remountGroupButton: ( group ) => {
+			if ( ! $( '#wc-stripe-express-checkout-element' ).length ) {
+				return;
+			}
+			const containerName = `wc-stripe-express-checkout-element-${ group.type }`;
+			if ( ! $( `#${ containerName }` ).length ) {
+				$( '#wc-stripe-express-checkout-element' ).append(
+					`<div id="${ containerName }"></div>`
+				);
+			}
+			// unmount() first: the element may still reference the discarded
+			// markup. Event listeners were bound at creation and survive a
+			// remount, so renderButton() (which would rebind them) is not used.
+			group.button.unmount();
+			group.button.mount( `#${ containerName }` );
+		},
+
 		/**
 		 * Starts the Express Checkout Element
 		 *
 		 * @param {Object} options ECE options.
 		 */
 		startExpressCheckout: ( options ) => {
-			const getShippingRates = () => {
-				if ( ! options.requestShipping ) {
-					return [];
-				}
-
-				if ( getExpressCheckoutData( 'is_product_page' ) ) {
-					return getExpressCheckoutData( 'product' )?.shippingOptions;
-				}
-
-				return options.displayItems
-					.filter( ( i ) => i.key && i.key === 'total_shipping' )
-					.map( ( i ) => ( {
-						id: 'rate-shipping',
-						amount: i.amount,
-						displayName: useLegacyDisplayItems
-							? i.label ?? i.name
-							: i.name,
-					} ) );
-			};
-
-			const shippingRates = getShippingRates();
+			const shippingRates = getShippingRatesForOptions( options );
 
 			// Deliberately not `is_express_checkout_enabled`: that aggregate is true when
 			// any wallet's locations cover this page, which would render Apple/Google Pay
@@ -263,6 +370,11 @@ jQuery( function ( $ ) {
 					EXPRESS_PAYMENT_METHOD_SETTING_AMAZON_PAY,
 				isLinkEnabled && EXPRESS_PAYMENT_METHOD_SETTING_LINK,
 			].filter( Boolean );
+
+			// Tear down what a previous render mounted: dropping the old
+			// buttons unreferenced leaks their wallet iframes and stacks
+			// duplicate buttons in the containers.
+			wcStripeECE.teardownExpressCheckout();
 
 			// Reset the registry so variation/qty updates only touch the buttons
 			// mounted for this render.
@@ -412,6 +524,18 @@ jQuery( function ( $ ) {
 			// variation/qty change updates every group's amount.
 			wcStripeECE.expressCheckoutElements.push( elements );
 
+			// Registered before button creation so a failure below can't leave
+			// an untracked group behind: teardown iterates this registry.
+			const group = {
+				type: expressPaymentType,
+				elements,
+				options,
+				signature: wcStripeECE.getStructuralSignature( options ),
+				button: null,
+				available: null,
+			};
+			wcStripeECE.mountedGroups.push( group );
+
 			const buttonStyleSettings =
 				getExpressCheckoutButtonStyleSettings( expressPaymentType );
 
@@ -436,6 +560,8 @@ jQuery( function ( $ ) {
 					link: expressPaymentType === 'link' ? 'auto' : 'never',
 				},
 			} );
+
+			group.button = eceButton;
 
 			wcStripeECE.renderButton( eceButton, expressPaymentType );
 
@@ -531,17 +657,23 @@ jQuery( function ( $ ) {
 
 			eceButton.on( 'cancel', () => {
 				wcStripeECE.paymentAborted = true;
+				wcStripeECE.paymentInFlight = false;
 				onCancelHandler();
+				// A cart/checkout update arrived while the sheet was open;
+				// apply it now that touching the buttons is safe again.
+				if ( wcStripeECE.pendingRefresh ) {
+					wcStripeECE.pendingRefresh = false;
+					wcStripeECE.init();
+				}
 			} );
 
 			eceButton.on( 'ready', ( onReadyParams ) => {
-				if (
-					! isVariationSelectionNeeded() &&
-					onReadyParams.availablePaymentMethods &&
+				group.available =
+					!! onReadyParams.availablePaymentMethods &&
 					Object.values(
 						onReadyParams.availablePaymentMethods
-					).filter( Boolean ).length
-				) {
+					).filter( Boolean ).length > 0;
+				if ( ! isVariationSelectionNeeded() && group.available ) {
 					wcStripeECE.show();
 					wcStripeECE.getButtonSeparator().show();
 				}
@@ -669,7 +801,7 @@ jQuery( function ( $ ) {
 						return;
 					}
 
-					wcStripeECE.startExpressCheckout( {
+					wcStripeECE.refreshOrStartExpressCheckout( {
 						total,
 						currency:
 							getExpressCheckoutData( 'checkout' )?.currency_code,
@@ -863,6 +995,7 @@ jQuery( function ( $ ) {
 		 * @param {string} url Order thank you page URL.
 		 */
 		completePayment: ( url ) => {
+			wcStripeECE.paymentInFlight = false;
 			onCompletePaymentHandler( url );
 			window.location = url;
 		},
@@ -875,6 +1008,7 @@ jQuery( function ( $ ) {
 		 * @param {boolean}         isOrderError Whether the error is related to the order creation.
 		 */
 		abortPayment: ( payment, message, isOrderError = false ) => {
+			wcStripeECE.paymentInFlight = false;
 			if ( ! isOrderError ) {
 				payment.paymentFailed( { reason: 'fail' } );
 			}
@@ -1083,13 +1217,24 @@ jQuery( function ( $ ) {
 		);
 	}
 
-	// We need to refresh ECE data when total is updated.
-	$( document.body ).on( 'updated_cart_totals', () => {
-		wcStripeECE.init();
-	} );
+	// Refresh ECE data when totals update. A single recalculation can emit a
+	// burst of these events, so coalesce them into one cart fetch; the leading
+	// call keeps the common single-event case immediate.
+	const refreshExpressCheckout = debounce(
+		() => {
+			// Never rebuild while the wallet sheet is open: destroying the
+			// button mid-payment kills the shopper's session. The refresh is
+			// applied when the sheet closes (see the cancel handler).
+			if ( wcStripeECE.paymentInFlight ) {
+				wcStripeECE.pendingRefresh = true;
+				return;
+			}
+			wcStripeECE.init();
+		},
+		300,
+		{ leading: true, trailing: true }
+	);
 
-	// We need to refresh ECE data when total is updated.
-	$( document.body ).on( 'updated_checkout', () => {
-		wcStripeECE.init();
-	} );
+	$( document.body ).on( 'updated_cart_totals', refreshExpressCheckout );
+	$( document.body ).on( 'updated_checkout', refreshExpressCheckout );
 } );

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -131,15 +131,14 @@ jQuery( function ( $ ) {
 				} ),
 		};
 
-		// The wallet sheet opens once this resolves; cart/checkout refreshes
-		// must not tear the buttons down underneath it (see the update-event
-		// guard at the bottom of this file).
+		// The wallet sheet opens once this resolves; refreshes are deferred
+		// while it's open (see the update-event guard below).
 		wcStripeECE.paymentInFlight = true;
 		return event.resolve( clickOptions );
 	};
 
-	// Shared between the initial render and in-place refreshes so a refreshed
-	// wallet sheet derives its rates from the same items as the first paint.
+	// Shared by the initial render and in-place refreshes so both derive
+	// shipping rates the same way.
 	const getShippingRatesForOptions = ( options ) => {
 		if ( ! options.requestShipping ) {
 			return [];
@@ -223,17 +222,14 @@ jQuery( function ( $ ) {
 			).length;
 		},
 
-		// Mounted Elements groups, with the inputs that decide whether they can
-		// be refreshed in place on a cart/checkout update.
+		// Mounted Elements groups and the inputs that decide reuse.
 		mountedGroups: [],
 
-		// True while the wallet sheet is open (set when a click resolves,
-		// cleared on cancel/abort/complete); refreshes are deferred meanwhile.
+		// True while the wallet sheet is open; refreshes are deferred meanwhile.
 		paymentInFlight: false,
 		pendingRefresh: false,
 
-		// Only currency and the shipping requirement can't be changed through
-		// elements.update(); anything else refreshes in place.
+		// The only inputs elements.update() can't change.
 		getStructuralSignature: ( options ) =>
 			JSON.stringify( {
 				currency: options.currency,
@@ -245,9 +241,7 @@ jQuery( function ( $ ) {
 				try {
 					group.button?.destroy();
 				} catch ( error ) {
-					// The button may already be gone (e.g. WooCommerce replaced
-					// the surrounding markup); a stale reference must not block
-					// the rebuild.
+					// A stale reference must not block the rebuild.
 				}
 				$(
 					`#wc-stripe-express-checkout-element-${ group.type }`
@@ -257,11 +251,9 @@ jQuery( function ( $ ) {
 		},
 
 		/**
-		 * Refreshes the mounted buttons in place when only amounts/items
-		 * changed, falling back to a full rebuild when a structural input
-		 * changed or nothing is mounted. Reuse skips the /v1/elements/sessions
-		 * call and the wallet availability re-probe a rebuild would repeat on
-		 * every cart/checkout update.
+		 * Refreshes the mounted buttons in place, rebuilding only when a
+		 * structural input changed or nothing is mounted. Reuse skips the
+		 * /v1/elements/sessions call and wallet re-probe of a rebuild.
 		 *
 		 * @param {Object} options ECE options (same shape as startExpressCheckout).
 		 */
@@ -281,15 +273,13 @@ jQuery( function ( $ ) {
 
 			const shippingRates = getShippingRatesForOptions( options );
 			groups.forEach( ( group ) => {
-				// The click/confirm closures read this same options object, so
-				// mutate it in place to keep the wallet sheet contents in sync
-				// with the refreshed cart.
+				// The click/confirm closures read this same options object;
+				// mutate it in place so the wallet sheet stays in sync.
 				Object.assign( group.options, options, { shippingRates } );
 				group.elements.update( { amount: options.total } );
 
-				// WooCommerce re-renders the cart totals wholesale on
-				// updated_cart_totals, discarding the button markup; remount
-				// the existing button instead of paying for a new group.
+				// updated_cart_totals re-renders the cart totals wholesale,
+				// discarding the button markup; remount instead of rebuilding.
 				const container = document.getElementById(
 					`wc-stripe-express-checkout-element-${ group.type }`
 				);
@@ -301,8 +291,8 @@ jQuery( function ( $ ) {
 				}
 			} );
 
-			// A zero-total update may have hidden the buttons; only groups that
-			// reported availability justify re-showing the section.
+			// Recover from a zero-total hide, but only if a group reported
+			// availability — otherwise the separator would linger empty.
 			if ( groups.some( ( group ) => group.available ) ) {
 				wcStripeECE.show();
 				wcStripeECE.getButtonSeparator().show();
@@ -320,8 +310,7 @@ jQuery( function ( $ ) {
 				);
 			}
 			// unmount() first: the element may still reference the discarded
-			// markup. Event listeners were bound at creation and survive a
-			// remount, so renderButton() (which would rebind them) is not used.
+			// markup. Not renderButton(), which would rebind the listeners.
 			group.button.unmount();
 			group.button.mount( `#${ containerName }` );
 		},
@@ -371,9 +360,8 @@ jQuery( function ( $ ) {
 				isLinkEnabled && EXPRESS_PAYMENT_METHOD_SETTING_LINK,
 			].filter( Boolean );
 
-			// Tear down what a previous render mounted: dropping the old
-			// buttons unreferenced leaks their wallet iframes and stacks
-			// duplicate buttons in the containers.
+			// Dropping the old buttons unreferenced would leak their iframes
+			// and stack duplicates in the containers.
 			wcStripeECE.teardownExpressCheckout();
 
 			// Reset the registry so variation/qty updates only touch the buttons
@@ -524,8 +512,8 @@ jQuery( function ( $ ) {
 			// variation/qty change updates every group's amount.
 			wcStripeECE.expressCheckoutElements.push( elements );
 
-			// Registered before button creation so a failure below can't leave
-			// an untracked group behind: teardown iterates this registry.
+			// Registered before button creation so a failure below can't
+			// leave an untracked group behind.
 			const group = {
 				type: expressPaymentType,
 				elements,
@@ -659,8 +647,7 @@ jQuery( function ( $ ) {
 				wcStripeECE.paymentAborted = true;
 				wcStripeECE.paymentInFlight = false;
 				onCancelHandler();
-				// A cart/checkout update arrived while the sheet was open;
-				// apply it now that touching the buttons is safe again.
+				// Apply an update deferred while the sheet was open.
 				if ( wcStripeECE.pendingRefresh ) {
 					wcStripeECE.pendingRefresh = false;
 					wcStripeECE.init();
@@ -1217,14 +1204,12 @@ jQuery( function ( $ ) {
 		);
 	}
 
-	// Refresh ECE data when totals update. A single recalculation can emit a
-	// burst of these events, so coalesce them into one cart fetch; the leading
-	// call keeps the common single-event case immediate.
+	// Refresh ECE data when totals update, coalescing event bursts into one
+	// cart fetch; the leading call keeps the single-event case immediate.
 	const refreshExpressCheckout = debounce(
 		() => {
-			// Never rebuild while the wallet sheet is open: destroying the
-			// button mid-payment kills the shopper's session. The refresh is
-			// applied when the sheet closes (see the cancel handler).
+			// Rebuilding while the wallet sheet is open would kill the
+			// shopper's session; apply on cancel instead.
 			if ( wcStripeECE.paymentInFlight ) {
 				wcStripeECE.pendingRefresh = true;
 				return;

--- a/readme.txt
+++ b/readme.txt
@@ -186,5 +186,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Reject negative refund amounts with an explicit error instead of silently refunding the absolute value
 * Fix - Hide the Apple Pay and Google Pay express buttons on pages unchecked in their own locations setting, instead of following other wallets' locations
 * Fix - Hide the save payment method checkbox for Bancontact, iDEAL and Sofort in the Adaptive Pricing checkout on non-EUR stores whose currency excludes them
+* Update - Reuse the mounted express checkout buttons on cart and checkout updates instead of re-creating them on every totals refresh, and defer refreshes while the wallet sheet is open
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Related to STRIPE-1224
Towards STRIPE-956 / #1439
Supersedes #5709.

## Changes proposed in this Pull Request:

Every `updated_cart_totals` / `updated_checkout` re-created the Elements group per express method — a new `GET /v1/elements/sessions` and wallet re-probe each time, with the old groups leaked and buttons stacking.

Now updates reuse what is mounted:

- **In-place refresh** when the structural signature (`currency`, `requestShipping` — the only inputs `elements.update()` can't change) matches: the amount is pushed via `elements.update()` and the options object the click/confirm closures read is mutated in place.
- **Remount instead of rebuild** when WooCommerce discards the cart-totals markup — still no new Elements group (#5709 paid one session per cart update here).
- **Clean rebuild on structural change**, tearing the old buttons down first.
- **Never mid-payment**: a refresh while the wallet sheet is open is deferred and applied on close.
- **Debounce** coalesces event bursts into one cart fetch.

Review feedback from #5709, addressed: refreshes deferred while a payment is in flight; registry entries pushed before button creation so failures can't leave untracked groups; re-shows gated on reported availability so the separator can't linger; teardown guards stale references.

**Backward compatibility:** client-only change on the classic cart/checkout path; no hooks or PHP surface touched. Blocks path unaffected. Conflicts textually with #5773 (same file, composable designs) — merge order to be agreed.

## Testing instructions

**Prerequisite:** express checkout enabled on classic (shortcode) cart and checkout, in a browser where a wallet button renders.

1. On checkout, with DevTools → Network filtered to `elements/sessions`, change shipping method/address fields several times: no new request per update, buttons stay put.
2. On the cart, change quantities / apply a coupon: one set of buttons, correct amounts, no new `elements/sessions`.
3. Toggle the cart between needing and not needing shipping: buttons rebuild cleanly.
4. Open the wallet sheet, trigger an update, cancel: the sheet isn't torn down while open; buttons reflect the latest totals after closing.
5. 100% coupon hides the buttons; removing it brings them back with the right amount.
6. Complete a wallet purchase from cart and checkout.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
