### PR TITLE
Fix Express Checkout silent drop after wallet sheet

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Record the charge-captured state for asynchronously confirmed payments (e.g. ACH) so refunds from wp-admin and the Stripe Dashboard behave correctly
 * Fix - Reject negative refund amounts with an explicit error instead of silently refunding the absolute value
 * Fix - Hide the Apple Pay and Google Pay express buttons on pages unchecked in their own locations setting, instead of following other wallets' locations
+* Fix - Surface express checkout order failures instead of leaving the Apple Pay or Google Pay sheet open with no error
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/client/blocks/express-checkout/__tests__/hooks.test.js
+++ b/client/blocks/express-checkout/__tests__/hooks.test.js
@@ -1,5 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { useExpressCheckout } from '../hooks';
+import { onConfirmHandler } from 'wcstripe/express-checkout/event-handler';
 import { getExpressCheckoutData } from 'wcstripe/express-checkout/utils';
 
 // Stable singletons, matching how react-stripe-js returns the same instances.
@@ -222,6 +223,42 @@ describe( 'useExpressCheckout', () => {
 				shippingAddressRequired: false,
 				phoneNumberRequired: true,
 			} )
+		);
+	} );
+
+	// An order-side failure still has to give the wallet sheet a terminal result,
+	// otherwise it stays open and the shopper is left with nothing.
+	it( 'fails the payment on the wallet sheet when the order errors', async () => {
+		const setExpressPaymentError = jest.fn();
+
+		const { result } = renderHook( () =>
+			useExpressCheckout( {
+				api: {},
+				billing: {
+					currency: { minorUnit: 2 },
+					cartTotal: { value: 7500 },
+					cartTotalItems: [],
+				},
+				shippingData: { needsShipping: false, shippingRates: [] },
+				onClick: jest.fn(),
+				onClose: jest.fn(),
+				setExpressPaymentError,
+			} )
+		);
+
+		const event = { paymentFailed: jest.fn() };
+		await act( async () => {
+			await result.current.onConfirm( event );
+		} );
+
+		const { abortPayment } = onConfirmHandler.mock.calls[ 0 ][ 0 ];
+		abortPayment( event, 'Order creation error' );
+
+		expect( event.paymentFailed ).toHaveBeenCalledWith( {
+			reason: 'fail',
+		} );
+		expect( setExpressPaymentError ).toHaveBeenCalledWith(
+			'Order creation error'
 		);
 	} );
 

--- a/client/blocks/express-checkout/__tests__/hooks.test.js
+++ b/client/blocks/express-checkout/__tests__/hooks.test.js
@@ -227,7 +227,8 @@ describe( 'useExpressCheckout', () => {
 	} );
 
 	// An order-side failure still has to give the wallet sheet a terminal result,
-	// otherwise it stays open and the shopper is left with nothing.
+	// otherwise it stays open and the shopper is left with nothing. The third
+	// argument is the removed `isOrderError` opt-out: passing it must change nothing.
 	it( 'fails the payment on the wallet sheet when the order errors', async () => {
 		const setExpressPaymentError = jest.fn();
 
@@ -252,7 +253,7 @@ describe( 'useExpressCheckout', () => {
 		} );
 
 		const { abortPayment } = onConfirmHandler.mock.calls[ 0 ][ 0 ];
-		abortPayment( event, 'Order creation error' );
+		abortPayment( event, 'Order creation error', true );
 
 		expect( event.paymentFailed ).toHaveBeenCalledWith( {
 			reason: 'fail',
@@ -260,6 +261,11 @@ describe( 'useExpressCheckout', () => {
 		expect( setExpressPaymentError ).toHaveBeenCalledWith(
 			'Order creation error'
 		);
+
+		// The message has to be in front of the shopper before the sheet closes.
+		expect(
+			setExpressPaymentError.mock.invocationCallOrder[ 0 ]
+		).toBeLessThan( event.paymentFailed.mock.invocationCallOrder[ 0 ] );
 	} );
 
 	// Blocks passes fresh billing/shippingData refs each cart tick; memoised

--- a/client/blocks/express-checkout/hooks.js
+++ b/client/blocks/express-checkout/hooks.js
@@ -56,15 +56,16 @@ export const useExpressCheckout = ( {
 
 	const abortPayment = useCallback(
 		( onConfirmEvent, message ) => {
-			// The wallet sheet only closes once the confirm event gets a
-			// terminal result, so this must run for order errors too.
-			onConfirmEvent.paymentFailed( { reason: 'fail' } );
-
 			// If we have a multiline message using newlines, replace them with <br>.
 			const formattedMessage = message.replace( /\n/g, '<br>' );
 			setExpressPaymentError( formattedMessage );
 
 			onAbortPaymentHandler( onConfirmEvent, message );
+
+			// The wallet sheet only closes once the confirm event gets a
+			// terminal result, so this must run for order errors too. Last,
+			// so a rejected late call can't cost the shopper the message.
+			onConfirmEvent.paymentFailed( { reason: 'fail' } );
 		},
 		[ setExpressPaymentError ]
 	);

--- a/client/blocks/express-checkout/hooks.js
+++ b/client/blocks/express-checkout/hooks.js
@@ -62,9 +62,9 @@ export const useExpressCheckout = ( {
 
 			onAbortPaymentHandler( onConfirmEvent, message );
 
-			// The wallet sheet only closes once the confirm event gets a
-			// terminal result, so this must run for order errors too. Last,
-			// so a rejected late call can't cost the shopper the message.
+			// The wallet sheet only closes once the confirm event gets a terminal
+			// result, so order errors must fail it too. A late call rejects an
+			// internal Stripe promise asynchronously, after the message is shown.
 			onConfirmEvent.paymentFailed( { reason: 'fail' } );
 		},
 		[ setExpressPaymentError ]

--- a/client/blocks/express-checkout/hooks.js
+++ b/client/blocks/express-checkout/hooks.js
@@ -55,10 +55,10 @@ export const useExpressCheckout = ( {
 	}, [] );
 
 	const abortPayment = useCallback(
-		( onConfirmEvent, message, isOrderError = false ) => {
-			if ( ! isOrderError ) {
-				onConfirmEvent.paymentFailed( { reason: 'fail' } );
-			}
+		( onConfirmEvent, message ) => {
+			// The wallet sheet only closes once the confirm event gets a
+			// terminal result, so this must run for order errors too.
+			onConfirmEvent.paymentFailed( { reason: 'fail' } );
 
 			// If we have a multiline message using newlines, replace them with <br>.
 			const formattedMessage = message.replace( /\n/g, '<br>' );

--- a/client/entrypoints/express-checkout/__tests__/index.test.js
+++ b/client/entrypoints/express-checkout/__tests__/index.test.js
@@ -51,6 +51,18 @@ jest.mock( 'wcstripe/express-checkout/transformers/wc-to-stripe', () => ( {
 	transformPrice: jest.fn( () => 1500 ),
 } ) );
 
+// Stub the shared event handlers so the entrypoint's own `abortPayment` can be
+// captured from the params it hands to onConfirmHandler.
+jest.mock( 'wcstripe/express-checkout/event-handler', () => ( {
+	onAbortPaymentHandler: jest.fn(),
+	onCancelHandler: jest.fn(),
+	onClickHandler: jest.fn(),
+	onCompletePaymentHandler: jest.fn(),
+	onConfirmHandler: jest.fn(),
+	shippingAddressChangeHandler: jest.fn(),
+	shippingRateChangeHandler: jest.fn(),
+} ) );
+
 // Side-effect-only compatibility shims attach jQuery handlers we don't drive here.
 jest.mock(
 	'wcstripe/express-checkout/compatibility/wc-order-attribution',
@@ -448,5 +460,93 @@ describe( 'Express Checkout per-method location gating', () => {
 		loadEntrypoint();
 
 		expect( mountedTypes() ).toEqual( [ 'googlePay' ] );
+	} );
+} );
+
+describe( 'Express Checkout order failures', () => {
+	const stubStripeButton = () => {
+		const handlers = {};
+		const button = {
+			on: ( evt, cb ) => {
+				handlers[ evt ] = cb;
+				return button;
+			},
+			mount: jest.fn(),
+		};
+		mockGetStripe.mockReturnValue( {
+			elements: jest.fn( () => ( {
+				create: jest.fn( () => button ),
+				update: jest.fn(),
+			} ) ),
+		} );
+		return handlers;
+	};
+
+	beforeEach( () => {
+		jest.resetModules();
+		mockGetStripe.mockReset();
+
+		// No notices wrapper: the storefront case where the message used to vanish.
+		document.body.innerHTML =
+			'<div id="wc-stripe-express-checkout-element"></div>';
+
+		global.wc_stripe_express_checkout_params = {
+			...baseParams(),
+			is_cart_page: false,
+			stripe: {
+				publishable_key: 'pk_test_123',
+				locale: 'en',
+				is_apple_pay_enabled: true,
+			},
+			cart: {
+				total: 1500,
+				currency: 'usd',
+				requestShipping: false,
+				requestPhone: false,
+				displayItems: [],
+			},
+		};
+	} );
+
+	afterEach( () => {
+		delete global.wc_stripe_express_checkout_params;
+	} );
+
+	// The order-side abort used to skip paymentFailed(), leaving the approved wallet
+	// sheet open with nothing on screen. The third argument is the removed
+	// `isOrderError` opt-out: passing it must change nothing.
+	it( 'fails the wallet sheet and shows the message when the order errors', async () => {
+		const handlers = stubStripeButton();
+		loadEntrypoint();
+
+		// Resolve the mocks from the same module registry the entrypoint loaded from;
+		// `jest.resetModules()` hands each test its own copy.
+		// eslint-disable-next-line global-require
+		const jq = require( 'jquery' );
+		const {
+			onAbortPaymentHandler,
+			onConfirmHandler,
+			// eslint-disable-next-line global-require
+		} = require( 'wcstripe/express-checkout/event-handler' );
+
+		jq( document.body ).trigger( 'updated_checkout' );
+
+		const event = { paymentFailed: jest.fn() };
+		await handlers.confirm( event );
+
+		const { abortPayment } = onConfirmHandler.mock.calls[ 0 ][ 0 ];
+		abortPayment( event, 'Order creation error', true );
+
+		expect( event.paymentFailed ).toHaveBeenCalledWith( {
+			reason: 'fail',
+		} );
+		expect(
+			document.querySelector( '.woocommerce-error' ).textContent
+		).toBe( 'Order creation error' );
+
+		// The message has to be in front of the shopper before the sheet closes.
+		expect(
+			onAbortPaymentHandler.mock.invocationCallOrder[ 0 ]
+		).toBeLessThan( event.paymentFailed.mock.invocationCallOrder[ 0 ] );
 	} );
 } );

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -877,9 +877,9 @@ jQuery( function ( $ ) {
 			onAbortPaymentHandler( payment, message );
 			displayExpressCheckoutNotice( message, 'error' );
 
-			// The wallet sheet only closes once the confirm event gets a
-			// terminal result, so this must run for order errors too. Last,
-			// so a rejected late call can't cost the shopper the message.
+			// The wallet sheet only closes once the confirm event gets a terminal
+			// result, so order errors must fail it too. A late call rejects an
+			// internal Stripe promise asynchronously, after the message is shown.
 			payment.paymentFailed( { reason: 'fail' } );
 		},
 

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -874,12 +874,13 @@ jQuery( function ( $ ) {
 		 * @param {string}          message Error message to display.
 		 */
 		abortPayment: ( payment, message ) => {
-			// The wallet sheet only closes once the confirm event gets a
-			// terminal result, so this must run for order errors too.
-			payment.paymentFailed( { reason: 'fail' } );
 			onAbortPaymentHandler( payment, message );
-
 			displayExpressCheckoutNotice( message, 'error' );
+
+			// The wallet sheet only closes once the confirm event gets a
+			// terminal result, so this must run for order errors too. Last,
+			// so a rejected late call can't cost the shopper the message.
+			payment.paymentFailed( { reason: 'fail' } );
 		},
 
 		attachProductPageEventListeners: () => {

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -870,14 +870,13 @@ jQuery( function ( $ ) {
 		/**
 		 * Abort the payment and display error messages.
 		 *
-		 * @param {PaymentResponse} payment      Payment response instance.
-		 * @param {string}          message      Error message to display.
-		 * @param {boolean}         isOrderError Whether the error is related to the order creation.
+		 * @param {PaymentResponse} payment Payment response instance.
+		 * @param {string}          message Error message to display.
 		 */
-		abortPayment: ( payment, message, isOrderError = false ) => {
-			if ( ! isOrderError ) {
-				payment.paymentFailed( { reason: 'fail' } );
-			}
+		abortPayment: ( payment, message ) => {
+			// The wallet sheet only closes once the confirm event gets a
+			// terminal result, so this must run for order errors too.
+			payment.paymentFailed( { reason: 'fail' } );
 			onAbortPaymentHandler( payment, message );
 
 			displayExpressCheckoutNotice( message, 'error' );

--- a/client/express-checkout/__tests__/event-handler.test.js
+++ b/client/express-checkout/__tests__/event-handler.test.js
@@ -395,8 +395,7 @@ describe( 'Express checkout event handlers', () => {
 			);
 			expect( abortPayment ).toHaveBeenCalledWith(
 				event,
-				'Order creation error',
-				true
+				'Order creation error'
 			);
 			expect( completePayment ).not.toHaveBeenCalled();
 		} );
@@ -498,8 +497,7 @@ describe( 'Express checkout event handlers', () => {
 			);
 			expect( abortPayment ).toHaveBeenCalledWith(
 				event,
-				'Intent confirmation error',
-				true
+				'Intent confirmation error'
 			);
 			expect( completePayment ).not.toHaveBeenCalled();
 		} );
@@ -542,8 +540,7 @@ describe( 'Express checkout event handlers', () => {
 			);
 			expect( abortPayment ).toHaveBeenCalledWith(
 				event,
-				'Order creation error',
-				true
+				'Order creation error'
 			);
 			expect( completePayment ).not.toHaveBeenCalled();
 		} );
@@ -648,8 +645,7 @@ describe( 'Express checkout event handlers', () => {
 			);
 			expect( abortPayment ).toHaveBeenCalledWith(
 				event,
-				'Intent confirmation error',
-				true
+				'Intent confirmation error'
 			);
 			expect( completePayment ).not.toHaveBeenCalled();
 		} );

--- a/client/express-checkout/__tests__/payment-flow.test.js
+++ b/client/express-checkout/__tests__/payment-flow.test.js
@@ -376,6 +376,33 @@ describe( 'handleManualPaymentMethodFlow', () => {
 		expect( abortPayment ).not.toHaveBeenCalled();
 	} );
 
+	// WooCommerce answers 200 with an empty payment status when it skips payment
+	// entirely (e.g. it could not resolve the gateway), leaving the order unpaid
+	// with nothing attached to explain why. The shopper still needs a message.
+	test( 'should abort with a generic message when the order reports no payment status', async () => {
+		stripe.createPaymentMethod.mockResolvedValue( {
+			paymentMethod: { id: 'pm_test_123' },
+		} );
+		api.expressCheckoutECECreateOrder.mockResolvedValue( {
+			payment_result: { payment_status: '' },
+		} );
+
+		await handleManualPaymentMethodFlow( {
+			api,
+			stripe,
+			elements,
+			completePayment,
+			abortPayment,
+			event,
+		} );
+
+		expect( abortPayment ).toHaveBeenCalledWith(
+			event,
+			'There was a problem processing the order.'
+		);
+		expect( completePayment ).not.toHaveBeenCalled();
+	} );
+
 	test( 'should abort when order creation fails', async () => {
 		stripe.createPaymentMethod.mockResolvedValue( {
 			paymentMethod: { id: 'pm_test_123' },

--- a/client/express-checkout/__tests__/payment-flow.test.js
+++ b/client/express-checkout/__tests__/payment-flow.test.js
@@ -349,6 +349,28 @@ describe( 'handleManualPaymentMethodFlow', () => {
 		expect( completePayment ).not.toHaveBeenCalled();
 	} );
 
+	// Stripe messages are plain text; parsing them as HTML truncated anything
+	// tag-like, e.g. an email address in angle brackets.
+	test( 'should not truncate a Stripe error containing angle brackets', async () => {
+		stripe.createPaymentMethod.mockResolvedValue( {
+			error: { message: 'Invalid email <user@example.com>' },
+		} );
+
+		await handleManualPaymentMethodFlow( {
+			api,
+			stripe,
+			elements,
+			completePayment,
+			abortPayment,
+			event,
+		} );
+
+		expect( abortPayment ).toHaveBeenCalledWith(
+			event,
+			'Invalid email <user@example.com>'
+		);
+	} );
+
 	test( 'should complete payment on successful order', async () => {
 		stripe.createPaymentMethod.mockResolvedValue( {
 			paymentMethod: { id: 'pm_test_123' },

--- a/client/express-checkout/event-handler.js
+++ b/client/express-checkout/event-handler.js
@@ -1,4 +1,8 @@
-import { isManualPaymentMethodCreation, getExpressCheckoutData } from './utils';
+import {
+	getExpressCheckoutData,
+	getExpressCheckoutErrorMessage,
+	isManualPaymentMethodCreation,
+} from './utils';
 import {
 	handleConfirmationTokenFlow,
 	handleManualPaymentMethodFlow,
@@ -115,7 +119,10 @@ export const onConfirmHandler = async ( params ) => {
 
 	const submitResponse = await elements.submit();
 	if ( submitResponse?.error ) {
-		return abortPayment( event, submitResponse?.error?.message );
+		return abortPayment(
+			event,
+			getExpressCheckoutErrorMessage( submitResponse?.error?.message )
+		);
 	}
 
 	// For subscription change payment method, create a payment method and submit the form.

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -3,6 +3,23 @@ import { getErrorMessageFromNotice, normalizeOrderData } from './utils';
 import { __ } from '@wordpress/i18n';
 
 /**
+ * Resolves the message shown when the order could not be processed.
+ *
+ * The Store API can report a non-success payment status with no error attached
+ * (e.g. WooCommerce skipped payment because it could not resolve the gateway),
+ * so fall back to a generic message rather than aborting with an empty one.
+ *
+ * @param {string|undefined} errorMessage The error message returned by the server, if any.
+ * @return {string} The message to display.
+ */
+const getOrderErrorMessage = ( errorMessage ) =>
+	getErrorMessageFromNotice( errorMessage ) ||
+	__(
+		'There was a problem processing the order.',
+		'woocommerce-gateway-stripe'
+	);
+
+/**
  * Handles exceptions thrown during the payment flow by extracting a human-readable
  * error message and calling the abort payment callback.
  *
@@ -29,14 +46,8 @@ const handlePaymentFlowException = ( event, exception, abortPayment ) => {
 			errorMessage = paymentDetailsErrorMessage;
 		}
 	}
-	if ( ! errorMessage ) {
-		errorMessage = __(
-			'There was a problem processing the order.',
-			'woocommerce-gateway-stripe'
-		);
-	}
 
-	return abortPayment( event, getErrorMessageFromNotice( errorMessage ) );
+	return abortPayment( event, getOrderErrorMessage( errorMessage ) );
 };
 
 /**
@@ -154,10 +165,7 @@ export const handleManualPaymentMethodFlow = async ( {
 		} );
 
 		if ( result !== 'success' ) {
-			return abortPayment(
-				event,
-				getErrorMessageFromNotice( errorMessage )
-			);
+			return abortPayment( event, getOrderErrorMessage( errorMessage ) );
 		}
 
 		const confirmationRequest = api.confirmIntent( redirect );
@@ -225,10 +233,7 @@ export const handleConfirmationTokenFlow = async ( {
 		} );
 
 		if ( result !== 'success' ) {
-			return abortPayment(
-				event,
-				getErrorMessageFromNotice( errorMessage )
-			);
+			return abortPayment( event, getOrderErrorMessage( errorMessage ) );
 		}
 
 		const confirmationRequest = api.confirmIntent( redirect );

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -1,5 +1,9 @@
 import jQuery from 'jquery';
-import { getExpressCheckoutErrorMessage, normalizeOrderData } from './utils';
+import {
+	getErrorMessageFromNotice,
+	getExpressCheckoutErrorMessage,
+	normalizeOrderData,
+} from './utils';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -32,7 +36,9 @@ const handlePaymentFlowException = ( event, exception, abortPayment ) => {
 
 	return abortPayment(
 		event,
-		getExpressCheckoutErrorMessage( errorMessage )
+		getExpressCheckoutErrorMessage(
+			getErrorMessageFromNotice( errorMessage )
+		)
 	);
 };
 
@@ -168,7 +174,9 @@ export const handleManualPaymentMethodFlow = async ( {
 		if ( result !== 'success' ) {
 			return abortPayment(
 				event,
-				getExpressCheckoutErrorMessage( errorMessage )
+				getExpressCheckoutErrorMessage(
+					getErrorMessageFromNotice( errorMessage )
+				)
 			);
 		}
 
@@ -224,7 +232,9 @@ export const handleConfirmationTokenFlow = async ( {
 		if ( error ) {
 			return abortPayment(
 				event,
-				getExpressCheckoutErrorMessage( error.message )
+				getExpressCheckoutErrorMessage(
+					getErrorMessageFromNotice( error.message )
+				)
 			);
 		}
 
@@ -239,7 +249,9 @@ export const handleConfirmationTokenFlow = async ( {
 		if ( result !== 'success' ) {
 			return abortPayment(
 				event,
-				getExpressCheckoutErrorMessage( errorMessage )
+				getExpressCheckoutErrorMessage(
+					getErrorMessageFromNotice( errorMessage )
+				)
 			);
 		}
 

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -36,11 +36,7 @@ const handlePaymentFlowException = ( event, exception, abortPayment ) => {
 		);
 	}
 
-	return abortPayment(
-		event,
-		getErrorMessageFromNotice( errorMessage ),
-		true
-	);
+	return abortPayment( event, getErrorMessageFromNotice( errorMessage ) );
 };
 
 /**
@@ -160,8 +156,7 @@ export const handleManualPaymentMethodFlow = async ( {
 		if ( result !== 'success' ) {
 			return abortPayment(
 				event,
-				getErrorMessageFromNotice( errorMessage ),
-				true
+				getErrorMessageFromNotice( errorMessage )
 			);
 		}
 
@@ -217,8 +212,7 @@ export const handleConfirmationTokenFlow = async ( {
 		if ( error ) {
 			return abortPayment(
 				event,
-				getErrorMessageFromNotice( error.message ),
-				true
+				getErrorMessageFromNotice( error.message )
 			);
 		}
 
@@ -233,8 +227,7 @@ export const handleConfirmationTokenFlow = async ( {
 		if ( result !== 'success' ) {
 			return abortPayment(
 				event,
-				getErrorMessageFromNotice( errorMessage ),
-				true
+				getErrorMessageFromNotice( errorMessage )
 			);
 		}
 

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -1,23 +1,6 @@
 import jQuery from 'jquery';
-import { getErrorMessageFromNotice, normalizeOrderData } from './utils';
+import { getExpressCheckoutErrorMessage, normalizeOrderData } from './utils';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Resolves the message shown when the order could not be processed.
- *
- * The Store API can report a non-success payment status with no error attached
- * (e.g. WooCommerce skipped payment because it could not resolve the gateway),
- * so fall back to a generic message rather than aborting with an empty one.
- *
- * @param {string|undefined} errorMessage The error message returned by the server, if any.
- * @return {string} The message to display.
- */
-const getOrderErrorMessage = ( errorMessage ) =>
-	getErrorMessageFromNotice( errorMessage ) ||
-	__(
-		'There was a problem processing the order.',
-		'woocommerce-gateway-stripe'
-	);
 
 /**
  * Handles exceptions thrown during the payment flow by extracting a human-readable
@@ -47,7 +30,10 @@ const handlePaymentFlowException = ( event, exception, abortPayment ) => {
 		}
 	}
 
-	return abortPayment( event, getOrderErrorMessage( errorMessage ) );
+	return abortPayment(
+		event,
+		getExpressCheckoutErrorMessage( errorMessage )
+	);
 };
 
 /**
@@ -152,7 +138,10 @@ export const handleManualPaymentMethodFlow = async ( {
 		} );
 
 		if ( error ) {
-			return abortPayment( event, error.message );
+			return abortPayment(
+				event,
+				getExpressCheckoutErrorMessage( error.message )
+			);
 		}
 
 		// Kick off checkout processing step.
@@ -165,7 +154,10 @@ export const handleManualPaymentMethodFlow = async ( {
 		} );
 
 		if ( result !== 'success' ) {
-			return abortPayment( event, getOrderErrorMessage( errorMessage ) );
+			return abortPayment(
+				event,
+				getExpressCheckoutErrorMessage( errorMessage )
+			);
 		}
 
 		const confirmationRequest = api.confirmIntent( redirect );
@@ -220,7 +212,7 @@ export const handleConfirmationTokenFlow = async ( {
 		if ( error ) {
 			return abortPayment(
 				event,
-				getErrorMessageFromNotice( error.message )
+				getExpressCheckoutErrorMessage( error.message )
 			);
 		}
 
@@ -233,7 +225,10 @@ export const handleConfirmationTokenFlow = async ( {
 		} );
 
 		if ( result !== 'success' ) {
-			return abortPayment( event, getOrderErrorMessage( errorMessage ) );
+			return abortPayment(
+				event,
+				getExpressCheckoutErrorMessage( errorMessage )
+			);
 		}
 
 		const confirmationRequest = api.confirmIntent( redirect );
@@ -289,7 +284,10 @@ export const handleChangePaymentMethodFlow = async ( {
 		} );
 
 		if ( error ) {
-			return abortPayment( event, error.message );
+			return abortPayment(
+				event,
+				getExpressCheckoutErrorMessage( error.message )
+			);
 		}
 
 		// Populate the hidden fields that the UPE gateway expects.

--- a/client/express-checkout/utils/__tests__/index.test.js
+++ b/client/express-checkout/utils/__tests__/index.test.js
@@ -98,6 +98,25 @@ describe( 'Express checkout utils', () => {
 			render( <App /> );
 			expect( screen.queryByRole( 'note' ) ).toBeInTheDocument();
 		} );
+
+		// Without a fallback the message is dropped and the shopper sees nothing.
+		test( 'falls back to the express checkout button when no wrapper exists', () => {
+			const button = document.createElement( 'div' );
+			button.id = 'wc-stripe-express-checkout-element';
+			document.body.appendChild( button );
+
+			displayExpressCheckoutNotice( 'Test message', 'error' );
+
+			const note = screen.queryByRole( 'note' );
+			expect( note ).toBeInTheDocument();
+			expect( note.nextElementSibling ).toBe( button );
+		} );
+
+		test( 'does nothing when there is nowhere to render the notice', () => {
+			displayExpressCheckoutNotice( 'Test message', 'error' );
+
+			expect( screen.queryByRole( 'note' ) ).not.toBeInTheDocument();
+		} );
 	} );
 
 	describe( 'getPaymentMethodTypesForExpressMethod', () => {

--- a/client/express-checkout/utils/index.js
+++ b/client/express-checkout/utils/index.js
@@ -39,15 +39,20 @@ export const getErrorMessageFromNotice = ( notice ) => {
  * non-success payment status with nothing attached, or a Stripe error whose `message`
  * is unset — and aborting with an empty one leaves the shopper with no explanation.
  *
+ * Takes the message as-is: callers that receive a WooCommerce notice run it through
+ * `getErrorMessageFromNotice()` first, and parsing a plain Stripe message as HTML would
+ * truncate it at anything tag-like (e.g. an email address in angle brackets).
+ *
  * @param {string|undefined} message The message reported by Stripe or the server, if any.
  * @return {string} The message to display.
  */
 export const getExpressCheckoutErrorMessage = ( message ) =>
-	getErrorMessageFromNotice( message ) ||
-	__(
-		'There was a problem processing the order.',
-		'woocommerce-gateway-stripe'
-	);
+	message?.trim()
+		? message
+		: __(
+				'There was a problem processing the order.',
+				'woocommerce-gateway-stripe'
+		  );
 
 /**
  * Retrieves express checkout data from global variable.

--- a/client/express-checkout/utils/index.js
+++ b/client/express-checkout/utils/index.js
@@ -1,5 +1,6 @@
 /* global wc_stripe_express_checkout_params */
 import jQuery from 'jquery';
+import { __ } from '@wordpress/i18n';
 import { isAmazonPayEnabled, isLinkEnabled } from 'wcstripe/stripe-utils';
 import { EXPRESS_CHECKOUT_NOTICE_DELAY } from 'wcstripe/data/constants';
 import {
@@ -30,6 +31,23 @@ export const getErrorMessageFromNotice = ( notice ) => {
 	div.innerHTML = notice.trim();
 	return div.firstChild?.textContent || '';
 };
+
+/**
+ * Resolves the message shown when an express checkout payment is aborted.
+ *
+ * Stripe errors and Store API responses can both arrive without a usable message — a
+ * non-success payment status with nothing attached, or a Stripe error whose `message`
+ * is unset — and aborting with an empty one leaves the shopper with no explanation.
+ *
+ * @param {string|undefined} message The message reported by Stripe or the server, if any.
+ * @return {string} The message to display.
+ */
+export const getExpressCheckoutErrorMessage = ( message ) =>
+	getErrorMessageFromNotice( message ) ||
+	__(
+		'There was a problem processing the order.',
+		'woocommerce-gateway-stripe'
+	);
 
 /**
  * Retrieves express checkout data from global variable.
@@ -399,22 +417,23 @@ export const displayExpressCheckoutNotice = (
 		`<div class="${ classNames.join( ' ' ) }" role="note" />`
 	).html( safeMessage );
 
-	if ( $container.length ) {
-		if ( isBlockCheckout ) {
-			$container.prepend( note );
-		} else {
-			$container.append( note );
-		}
-	} else {
+	if ( ! $container.length ) {
 		// Product pages, and themes that render no notices wrapper, would drop the
-		// message entirely. Fall back to the button, which is on every page that
-		// can raise one of these errors.
+		// message entirely. Fall back to the classic express checkout container; it
+		// sits where the shopper just tapped, so no scrolling is needed (and none is
+		// wanted, with a wallet sheet opening over the page).
 		const $button = jQuery( '#wc-stripe-express-checkout-element' );
-		if ( ! $button.length ) {
-			return;
+		if ( $button.length ) {
+			$button.before( note );
 		}
 
-		$button.before( note );
+		return;
+	}
+
+	if ( isBlockCheckout ) {
+		$container.prepend( note );
+	} else {
+		$container.append( note );
 	}
 
 	// Scroll to the notice.

--- a/client/express-checkout/utils/index.js
+++ b/client/express-checkout/utils/index.js
@@ -391,29 +391,34 @@ export const displayExpressCheckoutNotice = (
 		: 'woocommerce-notices-wrapper';
 	const $container = jQuery( '.' + containerClass ).first();
 
+	const safeMessage = jQuery( '<div>' )
+		.text( message )
+		.html()
+		.replace( /\n/g, '<br>' );
+	const note = jQuery(
+		`<div class="${ classNames.join( ' ' ) }" role="note" />`
+	).html( safeMessage );
+
 	if ( $container.length ) {
-		const safeMessage = jQuery( '<div>' )
-			.text( message )
-			.html()
-			.replace( /\n/g, '<br>' );
-		const note = jQuery(
-			`<div class="${ classNames.join( ' ' ) }" role="note" />`
-		).html( safeMessage );
 		if ( isBlockCheckout ) {
 			$container.prepend( note );
 		} else {
 			$container.append( note );
 		}
+	} else {
+		// Product pages, and themes that render no notices wrapper, would drop the
+		// message entirely. Fall back to the button, which is on every page that
+		// can raise one of these errors.
+		const $button = jQuery( '#wc-stripe-express-checkout-element' );
+		if ( ! $button.length ) {
+			return;
+		}
 
-		// Scroll to notices.
-		jQuery( 'html, body' ).animate(
-			{
-				scrollTop: $container.find( `.${ mainNoticeClass }` ).offset()
-					.top,
-			},
-			600
-		);
+		$button.before( note );
 	}
+
+	// Scroll to the notice.
+	jQuery( 'html, body' ).animate( { scrollTop: note.offset().top }, 600 );
 };
 
 /**

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -629,8 +629,11 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 			return;
 		}
 
+		// The context is hook-derived, so don't let the log line itself be what fatals.
+		$order_id = $context->order instanceof WC_Order ? $context->order->get_id() : 0;
+
 		WC_Stripe_Logger::error(
-			'Payment was never processed for order: ' . $context->order->get_id(),
+			'Payment was never processed for order: ' . $order_id,
 			[
 				'payment_method' => $payment_method,
 				'reason'         => 'WooCommerce set no payment result status, so the gateway was never invoked.',

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -63,6 +63,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 
 		add_action( 'woocommerce_rest_checkout_process_payment_with_context', [ $this, 'add_express_checkout_order_meta' ], 8, 2 );
 		add_action( 'woocommerce_rest_checkout_process_payment_with_context', [ $this, 'add_stripe_intents' ], 9999, 2 );
+		add_action( 'woocommerce_rest_checkout_process_payment_with_context', [ $this, 'fail_unprocessed_payment' ], 10000, 2 );
 
 		if ( null === $express_checkout_configuration ) {
 			$helper                         = new WC_Stripe_Express_Checkout_Helper();
@@ -582,6 +583,43 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 			$result->set_payment_details( $payment_details );
 			$result->set_status( 'success' );
 		}
+	}
+
+	/**
+	 * Fails the payment when WooCommerce never handed it to the gateway.
+	 *
+	 * `Legacy::process_legacy_payment()` returns without setting a status when it cannot
+	 * resolve the payment method to an available gateway. The Store API then answers 200
+	 * with an empty payment status, leaving the order unpaid with no charge attempted and
+	 * nothing logged; express checkout reads that as a failure it cannot explain and the
+	 * wallet sheet is left with no reason to show. Turn it into a real error instead.
+	 *
+	 * @param PaymentContext $context Holds context for the payment.
+	 * @param PaymentResult  $result  Result object for the payment.
+	 *
+	 * @throws Exception When the payment was never processed.
+	 *
+	 * @return void
+	 */
+	public function fail_unprocessed_payment( PaymentContext $context, PaymentResult &$result ) {
+		if ( '' !== (string) $result->status ) {
+			return;
+		}
+
+		$payment_method = (string) $context->payment_method;
+		if ( $this->name !== $payment_method && 0 !== strpos( $payment_method, $this->name . '_' ) ) {
+			return;
+		}
+
+		WC_Stripe_Logger::error(
+			'Payment was never processed for order: ' . $context->order->get_id(),
+			[
+				'payment_method' => $payment_method,
+				'reason'         => 'WooCommerce could not resolve the payment method to an available gateway.',
+			]
+		);
+
+		throw new Exception( __( 'This payment method is not available right now. Please try again or use a different one.', 'woocommerce-gateway-stripe' ) );
 	}
 
 	/**

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -617,11 +617,11 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	/**
 	 * Fails the payment when WooCommerce never handed it to the gateway.
 	 *
-	 * `Legacy::process_legacy_payment()` returns without setting a status when it cannot
-	 * resolve the payment method to an available gateway. The Store API then answers 200
-	 * with an empty payment status, leaving the order unpaid with no charge attempted and
-	 * nothing logged; express checkout reads that as a failure it cannot explain and the
-	 * wallet sheet is left with no reason to show. Turn it into a real error instead.
+	 * Every path through `Legacy::process_legacy_payment()` sets a status once the gateway
+	 * runs, so an empty one here means the gateway was never invoked and no charge was
+	 * attempted. The Store API would otherwise answer 200 with an empty payment status,
+	 * leaving an unpaid order with its stock still reserved and nothing logged. Throwing
+	 * gives the shopper an error and lets WooCommerce release the stock it held.
 	 *
 	 * @param PaymentContext $context Holds context for the payment.
 	 * @param PaymentResult  $result  Result object for the payment.
@@ -644,7 +644,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 			'Payment was never processed for order: ' . $context->order->get_id(),
 			[
 				'payment_method' => $payment_method,
-				'reason'         => 'WooCommerce could not resolve the payment method to an available gateway.',
+				'reason'         => 'WooCommerce set no payment result status, so the gateway was never invoked.',
 			]
 		);
 

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -499,18 +499,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 			$this->add_order_meta( $context->order, $data['express_checkout_type'] );
 		}
 
-		$is_stripe_payment_method = $this->name === $context->payment_method;
-		$main_gateway             = WC_Stripe::get_instance()->get_main_stripe_gateway();
-		$is_upe                   = $main_gateway instanceof WC_Stripe_UPE_Payment_Gateway;
-
-		// Check if the payment method is a UPE payment method. UPE methods start with `stripe_`.
-		if ( $is_upe && ! $is_stripe_payment_method && 0 === strpos( $context->payment_method, "{$this->name}_" ) ) {
-			// Strip "Stripe_" from the payment method name to get the payment method type.
-			$payment_method_type      = substr( $context->payment_method, strlen( $this->name ) + 1 );
-			$is_stripe_payment_method = isset( $main_gateway->payment_methods[ $payment_method_type ] );
-		}
-
-		if ( ! $is_stripe_payment_method ) {
+		if ( ! $this->is_stripe_payment_method( (string) $context->payment_method ) ) {
 			return;
 		}
 

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -586,6 +586,35 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	}
 
 	/**
+	 * Whether the given Store API payment method id belongs to this gateway.
+	 *
+	 * A bare `stripe_` prefix test is not enough: other vendors register gateways under
+	 * that prefix too, so split UPE ids are matched against the methods this gateway
+	 * actually registers.
+	 *
+	 * @param string $payment_method The payment method id from the payment context.
+	 *
+	 * @return bool
+	 */
+	private function is_stripe_payment_method( string $payment_method ): bool {
+		if ( $this->name === $payment_method ) {
+			return true;
+		}
+
+		$prefix = $this->name . '_';
+		if ( 0 !== strpos( $payment_method, $prefix ) ) {
+			return false;
+		}
+
+		$main_gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
+		if ( ! $main_gateway instanceof WC_Stripe_UPE_Payment_Gateway ) {
+			return false;
+		}
+
+		return isset( $main_gateway->payment_methods[ substr( $payment_method, strlen( $prefix ) ) ] );
+	}
+
+	/**
 	 * Fails the payment when WooCommerce never handed it to the gateway.
 	 *
 	 * `Legacy::process_legacy_payment()` returns without setting a status when it cannot
@@ -607,7 +636,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 		}
 
 		$payment_method = (string) $context->payment_method;
-		if ( $this->name !== $payment_method && 0 !== strpos( $payment_method, $this->name . '_' ) ) {
+		if ( ! $this->is_stripe_payment_method( $payment_method ) ) {
 			return;
 		}
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1557,7 +1557,7 @@ parameters:
 		-
 			message: '#^Access to protected property Automattic\\WooCommerce\\StoreApi\\Payments\\PaymentContext\:\:\$order\.$#'
 			identifier: property.protected
-			count: 2
+			count: 3
 			path: includes/class-wc-stripe-blocks-support.php
 
 		-
@@ -1569,13 +1569,19 @@ parameters:
 		-
 			message: '#^Access to protected property Automattic\\WooCommerce\\StoreApi\\Payments\\PaymentContext\:\:\$payment_method\.$#'
 			identifier: property.protected
-			count: 6
+			count: 7
 			path: includes/class-wc-stripe-blocks-support.php
 
 		-
 			message: '#^Access to protected property Automattic\\WooCommerce\\StoreApi\\Payments\\PaymentResult\:\:\$payment_details\.$#'
 			identifier: property.protected
 			count: 2
+			path: includes/class-wc-stripe-blocks-support.php
+
+		-
+			message: '#^Access to protected property Automattic\\WooCommerce\\StoreApi\\Payments\\PaymentResult\:\:\$status\.$#'
+			identifier: property.protected
+			count: 1
 			path: includes/class-wc-stripe-blocks-support.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1557,7 +1557,7 @@ parameters:
 		-
 			message: '#^Access to protected property Automattic\\WooCommerce\\StoreApi\\Payments\\PaymentContext\:\:\$order\.$#'
 			identifier: property.protected
-			count: 3
+			count: 4
 			path: includes/class-wc-stripe-blocks-support.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1569,7 +1569,7 @@ parameters:
 		-
 			message: '#^Access to protected property Automattic\\WooCommerce\\StoreApi\\Payments\\PaymentContext\:\:\$payment_method\.$#'
 			identifier: property.protected
-			count: 7
+			count: 5
 			path: includes/class-wc-stripe-blocks-support.php
 
 		-

--- a/readme.txt
+++ b/readme.txt
@@ -186,5 +186,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Reject negative refund amounts with an explicit error instead of silently refunding the absolute value
 * Fix - Hide the Apple Pay and Google Pay express buttons on pages unchecked in their own locations setting, instead of following other wallets' locations
 * Fix - Hide the save payment method checkbox for Bancontact, iDEAL and Sofort in the Adaptive Pricing checkout on non-EUR stores whose currency excludes them
+* Fix - Surface express checkout order failures instead of leaving the Apple Pay or Google Pay sheet open with no error
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-blocks-support-test.php
+++ b/tests/phpunit/class-wc-stripe-blocks-support-test.php
@@ -387,6 +387,7 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 			'payment failed'      => [ 'stripe', 'failure' ],
 			'another gateway'     => [ 'cheque', '' ],
 			'lookalike method id' => [ 'stripey', '' ],
+			'unregistered split'  => [ 'stripe_not_a_payment_method', '' ],
 		];
 	}
 

--- a/tests/phpunit/class-wc-stripe-blocks-support-test.php
+++ b/tests/phpunit/class-wc-stripe-blocks-support-test.php
@@ -317,6 +317,75 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 		];
 	}
 
+	/**
+	 * WooCommerce answers 200 with an empty payment status when it never handed the payment
+	 * to the gateway, which would leave the order unpaid with nothing to show the shopper.
+	 *
+	 * @dataProvider provider_unprocessed_stripe_payment_methods
+	 *
+	 * @param string $payment_method The payment method id on the payment context.
+	 *
+	 * @return void
+	 */
+	public function test_fail_unprocessed_payment_throws_for_stripe_payment_methods( string $payment_method ): void {
+		$blocks_support = new WC_Stripe_Blocks_Support();
+		$order          = WC_Helper_Order::create_order();
+
+		$context = new \Automattic\WooCommerce\StoreApi\Payments\PaymentContext();
+		$context->set_payment_method( $payment_method );
+		$context->set_order( $order );
+
+		$result = new \Automattic\WooCommerce\StoreApi\Payments\PaymentResult();
+
+		$this->expectException( Exception::class );
+		$blocks_support->fail_unprocessed_payment( $context, $result );
+	}
+
+	/**
+	 * @return array[]
+	 */
+	public function provider_unprocessed_stripe_payment_methods(): array {
+		return [
+			'main gateway'      => [ 'stripe' ],
+			'split UPE gateway' => [ 'stripe_us_bank_account' ],
+		];
+	}
+
+	/**
+	 * @dataProvider provider_processed_or_foreign_payments
+	 *
+	 * @param string $payment_method The payment method id on the payment context.
+	 * @param string $status         The status already set on the payment result.
+	 *
+	 * @return void
+	 */
+	public function test_fail_unprocessed_payment_leaves_other_payments_alone( string $payment_method, string $status ): void {
+		$blocks_support = new WC_Stripe_Blocks_Support();
+		$order          = WC_Helper_Order::create_order();
+
+		$context = new \Automattic\WooCommerce\StoreApi\Payments\PaymentContext();
+		$context->set_payment_method( $payment_method );
+		$context->set_order( $order );
+
+		$result = new \Automattic\WooCommerce\StoreApi\Payments\PaymentResult( $status );
+
+		$blocks_support->fail_unprocessed_payment( $context, $result );
+
+		$this->assertSame( $status, $result->status );
+	}
+
+	/**
+	 * @return array[]
+	 */
+	public function provider_processed_or_foreign_payments(): array {
+		return [
+			'payment succeeded'   => [ 'stripe', 'success' ],
+			'payment failed'      => [ 'stripe', 'failure' ],
+			'another gateway'     => [ 'cheque', '' ],
+			'lookalike method id' => [ 'stripey', '' ],
+		];
+	}
+
 	private function get_block_script_handle(): string {
 		return WC_Stripe_Test_Helper::get_class_const_value( WC_Stripe_Blocks_Support::class, 'BLOCKS_SCRIPT_HANDLE', 'string' );
 	}

--- a/tests/phpunit/class-wc-stripe-blocks-support-test.php
+++ b/tests/phpunit/class-wc-stripe-blocks-support-test.php
@@ -71,6 +71,10 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 		}
 		$this->registered_test_scripts = [];
 
+		// The constructor registers this at a priority unique to it, and it throws when it
+		// fires, so a leaked instance would abort an unrelated test's checkout.
+		remove_all_actions( 'woocommerce_rest_checkout_process_payment_with_context', 10000 );
+
 		foreach ( $this->initialized_blocks_support as $blocks_support ) {
 			remove_filter( 'render_block_woocommerce/checkout', [ $blocks_support, 'maybe_enqueue_blocks_style' ] );
 			remove_filter( 'render_block_woocommerce/cart', [ $blocks_support, 'maybe_enqueue_blocks_style' ] );

--- a/tests/phpunit/class-wc-stripe-blocks-support-test.php
+++ b/tests/phpunit/class-wc-stripe-blocks-support-test.php
@@ -346,6 +346,24 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The payment context arrives from a hook, so a context without an order must still
+	 * produce the intended error rather than a fatal from the log line.
+	 *
+	 * @return void
+	 */
+	public function test_fail_unprocessed_payment_throws_when_the_context_has_no_order(): void {
+		$blocks_support = $this->get_initialized_blocks_support();
+
+		$context = new \Automattic\WooCommerce\StoreApi\Payments\PaymentContext();
+		$context->set_payment_method( 'stripe' );
+
+		$result = new \Automattic\WooCommerce\StoreApi\Payments\PaymentResult();
+
+		$this->expectException( Exception::class );
+		$blocks_support->fail_unprocessed_payment( $context, $result );
+	}
+
+	/**
 	 * @return array[]
 	 */
 	public function provider_unprocessed_stripe_payment_methods(): array {


### PR DESCRIPTION
Fixes STRIPE-1406
Fixes #5845

## Changes proposed in this Pull Request:

For order-side errors (`isOrderError` opt-out from #3551) `abortPayment()` skipped `event.paymentFailed()`, so the approved Apple Pay / Google Pay sheet never got a _terminal_ result and stayed open. 

And `displayExpressCheckoutNotice()` silently no-ops on pages with no notices wrapper (which is common on single-product templates). No PaymentIntent was created and nothing reached the gateway log, so the attempt was invisible to the shopper and to support.

This PR changes `abortPayment()` to always fail the sheet, after putting the message on screen; aborts always carry a message; and the notice falls back to the express checkout container.

Separately, `Legacy::process_legacy_payment()` (priority 999) returns without setting a status when it can’t resolve the payment method to an available gateway — after WooCommerce has already moved the order to pending — so the Store API answers 200 with an empty payment status and nothing logged anywhere. `WC_Stripe_Blocks_Support::fail_unprocessed_payment()` now catches that at priority 10000, logs it, and throws.

This makes the failure visible and diagnosable; it does not change why a store’s gateway becomes unresolvable, which needs a store-specific reproduction the new log line should now supply.

**_Backward compatibility impact_**:
`abortPayment()`’s third argument is gone, but it is module-private in both entrypoints and not exposed on window. The new PHP method and JS export are additive; no hook, filter, option key or public signature changed. The new guard is scoped to payment method ids this gateway actually registers, so it can’t claim another vendor’s stripe_-prefixed gateway, and it only fires when the payment result is still empty — which only happens when the gateway was never invoked.

## Testing instructions

1. Add this to a mu-plugin to make the order fail after the wallet sheet is approved:
    ```php
    add_action( 'woocommerce_store_api_checkout_update_order_from_request', function () {
        throw new \Automattic\WooCommerce\StoreApi\Exceptions\RouteException(
            'test_failure', 'Simulated order failure', 400
        );
    } );
    ```
2. On a product page, click the Apple Pay / Google Pay button and approve the sheet.
    - in develop: the sheet does not close and no error appears anywhere on the page.
    - in this PR: the wallet sheet now closes with a failure
3. Repeat on the cart page and on classic checkout:
    - the message renders in the store’s normal notices area, as it did before.
4. Repeat on a Blocks checkout:
    - the message renders in the Blocks error area.
5. Remove the snippet and complete a normal Apple Pay / Google Pay purchase from the product, cart and checkout pages.
6. Verify they all still succeed and land on the order-received page.
7. With Optimized Checkout enabled, confirm express checkout still completes and card payments are unaffected.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [x] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [x] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)