### PR TITLE
Keep the customer's selected payment method under Optimized Checkout when the Stripe payment method fetch degrades

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -34,6 +34,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Remove the empty box shown under "Use a new payment method" on classic checkout when the save-payment-method checkbox is hidden
 * Fix - Ensure webhook status checks reset API key
 * Fix - Keep express checkout and the payment options rendering on the first block checkout load of a free-trial subscription cart
+* Fix - Keep the customer's selected payment method on Optimized Checkout when the Stripe payment method lookup fails, instead of processing it as a card
 
 2026-08-31 - version 10.9.1
 * Fix - Allow express checkout payments when automatic account password generation is disabled

--- a/client/blocks/upe/upe-deferred-intent-creation/__tests__/payment-processor.test.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/__tests__/payment-processor.test.js
@@ -1,5 +1,10 @@
-import { render } from '@testing-library/react';
-import { useElements, useStripe } from '@stripe/react-stripe-js';
+import { getPaymentMethods } from '@woocommerce/blocks-registry';
+import { act, render } from '@testing-library/react';
+import {
+	PaymentElement,
+	useElements,
+	useStripe,
+} from '@stripe/react-stripe-js';
 import PaymentProcessor from 'wcstripe/blocks/upe/upe-deferred-intent-creation/payment-processor';
 import { getBlocksConfiguration } from 'wcstripe/blocks/utils';
 import { getExcludedPaymentMethodTypesForBillingCountry } from 'wcstripe/stripe-utils';
@@ -192,5 +197,71 @@ describe( 'PaymentProcessor billing-country exclusions', () => {
 		expect(
 			getExcludedPaymentMethodTypesForBillingCountry
 		).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'PaymentProcessor payment setup data', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'submits the concrete payment method type alongside the payment method id', async () => {
+		useStripe.mockReturnValue( {} );
+		useElements.mockReturnValue( {
+			submit: jest.fn().mockResolvedValue( {} ),
+		} );
+		getPaymentMethods.mockReturnValue( {
+			stripe: { supports: { showSaveOption: false } },
+		} );
+		const onPaymentSetup = jest.fn();
+		const api = {
+			getStripe: () => ( {
+				createPaymentMethod: jest.fn().mockResolvedValue( {
+					paymentMethod: { id: 'pm_mock', type: 'wechat_pay' },
+				} ),
+			} ),
+		};
+
+		render(
+			<PaymentProcessor
+				api={ api }
+				activePaymentMethod="stripe"
+				eventRegistration={ {
+					onPaymentSetup,
+					onCheckoutSuccess: jest.fn(),
+					onCheckoutFail: jest.fn(),
+				} }
+				emitResponse={ {} }
+				paymentMethodId="card"
+				upeMethods={ { card: 'stripe' } }
+				errorMessage=""
+				shouldSavePayment={ false }
+				fingerprint=""
+				billing={ {
+					billingAddress: {
+						first_name: 'Test',
+						last_name: 'Shopper',
+						email: 'shopper@example.com',
+						country: 'US',
+					},
+				} }
+			/>
+		);
+
+		const { onChange } = PaymentElement.mock.calls.at( -1 )[ 0 ];
+		act( () => {
+			onChange( { complete: true, value: { type: 'wechat_pay' } } );
+		} );
+
+		const setupHandler = onPaymentSetup.mock.calls.at( -1 )[ 0 ];
+		const result = await setupHandler();
+
+		expect( result.type ).toBe( 'success' );
+		expect(
+			result.meta.paymentMethodData[ 'wc-stripe-payment-method' ]
+		).toBe( 'pm_mock' );
+		expect(
+			result.meta.paymentMethodData.wc_stripe_selected_upe_payment_type
+		).toBe( 'wechat_pay' );
 	} );
 } );

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
@@ -249,6 +249,12 @@ const PaymentProcessor = ( {
 								wc_payment_intent_id: paymentIntentId ?? '',
 								'wc-stripe-payment-method':
 									paymentMethodObject.paymentMethod.id,
+								// Under Optimized Checkout `payment_method` is the consolidated
+								// pseudo-method, so mirror the concrete type: the server falls
+								// back to it when its Stripe payment method fetch degrades.
+								wc_stripe_selected_upe_payment_type:
+									paymentMethodObject.paymentMethod.type ??
+									'',
 								save_payment_method: shouldSavePayment
 									? 'yes'
 									: 'no',

--- a/includes/payment-methods/class-wc-stripe-ocs-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-ocs-payment-gateway.php
@@ -459,6 +459,16 @@ class WC_Stripe_OCS_Payment_Gateway extends WC_Stripe_UPE_Payment_Gateway {
 			// Express paths won't have a payment method created yet; fall back to the express type.
 			if ( '' === $selected_payment_type && null !== $express_payment_type ) {
 				$selected_payment_type = $express_payment_type;
+			} elseif ( ! empty( $payment_method_id ) ) {
+				// A degraded details fetch (API outage, invalid-key error threshold) leaves the
+				// type unknown while the payment method itself may be fine. The form-derived
+				// type is the OC pseudo-method's 'card', which would silently send a
+				// wallet/voucher selection down the card flow, so prefer the type the client
+				// mirrored from the payment element — the only remaining selection signal.
+				$client_selected_type = $this->get_selected_upe_payment_type_from_request();
+				if ( '' !== $client_selected_type ) {
+					$selected_payment_type = $client_selected_type;
+				}
 			}
 		} else {
 			$selected_payment_type = $payment_method_details->type;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1644,12 +1644,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 
 		// Resolve the method the customer actually picked: for Optimized Checkout the gateway type is
 		// always 'card', so prefer the hidden `wc_stripe_selected_upe_payment_type` input when present.
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$selected_upe_payment_type = isset( $_POST['wc_stripe_selected_upe_payment_type'] )
-			? sanitize_text_field( wp_unslash( $_POST['wc_stripe_selected_upe_payment_type'] ) )
-			: '';
+		$selected_upe_payment_type = $this->get_selected_upe_payment_type_from_request();
 
-		$resolved_payment_type   = ( ! empty( $selected_upe_payment_type ) && isset( $this->payment_methods[ $selected_upe_payment_type ] ) )
+		$resolved_payment_type   = '' !== $selected_upe_payment_type
 			? $selected_upe_payment_type
 			: $selected_payment_type;
 		$resolved_payment_method = $this->payment_methods[ $resolved_payment_type ] ?? null;
@@ -3844,6 +3841,24 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		}
 
 		return substr( $payment_method_type, 0, 7 ) === 'stripe_' ? substr( $payment_method_type, 7 ) : 'card';
+	}
+
+	/**
+	 * Gets the payment method type the client mirrored from the payment element into the
+	 * `wc_stripe_selected_upe_payment_type` request field, when it maps to a registered method.
+	 *
+	 * Under Optimized Checkout the form's `payment_method` is the consolidated pseudo-method,
+	 * so this field is the only request-derived record of the type the customer picked.
+	 *
+	 * @return string The registered payment method type, or '' when absent or unregistered.
+	 */
+	protected function get_selected_upe_payment_type_from_request(): string {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$posted_type = isset( $_POST['wc_stripe_selected_upe_payment_type'] )
+			? sanitize_text_field( wp_unslash( $_POST['wc_stripe_selected_upe_payment_type'] ) )
+			: '';
+
+		return isset( $this->payment_methods[ $posted_type ] ) ? $posted_type : '';
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -196,5 +196,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Remove the empty box shown under "Use a new payment method" on classic checkout when the save-payment-method checkbox is hidden
 * Fix - Ensure webhook status checks reset API key
 * Fix - Keep express checkout and the payment options rendering on the first block checkout load of a free-trial subscription cart
+* Fix - Keep the customer's selected payment method on Optimized Checkout when the Stripe payment method lookup fails, instead of processing it as a card
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/payment-methods/class-wc-stripe-ocs-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-ocs-payment-gateway-test.php
@@ -410,6 +410,112 @@ class WC_Stripe_OCS_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * A degraded Stripe payment method fetch leaves `payment_method_details` without a type; the
+	 * form-derived selection is the OC pseudo-method's 'card', so the client-mirrored element type
+	 * must win — otherwise a wallet/voucher selection silently takes the card flow.
+	 *
+	 * @dataProvider provide_test_resolve_intent_payment_method_types_falls_back_to_client_type
+	 *
+	 * @param object      $payment_method_details Details object as normalized by the caller.
+	 * @param string|null $posted_type            Value of the client-mirrored type field, null when absent.
+	 * @param string      $expected_type          Expected resolved selected payment type.
+	 */
+	public function test_resolve_intent_payment_method_types_falls_back_to_client_type( object $payment_method_details, ?string $posted_type, string $expected_type ): void {
+		$order   = WC_Helper_Order::create_order();
+		$gateway = new WC_Stripe_OCS_Payment_Gateway();
+
+		if ( null !== $posted_type ) {
+			$_POST['wc_stripe_selected_upe_payment_type'] = $posted_type;
+		}
+
+		$method = new \ReflectionMethod( WC_Stripe_OCS_Payment_Gateway::class, 'resolve_intent_payment_method_types' );
+		$method->setAccessible( true );
+
+		try {
+			$result = $method->invoke( $gateway, WC_Stripe_Payment_Methods::CARD, 'pm_mock', $payment_method_details, $order, null );
+		} finally {
+			$_POST = [];
+		}
+
+		$this->assertSame( $expected_type, $result['selected_payment_type'] );
+		$this->assertSame( [ $expected_type ], $result['payment_method_types'] );
+	}
+
+	/**
+	 * Provider for `test_resolve_intent_payment_method_types_falls_back_to_client_type`.
+	 *
+	 * @return array<string, array{object, string|null, string}>
+	 */
+	public function provide_test_resolve_intent_payment_method_types_falls_back_to_client_type(): array {
+		return [
+			'degraded fetch, client-mirrored wallet type' => [
+				'payment_method_details' => (object) [],
+				'posted_type'            => WC_Stripe_Payment_Methods::WECHAT_PAY,
+				'expected_type'          => WC_Stripe_Payment_Methods::WECHAT_PAY,
+			],
+			'degraded fetch, no client type'              => [
+				'payment_method_details' => (object) [],
+				'posted_type'            => null,
+				'expected_type'          => WC_Stripe_Payment_Methods::CARD,
+			],
+			'degraded fetch, unregistered client type'    => [
+				'payment_method_details' => (object) [],
+				'posted_type'            => 'not_a_method',
+				'expected_type'          => WC_Stripe_Payment_Methods::CARD,
+			],
+			'healthy fetch outranks the client type'      => [
+				'payment_method_details' => (object) [ 'type' => WC_Stripe_Payment_Methods::IDEAL ],
+				'posted_type'            => WC_Stripe_Payment_Methods::WECHAT_PAY,
+				'expected_type'          => WC_Stripe_Payment_Methods::IDEAL,
+			],
+		];
+	}
+
+	/**
+	 * When the Stripe payment method fetch fails outright (network error/outage), the selection
+	 * resolved by `prepare_payment_information_from_request` must come from the client-mirrored
+	 * type field instead of degrading to 'card'.
+	 */
+	public function test_prepare_payment_information_uses_client_type_when_payment_method_fetch_fails(): void {
+		$order = WC_Helper_Order::create_order();
+
+		$gateway = $this->getMockBuilder( WC_Stripe_OCS_Payment_Gateway::class )
+			->setConstructorArgs( [] )
+			->onlyMethods( [ 'get_stripe_customer_id' ] )
+			->getMock();
+		$gateway->method( 'get_stripe_customer_id' )->willReturn( 'cus_mock' );
+
+		$_POST = [
+			'payment_method'                      => 'stripe',
+			'wc-stripe-payment-method'            => 'pm_mock',
+			'wc_stripe_selected_upe_payment_type' => WC_Stripe_Payment_Methods::WECHAT_PAY,
+		];
+
+		$failing_pre_http_filter = function ( $result, $args, $url ) {
+			if ( false !== strpos( $url, 'payment_methods/pm_mock' ) ) {
+				return new WP_Error( 'http_request_failed', 'Connection timed out' );
+			}
+			return $result;
+		};
+		add_filter( 'pre_http_request', $failing_pre_http_filter, 10, 3 );
+
+		$method = new \ReflectionMethod( WC_Stripe_UPE_Payment_Gateway::class, 'prepare_payment_information_from_request' );
+		$method->setAccessible( true );
+
+		try {
+			$payment_information = $method->invoke( $gateway, $order );
+		} finally {
+			remove_filter( 'pre_http_request', $failing_pre_http_filter, 10 );
+			// The failed request records an API outage; clear it so later tests see a healthy API.
+			delete_transient( WC_Stripe_API_Outage_Status::OUTAGE_TRANSIENT_KEY );
+			$_POST = [];
+		}
+
+		$this->assertSame( WC_Stripe_Payment_Methods::WECHAT_PAY, $payment_information['selected_payment_type'] );
+		$this->assertSame( [ WC_Stripe_Payment_Methods::WECHAT_PAY ], $payment_information['payment_method_types'] );
+	}
+
+	/**
 	 * Tests for `is_valid_optimized_checkout_page`.
 	 *
 	 * @dataProvider provide_test_is_valid_optimized_checkout_page


### PR DESCRIPTION
Fixes STRIPE-1428. Surfaced by [a review thread on #5857](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5857#discussion_r3904359372); pre-existing behavior, not a regression from that PR.

## What

Under Optimized Checkout, the form's `payment_method` is the consolidated pseudo-method, which the request-derived resolution maps to `card`. The real type normally comes from fetching the Stripe payment method, but `WC_Stripe_API::get_payment_method()` can degrade without throwing (API outage, invalid-key error-count threshold), leaving the details without a `type`. The selection then silently resolved to `card`, so a wallet/voucher selection (e.g. WeChat Pay) skipped the wallet flow, created the intent with the wrong type, and set the wrong payment method title.

## How

- When the details fetch degrades and a payment method ID is present, `WC_Stripe_OCS_Payment_Gateway::resolve_intent_payment_method_types()` now falls back to the type the client mirrors from the payment element (`wc_stripe_selected_upe_payment_type`), validated against the registered payment methods. Healthy fetches are untouched: the Stripe-returned type still wins.
- Classic checkout already posts that hidden field; the Blocks deferred-intent processor now posts it too, using the concrete type from `createPaymentMethod`.
- The existing checkout-session reader of the same field and the new fallback share one registry-validated helper, `get_selected_upe_payment_type_from_request()`.

The corrected selection flows through `payment_information['selected_payment_type']`, so intent creation, the wallet/voucher redirect gate, method-title assignment, and reusability re-checks all pick it up from the single fix point. When the field is absent (e.g. cached pre-update JS), behavior is unchanged from develop.

## Backward compatibility

- No hooks, REST routes, or option keys change. One new protected method on `WC_Stripe_UPE_Payment_Gateway` (additive; no existing overridable method changed signature or stopped being called). One new POST field from Blocks checkout (additive).
- The posted type is client-controlled but only consulted when Stripe's authoritative answer is unavailable, and only accepted when it maps to a registered payment method - the same trust level as the existing checkout-session title resolution that reads the same field.
- Behavior changes only in the degraded state; a shopper who selected a card still resolves to `card` there (the field mirrors their actual selection).
- Not tested under multisite; no site-scoped state is read or written beyond existing options.

## Testing

- PHPUnit: data-provider coverage of the fallback (degraded + mirrored type wins; absent or unregistered type keeps `card`; healthy fetch outranks the mirrored type), plus a wiring test through `prepare_payment_information_from_request()` with a failing HTTP request.
- Jest: the Blocks processor submits the concrete type alongside the payment method ID.
- Full `WC_Stripe_OCS_Payment_Gateway_Test` + `WC_Stripe_UPE_Payment_Gateway_Test` (284 tests) green; PHPStan clean.

### Manual testing steps

1. Enable Optimized Checkout with a PMC that has WeChat Pay active.
2. Simulate a degraded GET (e.g. block `api.stripe.com` GETs while allowing POSTs, or stub `WC_Stripe_API::get_payment_method()` to return `null`).
3. Classic and Blocks checkout: select WeChat Pay and pay. Before this change the payment took the card flow; now the wallet flow (QR modal) opens and the order's payment method title is WeChat Pay.
4. With a healthy API, verify card and WeChat Pay payments behave exactly as on develop on both checkouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
