### PR TITLE
Clear the invalid-key error counter when account keys are saved

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -30,7 +30,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Hide the Apple Pay and Google Pay express buttons on pages unchecked in their own locations setting, instead of following other wallets' locations
 * Fix - Leave the Expires column blank instead of showing "N/A" on My Account → Payment methods for saved payment methods that have no expiry date, such as Link, SEPA and Cash App Pay
 * Fix - Remove the empty box shown under "Use a new payment method" on classic checkout when the save-payment-method checkbox is hidden
-* Fix - Resume Stripe API reads as soon as account keys are saved, instead of staying blocked for up to two hours after repeated invalid-key errors
+* Fix - Clear the invalid-key block as soon as account keys are saved, instead of after up to two hours
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Hide the Apple Pay and Google Pay express buttons on pages unchecked in their own locations setting, instead of following other wallets' locations
 * Fix - Leave the Expires column blank instead of showing "N/A" on My Account → Payment methods for saved payment methods that have no expiry date, such as Link, SEPA and Cash App Pay
 * Fix - Remove the empty box shown under "Use a new payment method" on classic checkout when the save-payment-method checkbox is hidden
+* Fix - Resume Stripe API reads as soon as account keys are saved, instead of staying blocked for up to two hours after repeated invalid-key errors
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -312,10 +312,8 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 		// Before saving the settings, decommission any previously automatically configured webhook endpoint.
 		$settings = $this->decommission_configured_webhook_after_key_update( $settings, $current_account_keys );
 
-		// Lift the consecutive-401 read blackout: a merchant replacing an invalid
-		// key must not stay blocked for up to two hours after saving a valid one.
-		// Cleared before the save because the option-update hooks fired by it may
-		// already read from Stripe with the new key.
+		// Lift the consecutive-401 read blackout before the save, since its
+		// option-update hooks may already read from Stripe with the new key.
 		WC_Stripe_Database_Cache::delete( WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY );
 
 		WC_Stripe_Helper::update_main_stripe_settings( $settings );

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -312,6 +312,12 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 		// Before saving the settings, decommission any previously automatically configured webhook endpoint.
 		$settings = $this->decommission_configured_webhook_after_key_update( $settings, $current_account_keys );
 
+		// Lift the consecutive-401 read blackout: a merchant replacing an invalid
+		// key must not stay blocked for up to two hours after saving a valid one.
+		// Cleared before the save because the option-update hooks fired by it may
+		// already read from Stripe with the new key.
+		WC_Stripe_Database_Cache::delete( WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY );
+
 		WC_Stripe_Helper::update_main_stripe_settings( $settings );
 
 		// Disable all payment methods if all keys are different from the current ones

--- a/readme.txt
+++ b/readme.txt
@@ -191,5 +191,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Hide the save payment method checkbox for Bancontact, iDEAL and Sofort in the Adaptive Pricing checkout on non-EUR stores whose currency excludes them
 * Fix - Stop flagging the checkout page as the cart page (is_cart() returning true) when express checkout buttons are enabled, which made analytics and other plugins misread the page
 * Fix - Remove the empty box shown under "Use a new payment method" on classic checkout when the save-payment-method checkbox is hidden
+* Fix - Resume Stripe API reads as soon as account keys are saved, instead of staying blocked for up to two hours after repeated invalid-key errors
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -191,6 +191,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Hide the save payment method checkbox for Bancontact, iDEAL and Sofort in the Adaptive Pricing checkout on non-EUR stores whose currency excludes them
 * Fix - Stop flagging the checkout page as the cart page (is_cart() returning true) when express checkout buttons are enabled, which made analytics and other plugins misread the page
 * Fix - Remove the empty box shown under "Use a new payment method" on classic checkout when the save-payment-method checkbox is hidden
-* Fix - Resume Stripe API reads as soon as account keys are saved, instead of staying blocked for up to two hours after repeated invalid-key errors
+* Fix - Clear the invalid-key block as soon as account keys are saved, instead of after up to two hours
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-rest-stripe-account-keys-controller-test.php
+++ b/tests/phpunit/class-wc-rest-stripe-account-keys-controller-test.php
@@ -335,4 +335,20 @@ class WC_REST_Stripe_Account_Keys_Controller_Test extends WC_Mock_Stripe_API_Uni
 		$this->assertSame( [], $settings['webhook_data'] );
 		$this->assertSame( '', $settings['webhook_secret'] );
 	}
+	/**
+	 * Saving keys clears the consecutive-401 circuit breaker, so API reads
+	 * resume immediately with the new key instead of staying blocked for up
+	 * to two hours after the merchant has already fixed the key.
+	 */
+	public function test_set_account_keys_clears_invalid_api_key_error_count() {
+		WC_Stripe_Database_Cache::set( WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY, 5 );
+
+		$request = new WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_param( 'secret_key', 'sk_live_replacement-key-12345' );
+
+		$response = $this->controller->set_account_keys( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertNull( WC_Stripe_Database_Cache::get( WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY ) );
+	}
 }

--- a/tests/phpunit/class-wc-rest-stripe-account-keys-controller-test.php
+++ b/tests/phpunit/class-wc-rest-stripe-account-keys-controller-test.php
@@ -336,9 +336,7 @@ class WC_REST_Stripe_Account_Keys_Controller_Test extends WC_Mock_Stripe_API_Uni
 		$this->assertSame( '', $settings['webhook_secret'] );
 	}
 	/**
-	 * Saving keys clears the consecutive-401 circuit breaker, so API reads
-	 * resume immediately with the new key instead of staying blocked for up
-	 * to two hours after the merchant has already fixed the key.
+	 * Saving keys clears the consecutive-401 circuit breaker.
 	 */
 	public function test_set_account_keys_clears_invalid_api_key_error_count() {
 		WC_Stripe_Database_Cache::set( WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY, 5 );


### PR DESCRIPTION
Towards STRIPE-3
Towards #634

## Changes proposed in this Pull Request:

`WC_Stripe_API::retrieve()` keeps a counter of consecutive 401 responses; after 5 of them it stops making read requests for two hours and clears the cached account data. The docblock says the counter is cleared "when the keys are updated", but the only code that clears it is the OAuth connect flow (`WC_Stripe_Connect::save_stripe_keys()`). A merchant who saves a corrected key through the account keys REST endpoint stays blocked for up to two hours, with the settings screen showing "your API keys are no longer valid" and no way to reset it.

This is especially painful with restricted API keys (#634): a restricted key missing one read permission produces 401s that trip the breaker, and after the merchant fixes the key's permissions the block persists.

The fix clears the counter in `WC_REST_Stripe_Account_Keys_Controller::set_account_keys()`, before the settings write, because the option-update hooks fired by the write may already read from Stripe with the new key.

**Backward compatibility:** no public surface changes. Worst case a save of unchanged keys lets up to 5 reads through before the breaker re-trips, which is the same behavior the OAuth reconnect path already has.

## Testing instructions

1. Connect a store to Stripe, then corrupt the saved secret key (e.g. `wp option patch update woocommerce_stripe_settings test_secret_key sk_test_broken`).
2. Reload the Stripe settings page until the "keys are no longer valid" state appears (5+ failed reads; the plugin log records "Invalid API keys request rate limit exceeded").
3. Save a valid secret key through the account keys modal (or `POST /wp-json/wc/v3/wc_stripe/account_keys`).
4. Without this fix, the settings page keeps reporting invalid keys for up to two hours. With it, reload the settings page: account data loads immediately.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @aheckler 
