### PR TITLE
Guard the express checkout availability probe against an unhydrated Blocks cart

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -33,6 +33,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Leave the Expires column blank instead of showing "N/A" on My Account → Payment methods for saved payment methods that have no expiry date, such as Link, SEPA and Cash App Pay
 * Fix - Remove the empty box shown under "Use a new payment method" on classic checkout when the save-payment-method checkbox is hidden
 * Fix - Ensure webhook status checks reset API key
+* Fix - Keep express checkout and the payment options rendering on the first block checkout load of a free-trial subscription cart
 
 2026-08-31 - version 10.9.1
 * Fix - Allow express checkout payments when automatic account password generation is disabled

--- a/client/express-checkout/utils/__tests__/check-payment-method-availability.test.js
+++ b/client/express-checkout/utils/__tests__/check-payment-method-availability.test.js
@@ -1,0 +1,120 @@
+import { createRoot } from 'react-dom/client';
+import { checkPaymentMethodIsAvailable } from 'wcstripe/express-checkout/utils/check-payment-method-availability';
+import { getExpressCheckoutData } from 'wcstripe/express-checkout/utils';
+
+jest.mock( 'react-dom/client', () => ( {
+	createRoot: jest.fn(),
+} ) );
+
+jest.mock( 'wcstripe/express-checkout/utils', () => ( {
+	getExpressCheckoutData: jest.fn(),
+	getPaymentMethodTypesForExpressMethod: jest.fn( () => [ 'card' ] ),
+	isManualPaymentMethodCreation: jest.fn( () => false ),
+} ) );
+
+describe( 'checkPaymentMethodIsAvailable', () => {
+	const api = { loadStripe: jest.fn( () => Promise.resolve( {} ) ) };
+
+	const render = jest.fn();
+	const unmount = jest.fn();
+
+	const hydratedCart = ( currencyCode = 'USD' ) => ( {
+		cartTotals: {
+			total_price: '1000',
+			currency_minor_unit: 2,
+			currency_code: currencyCode,
+		},
+	} );
+
+	// The default cart totals @woocommerce/block-data seeds before the Store
+	// API response is applied.
+	const unhydratedCart = () => ( {
+		cartTotals: {
+			total_price: '0',
+			currency_minor_unit: 2,
+			currency_code: '',
+		},
+	} );
+
+	const getRenderedExpressCheckoutElement = ( call = 0 ) =>
+		render.mock.calls[ call ][ 0 ].props.children;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		createRoot.mockReturnValue( { render, unmount } );
+		getExpressCheckoutData.mockReturnValue( false );
+	} );
+
+	it( 'resolves false without mounting a probe element when the cart currency is not hydrated', async () => {
+		const result = await checkPaymentMethodIsAvailable(
+			'amazonPay',
+			api,
+			unhydratedCart()
+		);
+
+		expect( result ).toBe( false );
+		expect( createRoot ).not.toHaveBeenCalled();
+	} );
+
+	it( 'probes again once the cart hydrates instead of reusing the unhydrated result', async () => {
+		const beforeHydration = await checkPaymentMethodIsAvailable(
+			'applePay',
+			api,
+			unhydratedCart()
+		);
+		expect( beforeHydration ).toBe( false );
+		expect( createRoot ).not.toHaveBeenCalled();
+
+		const afterHydration = checkPaymentMethodIsAvailable(
+			'applePay',
+			api,
+			hydratedCart()
+		);
+		expect( createRoot ).toHaveBeenCalledTimes( 1 );
+		expect( render.mock.calls[ 0 ][ 0 ].props.options.currency ).toBe(
+			'usd'
+		);
+
+		getRenderedExpressCheckoutElement().props.onReady( {
+			availablePaymentMethods: { applePay: true },
+		} );
+
+		expect( await afterHydration ).toBe( true );
+		expect( unmount ).toHaveBeenCalled();
+	} );
+
+	it( 'memoizes the probe per payment method for hydrated carts', async () => {
+		const first = checkPaymentMethodIsAvailable(
+			'googlePay',
+			api,
+			hydratedCart()
+		);
+		getRenderedExpressCheckoutElement().props.onReady( {
+			availablePaymentMethods: { googlePay: true },
+		} );
+
+		const second = checkPaymentMethodIsAvailable(
+			'googlePay',
+			api,
+			hydratedCart()
+		);
+
+		expect( createRoot ).toHaveBeenCalledTimes( 1 );
+		expect( await first ).toBe( true );
+		expect( await second ).toBe( true );
+	} );
+
+	it( 'resolves false when the ready event does not report the method as available', async () => {
+		const result = checkPaymentMethodIsAvailable(
+			'link',
+			api,
+			hydratedCart()
+		);
+
+		getRenderedExpressCheckoutElement().props.onReady( {
+			availablePaymentMethods: { link: false },
+		} );
+
+		expect( await result ).toBe( false );
+	} );
+} );

--- a/client/express-checkout/utils/__tests__/check-payment-method-availability.test.js
+++ b/client/express-checkout/utils/__tests__/check-payment-method-availability.test.js
@@ -36,8 +36,13 @@ describe( 'checkPaymentMethodIsAvailable', () => {
 		},
 	} );
 
+	// The rendered tree is ProbeErrorBoundary > Elements > ExpressCheckoutElement.
+	const getRenderedErrorBoundary = ( call = 0 ) =>
+		render.mock.calls[ call ][ 0 ];
+	const getRenderedElements = ( call = 0 ) =>
+		getRenderedErrorBoundary( call ).props.children;
 	const getRenderedExpressCheckoutElement = ( call = 0 ) =>
-		render.mock.calls[ call ][ 0 ].props.children;
+		getRenderedElements( call ).props.children;
 
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -71,9 +76,7 @@ describe( 'checkPaymentMethodIsAvailable', () => {
 			hydratedCart()
 		);
 		expect( createRoot ).toHaveBeenCalledTimes( 1 );
-		expect( render.mock.calls[ 0 ][ 0 ].props.options.currency ).toBe(
-			'usd'
-		);
+		expect( getRenderedElements().props.options.currency ).toBe( 'usd' );
 
 		getRenderedExpressCheckoutElement().props.onReady( {
 			availablePaymentMethods: { applePay: true },
@@ -116,5 +119,34 @@ describe( 'checkPaymentMethodIsAvailable', () => {
 		} );
 
 		expect( await result ).toBe( false );
+	} );
+
+	it( 'resolves false on probe failures without caching them, so later calls probe again', async () => {
+		// Mount error caught by the error boundary.
+		const first = checkPaymentMethodIsAvailable(
+			'amazonPay',
+			api,
+			hydratedCart()
+		);
+		getRenderedErrorBoundary().props.onError();
+		expect( await first ).toBe( false );
+
+		// The failure was evicted, so this call probes again; this time the
+		// element reports a load error.
+		const second = checkPaymentMethodIsAvailable(
+			'amazonPay',
+			api,
+			hydratedCart()
+		);
+		expect( createRoot ).toHaveBeenCalledTimes( 2 );
+		getRenderedExpressCheckoutElement( 1 ).props.onLoadError();
+		expect( await second ).toBe( false );
+
+		checkPaymentMethodIsAvailable( 'amazonPay', api, hydratedCart() );
+		expect( createRoot ).toHaveBeenCalledTimes( 3 );
+
+		// Failed probes tear down their container on a deferred tick.
+		await new Promise( ( resolve ) => setTimeout( resolve ) );
+		expect( unmount ).toHaveBeenCalled();
 	} );
 } );

--- a/client/express-checkout/utils/check-payment-method-availability.js
+++ b/client/express-checkout/utils/check-payment-method-availability.js
@@ -1,3 +1,4 @@
+import { Component } from 'react';
 import { createRoot } from 'react-dom/client';
 import { ExpressCheckoutElement, Elements } from '@stripe/react-stripe-js';
 import { memoize } from 'lodash';
@@ -15,10 +16,32 @@ import {
 import { transformPriceWithMinorUnits } from 'wcstripe/express-checkout/transformers/wc-to-stripe';
 
 /**
+ * React error boundaries must be class components. This one lets a failure
+ * while mounting the probe (e.g. Stripe rejecting the Elements options) be
+ * reported to the caller instead of becoming an uncaught render error.
+ */
+class ProbeErrorBoundary extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = { hasError: false };
+	}
+
+	static getDerivedStateFromError() {
+		return { hasError: true };
+	}
+
+	componentDidCatch() {
+		this.props.onError();
+	}
+
+	render() {
+		return this.state.hasError ? null : this.props.children;
+	}
+}
+
+/**
  * Renders an invisible Stripe Express Checkout Element and waits for its ready
  * event to learn whether the given express payment method is available.
- *
- * Results are memoized so the availability check is only performed once per payment method.
  *
  * @param {string} paymentMethod The express payment method identifier (e.g. 'googlePay', 'applePay').
  * @param {Object} api           The WCStripeAPI instance used to load Stripe.
@@ -45,66 +68,82 @@ const checkPaymentMethodAvailability = memoize(
 				cart.cartTotals.currency_minor_unit
 			);
 
+			// A failed probe says nothing about the method's real availability,
+			// so evict the memoized entry to let a later call retry. Unmounting
+			// is deferred because React forbids unmounting a root from within
+			// its own lifecycle (the error boundary's commit phase).
+			const failProbe = () => {
+				checkPaymentMethodAvailability.cache.delete( paymentMethod );
+				resolve( false );
+				setTimeout( () => {
+					root.unmount();
+					containerEl.remove();
+				} );
+			};
+
 			root.render(
-				<Elements
-					stripe={ api.loadStripe() }
-					options={ {
-						mode: hasFreeTrial ? 'subscription' : 'payment',
-						...( isManualPaymentMethodCreation(
-							paymentMethod,
-							hasFreeTrial
-						) && {
-							paymentMethodCreation: 'manual',
-						} ),
-						amount: Number( amount ),
-						currency: cart.cartTotals.currency_code.toLowerCase(),
-						paymentMethodTypes:
-							getPaymentMethodTypesForExpressMethod(
-								paymentMethod
-							),
-					} }
-				>
-					<ExpressCheckoutElement
-						onLoadError={ () => resolve( false ) }
+				<ProbeErrorBoundary onError={ failProbe }>
+					<Elements
+						stripe={ api.loadStripe() }
 						options={ {
-							paymentMethods: {
-								amazonPay:
-									paymentMethod ===
-									EXPRESS_PAYMENT_METHOD_SETTING_AMAZON_PAY
-										? 'auto'
-										: 'never',
-								applePay:
-									paymentMethod ===
-									EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY
-										? 'always'
-										: 'never',
-								googlePay:
-									paymentMethod ===
-									EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY
-										? 'always'
-										: 'never',
-								link:
-									paymentMethod ===
-									EXPRESS_PAYMENT_METHOD_SETTING_LINK
-										? 'auto'
-										: 'never',
-								paypal: 'never',
-							},
+							mode: hasFreeTrial ? 'subscription' : 'payment',
+							...( isManualPaymentMethodCreation(
+								paymentMethod,
+								hasFreeTrial
+							) && {
+								paymentMethodCreation: 'manual',
+							} ),
+							amount: Number( amount ),
+							currency:
+								cart.cartTotals.currency_code.toLowerCase(),
+							paymentMethodTypes:
+								getPaymentMethodTypesForExpressMethod(
+									paymentMethod
+								),
 						} }
-						onReady={ ( event ) => {
-							let canMakePayment = false;
-							if ( event.availablePaymentMethods ) {
-								canMakePayment =
-									event.availablePaymentMethods[
-										paymentMethod
-									];
-							}
-							resolve( canMakePayment );
-							root.unmount();
-							containerEl.remove();
-						} }
-					/>
-				</Elements>
+					>
+						<ExpressCheckoutElement
+							onLoadError={ failProbe }
+							options={ {
+								paymentMethods: {
+									amazonPay:
+										paymentMethod ===
+										EXPRESS_PAYMENT_METHOD_SETTING_AMAZON_PAY
+											? 'auto'
+											: 'never',
+									applePay:
+										paymentMethod ===
+										EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY
+											? 'always'
+											: 'never',
+									googlePay:
+										paymentMethod ===
+										EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY
+											? 'always'
+											: 'never',
+									link:
+										paymentMethod ===
+										EXPRESS_PAYMENT_METHOD_SETTING_LINK
+											? 'auto'
+											: 'never',
+									paypal: 'never',
+								},
+							} }
+							onReady={ ( event ) => {
+								let canMakePayment = false;
+								if ( event.availablePaymentMethods ) {
+									canMakePayment =
+										event.availablePaymentMethods[
+											paymentMethod
+										];
+								}
+								resolve( canMakePayment );
+								root.unmount();
+								containerEl.remove();
+							} }
+						/>
+					</Elements>
+				</ProbeErrorBoundary>
 			);
 		} );
 	}
@@ -112,6 +151,9 @@ const checkPaymentMethodAvailability = memoize(
 
 /**
  * Checks whether a given express payment method is available in the current context.
+ *
+ * Results are memoized so the underlying probe runs only once per payment
+ * method. Failed probes are not cached, so a later call retries.
  *
  * @param {string} paymentMethod The express payment method identifier (e.g. 'googlePay', 'applePay').
  * @param {Object} api           The WCStripeAPI instance used to load Stripe.

--- a/client/express-checkout/utils/check-payment-method-availability.js
+++ b/client/express-checkout/utils/check-payment-method-availability.js
@@ -15,8 +15,8 @@ import {
 import { transformPriceWithMinorUnits } from 'wcstripe/express-checkout/transformers/wc-to-stripe';
 
 /**
- * Checks whether a given express payment method is available in the current context
- * by rendering an invisible Stripe Express Checkout Element and waiting for its ready event.
+ * Renders an invisible Stripe Express Checkout Element and waits for its ready
+ * event to learn whether the given express payment method is available.
  *
  * Results are memoized so the availability check is only performed once per payment method.
  *
@@ -25,7 +25,7 @@ import { transformPriceWithMinorUnits } from 'wcstripe/express-checkout/transfor
  * @param {Object} cart          The WooCommerce cart object containing totals and currency info.
  * @return {Promise<boolean>} Promise that resolves to true if the payment method is available, false otherwise.
  */
-export const checkPaymentMethodIsAvailable = memoize(
+const probePaymentMethodAvailability = memoize(
 	( paymentMethod, api, cart ) => {
 		return new Promise( ( resolve ) => {
 			const hasFreeTrial = getExpressCheckoutData( 'has_free_trial' );
@@ -109,3 +109,25 @@ export const checkPaymentMethodIsAvailable = memoize(
 		} );
 	}
 );
+
+/**
+ * Checks whether a given express payment method is available in the current context.
+ *
+ * @param {string} paymentMethod The express payment method identifier (e.g. 'googlePay', 'applePay').
+ * @param {Object} api           The WCStripeAPI instance used to load Stripe.
+ * @param {Object} cart          The WooCommerce cart object containing totals and currency info.
+ * @return {Promise<boolean>} Promise that resolves to true if the payment method is available, false otherwise.
+ */
+export const checkPaymentMethodIsAvailable = ( paymentMethod, api, cart ) => {
+	// On first render, WooCommerce Blocks passes its seeded default cart totals
+	// (empty currency_code) before the Store API data is applied. Probing then
+	// would make Stripe's elements() throw with an invalid currency, and the
+	// memoized promise would never settle, hiding every payment method for the
+	// life of the page. Resolve false without caching; canMakePayment runs
+	// again once the cart hydrates, and only that probe is memoized.
+	if ( ! cart?.cartTotals?.currency_code ) {
+		return Promise.resolve( false );
+	}
+
+	return probePaymentMethodAvailability( paymentMethod, api, cart );
+};

--- a/client/express-checkout/utils/check-payment-method-availability.js
+++ b/client/express-checkout/utils/check-payment-method-availability.js
@@ -25,7 +25,7 @@ import { transformPriceWithMinorUnits } from 'wcstripe/express-checkout/transfor
  * @param {Object} cart          The WooCommerce cart object containing totals and currency info.
  * @return {Promise<boolean>} Promise that resolves to true if the payment method is available, false otherwise.
  */
-const probePaymentMethodAvailability = memoize(
+const checkPaymentMethodAvailability = memoize(
 	( paymentMethod, api, cart ) => {
 		return new Promise( ( resolve ) => {
 			const hasFreeTrial = getExpressCheckoutData( 'has_free_trial' );

--- a/client/express-checkout/utils/check-payment-method-availability.js
+++ b/client/express-checkout/utils/check-payment-method-availability.js
@@ -119,12 +119,9 @@ const probePaymentMethodAvailability = memoize(
  * @return {Promise<boolean>} Promise that resolves to true if the payment method is available, false otherwise.
  */
 export const checkPaymentMethodIsAvailable = ( paymentMethod, api, cart ) => {
-	// On first render, WooCommerce Blocks passes its seeded default cart totals
-	// (empty currency_code) before the Store API data is applied. Probing then
-	// would make Stripe's elements() throw with an invalid currency, and the
-	// memoized promise would never settle, hiding every payment method for the
-	// life of the page. Resolve false without caching; canMakePayment runs
-	// again once the cart hydrates, and only that probe is memoized.
+	// Before the cart hydrates, Blocks passes seeded totals with an empty
+	// currency_code, which makes Stripe's elements() throw. Resolve false
+	// without caching so the probe runs once the cart hydrates.
 	if ( ! cart?.cartTotals?.currency_code ) {
 		return Promise.resolve( false );
 	}

--- a/client/express-checkout/utils/check-payment-method-availability.js
+++ b/client/express-checkout/utils/check-payment-method-availability.js
@@ -126,5 +126,5 @@ export const checkPaymentMethodIsAvailable = ( paymentMethod, api, cart ) => {
 		return Promise.resolve( false );
 	}
 
-	return probePaymentMethodAvailability( paymentMethod, api, cart );
+	return checkPaymentMethodAvailability( paymentMethod, api, cart );
 };

--- a/readme.txt
+++ b/readme.txt
@@ -195,5 +195,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Hide the save payment method checkbox for Bancontact, iDEAL and Sofort in the Adaptive Pricing checkout on non-EUR stores whose currency excludes them
 * Fix - Remove the empty box shown under "Use a new payment method" on classic checkout when the save-payment-method checkbox is hidden
 * Fix - Ensure webhook status checks reset API key
+* Fix - Keep express checkout and the payment options rendering on the first block checkout load of a free-trial subscription cart
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-1420
Fixes #5876

## Changes proposed in this Pull Request:

On the block checkout, `canMakePayment` for the express methods short-circuits $0 carts before probing, but a free-trial subscription cart is allowed through (`has_free_trial`). On the first render, WooCommerce Blocks passes its seeded default cart totals (empty `currency_code`) before the Store API data is applied, so the availability probe mounted a Stripe Elements group with `currency: ''`. Stripe's `elements()` throws an `IntegrationError`, and because the probe promise is memoized and never settles, express checkout and every regular payment option stay hidden until a full page reload.

This change puts a hydration guard in front of the memoized probe: when `cart.cartTotals.currency_code` is empty, `checkPaymentMethodIsAvailable` resolves `false` without mounting anything and without entering the memo cache. When Blocks re-runs `canMakePayment` after the cart hydrates, the probe runs normally with the real currency and is memoized as before.

The exported function keeps its signature and semantics; only the pre-hydration call changes behavior (it used to crash). No BC impact: this file is bundled frontend code with no public hooks or handles touched.

Verified in a local environment against a free-trial subscription cart on a cold block-checkout load: without the guard, 3 `IntegrationError` throws and an empty payment options block; with it, no errors and all payment options render.

## Testing instructions

1. Enable Express Checkout (Apple Pay / Google Pay) with the Checkout button location, and use the block-based cart and checkout pages.
2. With WooCommerce Subscriptions active, create a Simple subscription product with a free trial (e.g. 7 days) and no sign-up fee, so the amount due today is $0.00.
3. In a fresh browser session (or with the cache disabled in devtools), add that product to the cart and go to the checkout page.
4. Before this fix: the console shows `IntegrationError: Invalid value for elements(): currency should be one of the following strings: …` and the payment options area stays blank.
5. With this fix: no console error, and the payment options (and express checkout buttons, when the device supports them) render on the first load.
6. Regression check: with a regular (non-trial) paid product, confirm express checkout buttons and payment options still render on block checkout.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
