### PR TITLE
Load Stripe.js and the frontend bundles with the defer strategy

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Record the charge-captured state for asynchronously confirmed payments (e.g. ACH) so refunds from wp-admin and the Stripe Dashboard behave correctly
 * Fix - Reject negative refund amounts with an explicit error instead of silently refunding the absolute value
 * Fix - Hide the Apple Pay and Google Pay express buttons on pages unchecked in their own locations setting, instead of following other wallets' locations
+* Update - Load Stripe.js and the plugin's frontend scripts with the defer loading strategy so they no longer block page rendering
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -2451,7 +2451,16 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		wp_register_style( 'stripe_styles', plugins_url( 'assets/css/stripe-styles.css', WC_STRIPE_MAIN_FILE ), [], WC_STRIPE_VERSION );
 		wp_enqueue_style( 'stripe_styles' );
 
-		wp_register_script( 'woocommerce_stripe', plugins_url( 'assets/js/stripe' . $suffix . '.js', WC_STRIPE_MAIN_FILE ), [ 'jquery-payment', 'stripe' ], WC_STRIPE_VERSION, true );
+		wp_register_script(
+			'woocommerce_stripe',
+			plugins_url( 'assets/js/stripe' . $suffix . '.js', WC_STRIPE_MAIN_FILE ),
+			[ 'jquery-payment', 'stripe' ],
+			WC_STRIPE_VERSION,
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			]
+		);
 
 		wp_localize_script(
 			'woocommerce_stripe',

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -58,7 +58,19 @@ class WC_Stripe_Helper {
 	 * @return void
 	 */
 	public static function register_stripe_js() {
-		wp_register_script( 'stripe', self::STRIPE_JS_URL, [], null, true );
+		// 'defer' is an intended strategy: WordPress downgrades it to blocking
+		// when a non-deferred dependent (e.g. the Blocks integration bundle)
+		// is enqueued, so pages we haven't converted keep their old behavior.
+		wp_register_script(
+			'stripe',
+			self::STRIPE_JS_URL,
+			[],
+			null,
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			]
+		);
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -434,7 +434,10 @@ class WC_Stripe_Express_Checkout_Element {
 			WC_STRIPE_PLUGIN_URL . '/build/express-checkout.js',
 			array_merge( [ 'jquery', 'stripe' ], $asset_data['dependencies'] ),
 			$asset_data['version'],
-			true
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			]
 		);
 	}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -495,7 +495,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			WC_STRIPE_PLUGIN_URL . '/build/upe-classic.js',
 			array_merge( [ 'stripe', 'wc-checkout' ], $dependencies ),
 			$version,
-			true
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			]
 		);
 		wp_set_script_translations(
 			'wc-stripe-upe-classic',

--- a/readme.txt
+++ b/readme.txt
@@ -186,5 +186,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Reject negative refund amounts with an explicit error instead of silently refunding the absolute value
 * Fix - Hide the Apple Pay and Google Pay express buttons on pages unchecked in their own locations setting, instead of following other wallets' locations
 * Fix - Hide the save payment method checkbox for Bancontact, iDEAL and Sofort in the Adaptive Pricing checkout on non-EUR stores whose currency excludes them
+* Update - Load Stripe.js and the plugin's frontend scripts with the defer loading strategy so they no longer block page rendering
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-helper-test.php
@@ -2808,5 +2808,6 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		$registered = wp_scripts()->registered['stripe'];
 		$this->assertSame( 'https://js.stripe.com/dahlia/stripe.js', $registered->src );
 		$this->assertSame( 1, wp_scripts()->get_data( 'stripe', 'group' ), 'Stripe.js must load in the footer.' );
+		$this->assertSame( 'defer', wp_scripts()->get_data( 'stripe', 'strategy' ), 'Stripe.js must not block rendering.' );
 	}
 }


### PR DESCRIPTION
Towards STRIPE-956
Towards #1439

## Changes proposed in this Pull Request:

Stripe.js (`stripe`) and the classic frontend bundles (`wc-stripe-upe-classic`, `wc_stripe_express_checkout`, legacy `woocommerce_stripe`) were plain blocking footer scripts. On checkout and pay-for-order pages — where #5772's product/cart deferral intentionally doesn't apply — Stripe.js still blocked rendering. This registers all four with WP's `defer` loading strategy (WP 6.3+; we require 6.7+), moving their execution off the parser's critical path while preserving execution order.

**Why this is safe:** `defer` is an *intended* strategy — WordPress automatically downgrades a script to blocking when any enqueued dependent isn't deferred. The Blocks integration bundle is not converted here, so Blocks cart/checkout keep today's behavior; only pages where every dependent defers (classic checkout, product, cart, pay-for-order) change. `wp_localize_script` data is position-`before` and unaffected; the plugin has no front-end `wp_add_inline_script`. The classic checkout already tolerates deferred JS — that path was hardened for host optimizers that force-defer scripts (SiteGround Speed Optimizer).

**Backward compatibility:** registration-args-only change; no handles, URLs, dependencies, hooks, or load order changed. Merchants running optimizer plugins that already defer these tags see no difference.

Verified in the local env: all three tags carry `defer` on classic checkout and product pages, and the UPE payment element and express checkout buttons render normally.

## Testing instructions

1. Enable Stripe with express checkout on product/cart/checkout; use a classic `[woocommerce_checkout]` page.
2. View source (or DevTools → Elements) on the checkout page: the `js.stripe.com` tag and the `upe-classic.js` / `express-checkout.js` tags have a `defer` attribute.
3. Confirm the card fields and express buttons render and a test purchase completes.
4. On the Blocks checkout, confirm payment still works (the Stripe.js tag may legitimately remain blocking there).

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
