### PR TITLE
Sweep expired payment lock owner rows in the daily cleanup

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -47,6 +47,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Explain that payment details were not submitted, instead of reporting the selected payment method as invalid, when checkout is submitted without them
 * Fix - Honor subscription renewal payment locks while preserving retry attempts
 * Fix - Claim an atomic owner row before writing an order payment lock, and only release locks this request acquired
+* Dev - Delete expired payment lock owner rows in a daily scheduled sweep
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/includes/class-wc-stripe-order-helper.php
+++ b/includes/class-wc-stripe-order-helper.php
@@ -207,6 +207,17 @@ class WC_Stripe_Order_Helper {
 	private const OPTION_STRIPE_LOCK_PAYMENT_OWNER_PREFIX = 'wc_stripe_payment_lock_owner_';
 
 	/**
+	 * Action Scheduler hook for the daily sweep of expired payment-lock owner rows.
+	 *
+	 * @since 11.0.0
+	 */
+	public const PAYMENT_LOCK_OWNER_SWEEP_ACTION = 'wc_stripe_payment_lock_owner_sweep';
+
+	private const PAYMENT_LOCK_OWNER_SWEEP_BATCH_SIZE = 500;
+
+	private const PAYMENT_LOCK_OWNER_SWEEP_MAX_BATCHES = 20;
+
+	/**
 	 * Meta key for lock refund to prevent multiple simultaneous refund attempts.
 	 *
 	 * @var string
@@ -1794,6 +1805,104 @@ class WC_Stripe_Order_Helper {
 				$expected_lock
 			)
 		);
+	}
+
+	/**
+	 * Deletes expired payment-lock owner rows that no later lock reclaimed.
+	 *
+	 * Rows are read in batches by option_id. A run stops after a fixed number
+	 * of batches so a large backlog cannot hold the queue.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @return void
+	 */
+	public static function sweep_expired_payment_lock_owners(): void {
+		global $wpdb;
+
+		$deleted        = 0;
+		$now            = time();
+		$last_option_id = 0;
+
+		for ( $batch = 0; $batch < self::PAYMENT_LOCK_OWNER_SWEEP_MAX_BATCHES; $batch++ ) {
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					'SELECT option_id, option_name, option_value FROM %i WHERE option_name LIKE %s AND option_id > %d ORDER BY option_id ASC LIMIT %d',
+					$wpdb->options,
+					$wpdb->esc_like( self::OPTION_STRIPE_LOCK_PAYMENT_OWNER_PREFIX ) . '%',
+					$last_option_id,
+					self::PAYMENT_LOCK_OWNER_SWEEP_BATCH_SIZE
+				),
+				ARRAY_A
+			);
+
+			if ( empty( $rows ) ) {
+				break;
+			}
+
+			foreach ( $rows as $row ) {
+				$last_option_id = (int) $row['option_id'];
+				$parts          = explode( '|', (string) $row['option_value'], 2 );
+
+				// A row without a leading timestamp cannot be proven expired.
+				if ( ! ctype_digit( $parts[0] ) || $now <= (int) $parts[0] ) {
+					continue;
+				}
+
+				// Owner-checked, so a row a worker just reclaimed is left alone.
+				$deleted += (int) $wpdb->query(
+					$wpdb->prepare(
+						'DELETE FROM %i WHERE option_name = %s AND CAST( option_value AS BINARY ) = CAST( %s AS BINARY )',
+						$wpdb->options,
+						$row['option_name'],
+						$row['option_value']
+					)
+				);
+			}
+
+			if ( count( $rows ) < self::PAYMENT_LOCK_OWNER_SWEEP_BATCH_SIZE ) {
+				break;
+			}
+		}
+
+		if ( 0 < $deleted ) {
+			WC_Stripe_Logger::debug( 'Deleted expired payment lock owner rows.', [ 'deleted' => $deleted ] );
+		}
+	}
+
+	/**
+	 * Schedules the daily sweep of expired payment-lock owner rows.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @return void
+	 */
+	public static function maybe_schedule_payment_lock_owner_sweep(): void {
+		if ( ! did_action( 'action_scheduler_init' ) || ! function_exists( 'as_has_scheduled_action' ) || ! function_exists( 'as_schedule_recurring_action' ) ) {
+			return;
+		}
+
+		if ( as_has_scheduled_action( self::PAYMENT_LOCK_OWNER_SWEEP_ACTION, null ) ) {
+			return;
+		}
+
+		// An hour after the database cache cleanup.
+		as_schedule_recurring_action( strtotime( 'tomorrow 02:00' ), DAY_IN_SECONDS, self::PAYMENT_LOCK_OWNER_SWEEP_ACTION, [], 'woocommerce-gateway-stripe' );
+	}
+
+	/**
+	 * Unschedules the daily sweep of expired payment-lock owner rows.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @return void
+	 */
+	public static function unschedule_payment_lock_owner_sweep(): void {
+		if ( ! did_action( 'action_scheduler_init' ) || ! function_exists( 'as_unschedule_all_actions' ) ) {
+			return;
+		}
+
+		as_unschedule_all_actions( self::PAYMENT_LOCK_OWNER_SWEEP_ACTION, [], 'woocommerce-gateway-stripe' );
 	}
 
 	/**

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -366,6 +366,8 @@ class WC_Stripe {
 
 			add_action( WC_Stripe_Database_Cache::ASYNC_CLEANUP_ACTION, [ WC_Stripe_Database_Cache::class, 'delete_all_stale_entries_async' ], 10, 2 );
 			add_action( 'action_scheduler_run_recurring_actions_schedule_hook', [ WC_Stripe_Database_Cache::class, 'maybe_schedule_daily_async_cleanup' ], 10, 0 );
+			add_action( WC_Stripe_Order_Helper::PAYMENT_LOCK_OWNER_SWEEP_ACTION, [ WC_Stripe_Order_Helper::class, 'sweep_expired_payment_lock_owners' ], 10, 0 );
+			add_action( 'action_scheduler_run_recurring_actions_schedule_hook', [ WC_Stripe_Order_Helper::class, 'maybe_schedule_payment_lock_owner_sweep' ], 10, 0 );
 
 			// Handle the async cache prefetch action.
 			add_action( WC_Stripe_Database_Cache_Prefetch::ASYNC_PREFETCH_ACTION, [ WC_Stripe_Database_Cache_Prefetch::get_instance(), 'handle_prefetch_action' ], 10, 1 );
@@ -467,6 +469,7 @@ class WC_Stripe {
 
 		// Try to schedule the daily async cleanup of the Stripe database cache.
 		WC_Stripe_Database_Cache::maybe_schedule_daily_async_cleanup();
+		WC_Stripe_Order_Helper::maybe_schedule_payment_lock_owner_sweep();
 
 		// If we have previously disabled settings synchronization, remove the flag after the upgrade,
 		// just to make sure we are still ineligible for settings synchronization.

--- a/readme.txt
+++ b/readme.txt
@@ -202,5 +202,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Keep express checkout and the payment options rendering on the first block checkout load of a free-trial subscription cart
 * Fix - Honor subscription renewal payment locks while preserving retry attempts
 * Fix - Claim an atomic owner row before writing an order payment lock, and only release locks this request acquired
+* Dev - Delete expired payment lock owner rows in a daily scheduled sweep
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-order-helper-test.php
+++ b/tests/phpunit/class-wc-stripe-order-helper-test.php
@@ -450,6 +450,71 @@ class WC_Stripe_Order_Helper_Test extends WP_UnitTestCase {
 		$this->assertEmpty( wc_get_order( $order->get_id() )->get_meta( '_unsaved_extension_meta', true ) );
 	}
 
+	public function test_sweep_expired_payment_lock_owners_deletes_only_expired_rows(): void {
+		$expired_order   = WC_Helper_Order::create_order();
+		$active_order    = WC_Helper_Order::create_order();
+		$malformed_order = WC_Helper_Order::create_order();
+		$active_lock     = ( time() + 5 * MINUTE_IN_SECONDS ) . '|' . wp_generate_uuid4();
+
+		$this->set_payment_lock_owner_row( $expired_order, ( time() - 1 ) . '|' . wp_generate_uuid4() );
+		$this->set_payment_lock_owner_row( $active_order, $active_lock );
+		$this->set_payment_lock_owner_row( $malformed_order, 'corrupt-owner-value' );
+
+		try {
+			WC_Stripe_Order_Helper::sweep_expired_payment_lock_owners();
+
+			$this->assertNull( $this->get_payment_lock_owner_row( $expired_order ) );
+			$this->assertSame( $active_lock, $this->get_payment_lock_owner_row( $active_order ) );
+			$this->assertSame( 'corrupt-owner-value', $this->get_payment_lock_owner_row( $malformed_order ) );
+		} finally {
+			$this->set_payment_lock_owner_row( $active_order, null );
+			$this->set_payment_lock_owner_row( $malformed_order, null );
+		}
+	}
+
+	/**
+	 * @dataProvider provide_sweep_row_outcomes
+	 */
+	public function test_sweep_expired_payment_lock_owners_deletes_rows_with_a_past_timestamp( $value, $expect_deleted ): void {
+		$order = WC_Helper_Order::create_order();
+
+		$this->set_payment_lock_owner_row( $order, $value );
+
+		try {
+			WC_Stripe_Order_Helper::sweep_expired_payment_lock_owners();
+
+			$this->assertSame( $expect_deleted ? null : $value, $this->get_payment_lock_owner_row( $order ) );
+		} finally {
+			$this->set_payment_lock_owner_row( $order, null );
+		}
+	}
+
+	public function provide_sweep_row_outcomes(): array {
+		return [
+			'expired without token'  => [ (string) ( time() - 1 ), true ],
+			'expired with token'     => [ ( time() - 1 ) . '|' . wp_generate_uuid4(), true ],
+			'active with token'      => [ ( time() + 60 ) . '|' . wp_generate_uuid4(), false ],
+			'no leading timestamp'   => [ '|' . wp_generate_uuid4(), false ],
+			'not a timestamp at all' => [ 'corrupt-owner-value', false ],
+		];
+	}
+
+	public function test_sweep_expired_payment_lock_owners_has_its_own_daily_action(): void {
+		$this->assertSame( 10, has_action( WC_Stripe_Order_Helper::PAYMENT_LOCK_OWNER_SWEEP_ACTION, [ WC_Stripe_Order_Helper::class, 'sweep_expired_payment_lock_owners' ] ) );
+		$this->assertSame( 10, has_action( 'action_scheduler_run_recurring_actions_schedule_hook', [ WC_Stripe_Order_Helper::class, 'maybe_schedule_payment_lock_owner_sweep' ] ) );
+	}
+
+	public function test_payment_lock_owner_sweep_can_be_scheduled_and_unscheduled(): void {
+		WC_Stripe_Order_Helper::unschedule_payment_lock_owner_sweep();
+		$this->assertFalse( as_has_scheduled_action( WC_Stripe_Order_Helper::PAYMENT_LOCK_OWNER_SWEEP_ACTION, null ) );
+
+		WC_Stripe_Order_Helper::maybe_schedule_payment_lock_owner_sweep();
+		$this->assertTrue( as_has_scheduled_action( WC_Stripe_Order_Helper::PAYMENT_LOCK_OWNER_SWEEP_ACTION, null ) );
+
+		WC_Stripe_Order_Helper::unschedule_payment_lock_owner_sweep();
+		$this->assertFalse( as_has_scheduled_action( WC_Stripe_Order_Helper::PAYMENT_LOCK_OWNER_SWEEP_ACTION, null ) );
+	}
+
 	/**
 	 * @dataProvider provide_malformed_payment_locks
 	 * @param mixed $malformed_lock Malformed payment lock metadata.

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -174,6 +174,10 @@ function wcstripe_deactivated(): void {
 
 	WC_Stripe_Database_Cache::unschedule_daily_async_cleanup();
 
+	require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-order-helper.php';
+
+	WC_Stripe_Order_Helper::unschedule_payment_lock_owner_sweep();
+
 	// Cancel scheduled Agentic Commerce feed syncs.
 	if ( interface_exists( 'Automattic\WooCommerce\Internal\ProductFeed\Feed\FeedInterface' ) ) {
 		$integration = new WC_Stripe_Agentic_Commerce_Integration();


### PR DESCRIPTION
Fixes STRIPE-1187

This PR builds on #5897. Change the base to `develop` after #5897 merges.

## Changes proposed in this Pull Request:

#5897 adds an owner row in `wp_options` for each payment lock. A request that dies between the row insert and the unlock leaves the row behind. The next lock on that order reclaims it, but if no lock follows, the row stays for good.

- Add `WC_Stripe_Order_Helper::sweep_expired_payment_lock_owners()`. It reads owner rows in batches of 500 by `option_id` and deletes each row whose leading timestamp is in the past. The delete checks the row value, so it does not touch a row a worker reclaimed in the meantime. A run stops after 20 batches. A row with no leading timestamp is kept, because the code cannot prove it expired; the lock code treats such a row as held, so a merchant can see it in the log of the failed lock.
- Run the sweep on its own daily Action Scheduler action, `wc_stripe_payment_lock_owner_sweep`, one hour after the database cache cleanup. The plugin schedules it where it schedules the cache cleanup and unschedules it on deactivation. A separate action keeps the sweep out of the cache job's continuation runs and its arguments.

## Testing instructions

**Environment:** Docker (`npm run up`), PHP dependencies installed.

**Action:** Run `npm run test:php -- --filter=WC_Stripe_Order_Helper_Test`, `npm run phpstan`, and `npm run lint:php`.

**Validation:** All tests pass. The sweep deletes an expired row with or without a token, keeps an active row, and keeps a row with no leading timestamp. The sweep action and its scheduler are hooked, and the sweep can be scheduled and unscheduled.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

`Dev - Delete expired payment lock owner rows in a daily scheduled sweep`

</details>

> *Drafted with AI; reviewed by me.*
