### PR TITLE
Support defining Stripe secret keys as wp-config.php constants

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -30,7 +30,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Hide the Apple Pay and Google Pay express buttons on pages unchecked in their own locations setting, instead of following other wallets' locations
 * Fix - Leave the Expires column blank instead of showing "N/A" on My Account → Payment methods for saved payment methods that have no expiry date, such as Link, SEPA and Cash App Pay
 * Fix - Remove the empty box shown under "Use a new payment method" on classic checkout when the save-payment-method checkbox is hidden
-* Add - Support defining the Stripe secret keys as constants in wp-config.php (WC_STRIPE_SECRET_KEY, WC_STRIPE_TEST_SECRET_KEY), so a restricted API key can be used without storing it in the database
+* Add - Allow defining the Stripe secret keys as wp-config.php constants, keeping them out of the database
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Hide the Apple Pay and Google Pay express buttons on pages unchecked in their own locations setting, instead of following other wallets' locations
 * Fix - Leave the Expires column blank instead of showing "N/A" on My Account → Payment methods for saved payment methods that have no expiry date, such as Link, SEPA and Cash App Pay
 * Fix - Remove the empty box shown under "Use a new payment method" on classic checkout when the save-payment-method checkbox is hidden
+* Add - Support defining the Stripe secret keys as constants in wp-config.php (WC_STRIPE_SECRET_KEY, WC_STRIPE_TEST_SECRET_KEY), so a restricted API key can be used without storing it in the database
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "includes/class-wc-stripe-co-branded-cc-compatibility.php",
         "includes/class-wc-stripe-exception.php",
         "includes/class-wc-stripe-hook-manager.php",
+        "includes/class-wc-stripe-key-constants.php",
         "includes/class-wc-stripe-payment-cancelled-exception.php",
         "includes/class-wc-stripe-upe-compatibility.php",
         "includes/class-wc-stripe-update-manager.php",

--- a/includes/class-wc-stripe-key-constants.php
+++ b/includes/class-wc-stripe-key-constants.php
@@ -4,28 +4,23 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Overrides the stored Stripe secret keys with values defined as constants.
+ * Overrides the stored Stripe secret keys with wp-config.php constants.
  *
- * Merchants define the constants in wp-config.php:
+ * Applied on the option filters (not the plugin's settings accessors) because
+ * WooCommerce core also reads and writes this option directly, and every
+ * reader must see the same key. Usage:
  *
  *     define( 'WC_STRIPE_SECRET_KEY', 'rk_live_...' );
  *     define( 'WC_STRIPE_TEST_SECRET_KEY', 'rk_test_...' );
- *
- * This lets merchants keep the secret key (for example a Restricted API Key)
- * out of the database. The override is applied on the option filters rather
- * than inside the plugin's own settings accessors because WooCommerce core
- * also reads and writes this option directly (WC_Settings_API::init_settings()
- * and process_admin_options()), and every reader must see the same key.
  *
  * @since 11.0.0
  */
 class WC_Stripe_Key_Constants {
 
 	/**
-	 * The settings fields that can be overridden, mapped to the constant that overrides each.
-	 *
-	 * Only secret keys are overridable: publishable keys are not sensitive, and
-	 * webhook signing secrets are required at runtime to verify inbound events.
+	 * Overridable settings fields mapped to their constant. Secret keys only:
+	 * publishable keys are not sensitive, and webhook signing secrets are
+	 * needed at runtime to verify inbound events.
 	 *
 	 * @var array<string, string>
 	 */
@@ -75,7 +70,7 @@ class WC_Stripe_Key_Constants {
 	}
 
 	/**
-	 * Removes the option filters. Mainly useful for tests and for reading the raw stored value.
+	 * Removes the option filters.
 	 *
 	 * @return void
 	 */
@@ -85,7 +80,7 @@ class WC_Stripe_Key_Constants {
 	}
 
 	/**
-	 * Whether any secret key is currently being overridden by a constant.
+	 * Whether any secret key is currently overridden by a constant.
 	 *
 	 * @return bool
 	 */
@@ -102,8 +97,7 @@ class WC_Stripe_Key_Constants {
 	public function apply_overrides( $settings ) {
 		$overrides = $this->get_configured_overrides();
 
-		// A non-array value is normalized by the readers themselves; forcing an
-		// array here would change behavior for a store that has never saved settings.
+		// Non-array values are normalized by the readers themselves.
 		if ( [] === $overrides || ! is_array( $settings ) ) {
 			return $settings;
 		}
@@ -112,13 +106,10 @@ class WC_Stripe_Key_Constants {
 	}
 
 	/**
-	 * Strips the substituted keys back out before the settings are written.
-	 *
-	 * Settings writes are read-modify-write: the caller read the settings through
-	 * apply_overrides(), so without this filter the first save would persist the
-	 * constant-defined key into the database, defeating the point of keeping it
-	 * in wp-config.php. Only a value identical to the constant is reverted, so a
-	 * caller that deliberately writes a different key is not interfered with.
+	 * Strips the substituted keys back out before the settings are written,
+	 * so a read-modify-write save never persists the constant into the
+	 * database. Only exact matches are reverted; a deliberately changed key
+	 * is written as-is.
 	 *
 	 * @param mixed $value The settings about to be written.
 	 * @return mixed
@@ -141,8 +132,7 @@ class WC_Stripe_Key_Constants {
 				$stored = $this->get_stored_settings_unfiltered();
 			}
 
-			// Restore the stored value rather than blanking it, so defining a
-			// constant never destroys the key already saved in the database.
+			// Restore rather than blank, so a constant never destroys the stored key.
 			$value[ $field ] = isset( $stored[ $field ] ) && is_string( $stored[ $field ] ) ? $stored[ $field ] : '';
 		}
 
@@ -151,10 +141,8 @@ class WC_Stripe_Key_Constants {
 
 	/**
 	 * Reads the settings option as stored, bypassing apply_overrides().
-	 *
-	 * The 'old value' WordPress passes to pre_update_option filters has already
-	 * been through the option filter, so it holds the constant, not the stored
-	 * key; this is the only way to recover what is actually in the database.
+	 * The old value pre_update_option filters receive is already filtered,
+	 * so it holds the constant, not the stored key.
 	 *
 	 * @return array
 	 */
@@ -167,7 +155,7 @@ class WC_Stripe_Key_Constants {
 	}
 
 	/**
-	 * Returns the overrides that are actually configured, as field => key.
+	 * Returns the configured overrides as field => key.
 	 *
 	 * @return array<string, string>
 	 */
@@ -177,9 +165,8 @@ class WC_Stripe_Key_Constants {
 		foreach ( static::FIELD_CONSTANTS as $field => $constant ) {
 			$value = $this->get_constant_value( $constant );
 
-			// A blank or non-string constant is ignored rather than applied:
-			// injecting an empty key would make the store report itself as
-			// disconnected with no error pointing at the constant.
+			// Ignore blank or non-string constants: injecting an empty key
+			// would silently disconnect the store.
 			if ( is_string( $value ) && '' !== trim( $value ) ) {
 				$overrides[ $field ] = trim( $value );
 			}
@@ -189,11 +176,8 @@ class WC_Stripe_Key_Constants {
 	}
 
 	/**
-	 * Reads a constant's value.
-	 *
-	 * Seam for tests: constants cannot be undefined once set, so tests override
-	 * this method instead of defining real constants that would leak into every
-	 * other test in the process.
+	 * Reads a constant's value. Seam for tests, since constants cannot be
+	 * undefined once set.
 	 *
 	 * @param string $constant The constant name.
 	 * @return mixed|null Null when the constant is not defined.

--- a/includes/class-wc-stripe-key-constants.php
+++ b/includes/class-wc-stripe-key-constants.php
@@ -1,0 +1,204 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Overrides the stored Stripe secret keys with values defined as constants.
+ *
+ * Merchants define the constants in wp-config.php:
+ *
+ *     define( 'WC_STRIPE_SECRET_KEY', 'rk_live_...' );
+ *     define( 'WC_STRIPE_TEST_SECRET_KEY', 'rk_test_...' );
+ *
+ * This lets merchants keep the secret key (for example a Restricted API Key)
+ * out of the database. The override is applied on the option filters rather
+ * than inside the plugin's own settings accessors because WooCommerce core
+ * also reads and writes this option directly (WC_Settings_API::init_settings()
+ * and process_admin_options()), and every reader must see the same key.
+ *
+ * @since 11.0.0
+ */
+class WC_Stripe_Key_Constants {
+
+	/**
+	 * The settings fields that can be overridden, mapped to the constant that overrides each.
+	 *
+	 * Only secret keys are overridable: publishable keys are not sensitive, and
+	 * webhook signing secrets are required at runtime to verify inbound events.
+	 *
+	 * @var array<string, string>
+	 */
+	protected const FIELD_CONSTANTS = [
+		'secret_key'      => 'WC_STRIPE_SECRET_KEY',
+		'test_secret_key' => 'WC_STRIPE_TEST_SECRET_KEY',
+	];
+
+	/**
+	 * The *Singleton* instance of this class.
+	 *
+	 * @var WC_Stripe_Key_Constants|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Returns the *Singleton* instance of this class.
+	 *
+	 * @return WC_Stripe_Key_Constants
+	 */
+	public static function get_instance(): WC_Stripe_Key_Constants {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Registers the singleton's option filters.
+	 *
+	 * @return void
+	 */
+	public static function init(): void {
+		self::get_instance()->register_filters();
+	}
+
+	/**
+	 * Hooks the override into every read and write of the Stripe settings option.
+	 *
+	 * @return void
+	 */
+	public function register_filters(): void {
+		// Priority 999 so the override wins over other filters on this option.
+		add_filter( 'option_' . WC_Stripe::SETTINGS_OPTION_NAME, [ $this, 'apply_overrides' ], 999 );
+		add_filter( 'pre_update_option_' . WC_Stripe::SETTINGS_OPTION_NAME, [ $this, 'strip_overrides_before_save' ], 999 );
+	}
+
+	/**
+	 * Removes the option filters. Mainly useful for tests and for reading the raw stored value.
+	 *
+	 * @return void
+	 */
+	public function unregister_filters(): void {
+		remove_filter( 'option_' . WC_Stripe::SETTINGS_OPTION_NAME, [ $this, 'apply_overrides' ], 999 );
+		remove_filter( 'pre_update_option_' . WC_Stripe::SETTINGS_OPTION_NAME, [ $this, 'strip_overrides_before_save' ], 999 );
+	}
+
+	/**
+	 * Whether any secret key is currently being overridden by a constant.
+	 *
+	 * @return bool
+	 */
+	public function has_overrides(): bool {
+		return [] !== $this->get_configured_overrides();
+	}
+
+	/**
+	 * Substitutes the constant-defined keys into the settings on every read.
+	 *
+	 * @param mixed $settings The stored settings. Not guaranteed to be an array.
+	 * @return mixed
+	 */
+	public function apply_overrides( $settings ) {
+		$overrides = $this->get_configured_overrides();
+
+		// A non-array value is normalized by the readers themselves; forcing an
+		// array here would change behavior for a store that has never saved settings.
+		if ( [] === $overrides || ! is_array( $settings ) ) {
+			return $settings;
+		}
+
+		return array_merge( $settings, $overrides );
+	}
+
+	/**
+	 * Strips the substituted keys back out before the settings are written.
+	 *
+	 * Settings writes are read-modify-write: the caller read the settings through
+	 * apply_overrides(), so without this filter the first save would persist the
+	 * constant-defined key into the database, defeating the point of keeping it
+	 * in wp-config.php. Only a value identical to the constant is reverted, so a
+	 * caller that deliberately writes a different key is not interfered with.
+	 *
+	 * @param mixed $value The settings about to be written.
+	 * @return mixed
+	 */
+	public function strip_overrides_before_save( $value ) {
+		$overrides = $this->get_configured_overrides();
+
+		if ( [] === $overrides || ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$stored = null;
+
+		foreach ( $overrides as $field => $override_value ) {
+			if ( ! isset( $value[ $field ] ) || $value[ $field ] !== $override_value ) {
+				continue;
+			}
+
+			if ( null === $stored ) {
+				$stored = $this->get_stored_settings_unfiltered();
+			}
+
+			// Restore the stored value rather than blanking it, so defining a
+			// constant never destroys the key already saved in the database.
+			$value[ $field ] = isset( $stored[ $field ] ) && is_string( $stored[ $field ] ) ? $stored[ $field ] : '';
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Reads the settings option as stored, bypassing apply_overrides().
+	 *
+	 * The 'old value' WordPress passes to pre_update_option filters has already
+	 * been through the option filter, so it holds the constant, not the stored
+	 * key; this is the only way to recover what is actually in the database.
+	 *
+	 * @return array
+	 */
+	private function get_stored_settings_unfiltered(): array {
+		remove_filter( 'option_' . WC_Stripe::SETTINGS_OPTION_NAME, [ $this, 'apply_overrides' ], 999 );
+		$stored = get_option( WC_Stripe::SETTINGS_OPTION_NAME, [] );
+		add_filter( 'option_' . WC_Stripe::SETTINGS_OPTION_NAME, [ $this, 'apply_overrides' ], 999 );
+
+		return is_array( $stored ) ? $stored : [];
+	}
+
+	/**
+	 * Returns the overrides that are actually configured, as field => key.
+	 *
+	 * @return array<string, string>
+	 */
+	private function get_configured_overrides(): array {
+		$overrides = [];
+
+		foreach ( static::FIELD_CONSTANTS as $field => $constant ) {
+			$value = $this->get_constant_value( $constant );
+
+			// A blank or non-string constant is ignored rather than applied:
+			// injecting an empty key would make the store report itself as
+			// disconnected with no error pointing at the constant.
+			if ( is_string( $value ) && '' !== trim( $value ) ) {
+				$overrides[ $field ] = trim( $value );
+			}
+		}
+
+		return $overrides;
+	}
+
+	/**
+	 * Reads a constant's value.
+	 *
+	 * Seam for tests: constants cannot be undefined once set, so tests override
+	 * this method instead of defining real constants that would leak into every
+	 * other test in the process.
+	 *
+	 * @param string $constant The constant name.
+	 * @return mixed|null Null when the constant is not defined.
+	 */
+	protected function get_constant_value( string $constant ) {
+		return defined( $constant ) ? constant( $constant ) : null;
+	}
+}

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -157,7 +157,6 @@ class WC_Stripe {
 		}
 
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-logger.php';
-		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-key-constants.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-helper.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-order-helper.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-database-cache.php';
@@ -179,8 +178,7 @@ class WC_Stripe {
 		if ( self::$instance === $this ) {
 			( new WC_Stripe_Webhook_Handler() )->register_hooks();
 
-			// Register the wp-config secret key override before any settings read,
-			// so every consumer (including WC core's settings API) sees the same key.
+			// Register the wp-config secret key override before any settings read.
 			WC_Stripe_Key_Constants::init();
 		}
 

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -157,6 +157,7 @@ class WC_Stripe {
 		}
 
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-logger.php';
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-key-constants.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-helper.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-order-helper.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-database-cache.php';
@@ -177,6 +178,10 @@ class WC_Stripe {
 
 		if ( self::$instance === $this ) {
 			( new WC_Stripe_Webhook_Handler() )->register_hooks();
+
+			// Register the wp-config secret key override before any settings read,
+			// so every consumer (including WC core's settings API) sees the same key.
+			WC_Stripe_Key_Constants::init();
 		}
 
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-apple-pay-registration.php';

--- a/readme.txt
+++ b/readme.txt
@@ -191,5 +191,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Hide the save payment method checkbox for Bancontact, iDEAL and Sofort in the Adaptive Pricing checkout on non-EUR stores whose currency excludes them
 * Fix - Stop flagging the checkout page as the cart page (is_cart() returning true) when express checkout buttons are enabled, which made analytics and other plugins misread the page
 * Fix - Remove the empty box shown under "Use a new payment method" on classic checkout when the save-payment-method checkbox is hidden
+* Add - Support defining the Stripe secret keys as constants in wp-config.php (WC_STRIPE_SECRET_KEY, WC_STRIPE_TEST_SECRET_KEY), so a restricted API key can be used without storing it in the database
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -191,6 +191,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Hide the save payment method checkbox for Bancontact, iDEAL and Sofort in the Adaptive Pricing checkout on non-EUR stores whose currency excludes them
 * Fix - Stop flagging the checkout page as the cart page (is_cart() returning true) when express checkout buttons are enabled, which made analytics and other plugins misread the page
 * Fix - Remove the empty box shown under "Use a new payment method" on classic checkout when the save-payment-method checkbox is hidden
-* Add - Support defining the Stripe secret keys as constants in wp-config.php (WC_STRIPE_SECRET_KEY, WC_STRIPE_TEST_SECRET_KEY), so a restricted API key can be used without storing it in the database
+* Add - Allow defining the Stripe secret keys as wp-config.php constants, keeping them out of the database
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -111,6 +111,7 @@ require_once __DIR__ . '/helpers/class-oc-test-helper.php';
 require_once __DIR__ . '/helpers/class-pmc-test-helper.php';
 require_once __DIR__ . '/helpers/class-upe-test-helper.php';
 require_once __DIR__ . '/helpers/class-wc-stripe-test-helper.php';
+require_once __DIR__ . '/helpers/class-wc-stripe-key-constants-fake.php';
 require_once __DIR__ . '/helpers/trait-wc-stripe-hook-manager-reset.php';
 
 // Pre-create HPOS (Custom Orders Table) schema so that parallel workers don't

--- a/tests/phpunit/class-wc-stripe-key-constants-test.php
+++ b/tests/phpunit/class-wc-stripe-key-constants-test.php
@@ -16,7 +16,7 @@ class WC_Stripe_Key_Constants_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	private $key_constants;
 
 	/**
-	 * Pre-test setup: register a fake with no constants configured.
+	 * Registers a fake with no constants configured.
 	 *
 	 * @return void
 	 */
@@ -37,7 +37,7 @@ class WC_Stripe_Key_Constants_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
-	 * Post-test cleanup: drop the fake's filters so they cannot leak into other tests.
+	 * Drops the fake's filters so they cannot leak into other tests.
 	 *
 	 * @return void
 	 */
@@ -61,14 +61,13 @@ class WC_Stripe_Key_Constants_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
-	 * A defined constant overrides the stored key for its mode on every read,
-	 * through the plugin accessor and through a raw get_option() alike.
+	 * A defined constant overrides the stored key for its mode on every read.
 	 *
 	 * @dataProvider provide_constant_override_scenarios
 	 *
-	 * @param array  $constants       The constants the fake reports as defined.
-	 * @param string $expected_live   Expected effective live secret key.
-	 * @param string $expected_test   Expected effective test secret key.
+	 * @param array  $constants     Constants the fake reports as defined.
+	 * @param string $expected_live Expected live secret key.
+	 * @param string $expected_test Expected test secret key.
 	 * @return void
 	 */
 	public function test_constants_override_stored_keys_on_read( array $constants, string $expected_live, string $expected_test ): void {
@@ -117,8 +116,7 @@ class WC_Stripe_Key_Constants_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
-	 * Blank or non-string constants are ignored instead of blanking the key,
-	 * which would silently disconnect the store.
+	 * Blank or non-string constants are ignored instead of blanking the key.
 	 *
 	 * @dataProvider provide_ignored_constant_values
 	 *
@@ -149,8 +147,7 @@ class WC_Stripe_Key_Constants_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
-	 * A settings save that round-trips the constant-injected key must not
-	 * persist the constant into the database; the stored key is kept as-is.
+	 * A round-tripped save keeps the stored key, not the constant.
 	 *
 	 * @return void
 	 */
@@ -171,8 +168,7 @@ class WC_Stripe_Key_Constants_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
-	 * A caller that deliberately writes a key different from the constant is
-	 * not interfered with — only exact round-trips of the constant are reverted.
+	 * A deliberately changed key is written as-is.
 	 *
 	 * @return void
 	 */
@@ -190,8 +186,7 @@ class WC_Stripe_Key_Constants_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
-	 * A round-tripped save with no stored key for the overridden field falls
-	 * back to blank instead of persisting the constant.
+	 * With no stored key, a round-tripped save persists blank, not the constant.
 	 *
 	 * @return void
 	 */

--- a/tests/phpunit/class-wc-stripe-key-constants-test.php
+++ b/tests/phpunit/class-wc-stripe-key-constants-test.php
@@ -1,0 +1,231 @@
+<?php
+
+/**
+ * These tests make assertions against the class WC_Stripe_Key_Constants.
+ *
+ * Class WC_Stripe_Key_Constants_Test
+ *
+ * @package WooCommerce/Stripe/WC_Stripe_Key_Constants
+ */
+class WC_Stripe_Key_Constants_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
+	/**
+	 * The system under test, with the constant-reading seam faked.
+	 *
+	 * @var WC_Stripe_Key_Constants_Fake
+	 */
+	private $key_constants;
+
+	/**
+	 * Pre-test setup: register a fake with no constants configured.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->key_constants = new WC_Stripe_Key_Constants_Fake();
+		$this->key_constants->register_filters();
+
+		update_option(
+			WC_Stripe::SETTINGS_OPTION_NAME,
+			[
+				'enabled'         => 'yes',
+				'secret_key'      => 'sk_live_stored',
+				'test_secret_key' => 'sk_test_stored',
+			]
+		);
+	}
+
+	/**
+	 * Post-test cleanup: drop the fake's filters so they cannot leak into other tests.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		$this->key_constants->unregister_filters();
+		delete_option( WC_Stripe::SETTINGS_OPTION_NAME );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * With no constants defined, reads return the stored keys untouched.
+	 *
+	 * @return void
+	 */
+	public function test_reads_are_untouched_without_constants(): void {
+		$settings = WC_Stripe::get_instance()->get_settings();
+
+		$this->assertSame( 'sk_live_stored', $settings['secret_key'] );
+		$this->assertSame( 'sk_test_stored', $settings['test_secret_key'] );
+	}
+
+	/**
+	 * A defined constant overrides the stored key for its mode on every read,
+	 * through the plugin accessor and through a raw get_option() alike.
+	 *
+	 * @dataProvider provide_constant_override_scenarios
+	 *
+	 * @param array  $constants       The constants the fake reports as defined.
+	 * @param string $expected_live   Expected effective live secret key.
+	 * @param string $expected_test   Expected effective test secret key.
+	 * @return void
+	 */
+	public function test_constants_override_stored_keys_on_read( array $constants, string $expected_live, string $expected_test ): void {
+		$this->key_constants->constants = $constants;
+
+		$settings = WC_Stripe::get_instance()->get_settings();
+		$this->assertSame( $expected_live, $settings['secret_key'] );
+		$this->assertSame( $expected_test, $settings['test_secret_key'] );
+
+		$raw_read = get_option( WC_Stripe::SETTINGS_OPTION_NAME );
+		$this->assertSame( $expected_live, $raw_read['secret_key'] );
+		$this->assertSame( $expected_test, $raw_read['test_secret_key'] );
+	}
+
+	/**
+	 * Scenarios for test_constants_override_stored_keys_on_read().
+	 *
+	 * @return array
+	 */
+	public function provide_constant_override_scenarios(): array {
+		return [
+			'live only'                         => [
+				[ 'WC_STRIPE_SECRET_KEY' => 'rk_live_constant' ],
+				'rk_live_constant',
+				'sk_test_stored',
+			],
+			'test only'                         => [
+				[ 'WC_STRIPE_TEST_SECRET_KEY' => 'rk_test_constant' ],
+				'sk_live_stored',
+				'rk_test_constant',
+			],
+			'both modes'                        => [
+				[
+					'WC_STRIPE_SECRET_KEY'      => 'rk_live_constant',
+					'WC_STRIPE_TEST_SECRET_KEY' => 'rk_test_constant',
+				],
+				'rk_live_constant',
+				'rk_test_constant',
+			],
+			'surrounding whitespace is trimmed' => [
+				[ 'WC_STRIPE_SECRET_KEY' => "  rk_live_constant\n" ],
+				'rk_live_constant',
+				'sk_test_stored',
+			],
+		];
+	}
+
+	/**
+	 * Blank or non-string constants are ignored instead of blanking the key,
+	 * which would silently disconnect the store.
+	 *
+	 * @dataProvider provide_ignored_constant_values
+	 *
+	 * @param mixed $constant_value The invalid constant value.
+	 * @return void
+	 */
+	public function test_invalid_constant_values_are_ignored( $constant_value ): void {
+		$this->key_constants->constants = [ 'WC_STRIPE_SECRET_KEY' => $constant_value ];
+
+		$settings = WC_Stripe::get_instance()->get_settings();
+
+		$this->assertSame( 'sk_live_stored', $settings['secret_key'] );
+		$this->assertFalse( $this->key_constants->has_overrides() );
+	}
+
+	/**
+	 * Scenarios for test_invalid_constant_values_are_ignored().
+	 *
+	 * @return array
+	 */
+	public function provide_ignored_constant_values(): array {
+		return [
+			'empty string'    => [ '' ],
+			'whitespace only' => [ '   ' ],
+			'boolean'         => [ true ],
+			'integer'         => [ 123 ],
+		];
+	}
+
+	/**
+	 * A settings save that round-trips the constant-injected key must not
+	 * persist the constant into the database; the stored key is kept as-is.
+	 *
+	 * @return void
+	 */
+	public function test_round_tripped_save_does_not_persist_constant(): void {
+		$this->key_constants->constants = [ 'WC_STRIPE_SECRET_KEY' => 'rk_live_constant' ];
+
+		// Simulate the read-modify-write every settings save performs.
+		$settings            = WC_Stripe::get_instance()->get_settings();
+		$settings['enabled'] = 'no';
+		WC_Stripe::get_instance()->update_settings( $settings );
+
+		$this->key_constants->constants = [];
+		$stored                         = get_option( WC_Stripe::SETTINGS_OPTION_NAME );
+
+		$this->assertSame( 'no', $stored['enabled'] );
+		$this->assertSame( 'sk_live_stored', $stored['secret_key'] );
+		$this->assertSame( 'sk_test_stored', $stored['test_secret_key'] );
+	}
+
+	/**
+	 * A caller that deliberately writes a key different from the constant is
+	 * not interfered with — only exact round-trips of the constant are reverted.
+	 *
+	 * @return void
+	 */
+	public function test_deliberate_key_change_is_persisted(): void {
+		$this->key_constants->constants = [ 'WC_STRIPE_SECRET_KEY' => 'rk_live_constant' ];
+
+		$settings               = WC_Stripe::get_instance()->get_settings();
+		$settings['secret_key'] = 'sk_live_replacement';
+		WC_Stripe::get_instance()->update_settings( $settings );
+
+		$this->key_constants->constants = [];
+		$stored                         = get_option( WC_Stripe::SETTINGS_OPTION_NAME );
+
+		$this->assertSame( 'sk_live_replacement', $stored['secret_key'] );
+	}
+
+	/**
+	 * A round-tripped save with no stored key for the overridden field falls
+	 * back to blank instead of persisting the constant.
+	 *
+	 * @return void
+	 */
+	public function test_round_tripped_save_with_no_stored_key_persists_blank(): void {
+		update_option( WC_Stripe::SETTINGS_OPTION_NAME, [ 'enabled' => 'yes' ] );
+		$this->key_constants->constants = [ 'WC_STRIPE_SECRET_KEY' => 'rk_live_constant' ];
+
+		$settings = WC_Stripe::get_instance()->get_settings();
+		$this->assertSame( 'rk_live_constant', $settings['secret_key'] );
+		WC_Stripe::get_instance()->update_settings( $settings );
+
+		$this->key_constants->constants = [];
+		$stored                         = get_option( WC_Stripe::SETTINGS_OPTION_NAME );
+
+		$this->assertSame( '', $stored['secret_key'] );
+	}
+
+	/**
+	 * WC_Stripe_API picks up the constant-defined key for the active mode.
+	 *
+	 * @return void
+	 */
+	public function test_api_uses_constant_key_for_mode(): void {
+		$this->key_constants->constants = [
+			'WC_STRIPE_SECRET_KEY'      => 'rk_live_constant',
+			'WC_STRIPE_TEST_SECRET_KEY' => 'rk_test_constant',
+		];
+
+		WC_Stripe_API::set_secret_key_for_mode( 'live' );
+		$this->assertSame( 'rk_live_constant', WC_Stripe_API::get_secret_key() );
+
+		WC_Stripe_API::set_secret_key_for_mode( 'test' );
+		$this->assertSame( 'rk_test_constant', WC_Stripe_API::get_secret_key() );
+
+		WC_Stripe_API::set_secret_key( '' );
+	}
+}

--- a/tests/phpunit/helpers/class-wc-stripe-key-constants-fake.php
+++ b/tests/phpunit/helpers/class-wc-stripe-key-constants-fake.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Test double for WC_Stripe_Key_Constants.
+ *
+ * @package WooCommerce/Stripe/Tests
+ */
+
+/**
+ * Exposes the constant-reading seam so tests can vary the "defined" constants
+ * per case; real constants cannot be undefined and would leak across the process.
+ */
+class WC_Stripe_Key_Constants_Fake extends WC_Stripe_Key_Constants {
+	/**
+	 * The constants the fake reports as defined, name => value.
+	 *
+	 * @var array<string, mixed>
+	 */
+	public $constants = [];
+
+	/**
+	 * Reads a constant from the fake map instead of the real constant table.
+	 *
+	 * @param string $constant The constant name.
+	 * @return mixed|null Null when the fake does not define it.
+	 */
+	protected function get_constant_value( string $constant ) {
+		return $this->constants[ $constant ] ?? null;
+	}
+}

--- a/tests/phpunit/helpers/class-wc-stripe-key-constants-fake.php
+++ b/tests/phpunit/helpers/class-wc-stripe-key-constants-fake.php
@@ -7,7 +7,7 @@
 
 /**
  * Exposes the constant-reading seam so tests can vary the "defined" constants
- * per case; real constants cannot be undefined and would leak across the process.
+ * per case; real constants would leak across the process.
  */
 class WC_Stripe_Key_Constants_Fake extends WC_Stripe_Key_Constants {
 	/**
@@ -18,7 +18,7 @@ class WC_Stripe_Key_Constants_Fake extends WC_Stripe_Key_Constants {
 	public $constants = [];
 
 	/**
-	 * Reads a constant from the fake map instead of the real constant table.
+	 * Reads a constant from the fake map.
 	 *
 	 * @param string $constant The constant name.
 	 * @return mixed|null Null when the fake does not define it.


### PR DESCRIPTION
Towards STRIPE-3
Towards #634

## Changes proposed in this Pull Request:

Merchants who want to run the plugin on a [Stripe Restricted API Key](https://docs.stripe.com/keys#create-restricted-api-secret-key) currently have no supported way to keep that key out of the database: there is no UI field for entering keys (the settings screen is OAuth-only), and a key written directly to the `woocommerce_stripe_settings` option is still a database-stored credential, which defeats the main reason for using a restricted key.

This PR adds first-class support for supplying the secret keys from `wp-config.php`:

```php
define( 'WC_STRIPE_SECRET_KEY', 'rk_live_...' );      // or sk_live_...
define( 'WC_STRIPE_TEST_SECRET_KEY', 'rk_test_...' ); // or sk_test_...
```

A new `WC_Stripe_Key_Constants` class hooks `option_woocommerce_stripe_settings` and `pre_update_option_woocommerce_stripe_settings`:

- **On read**, a defined constant replaces the stored `secret_key` / `test_secret_key`. The filters are used (rather than the plugin's own settings accessors) because WooCommerce core also reads and writes this option directly via `WC_Settings_API::init_settings()` / `process_admin_options()`, and every reader must see the same key. This also means the override survives the Stripe App OAuth refresh job, which rewrites the stored key on `app`-type connections.
- **On write**, a value that round-tripped from the constant is reverted to the stored value, so a settings save never persists the constant into the database. A deliberately changed key (e.g. via the account keys REST endpoint) is written as-is; the constant simply keeps winning at read time while defined.
- Blank or non-string constants are ignored rather than applied, so a typo cannot silently disconnect the store.

**Backward compatibility:** purely additive. No existing symbol, hook, or option key changes. Stores that do not define the constants are unaffected: with no constants defined, both filters return their input unchanged. The stored keys are never modified by this feature (reverting on write restores what was already stored).

## Testing instructions

1. Connect a store to Stripe as usual (OAuth or keys via the REST endpoint).
2. In your Stripe dashboard, create a restricted key (or use any other valid secret key for the account).
3. Add to `wp-config.php`, above the "That's all, stop editing!" line: `define( 'WC_STRIPE_TEST_SECRET_KEY', 'rk_test_...' );`
4. Load the Stripe settings page and the checkout page: the account still shows as connected and payment methods render. Place a test order; in the Stripe dashboard request logs, the requests are made with the restricted key.
5. Save any Stripe setting (e.g. toggle test mode off/on), then check the stored option: `wp option get woocommerce_stripe_settings --format=json | jq '.test_secret_key'`: it still holds the originally stored key, not the constant.
6. Remove the constant from `wp-config.php`: the store immediately falls back to the stored key.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @aheckler 
