### PR TITLE
Forward use_stripe_sdk on payment intent requests to restore the on-page 3DS modal

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -34,6 +34,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Remove the empty box shown under "Use a new payment method" on classic checkout when the save-payment-method checkbox is hidden
 * Fix - Ensure webhook status checks reset API key
 * Fix - Keep express checkout and the payment options rendering on the first block checkout load of a free-trial subscription cart
+* Fix - Show the on-page 3D Secure authentication modal instead of a full-page redirect for card payments under Optimized Checkout with Dynamic Payment Methods
 
 2026-08-31 - version 10.9.1
 * Fix - Allow express checkout payments when automatic account password generation is disabled

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1270,6 +1270,14 @@ class WC_Stripe_Intent_Controller {
 
 		$request = $this->maybe_add_mandate_options( $request, $payment_information['selected_payment_type'] );
 
+		// Without this, an intent confirmed with a return_url (the Dynamic
+		// Payment Methods shape) gets a hosted-page redirect_to_url next
+		// action for 3DS instead of the SDK one the client renders as the
+		// on-page modal.
+		if ( isset( $payment_information['use_stripe_sdk'] ) ) {
+			$request['use_stripe_sdk'] = $payment_information['use_stripe_sdk'];
+		}
+
 		// Does not set the return URL if the request needs redirection.
 		if ( $this->request_needs_redirection( $payment_method_types ) ) {
 			$request['return_url'] = $payment_information['return_url'];

--- a/readme.txt
+++ b/readme.txt
@@ -196,5 +196,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Remove the empty box shown under "Use a new payment method" on classic checkout when the save-payment-method checkbox is hidden
 * Fix - Ensure webhook status checks reset API key
 * Fix - Keep express checkout and the payment options rendering on the first block checkout load of a free-trial subscription cart
+* Fix - Show the on-page 3D Secure authentication modal instead of a full-page redirect for card payments under Optimized Checkout with Dynamic Payment Methods
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-intent-controller-test.php
+++ b/tests/phpunit/class-wc-stripe-intent-controller-test.php
@@ -985,6 +985,57 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * `use_stripe_sdk` from the payment information must be forwarded on the payment intent
+	 * request: without it, an intent confirmed with a return_url (the Dynamic Payment Methods
+	 * shape) gets a hosted redirect next action for 3DS instead of the SDK-handled modal.
+	 *
+	 * @param string|null $use_stripe_sdk The value in the payment information, null when not set.
+	 *
+	 * @dataProvider provide_create_and_confirm_payment_intent_use_stripe_sdk
+	 */
+	public function test_create_and_confirm_payment_intent_forwards_use_stripe_sdk( $use_stripe_sdk ) {
+		$payment_information                              = $this->get_base_payment_information();
+		$payment_information['automatic_payment_methods'] = true;
+		$payment_information['return_url']                = 'https://example.com/return';
+
+		if ( null !== $use_stripe_sdk ) {
+			$payment_information['use_stripe_sdk'] = $use_stripe_sdk;
+		}
+
+		$test_request = function ( $preempt, $parsed_args, $url ) use ( $use_stripe_sdk ) {
+			$body = $parsed_args['body'];
+
+			if ( null === $use_stripe_sdk ) {
+				$this->assertArrayNotHasKey( 'use_stripe_sdk', $body );
+			} else {
+				$this->assertSame( $use_stripe_sdk, $body['use_stripe_sdk'] );
+			}
+
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => json_encode( [] ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		$this->mock_controller->create_and_confirm_payment_intent( $payment_information );
+	}
+
+	/**
+	 * Provider for `test_create_and_confirm_payment_intent_forwards_use_stripe_sdk`.
+	 *
+	 * @return array
+	 */
+	public function provide_create_and_confirm_payment_intent_use_stripe_sdk() {
+		return [
+			'forwarded when set'   => [ 'true' ],
+			'omitted when not set' => [ null ],
+		];
+	}
+
+	/**
 	 * Minimal valid payment information for a card create_and_confirm_payment_intent request.
 	 *
 	 * @return array


### PR DESCRIPTION
Fixes STRIPE-1430
Fixes #5892

## Changes proposed in this Pull Request:

Under Dynamic Payment Methods (#5683), on-session Optimized Checkout payments are confirmed server side with `automatic_payment_methods` (`allow_redirects: always`) and a `return_url`. For that request shape Stripe returns `next_action.redirect_to_url` for 3DS cards, so the shopper is sent through a full-page redirect to Stripe's hosted 3DS page instead of the on-page modal they got before (noticed by @daledupreez while testing #5857).

`prepare_payment_information_from_request()` already sets `use_stripe_sdk`, and the setup intent request already forwards it, but `build_base_payment_intent_request_params()` dropped it for payment intents. This PR forwards it there, which makes Stripe return the `use_stripe_sdk` next action that the existing `#wc-stripe-confirm-pi` client flow renders as the on-page modal.

Checked against the Stripe API in test mode before implementing:

- Current DPM shape without `use_stripe_sdk`: `next_action.type = redirect_to_url`
- Same request with `use_stripe_sdk: true`: `next_action.type = use_stripe_sdk` (modal)
- `confirm: false` intents (the voucher/wallet delayed-confirmation path) accept the parameter with no error
- Redirect payment methods (tested with Bancontact) still get `next_action.redirect_to_url`, so their flow is unchanged

**Backward compatibility:** no public symbols, hooks, or option keys change. The parameter is only added when callers provide it in the payment information, and explicit-types card intents already behaved as if it were set (Stripe returns the SDK next action for them without a `return_url`).

**Depends on #5857** for the end-to-end result on Optimized Checkout: without it, 3DS card payments under DPM are still misrouted into the wallet flow before the next action matters. Verified locally with both branches combined: on Blocks checkout with Optimized Checkout + PMC and the 3DS card, the 3D Secure 2 test modal now renders on the checkout page (no navigation away), and completing it takes the order to `processing`.

## Testing instructions

Needs #5857 (or a build containing it).

1. Use a test account with a Payment Method Configuration active, Optimized Checkout enabled, and Adaptive Pricing not active for the session.
2. On Blocks checkout, choose a new payment method (not a saved one), select Card, and pay with `4000 0027 6000 3184`.
3. Before this PR: a full-page redirect to Stripe's hosted 3DS page. After: the 3D Secure modal opens on the checkout page itself.
4. Click **Complete** in the modal and confirm the order reaches `processing`.
5. Regression checks: a saved card still pays without 3DS; WeChat Pay still shows the QR modal; a redirect method such as Bancontact still redirects.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeKekL9qsfgxNT1YVCFgzf