### PR TITLE
Update PHPDoc and method signatures for WC_Stripe_Order_Handler

### DIFF
--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -12,6 +12,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 4.0.0
  */
 class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
+	/**
+	 * Singleton instance of the class.
+	 *
+	 * @var WC_Stripe_Order_Handler
+	 */
 	private static $_this;
 
 	/**
@@ -50,6 +55,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.0.0
 	 * @version 4.0.0
+	 * @return WC_Stripe_Order_Handler
 	 */
 	public static function get_instance() {
 		return self::$_this;
@@ -58,10 +64,15 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Shows a warning message about editing uncaptured orders.
 	 *
-	 * @param $order_id
+	 * @param int $order_id
+	 * @return void
 	 */
-	public function show_warning_for_uncaptured_orders( $order_id ) {
+	public function show_warning_for_uncaptured_orders( $order_id ): void {
 		$order = wc_get_order( $order_id );
+		if ( ! $order instanceof WC_Order ) {
+			return;
+		}
+
 		// Bail if payment method is not manual capture supporting stripe method.
 		if ( ! WC_Stripe_Helper::payment_method_allows_manual_capture( $order->get_payment_method() ) ) {
 			return;
@@ -96,9 +107,10 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	 * @since 4.1.8 Add $previous_error parameter.
 	 * @param int  $order_id
 	 * @param bool $retry
-	 * @param mix  $previous_error Any error message from previous request.
+	 * @param mixed  $previous_error Any error message from previous request.
+	 * @return void
 	 */
-	public function process_redirect_payment( $order_id, $retry = true, $previous_error = false ) {
+	public function process_redirect_payment( $order_id, $retry = true, $previous_error = false ): void {
 		$order = null;
 		try {
 			$source = isset( $_GET['source'] ) ? wc_clean( wp_unslash( $_GET['source'] ) ) : '';
@@ -202,13 +214,15 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 					if ( $retry ) {
 						// Don't do anymore retries after this.
 						if ( 5 <= $this->retry_interval ) {
-							return $this->process_redirect_payment( $order_id, false, $response->error );
+							$this->process_redirect_payment( $order_id, false, $response->error );
+							return;
 						}
 
 						sleep( $this->retry_interval );
 
 						++$this->retry_interval;
-						return $this->process_redirect_payment( $order_id, true, $response->error );
+						$this->process_redirect_payment( $order_id, true, $response->error );
+						return;
 					} else {
 						$localized_message = __( 'Sorry, we are unable to process your payment at this time. Please retry later.', 'woocommerce-gateway-stripe' );
 						$order->add_order_note( $localized_message );
@@ -275,8 +289,9 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.0.0
 	 * @version 4.0.0
+	 * @return void
 	 */
-	public function maybe_process_redirect_order() {
+	public function maybe_process_redirect_order(): void {
 		$gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
 
 		if ( is_a( $gateway, 'WC_Stripe_UPE_Payment_Gateway' ) ) {
@@ -294,8 +309,9 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	 * Processes redirect payment for stores with legacy checkout experience enabled.
 	 *
 	 * @since 8.3.0
+	 * @return void
 	 */
-	private function maybe_process_legacy_redirect() {
+	private function maybe_process_legacy_redirect(): void {
 		if ( ! is_order_received_page() || empty( $_GET['client_secret'] ) || empty( $_GET['source'] ) ) {
 			return;
 		}
@@ -310,7 +326,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 3.1.0
 	 * @version 4.0.0
-	 * @param  int $order_id
+	 * @param  int|WC_Order $order_id
 	 * @return stdClass|void Result of payment capture.
 	 */
 	public function capture_payment( $order_id ) {
@@ -433,8 +449,9 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	 * @since 3.1.0
 	 * @version 4.2.2
 	 * @param  int $order_id
+	 * @return void
 	 */
-	public function cancel_payment( $order_id ) {
+	public function cancel_payment( $order_id ): void {
 		$order = wc_get_order( $order_id );
 
 		if ( ! $order instanceof WC_Order ) {
@@ -466,8 +483,9 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	 * Note that this filter is only called if WC_Site_Tracking::is_tracking_enabled.
 	 *
 	 * @since 4.5.1
-	 * @param array Properties to be appended to.
-	 * @param string Event name, e.g. orders_edit_status_change.
+	 * @param array  $properties          Properties to be appended to.
+	 * @param string $prefixed_event_name Event name, e.g. orders_edit_status_change.
+	 * @return array
 	 */
 	public function woocommerce_tracks_event_properties( $properties, $prefixed_event_name ) {
 		// Not the desired event? Bail.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1165,12 +1165,6 @@ parameters:
 			path: includes/admin/class-wc-rest-stripe-locations-controller.php
 
 		-
-			message: '#^Access to an undefined property object\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-orders-controller.php
-
-		-
 			message: '#^Parameter \#1 \$response of method WC_Stripe_Payment_Gateway\:\:process_response\(\) expects object, object\|string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -1579,13 +1573,13 @@ parameters:
 			path: includes/class-wc-stripe-blocks-support.php
 
 		-
-			message: '#^Access to protected property Automattic\\WooCommerce\\StoreApi\\Payments\\PaymentResult\:\:\$status\.$#'
+			message: '#^Access to protected property Automattic\\WooCommerce\\StoreApi\\Payments\\PaymentResult\:\:\$redirect_url\.$#'
 			identifier: property.protected
 			count: 1
 			path: includes/class-wc-stripe-blocks-support.php
 
 		-
-			message: '#^Access to protected property Automattic\\WooCommerce\\StoreApi\\Payments\\PaymentResult\:\:\$redirect_url\.$#'
+			message: '#^Access to protected property Automattic\\WooCommerce\\StoreApi\\Payments\\PaymentResult\:\:\$status\.$#'
 			identifier: property.protected
 			count: 1
 			path: includes/class-wc-stripe-blocks-support.php
@@ -2245,103 +2239,7 @@ parameters:
 			path: includes/class-wc-stripe-order-handler.php
 
 		-
-			message: '#^Cannot call method get_payment_method\(\) on bool\|WC_Order\|WC_Order_Refund\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: includes/class-wc-stripe-order-handler.php
-
-		-
-			message: '#^Default value of the parameter \#3 \$previous_error \(false\) of method WC_Stripe_Order_Handler\:\:process_redirect_payment\(\) is incompatible with type mix\.$#'
-			identifier: parameter.defaultValue
-			count: 1
-			path: includes/class-wc-stripe-order-handler.php
-
-		-
-			message: '#^Method WC_Stripe_Order_Handler\:\:cancel_payment\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-order-handler.php
-
-		-
-			message: '#^Method WC_Stripe_Order_Handler\:\:get_instance\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-order-handler.php
-
-		-
-			message: '#^Method WC_Stripe_Order_Handler\:\:maybe_process_legacy_redirect\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-order-handler.php
-
-		-
-			message: '#^Method WC_Stripe_Order_Handler\:\:maybe_process_redirect_order\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-order-handler.php
-
-		-
-			message: '#^Method WC_Stripe_Order_Handler\:\:process_redirect_payment\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-order-handler.php
-
-		-
-			message: '#^Method WC_Stripe_Order_Handler\:\:show_warning_for_uncaptured_orders\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-order-handler.php
-
-		-
-			message: '#^Method WC_Stripe_Order_Handler\:\:show_warning_for_uncaptured_orders\(\) has parameter \$order_id with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: includes/class-wc-stripe-order-handler.php
-
-		-
-			message: '#^Method WC_Stripe_Order_Handler\:\:woocommerce_tracks_event_properties\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-order-handler.php
-
-		-
-			message: '#^Method WC_Stripe_Order_Handler\:\:woocommerce_tracks_event_properties\(\) has parameter \$prefixed_event_name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: includes/class-wc-stripe-order-handler.php
-
-		-
-			message: '#^Method WC_Stripe_Order_Handler\:\:woocommerce_tracks_event_properties\(\) has parameter \$properties with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: includes/class-wc-stripe-order-handler.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(array Properties to be appended to\.\)\: Unexpected token "Properties", expected variable at offset 181 on line 6$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: includes/class-wc-stripe-order-handler.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(string Event name, e\.g\. orders_edit_status_change\.\)\: Unexpected token "Event", expected variable at offset 229 on line 7$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: includes/class-wc-stripe-order-handler.php
-
-		-
 			message: '#^Parameter \#1 \$intent of method WC_Stripe_Payment_Gateway\:\:get_latest_charge_from_intent\(\) expects object, array\|stdClass given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wc-stripe-order-handler.php
-
-		-
-			message: '#^Parameter \#1 \$order of method WC_Stripe_Order_Helper\:\:is_stripe_charge_captured\(\) expects WC_Order\|null, bool\|WC_Order\|WC_Order_Refund given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wc-stripe-order-handler.php
-
-		-
-			message: '#^Parameter \#1 \$order of method WC_Stripe_Payment_Gateway\:\:get_intent_from_order\(\) expects WC_Order, bool\|WC_Order\|WC_Order_Refund given\.$#'
 			identifier: argument.type
 			count: 1
 			path: includes/class-wc-stripe-order-handler.php
@@ -2355,18 +2253,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$payment_method_id of static method WC_Stripe_API\:\:get_payment_method\(\) expects string, array\|string given\.$#'
 			identifier: argument.type
-			count: 1
-			path: includes/class-wc-stripe-order-handler.php
-
-		-
-			message: '#^Parameter \$previous_error of method WC_Stripe_Order_Handler\:\:process_redirect_payment\(\) has invalid type mix\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/class-wc-stripe-order-handler.php
-
-		-
-			message: '#^Property WC_Stripe_Order_Handler\:\:\$_this has no type specified\.$#'
-			identifier: missingType.property
 			count: 1
 			path: includes/class-wc-stripe-order-handler.php
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Towards STRIPE-873

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR updates the PHPDoc and method signatures for `WC_Stripe_Order_Handler` to fix a number of PHPStan issues. I noticed the gaps and problems while working on #5887, and decided to get this done while I was in the class. The PR also makes some minor tweaks to ensure we match `void` returns, especially in `process_redirect_payment()`, which was previously calling `return $this->process_redirect_payment()` recursively, but the downstream code was always returning `void` anyway.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

Code inspection should be sufficient.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [N/A] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This is a minor tweak to the code that should have no merchant-facing impact.
</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
