### PR TITLE
Clear OAuth connection metadata when a secret key is replaced

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -30,7 +30,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Hide the Apple Pay and Google Pay express buttons on pages unchecked in their own locations setting, instead of following other wallets' locations
 * Fix - Leave the Expires column blank instead of showing "N/A" on My Account → Payment methods for saved payment methods that have no expiry date, such as Link, SEPA and Cash App Pay
 * Fix - Remove the empty box shown under "Use a new payment method" on classic checkout when the save-payment-method checkbox is hidden
-* Fix - Stop the Stripe App connection refresh from overwriting a manually saved secret key, and clear the stored OAuth connection type when a key is replaced through the account keys endpoint
+* Fix - Stop the Stripe App connection refresh from overwriting a manually saved secret key
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Hide the Apple Pay and Google Pay express buttons on pages unchecked in their own locations setting, instead of following other wallets' locations
 * Fix - Leave the Expires column blank instead of showing "N/A" on My Account → Payment methods for saved payment methods that have no expiry date, such as Link, SEPA and Cash App Pay
 * Fix - Remove the empty box shown under "Use a new payment method" on classic checkout when the save-payment-method checkbox is hidden
+* Fix - Stop the Stripe App connection refresh from overwriting a manually saved secret key, and clear the stored OAuth connection type when a key is replaced through the account keys endpoint
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -306,10 +306,8 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 			$settings['test_refresh_token']   = '';
 			$this->record_manual_account_disconnect_track_event( WC_Stripe_Mode::is_test() );
 		} else {
-			// A manually entered secret key supersedes the OAuth-issued one, so drop
-			// that mode's connection metadata: otherwise the plugin keeps reporting an
-			// OAuth connection it no longer has, and on 'app' connections the refresh
-			// job silently overwrites the new key within the hour.
+			// A manually entered secret key supersedes the OAuth-issued one; without
+			// this, the 'app' refresh job overwrites the new key within the hour.
 			foreach ( [ '', 'test_' ] as $prefix ) {
 				$field = $prefix . 'secret_key';
 				if ( ( $current_account_keys[ $field ] ?? '' ) !== ( $settings[ $field ] ?? '' ) ) {

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -306,6 +306,22 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 			$settings['test_refresh_token']   = '';
 			$this->record_manual_account_disconnect_track_event( WC_Stripe_Mode::is_test() );
 		} else {
+			// A manually entered secret key supersedes the OAuth-issued one, so drop
+			// that mode's connection metadata: otherwise the plugin keeps reporting an
+			// OAuth connection it no longer has, and on 'app' connections the refresh
+			// job silently overwrites the new key within the hour.
+			foreach ( [ '', 'test_' ] as $prefix ) {
+				$field = $prefix . 'secret_key';
+				if ( ( $current_account_keys[ $field ] ?? '' ) !== ( $settings[ $field ] ?? '' ) ) {
+					$settings[ $prefix . 'connection_type' ] = '';
+					$settings[ $prefix . 'refresh_token' ]   = '';
+				}
+			}
+
+			if ( 'app' !== ( $settings['connection_type'] ?? '' ) && 'app' !== ( $settings['test_connection_type'] ?? '' ) ) {
+				WC_Stripe::get_instance()->connect->unschedule_connection_refresh();
+			}
+
 			$this->record_manual_account_key_update_track_event( WC_Stripe_Mode::is_test() );
 		}
 

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -512,9 +512,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 		/**
 		 * Unschedules the App OAuth connection refresh.
 		 *
-		 * Public so key updates outside the OAuth flow (e.g. the account keys
-		 * REST endpoint) can disarm the refresh job once no mode is connected
-		 * via the Stripe App.
+		 * Public so key updates outside the OAuth flow can disarm the job.
 		 *
 		 * @since 8.6.0
 		 */

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -512,9 +512,13 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 		/**
 		 * Unschedules the App OAuth connection refresh.
 		 *
+		 * Public so key updates outside the OAuth flow (e.g. the account keys
+		 * REST endpoint) can disarm the refresh job once no mode is connected
+		 * via the Stripe App.
+		 *
 		 * @since 8.6.0
 		 */
-		protected function unschedule_connection_refresh() {
+		public function unschedule_connection_refresh() {
 			as_unschedule_all_actions( 'wc_stripe_refresh_connection', [], WC_Stripe_Action_Scheduler_Service::GROUP_ID );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -191,5 +191,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Hide the save payment method checkbox for Bancontact, iDEAL and Sofort in the Adaptive Pricing checkout on non-EUR stores whose currency excludes them
 * Fix - Stop flagging the checkout page as the cart page (is_cart() returning true) when express checkout buttons are enabled, which made analytics and other plugins misread the page
 * Fix - Remove the empty box shown under "Use a new payment method" on classic checkout when the save-payment-method checkbox is hidden
+* Fix - Stop the Stripe App connection refresh from overwriting a manually saved secret key, and clear the stored OAuth connection type when a key is replaced through the account keys endpoint
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -191,6 +191,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Hide the save payment method checkbox for Bancontact, iDEAL and Sofort in the Adaptive Pricing checkout on non-EUR stores whose currency excludes them
 * Fix - Stop flagging the checkout page as the cart page (is_cart() returning true) when express checkout buttons are enabled, which made analytics and other plugins misread the page
 * Fix - Remove the empty box shown under "Use a new payment method" on classic checkout when the save-payment-method checkbox is hidden
-* Fix - Stop the Stripe App connection refresh from overwriting a manually saved secret key, and clear the stored OAuth connection type when a key is replaced through the account keys endpoint
+* Fix - Stop the Stripe App connection refresh from overwriting a manually saved secret key
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-rest-stripe-account-keys-controller-test.php
+++ b/tests/phpunit/class-wc-rest-stripe-account-keys-controller-test.php
@@ -336,16 +336,13 @@ class WC_REST_Stripe_Account_Keys_Controller_Test extends WC_Mock_Stripe_API_Uni
 		$this->assertSame( '', $settings['webhook_secret'] );
 	}
 	/**
-	 * Changing a mode's secret key clears that mode's OAuth connection metadata,
-	 * so the plugin stops reporting an OAuth connection it no longer has and the
-	 * App OAuth refresh job cannot overwrite the manually entered key. The other
-	 * mode's metadata is left untouched.
+	 * Changing a mode's secret key clears only that mode's OAuth connection metadata.
 	 *
 	 * @dataProvider provide_secret_key_change_scenarios
 	 *
 	 * @param string $changed_field    The secret key field being changed.
-	 * @param string $cleared_prefix   The settings prefix expected to be cleared.
-	 * @param string $untouched_prefix The settings prefix expected to be kept.
+	 * @param string $cleared_prefix   Settings prefix expected to be cleared.
+	 * @param string $untouched_prefix Settings prefix expected to be kept.
 	 */
 	public function test_changing_secret_key_clears_connection_metadata_for_mode( string $changed_field, string $cleared_prefix, string $untouched_prefix ) {
 		$settings                         = WC_Stripe_Helper::get_stripe_settings();
@@ -382,8 +379,7 @@ class WC_REST_Stripe_Account_Keys_Controller_Test extends WC_Mock_Stripe_API_Uni
 	}
 
 	/**
-	 * A save that does not change any secret key (e.g. only a webhook secret)
-	 * leaves the OAuth connection metadata alone.
+	 * A save that changes no secret key leaves the OAuth connection metadata alone.
 	 */
 	public function test_saving_without_secret_key_change_keeps_connection_metadata() {
 		$settings                    = WC_Stripe_Helper::get_stripe_settings();
@@ -403,9 +399,7 @@ class WC_REST_Stripe_Account_Keys_Controller_Test extends WC_Mock_Stripe_API_Uni
 	}
 
 	/**
-	 * Once no mode is connected via the Stripe App any more, a key change
-	 * disarms the scheduled connection refresh so the job cannot fire against
-	 * a connection that no longer exists.
+	 * A key change disarms the scheduled refresh once no app-connected mode remains.
 	 */
 	public function test_key_change_unschedules_refresh_when_no_app_connection_remains() {
 		$settings                    = WC_Stripe_Helper::get_stripe_settings();
@@ -425,8 +419,7 @@ class WC_REST_Stripe_Account_Keys_Controller_Test extends WC_Mock_Stripe_API_Uni
 	}
 
 	/**
-	 * While the other mode is still connected via the Stripe App, its scheduled
-	 * connection refresh must stay armed after a key change in one mode.
+	 * The scheduled refresh stays armed while the other mode is still app-connected.
 	 */
 	public function test_key_change_keeps_refresh_scheduled_while_other_mode_is_app_connected() {
 		$settings                         = WC_Stripe_Helper::get_stripe_settings();

--- a/tests/phpunit/class-wc-rest-stripe-account-keys-controller-test.php
+++ b/tests/phpunit/class-wc-rest-stripe-account-keys-controller-test.php
@@ -335,4 +335,116 @@ class WC_REST_Stripe_Account_Keys_Controller_Test extends WC_Mock_Stripe_API_Uni
 		$this->assertSame( [], $settings['webhook_data'] );
 		$this->assertSame( '', $settings['webhook_secret'] );
 	}
+	/**
+	 * Changing a mode's secret key clears that mode's OAuth connection metadata,
+	 * so the plugin stops reporting an OAuth connection it no longer has and the
+	 * App OAuth refresh job cannot overwrite the manually entered key. The other
+	 * mode's metadata is left untouched.
+	 *
+	 * @dataProvider provide_secret_key_change_scenarios
+	 *
+	 * @param string $changed_field    The secret key field being changed.
+	 * @param string $cleared_prefix   The settings prefix expected to be cleared.
+	 * @param string $untouched_prefix The settings prefix expected to be kept.
+	 */
+	public function test_changing_secret_key_clears_connection_metadata_for_mode( string $changed_field, string $cleared_prefix, string $untouched_prefix ) {
+		$settings                         = WC_Stripe_Helper::get_stripe_settings();
+		$settings['connection_type']      = 'app';
+		$settings['refresh_token']        = 'live-refresh-token';
+		$settings['test_connection_type'] = 'app';
+		$settings['test_refresh_token']   = 'test-refresh-token';
+		WC_Stripe_Helper::update_main_stripe_settings( $settings );
+
+		$request = new WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_param( $changed_field, '' === $cleared_prefix ? 'sk_live_new-key-12345' : 'sk_test_new-key-12345' );
+
+		$response = $this->controller->set_account_keys( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$settings = WC_Stripe_Helper::get_stripe_settings();
+
+		$this->assertSame( '', $settings[ $cleared_prefix . 'connection_type' ] );
+		$this->assertSame( '', $settings[ $cleared_prefix . 'refresh_token' ] );
+		$this->assertSame( 'app', $settings[ $untouched_prefix . 'connection_type' ] );
+		$this->assertNotSame( '', $settings[ $untouched_prefix . 'refresh_token' ] );
+	}
+
+	/**
+	 * Scenarios for test_changing_secret_key_clears_connection_metadata_for_mode().
+	 *
+	 * @return array
+	 */
+	public function provide_secret_key_change_scenarios(): array {
+		return [
+			'live secret key changed' => [ 'secret_key', '', 'test_' ],
+			'test secret key changed' => [ 'test_secret_key', 'test_', '' ],
+		];
+	}
+
+	/**
+	 * A save that does not change any secret key (e.g. only a webhook secret)
+	 * leaves the OAuth connection metadata alone.
+	 */
+	public function test_saving_without_secret_key_change_keeps_connection_metadata() {
+		$settings                    = WC_Stripe_Helper::get_stripe_settings();
+		$settings['connection_type'] = 'app';
+		$settings['refresh_token']   = 'live-refresh-token';
+		WC_Stripe_Helper::update_main_stripe_settings( $settings );
+
+		$request = new WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_param( 'webhook_secret', 'whsec_new-12345' );
+
+		$this->controller->set_account_keys( $request );
+
+		$settings = WC_Stripe_Helper::get_stripe_settings();
+
+		$this->assertSame( 'app', $settings['connection_type'] );
+		$this->assertSame( 'live-refresh-token', $settings['refresh_token'] );
+	}
+
+	/**
+	 * Once no mode is connected via the Stripe App any more, a key change
+	 * disarms the scheduled connection refresh so the job cannot fire against
+	 * a connection that no longer exists.
+	 */
+	public function test_key_change_unschedules_refresh_when_no_app_connection_remains() {
+		$settings                    = WC_Stripe_Helper::get_stripe_settings();
+		$settings['connection_type'] = 'app';
+		$settings['refresh_token']   = 'live-refresh-token';
+		WC_Stripe_Helper::update_main_stripe_settings( $settings );
+
+		as_schedule_single_action( time() + 100, 'wc_stripe_refresh_connection', [], WC_Stripe_Action_Scheduler_Service::GROUP_ID );
+		$this->assertNotFalse( as_next_scheduled_action( 'wc_stripe_refresh_connection', [], WC_Stripe_Action_Scheduler_Service::GROUP_ID ) );
+
+		$request = new WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_param( 'secret_key', 'sk_live_new-key-12345' );
+
+		$this->controller->set_account_keys( $request );
+
+		$this->assertFalse( as_next_scheduled_action( 'wc_stripe_refresh_connection', [], WC_Stripe_Action_Scheduler_Service::GROUP_ID ) );
+	}
+
+	/**
+	 * While the other mode is still connected via the Stripe App, its scheduled
+	 * connection refresh must stay armed after a key change in one mode.
+	 */
+	public function test_key_change_keeps_refresh_scheduled_while_other_mode_is_app_connected() {
+		$settings                         = WC_Stripe_Helper::get_stripe_settings();
+		$settings['connection_type']      = 'app';
+		$settings['refresh_token']        = 'live-refresh-token';
+		$settings['test_connection_type'] = 'app';
+		$settings['test_refresh_token']   = 'test-refresh-token';
+		WC_Stripe_Helper::update_main_stripe_settings( $settings );
+
+		as_schedule_single_action( time() + 100, 'wc_stripe_refresh_connection', [], WC_Stripe_Action_Scheduler_Service::GROUP_ID );
+
+		$request = new WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_param( 'secret_key', 'sk_live_new-key-12345' );
+
+		$this->controller->set_account_keys( $request );
+
+		$this->assertNotFalse( as_next_scheduled_action( 'wc_stripe_refresh_connection', [], WC_Stripe_Action_Scheduler_Service::GROUP_ID ) );
+
+		as_unschedule_all_actions( 'wc_stripe_refresh_connection', [], WC_Stripe_Action_Scheduler_Service::GROUP_ID );
+	}
 }


### PR DESCRIPTION
Towards STRIPE-3
Towards #634

## Changes proposed in this Pull Request:

`set_account_keys()` only cleared `connection_type` / `refresh_token` when *all four* keys were emptied at once. After a partial key replacement (the normal way to install a different key, e.g. a restricted API key), the plugin still believed it held an OAuth connection:

- On `app`-type connections, the Action Scheduler refresh job kept running every ~55 minutes, and `refresh_connection()` calls `save_stripe_keys()`, which **silently overwrites the manually saved secret key** with a freshly minted OAuth key. The merchant's key works for under an hour and then reverts with no error anywhere.
- The stored `connection_type` no longer described how the active key was obtained, and the stale `refresh_token` stayed in the database.

Changes:

- When a mode's secret key is changed through the account keys endpoint, that mode's `connection_type` and `refresh_token` are cleared. The other mode is untouched.
- When no mode remains connected via the Stripe App afterwards, the scheduled `wc_stripe_refresh_connection` job is disarmed. While the other mode is still `app`-connected, the job stays armed.
- `WC_Stripe_Connect::unschedule_connection_refresh()` visibility widened from `protected` to `public` so the controller can call it.

**Backward compatibility:** widening a method's visibility is additive. Changing only a publishable key does not touch connection metadata (on an `app` connection the refresh job needs the refresh token to keep the access token alive, so it must survive edits that don't replace the secret). The OAuth connect/disconnect flows are unchanged.

## Testing instructions

1. Connect a store to Stripe. Check the connection type: `wp option get woocommerce_stripe_settings --format=json | jq '.connection_type, .refresh_token'`.
2. Save a different secret key via the account keys modal (or `POST /wp-json/wc/v3/wc_stripe/account_keys` with `secret_key`).
3. Re-check the option: `connection_type` and `refresh_token` are now empty, while `test_connection_type` / `test_refresh_token` are unchanged.
4. On an `app`-type connection, also verify with `wp action-scheduler list --hook=wc_stripe_refresh_connection --status=pending` that the refresh job is gone (when the test mode connection was not `app`), and that the saved key is still in place an hour later.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @aheckler 
