### PR TITLE
Prevent Classic Checkout submitting: followup to show an error instead of submitting when required fields are empty

### DIFF
--- a/client/classic/upe/__tests__/deferred-intent.test.js
+++ b/client/classic/upe/__tests__/deferred-intent.test.js
@@ -1,0 +1,103 @@
+/**
+ * The classic checkout handler's RETURN VALUE is the contract with WooCommerce core:
+ * core submits the form unless a `checkout_place_order_*` handler returns exactly false.
+ * Returning early without false lets the form POST with no payment method, which creates
+ * an order and then fails it. These tests pin the return value, not just the side effects.
+ */
+const mockProcessPayment = jest.fn();
+const mockShowErrorCheckout = jest.fn();
+let mockIsEmpty = false;
+let mockUsingSavedMethod = false;
+
+jest.mock( '../../../api', () => jest.fn() );
+
+jest.mock( '../../../stripe-utils', () => ( {
+	generateCheckoutEventNames: () => 'checkout_place_order_stripe',
+	getSelectedUPEGatewayPaymentMethod: () => 'card',
+	getStripeServerData: () => ( {} ),
+	isPaymentMethodRestrictedToLocation: () => false,
+	isUsingSavedPaymentMethod: () => mockUsingSavedMethod,
+	paymentMethodSupportsDeferredIntent: () => true,
+	showErrorCheckout: ( ...args ) => mockShowErrorCheckout( ...args ),
+	togglePaymentMethodForCountry: () => {},
+} ) );
+
+jest.mock( '../payment-processing', () => ( {
+	confirmVoucherPayment: () => {},
+	confirmWalletPayment: () => {},
+	createAndConfirmSetupIntent: () => {},
+	getMountedUPEComponent: () => null,
+	hasEmptyRequiredFields: () => mockIsEmpty,
+	initializeUPEComponents: () => {},
+	maybeUpdateAdaptivePricingCheckoutSession: () => Promise.resolve(),
+	maybeUpdateOptimizedCheckoutExclusions: () => {},
+	mountStripePaymentElement: () => Promise.resolve(),
+	processPayment: ( ...args ) => mockProcessPayment( ...args ),
+	trackMountInProgress: () => {},
+} ) );
+
+// jQuery defers its ready callback through setTimeout and then resolves it through a
+// promise chain, so binding needs several turns of the loop, not a single flush.
+const flushReady = async () => {
+	for ( let i = 0; i < 5; i++ ) {
+		await new Promise( ( resolve ) => setTimeout( resolve, 1 ) );
+	}
+};
+
+// The module under test binds its handler with the jQuery from its own module
+// registry, so the test has to trigger through that same instance.
+let $;
+
+const placeOrder = () =>
+	$( 'form.checkout' ).triggerHandler( 'checkout_place_order_stripe' );
+
+describe( 'classic checkout place-order handler', () => {
+	beforeEach( async () => {
+		mockIsEmpty = false;
+		mockUsingSavedMethod = false;
+		mockProcessPayment.mockReset();
+		mockProcessPayment.mockReturnValue( false );
+		mockShowErrorCheckout.mockReset();
+
+		document.body.innerHTML = '<form class="checkout"></form>';
+
+		await jest.isolateModulesAsync( async () => {
+			$ = require( 'jquery' );
+			require( '../deferred-intent' );
+			await flushReady();
+		} );
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+		jest.resetModules();
+	} );
+
+	it( 'returns false so core does not submit when a required field is empty', () => {
+		mockIsEmpty = true;
+
+		expect( placeOrder() ).toBe( false );
+		expect( mockProcessPayment ).not.toHaveBeenCalled();
+		expect( mockShowErrorCheckout ).toHaveBeenCalledWith(
+			'Please fill in all required fields.'
+		);
+	} );
+
+	it( 'delegates to processPayment when the required fields are filled', () => {
+		placeOrder();
+
+		expect( mockProcessPayment ).toHaveBeenCalled();
+		expect( mockShowErrorCheckout ).not.toHaveBeenCalled();
+	} );
+
+	// The saved token travels in the POST, so core must be allowed to submit even when
+	// the required-field check would have objected.
+	it( 'lets core submit a saved token without consulting the required fields', () => {
+		mockIsEmpty = true;
+		mockUsingSavedMethod = true;
+
+		expect( placeOrder() ).toBeUndefined();
+		expect( mockProcessPayment ).not.toHaveBeenCalled();
+		expect( mockShowErrorCheckout ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/classic/upe/__tests__/deferred-intent.test.js
+++ b/client/classic/upe/__tests__/deferred-intent.test.js
@@ -5,6 +5,7 @@
  * an order and then fails it. These tests pin the return value, not just the side effects.
  */
 const mockProcessPayment = jest.fn();
+const mockResetCheckoutCompletionState = jest.fn();
 const mockShowErrorCheckout = jest.fn();
 let mockIsEmpty = false;
 let mockUsingSavedMethod = false;
@@ -33,6 +34,8 @@ jest.mock( '../payment-processing', () => ( {
 	maybeUpdateOptimizedCheckoutExclusions: () => {},
 	mountStripePaymentElement: () => Promise.resolve(),
 	processPayment: ( ...args ) => mockProcessPayment( ...args ),
+	resetCheckoutCompletionState: ( ...args ) =>
+		mockResetCheckoutCompletionState( ...args ),
 	trackMountInProgress: () => {},
 } ) );
 
@@ -57,6 +60,7 @@ describe( 'classic checkout place-order handler', () => {
 		mockUsingSavedMethod = false;
 		mockProcessPayment.mockReset();
 		mockProcessPayment.mockReturnValue( false );
+		mockResetCheckoutCompletionState.mockReset();
 		mockShowErrorCheckout.mockReset();
 
 		document.body.innerHTML = '<form class="checkout"></form>';
@@ -78,6 +82,7 @@ describe( 'classic checkout place-order handler', () => {
 
 		expect( placeOrder() ).toBe( false );
 		expect( mockProcessPayment ).not.toHaveBeenCalled();
+		expect( mockResetCheckoutCompletionState ).toHaveBeenCalledTimes( 1 );
 		expect( mockShowErrorCheckout ).toHaveBeenCalledWith(
 			'Please fill in all required fields.'
 		);
@@ -87,17 +92,28 @@ describe( 'classic checkout place-order handler', () => {
 		placeOrder();
 
 		expect( mockProcessPayment ).toHaveBeenCalled();
+		expect( mockResetCheckoutCompletionState ).not.toHaveBeenCalled();
 		expect( mockShowErrorCheckout ).not.toHaveBeenCalled();
 	} );
 
-	// The saved token travels in the POST, so core must be allowed to submit even when
-	// the required-field check would have objected.
-	it( 'lets core submit a saved token without consulting the required fields', () => {
+	it( 'blocks a saved-token checkout when a required field is empty', () => {
 		mockIsEmpty = true;
+		mockUsingSavedMethod = true;
+
+		expect( placeOrder() ).toBe( false );
+		expect( mockProcessPayment ).not.toHaveBeenCalled();
+		expect( mockResetCheckoutCompletionState ).toHaveBeenCalledTimes( 1 );
+		expect( mockShowErrorCheckout ).toHaveBeenCalledWith(
+			'Please fill in all required fields.'
+		);
+	} );
+
+	it( 'lets core submit a saved token when required fields are filled', () => {
 		mockUsingSavedMethod = true;
 
 		expect( placeOrder() ).toBeUndefined();
 		expect( mockProcessPayment ).not.toHaveBeenCalled();
+		expect( mockResetCheckoutCompletionState ).not.toHaveBeenCalled();
 		expect( mockShowErrorCheckout ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/classic/upe/__tests__/payment-processing.test.js
+++ b/client/classic/upe/__tests__/payment-processing.test.js
@@ -310,6 +310,23 @@ describe( 'payment-processing', () => {
 		} );
 
 		describe( 'processPayment', () => {
+			it( 'blocks submission when the selected payment component is unavailable', () => {
+				const api = createMockApi( createMockElements() );
+				const form = createMockForm();
+
+				const result = paymentProcessing.processPayment(
+					api,
+					form,
+					'unknown'
+				);
+
+				expect( result ).toBe( false );
+				expect( stripeUtils.showErrorCheckout ).toHaveBeenCalledWith(
+					'Payment failed. Please try again.'
+				);
+				expect( form.trigger ).not.toHaveBeenCalled();
+			} );
+
 			it( 'validates elements, creates a payment method, and submits form', async () => {
 				const checkoutElements = createMockElements();
 				const api = createMockApi( checkoutElements );
@@ -331,6 +348,32 @@ describe( 'payment-processing', () => {
 					stripeUtils.appendPaymentMethodIdToForm
 				).toHaveBeenCalledWith( form, 'pm_test_123' );
 				expect( form.trigger ).toHaveBeenCalledWith( 'submit' );
+			} );
+
+			it( 'can reset completed state when the programmatic submit is blocked', async () => {
+				const api = createMockApi( createMockElements() );
+				api._stripe.elements.mockReturnValue( api._standardElements );
+
+				const dom = document.createElement( 'div' );
+				dom.dataset.paymentMethodType = 'card';
+				await paymentProcessing.mountStripePaymentElement( api, dom );
+
+				const form = createMockForm();
+				paymentProcessing.processPayment( api, form, 'card' );
+				await flushPromises();
+
+				paymentProcessing.resetCheckoutCompletionState();
+				const retryResult = paymentProcessing.processPayment(
+					api,
+					form,
+					'card'
+				);
+				await flushPromises();
+
+				expect( retryResult ).toBe( false );
+				expect( api._standardElements.submit ).toHaveBeenCalledTimes(
+					2
+				);
 			} );
 
 			it( 'waits for an in-flight re-mount before validating and submitting', async () => {
@@ -1733,6 +1776,26 @@ describe( 'payment-processing', () => {
 				'</p>';
 			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
 				true
+			);
+		} );
+
+		it( 'returns true when a required textarea is empty', () => {
+			form.innerHTML =
+				'<p class="validate-required">' +
+				'<textarea class="input-text"></textarea>' +
+				'</p>';
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				true
+			);
+		} );
+
+		it( 'returns false when a required textarea has a value', () => {
+			form.innerHTML =
+				'<p class="validate-required">' +
+				'<textarea class="input-text">Details</textarea>' +
+				'</p>';
+			expect( hasEmptyRequiredFields( getRequiredFieldWrappers() ) ).toBe(
+				false
 			);
 		} );
 

--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -7,6 +7,7 @@ import {
 	isPaymentMethodRestrictedToLocation,
 	isUsingSavedPaymentMethod,
 	paymentMethodSupportsDeferredIntent,
+	showErrorCheckout,
 	togglePaymentMethodForCountry,
 } from '../../stripe-utils';
 import './style.scss';
@@ -23,6 +24,7 @@ import {
 	processPayment,
 	trackMountInProgress,
 } from './payment-processing';
+import { __ } from '@wordpress/i18n';
 
 jQuery( function ( $ ) {
 	const stripeServerData = getStripeServerData();
@@ -102,27 +104,37 @@ jQuery( function ( $ ) {
 
 	function processPaymentIfNotUsingSavedMethod( $form ) {
 		const paymentMethodType = getSelectedUPEGatewayPaymentMethod();
-		if ( ! isUsingSavedPaymentMethod( paymentMethodType ) ) {
-			return processPayment( api, $form, paymentMethodType );
+
+		// A saved token travels in the POST and needs no payment method, so the
+		// required-field state is none of our business on that path.
+		if ( isUsingSavedPaymentMethod( paymentMethodType ) ) {
+			return;
 		}
-	}
 
-	$( 'form.checkout' ).on( generateCheckoutEventNames(), function () {
-		const $form = $( this );
-
-		// Don't create a Stripe payment method if required checkout fields are empty.
-		// This prevents unnecessary Stripe API calls before WC's server-side validation.
-		// jQuery :visible filters out fields hidden by conditional checkout logic
-		// (e.g. shipping fields when "Ship to different address" is unchecked).
+		// Returning false is what stops WooCommerce submitting: returning early without
+		// it would let the form POST with no payment method, and the order would be
+		// created and then failed. jQuery :visible filters out fields hidden by
+		// conditional checkout logic (e.g. shipping fields when "Ship to different
+		// address" is unchecked).
 		if (
 			hasEmptyRequiredFields(
 				$form.find( '.validate-required:visible' ).toArray()
 			)
 		) {
-			return;
+			showErrorCheckout(
+				__(
+					'Please fill in all required fields.',
+					'woocommerce-gateway-stripe'
+				)
+			);
+			return false;
 		}
 
-		return processPaymentIfNotUsingSavedMethod( $form );
+		return processPayment( api, $form, paymentMethodType );
+	}
+
+	$( 'form.checkout' ).on( generateCheckoutEventNames(), function () {
+		return processPaymentIfNotUsingSavedMethod( $( this ) );
 	} );
 
 	// Mount the Stripe Payment Elements onto the Add Payment Method page and Pay for Order page.

--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -22,6 +22,7 @@ import {
 	maybeUpdateOptimizedCheckoutExclusions,
 	mountStripePaymentElement,
 	processPayment,
+	resetCheckoutCompletionState,
 	trackMountInProgress,
 } from './payment-processing';
 import { __ } from '@wordpress/i18n';
@@ -103,14 +104,6 @@ jQuery( function ( $ ) {
 	} );
 
 	function processPaymentIfNotUsingSavedMethod( $form ) {
-		const paymentMethodType = getSelectedUPEGatewayPaymentMethod();
-
-		// A saved token travels in the POST and needs no payment method, so the
-		// required-field state is none of our business on that path.
-		if ( isUsingSavedPaymentMethod( paymentMethodType ) ) {
-			return;
-		}
-
 		// Returning false is what stops WooCommerce submitting: returning early without
 		// it would let the form POST with no payment method, and the order would be
 		// created and then failed. jQuery :visible filters out fields hidden by
@@ -121,6 +114,7 @@ jQuery( function ( $ ) {
 				$form.find( '.validate-required:visible' ).toArray()
 			)
 		) {
+			resetCheckoutCompletionState();
 			showErrorCheckout(
 				__(
 					'Please fill in all required fields.',
@@ -130,7 +124,10 @@ jQuery( function ( $ ) {
 			return false;
 		}
 
-		return processPayment( api, $form, paymentMethodType );
+		const paymentMethodType = getSelectedUPEGatewayPaymentMethod();
+		if ( ! isUsingSavedPaymentMethod( paymentMethodType ) ) {
+			return processPayment( api, $form, paymentMethodType );
+		}
 	}
 
 	$( 'form.checkout' ).on( generateCheckoutEventNames(), function () {

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -65,6 +65,14 @@ const gatewayUPEComponents = {};
 let hasCheckoutCompleted = false;
 
 /**
+ * Clears the one-shot completion flag when a later checkout check blocks the
+ * programmatic submit before processPayment can consume it.
+ */
+export function resetCheckoutCompletionState() {
+	hasCheckoutCompleted = false;
+}
+
+/**
  * OC exclusions last applied to each Elements instance (as a sorted key), so
  * redundant `elements.update()` calls can be skipped. Keyed by instance: a
  * re-mounted element starts fresh and stale state can't leak across mounts.
@@ -1163,17 +1171,19 @@ export const processPayment = (
 		return;
 	}
 
+	const genericErrorMessage = __(
+		'Payment failed. Please try again.',
+		'woocommerce-gateway-stripe'
+	);
+
 	if ( ! gatewayUPEComponents[ paymentMethodType ] ) {
-		return;
+		showErrorCheckout( genericErrorMessage );
+		return false;
 	}
 
 	blockUI( jQueryForm );
 
 	const getErrorMessage = ( err ) => {
-		const genericErrorMessage = __(
-			'Payment failed. Please try again.',
-			'woocommerce-gateway-stripe'
-		);
 		if ( ! err ) {
 			return genericErrorMessage;
 		}
@@ -1700,7 +1710,7 @@ export const hasEmptyRequiredFields = ( requiredWrappers ) => {
 	for ( const wrapper of requiredWrappers ) {
 		const inputs = [
 			...wrapper.querySelectorAll(
-				'input.input-text, select, input[type="checkbox"]'
+				'input.input-text, textarea.input-text, select, input[type="checkbox"]'
 			),
 		];
 		if ( ! inputs.length ) {

--- a/client/stripe-utils/__tests__/utils.test.js
+++ b/client/stripe-utils/__tests__/utils.test.js
@@ -766,27 +766,41 @@ describe( 'utils', () => {
 
 describe( 'showErrorCheckout', () => {
 	let container;
+	let checkoutForm;
+	let hasNoticesWrapper;
 	const originalJQuery = global.jQuery;
 	const originalWcSettings = global.wcSettings;
 	const originalWc = global.wc;
 
 	beforeEach( () => {
+		hasNoticesWrapper = true;
 		container = {
 			length: 1,
 			find: jest.fn().mockReturnThis(),
 			remove: jest.fn().mockReturnThis(),
 			prepend: jest.fn().mockReturnThis(),
 		};
+		checkoutForm = {
+			length: 1,
+			find: jest.fn( () => ( { length: 0, remove: jest.fn() } ) ),
+			prepend: jest.fn().mockReturnThis(),
+		};
 
 		const jQueryMock = jest.fn( ( selector ) => {
 			if ( selector === '.woocommerce-notices-wrapper' ) {
-				return { first: () => container };
+				return {
+					first: () =>
+						hasNoticesWrapper ? container : { length: 0 },
+				};
 			}
 			if ( selector === '.woocommerce-MyAccount-content' ) {
 				return { length: 0 };
 			}
 			if ( selector === 'form.checkout' ) {
-				return { find: () => ( { length: 0 } ) };
+				return {
+					first: () => checkoutForm,
+					find: checkoutForm.find,
+				};
 			}
 			return { trigger: jest.fn().mockReturnThis(), each: jest.fn() };
 		} );
@@ -843,6 +857,21 @@ describe( 'showErrorCheckout', () => {
 
 		expect( container.prepend ).toHaveBeenCalledWith(
 			expect.stringContaining( 'Your card was declined.' )
+		);
+	} );
+
+	it( 'falls back to the checkout form when the notices wrapper is missing', () => {
+		hasNoticesWrapper = false;
+		dispatch.mockReturnValue( null );
+		global.wcSettings = { wcBlocksConfig: false };
+
+		showErrorCheckout( 'Your card was declined.' );
+
+		expect( checkoutForm.prepend ).toHaveBeenCalledWith(
+			expect.stringContaining( 'Your card was declined.' )
+		);
+		expect( global.jQuery.scroll_to_notices ).toHaveBeenCalledWith(
+			checkoutForm
 		);
 	} );
 

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -862,9 +862,15 @@ export const clearStaleCheckoutTotalNotice = () => {
  * @param {string} errorMessage
  */
 export const showErrorCheckout = ( errorMessage ) => {
-	const $container = jQuery( '.woocommerce-notices-wrapper' ).first();
+	let $container = jQuery( '.woocommerce-notices-wrapper' ).first();
 	const isMyAccountPage =
 		jQuery( '.woocommerce-MyAccount-content' ).length > 0;
+
+	// Some custom checkout templates omit the standard notices wrapper. The form
+	// is the same fallback WooCommerce uses for checkout AJAX errors.
+	if ( ! $container.length ) {
+		$container = jQuery( 'form.checkout' ).first();
+	}
 
 	if ( ! $container.length ) {
 		return;

--- a/tests/e2e/tests/checkout/shortcode/third-party-required-fields.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/third-party-required-fields.spec.js
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import config from 'config';
+import { payments } from '../../../utils';
+
+const {
+	emptyCart,
+	setupCart,
+	setupShortcodeCheckout,
+	fillCreditCardDetailsShortcode,
+	waitForStripeReady,
+} = payments;
+
+const UPE_IFRAME_SELECTOR =
+	'.payment_method_stripe #wc-stripe-upe-form .wc-stripe-upe-element iframe';
+
+const FIELD_ID = 'third-party-required-field';
+
+/**
+ * Adds markup of the shape a third-party plugin contributes to classic checkout:
+ * a visible `.validate-required` wrapper holding an empty control, for a field
+ * WooCommerce knows nothing about and therefore will not validate server-side.
+ */
+const injectThirdPartyRequiredField = ( page ) =>
+	page.evaluate( ( id ) => {
+		const field = document.createElement( 'p' );
+		field.id = id;
+		field.className = 'form-row form-row-wide validate-required';
+		field.innerHTML =
+			'<label>Third party field <abbr class="required" title="required">*</abbr></label>' +
+			'<input type="text" class="input-text" name="third_party_required_field" value="" />';
+		document.querySelector( 'form.checkout' ).prepend( field );
+	}, FIELD_ID );
+
+/**
+ * The gate that skips Stripe payment method creation must also stop WooCommerce
+ * submitting. Returning early without stopping the submission posts the order with
+ * no payment method, which creates an order and then fails it — the STRIPE-1402
+ * shape. The shopper should instead stay on the form with an error, as they do
+ * when the card number is incomplete.
+ */
+test( 'keeps the shopper on the form when a third-party required field is empty', async ( {
+	page,
+} ) => {
+	await emptyCart( page );
+	await setupCart( page );
+	await setupShortcodeCheckout(
+		page,
+		config.get( 'addresses.customer.billing' )
+	);
+
+	await fillCreditCardDetailsShortcode( page, config.get( 'cards.basic' ) );
+	await waitForStripeReady( page, UPE_IFRAME_SELECTOR );
+
+	await injectThirdPartyRequiredField( page );
+
+	// The submission WooCommerce would make if the handler did not return false.
+	let checkoutRequests = 0;
+	page.on( 'request', ( request ) => {
+		if ( request.url().includes( 'wc-ajax=checkout' ) ) {
+			checkoutRequests++;
+		}
+	} );
+
+	// A single click: a retry would hide a regression that only affects the first.
+	await page
+		.getByRole( 'button', { name: 'Place order' } )
+		.dispatchEvent( 'click' );
+
+	await expect( page.locator( '.woocommerce-error' ) ).toContainText(
+		'Please fill in all required fields.'
+	);
+	expect( checkoutRequests ).toBe( 0 );
+	await expect( page ).toHaveURL( /checkout/ );
+
+	// The block must be recoverable: filling the field lets the order through.
+	await page.fill( `#${ FIELD_ID } input`, 'filled in' );
+	await page
+		.getByRole( 'button', { name: 'Place order' } )
+		.dispatchEvent( 'click' );
+
+	await page.waitForURL( /order-received/, { timeout: 30000 } );
+	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
+		'Order received'
+	);
+} );


### PR DESCRIPTION
Follow-up to merged PR #5853 (STRIPE-1402).

## Changes proposed in this Pull Request:

#5853 stops the required-field gate misreading fields that are filled. This PR handles genuinely empty fields and related submission failures.

WooCommerce submits Classic Checkout unless a `checkout_place_order_*` handler returns exactly `false`. The gate returned `undefined`, so WooCommerce submitted the form without the payment method that Stripe withheld. This created an order and then marked it failed.

This PR:

- Returns `false` and shows "Please fill in all required fields." when a visible required field is empty.
- Resets the one-shot checkout state when that validation blocks a programmatic retry.
- Recognizes required textareas rendered by `woocommerce_form_field()`.
- Blocks submission with an error when the selected Stripe component is unavailable.
- Falls back to rendering errors in `form.checkout` when a custom template omits `.woocommerce-notices-wrapper`.
- Applies required-field validation before saved-token handling, while still leaving payment processing for a valid saved-token submission to WooCommerce.

The new-card path now shows one generic required-fields message instead of WooCommerce's field-specific server messages. The affected fields are still marked through the existing checkout validation events. The DOM does not identify which fields WooCommerce knows how to validate server-side, so narrowing the gate to third-party fields would be unreliable.

## Testing instructions

1. Configure Stripe with a test account and use Classic Checkout.
2. Add a product to the cart, fill the billing fields and card details, then add the checkbox group using the snippet from #5853.
3. Leave both injected checkboxes unchecked and place the order.
   - No checkout request or order should be created.
   - "Please fill in all required fields." should appear.
   - The shopper should remain on the checkout page.
4. Check either injected checkbox and place the order again. The order should complete.
5. Start another checkout, run the #5853 snippet again, then replace the injected field with a required textarea:

   ```js
   const field = document.querySelector( '#stripe-1402-reproducer' );
   field.innerHTML = `
       <label>Required details <abbr class="required" title="required">*</abbr></label>
       <textarea class="input-text" name="stripe_1402_details"></textarea>
   `;
   ```

6. Place the order with the textarea empty. The same required-fields error should appear and no order should be created.
7. Fill the textarea and retry. The order should complete.
8. Repeat the empty-textarea check after running:

   ```js
   document.querySelector( '.woocommerce-notices-wrapper' )?.remove();
   ```

   The error should appear at the top of the checkout form.
9. On a new checkout, inject the same client-only required field and leave it empty, then pay with a saved card. The required-fields error should appear and no order should be created.
10. Fill the injected field and retry with the saved card. The order should complete without creating a new Stripe payment method in the browser.
11. On a new checkout with a new card, leave a native billing field empty. Confirm that the generic required-fields message appears and the field is marked invalid.

Covered by Jest tests for handler return values, retry state, textarea handling, missing components, and notice fallback. An E2E test verifies that an empty third-party field causes no checkout request and that filling it allows the order to complete.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Merged PR #5853 already contains the STRIPE-1402 changelog entry.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with AI assistance.
