### PR TITLE
Use the owned payment lock on the subscription renewal path

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -47,6 +47,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Explain that payment details were not submitted, instead of reporting the selected payment method as invalid, when checkout is submitted without them
 * Fix - Honor subscription renewal payment locks while preserving retry attempts
 * Fix - Claim an atomic owner row before writing an order payment lock, and only release locks this request acquired
+* Fix - Renew the subscription renewal payment lock before the charge and before the response is recorded, and only record a failed attempt while the lock is still owned
 
 2026-08-17 - version 10.9.0
 * Fix - Re-enable Adaptive Pricing if it was automatically disabled after a Checkout Session amount mismatch

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -503,25 +503,49 @@ trait WC_Stripe_Subscriptions_Trait {
 		$order_id     = $renewal_order->get_id();
 
 		// One lock covers the whole attempt, retries included, so a concurrent renewal cannot charge in between.
-		if ( $order_helper->lock_order_payment( $renewal_order ) ) {
+		$acquired_lock = $order_helper->acquire_order_payment_lock( $renewal_order );
+		if ( false === $acquired_lock ) {
 			// Error, not warning: warnings are dropped unless debug logging is on.
 			WC_Stripe_Logger::error( "Stripe: skipping duplicate renewal attempt for order {$order_id} because the payment lock is already held." );
 			$renewal_order->add_order_note( __( 'Stripe: skipped this renewal payment attempt because another payment attempt for this order was already in progress.', 'woocommerce-gateway-stripe' ) );
 			return;
 		}
 
-		// The 5-minute lock can lapse mid-retry; only release it while it is still ours.
-		$our_lock = (string) $order_helper->get_order_existing_payment_lock( $renewal_order );
-		// The lock is a bare timestamp or "{expiry}|{owner_token}".
-		$lock_expiry = (int) explode( '|', $our_lock, 2 )[0];
+		// Trust only the returned token; re-reading the meta could adopt another worker's lock.
+		$acquired_lock = (string) $acquired_lock;
+		$lock_expiry   = $this->get_subscription_payment_lock_expiry( $acquired_lock );
 
 		try {
-			$this->process_subscription_payment_attempt( $amount, $renewal_order, $retry, $previous_error, $lock_expiry );
+			$this->process_subscription_payment_attempt( $amount, $renewal_order, $retry, $previous_error, $lock_expiry, $acquired_lock );
 		} finally {
-			if ( (string) $order_helper->get_order_existing_payment_lock( $renewal_order ) === $our_lock ) {
-				$order_helper->unlock_order_payment( $renewal_order );
-			}
+			$order_helper->unlock_order_payment_if_owned( $renewal_order, $acquired_lock );
 		}
+	}
+
+	/**
+	 * Returns the expiry of a lock value, or 0 when it cannot be parsed.
+	 *
+	 * Accepts a bare timestamp or "{expiry}|{owner_token}".
+	 *
+	 * @param mixed $lock Payment lock value.
+	 * @return int
+	 */
+	private function get_subscription_payment_lock_expiry( $lock ): int {
+		if ( is_int( $lock ) ) {
+			return 0 < $lock ? $lock : 0;
+		}
+
+		if ( ! is_string( $lock ) || '' === $lock ) {
+			return 0;
+		}
+
+		$parts = explode( '|', $lock, 2 );
+
+		if ( ! ctype_digit( $parts[0] ) || 0 >= (int) $parts[0] || ( isset( $parts[1] ) && '' === $parts[1] ) ) {
+			return 0;
+		}
+
+		return (int) $parts[0];
 	}
 
 	/**
@@ -531,10 +555,11 @@ trait WC_Stripe_Subscriptions_Trait {
 	 * @param WC_Order     $renewal_order  The renewal order.
 	 * @param bool         $retry          Should we retry the process?
 	 * @param object|false $previous_error Previous error object.
-	 * @param int          $lock_expiry    Unix timestamp at which the caller's payment lock expires. 0 when unknown.
+	 * @param int          $lock_expiry    Unix timestamp at which the caller's payment lock expires.
+	 * @param string       $acquired_lock  Lock value the caller acquired; updated when the lock is renewed.
 	 * @return void
 	 */
-	private function process_subscription_payment_attempt( $amount, $renewal_order, $retry = true, $previous_error = false, int $lock_expiry = 0 ) {
+	private function process_subscription_payment_attempt( $amount, $renewal_order, $retry = true, $previous_error = false, int $lock_expiry = 0, string &$acquired_lock = '' ) {
 		$radar_reason = false;
 		$response     = null;
 
@@ -583,6 +608,19 @@ trait WC_Stripe_Subscriptions_Trait {
 				$prepared_source->source = '';
 			}
 
+			// Source preparation may have used up the lock; renew it so the request runs on a fresh one.
+			$renewed_lock = time() > $lock_expiry
+				? false
+				: WC_Stripe_Order_Helper::get_instance()->renew_order_payment_lock_if_owned( $renewal_order, $acquired_lock );
+			if ( ! is_string( $renewed_lock ) || 0 >= $this->get_subscription_payment_lock_expiry( $renewed_lock ) ) {
+				WC_Stripe_Logger::error( "Stripe: not continuing a subscription renewal attempt for order {$order_id} because its payment lock is no longer valid." );
+				$renewal_order->add_order_note( __( 'Stripe: this renewal payment was not attempted because its payment lock was no longer valid before the charge began.', 'woocommerce-gateway-stripe' ) );
+				return;
+			}
+
+			$acquired_lock = $renewed_lock;
+			$lock_expiry   = $this->get_subscription_payment_lock_expiry( $renewed_lock );
+
 			$payment_attempt            = $this->attempt_subscription_renewal_payment( $amount, $renewal_order, $prepared_source );
 			$response                   = $payment_attempt['response'];
 			$is_authentication_required = $payment_attempt['is_authentication_required'];
@@ -597,11 +635,11 @@ trait WC_Stripe_Subscriptions_Trait {
 				// would just create another blocked charge and inflate the block rate.
 				if ( $this->is_retryable_error( $response->error ) && false === $radar_reason ) {
 					// Stop retrying once the lock lapses; a concurrent renewal may hold its own lock by then.
-					$lock_expired = $lock_expiry > 0 && time() > $lock_expiry;
+					$lock_expired = time() > $lock_expiry;
 
 					if ( $retry && ! $lock_expired ) {
 						if ( 5 <= $this->retry_interval ) { // @phpstan-ignore-line (retry_interval is defined in classes using this class)
-							$this->process_subscription_payment_attempt( $amount, $renewal_order, false, $response->error, $lock_expiry );
+							$this->process_subscription_payment_attempt( $amount, $renewal_order, false, $response->error, $lock_expiry, $acquired_lock );
 							return;
 						}
 
@@ -609,9 +647,9 @@ trait WC_Stripe_Subscriptions_Trait {
 
 						++$this->retry_interval;
 
-						$lock_expired = $lock_expiry > 0 && time() > $lock_expiry;
+						$lock_expired = time() > $lock_expiry;
 						if ( ! $lock_expired ) {
-							$this->process_subscription_payment_attempt( $amount, $renewal_order, true, $response->error, $lock_expiry );
+							$this->process_subscription_payment_attempt( $amount, $renewal_order, true, $response->error, $lock_expiry, $acquired_lock );
 							return;
 						}
 					}
@@ -665,6 +703,12 @@ trait WC_Stripe_Subscriptions_Trait {
 			 * @param WC_Order            $order The order that failed payment processing.
 			 */
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $renewal_order );
+
+			// The hook always fires; order and Radar updates need the lock.
+			if ( ! WC_Stripe_Order_Helper::get_instance()->is_order_payment_lock_owned( $renewal_order, $acquired_lock ) ) {
+				WC_Stripe_Logger::error( "Stripe: not recording a failed renewal attempt for order {$renewal_order->get_id()} because its payment lock no longer matches the acquired value." );
+				return;
+			}
 
 			$renewal_order->update_status( OrderStatus::FAILED );
 
@@ -752,6 +796,16 @@ trait WC_Stripe_Subscriptions_Trait {
 		}
 
 		try {
+			// Renew the lock: response handling runs hooks and can be slow.
+			$renewed_lock = WC_Stripe_Order_Helper::get_instance()->renew_order_payment_lock_if_owned( $renewal_order, $acquired_lock );
+			if ( ! is_string( $renewed_lock ) || 0 >= $this->get_subscription_payment_lock_expiry( $renewed_lock ) ) {
+				throw new WC_Stripe_Exception(
+					"Stripe: subscription renewal order {$order_id} response was not processed because its payment lock could not be renewed.",
+					__( 'The Stripe renewal response could not be processed because its payment lock could not be renewed.', 'woocommerce-gateway-stripe' )
+				);
+			}
+
+			$acquired_lock = $renewed_lock;
 
 			// Either the charge was successfully captured, or it requires further authentication.
 			if ( $is_authentication_required ) {

--- a/readme.txt
+++ b/readme.txt
@@ -202,5 +202,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Keep express checkout and the payment options rendering on the first block checkout load of a free-trial subscription cart
 * Fix - Honor subscription renewal payment locks while preserving retry attempts
 * Fix - Claim an atomic owner row before writing an order payment lock, and only release locks this request acquired
+* Fix - Renew the subscription renewal payment lock before the charge and before the response is recorded, and only record a failed attempt while the lock is still owned
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/compat/class-wc-stripe-subscription-renewal-test.php
+++ b/tests/phpunit/compat/class-wc-stripe-subscription-renewal-test.php
@@ -439,13 +439,14 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 		$real_order_helper = WC_Stripe_Order_Helper::get_instance();
 		$order_helper_spy  = $this->getMockBuilder( WC_Stripe_Order_Helper::class )
 			->disableOriginalConstructor()
-			->onlyMethods( [ 'lock_order_payment', 'unlock_order_payment' ] )
+			->onlyMethods( [ 'acquire_order_payment_lock', 'unlock_order_payment_if_owned' ] )
 			->getMock();
 		$order_helper_spy->expects( $this->once() )
-			->method( 'lock_order_payment' )
-			->willReturnCallback( [ $real_order_helper, 'lock_order_payment' ] );
-		$order_helper_spy->method( 'unlock_order_payment' )
-			->willReturnCallback( [ $real_order_helper, 'unlock_order_payment' ] );
+			->method( 'acquire_order_payment_lock' )
+			->willReturnCallback( [ $real_order_helper, 'acquire_order_payment_lock' ] );
+		$order_helper_spy->expects( $this->once() )
+			->method( 'unlock_order_payment_if_owned' )
+			->willReturnCallback( [ $real_order_helper, 'unlock_order_payment_if_owned' ] );
 
 		$instance_property = new ReflectionProperty( WC_Stripe_Order_Helper::class, 'instance' );
 		$instance_property->setAccessible( true );
@@ -613,7 +614,7 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 		$this->assertEmpty( $order_helper->get_order_existing_payment_lock( wc_get_order( $renewal_order->get_id() ) ) );
 	}
 
-	public function test_renewal_stops_retrying_when_payment_lock_expires() {
+	public function test_renewal_does_not_start_payment_when_acquired_lock_is_expired() {
 		$renewal_order                 = WC_Helper_Order::create_order();
 		$payments_intents_api_endpoint = 'https://api.stripe.com/v1/payment_intents';
 		$request_count                 = 0;
@@ -638,16 +639,16 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 				]
 			);
 
-		// An expired lock must stop the retry chain after the first attempt.
-		$expired_lock = (string) ( time() - 10 );
+		$expired_lock = ( time() - 10 ) . '|' . wp_generate_uuid4();
 
 		$order_helper_mock = $this->getMockBuilder( WC_Stripe_Order_Helper::class )
 			->disableOriginalConstructor()
-			->onlyMethods( [ 'lock_order_payment', 'unlock_order_payment', 'get_order_existing_payment_lock' ] )
+			->onlyMethods( [ 'acquire_order_payment_lock', 'is_order_payment_lock_owned', 'unlock_order_payment_if_owned', 'get_order_existing_payment_lock' ] )
 			->getMock();
-		$order_helper_mock->method( 'lock_order_payment' )->willReturn( false );
-		$order_helper_mock->method( 'get_order_existing_payment_lock' )->willReturn( $expired_lock );
-		$order_helper_mock->method( 'unlock_order_payment' );
+		$order_helper_mock->method( 'acquire_order_payment_lock' )->willReturn( $expired_lock );
+		$order_helper_mock->method( 'get_order_existing_payment_lock' )->willReturn( '' );
+		$order_helper_mock->method( 'is_order_payment_lock_owned' )->willReturn( true );
+		$order_helper_mock->method( 'unlock_order_payment_if_owned' );
 
 		$instance_property = new ReflectionProperty( WC_Stripe_Order_Helper::class, 'instance' );
 		$instance_property->setAccessible( true );
@@ -691,8 +692,8 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 
 		$renewal_order = wc_get_order( $renewal_order->get_id() );
 
-		$this->assertSame( 1, $request_count );
-		$this->assertSame( OrderStatus::FAILED, $renewal_order->get_status() );
+		$this->assertSame( 0, $request_count );
+		$this->assertSame( OrderStatus::PENDING, $renewal_order->get_status() );
 	}
 
 	public function test_renewal_stops_retrying_when_payment_lock_expires_during_backoff_sleep() {
@@ -705,7 +706,7 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 
 		// The lock expires during the 3-second backoff sleep.
 		$this->set_gateway_retry_interval( 3 );
-		$lock_expiring_during_sleep = (string) ( time() + 1 );
+		$lock_expiring_during_sleep = ( time() + 1 ) . '|' . wp_generate_uuid4();
 
 		$this->wc_gateway_stripe
 			->expects( $this->any() )
@@ -724,11 +725,13 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 
 		$order_helper_mock = $this->getMockBuilder( WC_Stripe_Order_Helper::class )
 			->disableOriginalConstructor()
-			->onlyMethods( [ 'lock_order_payment', 'unlock_order_payment', 'get_order_existing_payment_lock' ] )
+			->onlyMethods( [ 'acquire_order_payment_lock', 'renew_order_payment_lock_if_owned', 'is_order_payment_lock_owned', 'unlock_order_payment_if_owned', 'get_order_existing_payment_lock' ] )
 			->getMock();
-		$order_helper_mock->method( 'lock_order_payment' )->willReturn( false );
-		$order_helper_mock->method( 'get_order_existing_payment_lock' )->willReturn( $lock_expiring_during_sleep );
-		$order_helper_mock->method( 'unlock_order_payment' );
+		$order_helper_mock->method( 'acquire_order_payment_lock' )->willReturn( $lock_expiring_during_sleep );
+		$order_helper_mock->method( 'renew_order_payment_lock_if_owned' )->willReturn( $lock_expiring_during_sleep );
+		$order_helper_mock->method( 'get_order_existing_payment_lock' )->willReturn( '' );
+		$order_helper_mock->method( 'is_order_payment_lock_owned' )->willReturn( true );
+		// An api_error keeps the lock.
 
 		$instance_property = new ReflectionProperty( WC_Stripe_Order_Helper::class, 'instance' );
 		$instance_property->setAccessible( true );
@@ -776,19 +779,13 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 		$this->assertSame( OrderStatus::FAILED, $renewal_order->get_status() );
 	}
 
-	public function test_renewal_does_not_release_lock_held_by_another_process() {
-		$renewal_order = WC_Helper_Order::create_order();
-
-		$renewal_order->set_payment_method( 'stripe' );
-		$renewal_order->save();
-
+	private function mock_prepared_card_source( $customer = 'cus_123abc' ) {
 		$this->wc_gateway_stripe
-			->expects( $this->any() )
 			->method( 'prepare_order_source' )
 			->willReturn(
 				(object) [
 					'token_id'       => false,
-					'customer'       => 'cus_123abc',
+					'customer'       => $customer,
 					'source'         => 'src_123abc',
 					'source_object'  => (object) [
 						'type' => WC_Stripe_Payment_Methods::CARD,
@@ -796,54 +793,620 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 					'payment_method' => null,
 				]
 			);
+	}
 
-		// Another process replaced the lock before the finally block; unlock must not run.
-		$our_lock     = (string) ( time() + 5 * MINUTE_IN_SECONDS );
-		$foreign_lock = (string) ( time() + 10 * MINUTE_IN_SECONDS );
+	private function build_mock_response( $body, $code = 200 ) {
+		return [
+			'headers'  => [],
+			'body'     => is_string( $body ) ? $body : wp_json_encode( $body ),
+			'response' => [
+				'code'    => $code,
+				'message' => 200 === $code ? 'OK' : 'Bad Request',
+			],
+			'cookies'  => [],
+			'filename' => null,
+		];
+	}
+
+	private function replace_payment_lock( WC_Order $renewal_order, string $replacement_lock, bool $replace_owner_row ): void {
+		if ( $replace_owner_row ) {
+			global $wpdb;
+			$wpdb->query(
+				$wpdb->prepare(
+					'UPDATE %i SET option_value = %s WHERE option_name = %s',
+					$wpdb->options,
+					$replacement_lock,
+					'wc_stripe_payment_lock_owner_' . $renewal_order->get_id()
+				)
+			);
+		}
+
+		// Write as another worker would.
+		$replacement_writer = wc_get_order( $renewal_order->get_id() );
+		$replacement_writer->update_meta_data( '_stripe_lock_payment', $replacement_lock );
+		$replacement_writer->save_meta_data();
+	}
+
+	private function clear_payment_lock( WC_Order $renewal_order ): void {
+		global $wpdb;
+
+		$order = wc_get_order( $renewal_order->get_id() );
+		$order->delete_meta_data( '_stripe_lock_payment' );
+		$order->save_meta_data();
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i WHERE option_name = %s', $wpdb->options, 'wc_stripe_payment_lock_owner_' . $renewal_order->get_id() ) );
+	}
+
+	public function test_renewal_honors_active_legacy_payment_lock() {
+		$renewal_order = WC_Helper_Order::create_order();
+		$legacy_lock   = ( time() + 5 * MINUTE_IN_SECONDS ) . '|pi_existing';
+
+		$renewal_order->set_payment_method( 'stripe' );
+		$renewal_order->update_meta_data( '_stripe_lock_payment', $legacy_lock );
+		$renewal_order->save();
+
+		$this->wc_gateway_stripe->expects( $this->never() )->method( 'prepare_order_source' );
+
+		$this->wc_gateway_stripe->process_subscription_payment( 20, $renewal_order, false, false );
+
+		$renewal_order = wc_get_order( $renewal_order->get_id() );
+
+		$this->assertSame( $legacy_lock, WC_Stripe_Order_Helper::get_instance()->get_order_existing_payment_lock( $renewal_order ) );
+		$this->assertSame( OrderStatus::PENDING, $renewal_order->get_status() );
+	}
+
+	/**
+	 * @dataProvider provide_stale_subscription_payment_locks
+	 */
+	public function test_renewal_replaces_stale_payment_lock( $stale_lock ) {
+		$renewal_order = WC_Helper_Order::create_order();
+		$caught        = null;
+
+		$renewal_order->set_payment_method( 'stripe' );
+		$renewal_order->update_meta_data( '_stripe_lock_payment', $stale_lock );
+		$renewal_order->save();
+
+		$this->wc_gateway_stripe
+			->expects( $this->once() )
+			->method( 'prepare_order_source' )
+			->willThrowException( new RuntimeException( 'Reached renewal processing.' ) );
+
+		try {
+			$this->wc_gateway_stripe->process_subscription_payment( 20, $renewal_order, false, false );
+		} catch ( RuntimeException $error ) {
+			$caught = $error;
+		}
+
+		$this->assertInstanceOf( RuntimeException::class, $caught );
+		$this->assertEmpty( WC_Stripe_Order_Helper::get_instance()->get_order_existing_payment_lock( wc_get_order( $renewal_order->get_id() ) ) );
+	}
+
+	public function provide_stale_subscription_payment_locks() {
+		return [
+			'expired legacy lock' => [ ( time() - MINUTE_IN_SECONDS ) . '|pi_old' ],
+			'stale scalar lock'   => [ 'not-a-timestamp' ],
+		];
+	}
+
+	/**
+	 * @dataProvider provide_replacement_subscription_payment_locks
+	 */
+	public function test_renewal_does_not_start_or_release_payment_after_lock_is_replaced( $foreign_lock ) {
+		$renewal_order = WC_Helper_Order::create_order();
+		$request_count = 0;
+		$our_lock      = ( time() + 5 * MINUTE_IN_SECONDS ) . '|' . wp_generate_uuid4();
+		$current_lock  = '';
+
+		$renewal_order->set_payment_method( 'stripe' );
+		$renewal_order->save();
+
+		// The lock changes hands while the source is being prepared.
+		$this->wc_gateway_stripe
+			->expects( $this->once() )
+			->method( 'prepare_order_source' )
+			->willReturnCallback(
+				function () use ( &$current_lock, $foreign_lock ) {
+					$current_lock = $foreign_lock;
+
+					return (object) [
+						'token_id'       => false,
+						'customer'       => 'cus_123abc',
+						'source'         => 'src_123abc',
+						'source_object'  => (object) [
+							'type' => WC_Stripe_Payment_Methods::CARD,
+						],
+						'payment_method' => null,
+					];
+				}
+			);
 
 		$order_helper_mock = $this->getMockBuilder( WC_Stripe_Order_Helper::class )
 			->disableOriginalConstructor()
-			->onlyMethods( [ 'lock_order_payment', 'unlock_order_payment', 'get_order_existing_payment_lock' ] )
+			->onlyMethods( [ 'acquire_order_payment_lock', 'is_order_payment_lock_owned', 'unlock_order_payment_if_owned', 'get_order_existing_payment_lock' ] )
 			->getMock();
-		$order_helper_mock->method( 'lock_order_payment' )->willReturn( false );
-		$order_helper_mock->method( 'get_order_existing_payment_lock' )
-			->willReturnOnConsecutiveCalls( $our_lock, $foreign_lock );
-		$order_helper_mock->expects( $this->never() )->method( 'unlock_order_payment' );
+		$order_helper_mock->method( 'acquire_order_payment_lock' )
+			->willReturnCallback(
+				function () use ( &$current_lock, $our_lock ) {
+					$current_lock = $our_lock;
+					return $our_lock;
+				}
+			);
+		$order_helper_mock->method( 'get_order_existing_payment_lock' )->willReturn( '' );
+		$order_helper_mock->method( 'is_order_payment_lock_owned' )
+			->willReturnCallback(
+				function ( $order, $expected_lock ) use ( &$current_lock ) {
+					return is_scalar( $current_lock ) && (string) $current_lock === $expected_lock;
+				}
+			);
 
-		$instance_property = new ReflectionProperty( WC_Stripe_Order_Helper::class, 'instance' );
-		$instance_property->setAccessible( true );
-		$original_instance = $instance_property->getValue();
-		$instance_property->setValue( null, $order_helper_mock );
+		$original_instance = WC_Stripe_Order_Helper::get_instance();
+		WC_Stripe_Order_Helper::set_instance( $order_helper_mock );
 
-		$pre_http_request_response_callback = function ( $preempt, $request_args, $url ) {
-			if ( 'https://api.stripe.com/v1/payment_intents' !== $url ) {
-				return $preempt;
+		$pre_http_request_response_callback = function ( $preempt, $request_args, $url ) use ( &$request_count ) {
+			if ( str_starts_with( $url, 'https://api.stripe.com/v1/' ) ) {
+				++$request_count;
+				return new WP_Error( 'unexpected_stripe_request', 'No Stripe request was expected.' );
 			}
 
-			return [
-				'headers'  => [],
-				'body'     => file_get_contents( __DIR__ . '/dummy-data/subscription_renewal_response_success.json' ),
-				'response' => [
-					'code'    => 200,
-					'message' => 'OK',
-				],
-				'cookies'  => [],
-				'filename' => null,
-			];
+			return $preempt;
 		};
-
 		add_filter( 'pre_http_request', $pre_http_request_response_callback, 10, 3 );
 
 		try {
 			$this->wc_gateway_stripe->process_subscription_payment( 20, $renewal_order, false, false );
 		} finally {
 			remove_filter( 'pre_http_request', $pre_http_request_response_callback, 10 );
-			$instance_property->setValue( null, $original_instance );
+			WC_Stripe_Order_Helper::set_instance( $original_instance );
 		}
 
 		$renewal_order = wc_get_order( $renewal_order->get_id() );
 
-		$this->assertSame( OrderStatus::PROCESSING, $renewal_order->get_status() );
+		$this->assertSame( 0, $request_count );
+		$this->assertSame( OrderStatus::PENDING, $renewal_order->get_status() );
+	}
+
+	public function provide_replacement_subscription_payment_locks() {
+		return [
+			'newer timestamp'  => [ (string) ( time() + 10 * MINUTE_IN_SECONDS ) ],
+			'malformed array'  => [ [] ],
+			'malformed object' => [ new stdClass() ],
+		];
+	}
+
+	public function test_renewal_does_not_adopt_a_lock_replaced_immediately_after_acquisition() {
+		$renewal_order    = WC_Helper_Order::create_order();
+		$our_lock         = ( time() + 5 * MINUTE_IN_SECONDS ) . '|' . wp_generate_uuid4();
+		$replacement_lock = ( time() + 5 * MINUTE_IN_SECONDS ) . '|' . wp_generate_uuid4();
+		$current_lock     = '';
+
+		$renewal_order->set_payment_method( 'stripe' );
+		$renewal_order->save();
+
+		$this->mock_prepared_card_source();
+
+		$order_helper_mock = $this->getMockBuilder( WC_Stripe_Order_Helper::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'acquire_order_payment_lock', 'is_order_payment_lock_owned', 'unlock_order_payment_if_owned', 'get_order_existing_payment_lock' ] )
+			->getMock();
+		$order_helper_mock->method( 'get_order_existing_payment_lock' )->willReturn( '' );
+		$order_helper_mock->method( 'acquire_order_payment_lock' )
+			->willReturnCallback(
+				function () use ( &$current_lock, $our_lock, $replacement_lock ) {
+					$current_lock = $replacement_lock;
+					return $our_lock;
+				}
+			);
+		$order_helper_mock->method( 'is_order_payment_lock_owned' )
+			->willReturnCallback(
+				function ( $order, $expected_lock ) use ( &$current_lock ) {
+					return $expected_lock === $current_lock;
+				}
+			);
+
+		$original_instance = WC_Stripe_Order_Helper::get_instance();
+		WC_Stripe_Order_Helper::set_instance( $order_helper_mock );
+
+		$pre_http_request_response_callback = function ( $preempt, $request_args, $url ) {
+			if ( str_starts_with( $url, 'https://api.stripe.com/v1/' ) ) {
+				return new WP_Error( 'unexpected_stripe_request', 'No Stripe request was expected.' );
+			}
+
+			return $preempt;
+		};
+		add_filter( 'pre_http_request', $pre_http_request_response_callback, 10, 3 );
+
+		try {
+			$this->wc_gateway_stripe->process_subscription_payment( 20, $renewal_order, false, false );
+		} finally {
+			remove_filter( 'pre_http_request', $pre_http_request_response_callback, 10 );
+			WC_Stripe_Order_Helper::set_instance( $original_instance );
+		}
+
+		$this->assertSame( $replacement_lock, $current_lock );
+		$this->assertSame( OrderStatus::PENDING, wc_get_order( $renewal_order->get_id() )->get_status() );
+	}
+
+	public function test_renewal_does_not_start_payment_when_fallback_filter_replaces_lock() {
+		$renewal_order    = WC_Helper_Order::create_order();
+		$replacement_lock = (string) ( time() + 10 * MINUTE_IN_SECONDS );
+		$request_count    = 0;
+
+		$this->mock_prepared_card_source();
+
+		$use_default_source_filter = function ( $use_default_source ) use ( $renewal_order, $replacement_lock ) {
+			$this->replace_payment_lock( $renewal_order, $replacement_lock, false );
+
+			return $use_default_source;
+		};
+
+		$pre_http_request_response_callback = function ( $preempt, $request_args, $url ) use ( &$request_count ) {
+			if ( str_starts_with( $url, 'https://api.stripe.com/v1/' ) ) {
+				++$request_count;
+				return new WP_Error( 'unexpected_stripe_request', 'No Stripe request was expected after the lock changed.' );
+			}
+
+			return $preempt;
+		};
+		$previous_error                     = (object) [
+			'type'    => 'invalid_request_error',
+			'message' => 'No such source: src_old',
+		];
+
+		add_filter( 'wc_stripe_use_default_customer_source', $use_default_source_filter );
+		add_filter( 'pre_http_request', $pre_http_request_response_callback, 10, 3 );
+
+		try {
+			$this->wc_gateway_stripe->process_subscription_payment( 20, $renewal_order, false, $previous_error );
+		} finally {
+			remove_filter( 'wc_stripe_use_default_customer_source', $use_default_source_filter );
+			remove_filter( 'pre_http_request', $pre_http_request_response_callback, 10 );
+			$this->clear_payment_lock( $renewal_order );
+		}
+
+		$renewal_order = wc_get_order( $renewal_order->get_id() );
+
+		$this->assertSame( 0, $request_count );
+		$this->assertSame( OrderStatus::PENDING, $renewal_order->get_status() );
+	}
+
+	public function test_successful_payment_is_not_recorded_when_lock_is_replaced_during_stripe_request() {
+		$renewal_order      = WC_Helper_Order::create_order();
+		$replacement_lock   = ( time() + 5 * MINUTE_IN_SECONDS ) . '|' . wp_generate_uuid4();
+		$request_count      = 0;
+		$error_hook_count   = 0;
+		$success_hook_count = 0;
+
+		$this->mock_prepared_card_source();
+
+		$pre_http_request_response_callback = function ( $preempt, $request_args, $url ) use ( &$request_count, $renewal_order, $replacement_lock ) {
+			if ( 'https://api.stripe.com/v1/payment_intents' !== $url ) {
+				return $preempt;
+			}
+
+			++$request_count;
+			$this->replace_payment_lock( $renewal_order, $replacement_lock, true );
+
+			return $this->build_mock_response( file_get_contents( __DIR__ . '/dummy-data/subscription_renewal_response_success.json' ) );
+		};
+
+		$error_hook   = function () use ( &$error_hook_count ) {
+			++$error_hook_count;
+		};
+		$success_hook = function () use ( &$success_hook_count ) {
+			++$success_hook_count;
+		};
+		add_filter( 'pre_http_request', $pre_http_request_response_callback, 10, 3 );
+		add_action( 'wc_gateway_stripe_process_payment_error', $error_hook );
+		add_action( 'wc_gateway_stripe_process_payment_charge', $success_hook );
+
+		try {
+			$this->wc_gateway_stripe->process_subscription_payment( 20, $renewal_order, false, false );
+		} finally {
+			remove_filter( 'pre_http_request', $pre_http_request_response_callback, 10 );
+			remove_action( 'wc_gateway_stripe_process_payment_error', $error_hook );
+			remove_action( 'wc_gateway_stripe_process_payment_charge', $success_hook );
+		}
+
+		$renewal_order = wc_get_order( $renewal_order->get_id() );
+		$current_lock  = (string) WC_Stripe_Order_Helper::get_instance()->get_order_existing_payment_lock( $renewal_order );
+		$this->clear_payment_lock( $renewal_order );
+
+		$this->assertSame( 1, $request_count );
+		$this->assertSame( 1, $error_hook_count );
+		$this->assertSame( 0, $success_hook_count );
+		$this->assertSame( OrderStatus::PENDING, $renewal_order->get_status() );
+		$this->assertSame( '', $renewal_order->get_transaction_id() );
+		$this->assertSame( $replacement_lock, $current_lock );
+	}
+
+	/**
+	 * @dataProvider provide_payment_lock_replacement_points
+	 */
+	public function test_payment_error_does_not_fail_order_after_payment_lock_is_replaced( $replace_during_request ) {
+		$renewal_order    = WC_Helper_Order::create_order();
+		$replacement_lock = (string) ( time() + 10 * MINUTE_IN_SECONDS );
+		$request_count    = 0;
+		$error_hook_count = 0;
+
+		$this->mock_prepared_card_source();
+
+		$pre_http_request_response_callback = function ( $preempt, $request_args, $url ) use ( &$request_count, $renewal_order, $replacement_lock, $replace_during_request ) {
+			if ( 'https://api.stripe.com/v1/payment_intents' !== $url ) {
+				return $preempt;
+			}
+
+			++$request_count;
+			if ( $replace_during_request ) {
+				$this->replace_payment_lock( $renewal_order, $replacement_lock, false );
+			}
+
+			return $this->build_mock_response(
+				[
+					'error' => [
+						'type'    => 'card_error',
+						'code'    => 'card_declined',
+						'message' => 'Mock card declined error',
+					],
+				],
+				400
+			);
+		};
+		$error_hook                         = function () use ( &$error_hook_count, $replace_during_request, $renewal_order, $replacement_lock ) {
+			++$error_hook_count;
+			if ( ! $replace_during_request ) {
+				$this->replace_payment_lock( $renewal_order, $replacement_lock, false );
+			}
+		};
+
+		add_filter( 'pre_http_request', $pre_http_request_response_callback, 10, 3 );
+		add_action( 'wc_gateway_stripe_process_payment_error', $error_hook, 10, 2 );
+
+		try {
+			$this->wc_gateway_stripe->process_subscription_payment( 20, $renewal_order, false, false );
+		} finally {
+			remove_filter( 'pre_http_request', $pre_http_request_response_callback, 10 );
+			remove_action( 'wc_gateway_stripe_process_payment_error', $error_hook, 10 );
+		}
+
+		$renewal_order = wc_get_order( $renewal_order->get_id() );
+		$current_lock  = (string) WC_Stripe_Order_Helper::get_instance()->get_order_existing_payment_lock( $renewal_order );
+		$this->clear_payment_lock( $renewal_order );
+
+		$this->assertSame( 1, $request_count );
+		$this->assertSame( 1, $error_hook_count );
+		$this->assertSame( OrderStatus::PENDING, $renewal_order->get_status() );
+		$this->assertSame( $replacement_lock, $current_lock );
+	}
+
+	public function provide_payment_lock_replacement_points() {
+		return [
+			'replaced during the request'   => [ true ],
+			'replaced by an error listener' => [ false ],
+		];
+	}
+
+	public function test_payment_error_hook_unsaved_metadata_is_preserved_across_lock_recheck() {
+		$renewal_order = WC_Helper_Order::create_order();
+
+		$this->mock_prepared_card_source();
+
+		$pre_http_request_response_callback = function ( $preempt, $request_args, $url ) {
+			if ( 'https://api.stripe.com/v1/payment_intents' !== $url ) {
+				return $preempt;
+			}
+
+			return $this->build_mock_response(
+				[
+					'error' => [
+						'type'    => 'card_error',
+						'code'    => 'card_declined',
+						'message' => 'Mock card declined error',
+					],
+				],
+				400
+			);
+		};
+		$error_hook                         = function ( $exception, $order ) use ( $renewal_order ) {
+			if ( $order->get_id() === $renewal_order->get_id() ) {
+				$order->update_meta_data( '_listener_unsaved_meta', 'preserved' );
+			}
+		};
+
+		add_filter( 'pre_http_request', $pre_http_request_response_callback, 10, 3 );
+		add_action( 'wc_gateway_stripe_process_payment_error', $error_hook, 10, 2 );
+
+		try {
+			$this->wc_gateway_stripe->process_subscription_payment( 20, $renewal_order, false, false );
+		} finally {
+			remove_filter( 'pre_http_request', $pre_http_request_response_callback, 10 );
+			remove_action( 'wc_gateway_stripe_process_payment_error', $error_hook, 10 );
+		}
+
+		$renewal_order = wc_get_order( $renewal_order->get_id() );
+
+		$this->assertSame( OrderStatus::FAILED, $renewal_order->get_status() );
+		$this->assertSame( 'preserved', $renewal_order->get_meta( '_listener_unsaved_meta', true ) );
+	}
+
+	public function test_radar_lookup_does_not_fail_order_after_payment_lock_is_replaced() {
+		$renewal_order    = WC_Helper_Order::create_order();
+		$replacement_lock = (string) ( time() + 10 * MINUTE_IN_SECONDS );
+		$request_count    = 0;
+		$error_hook_count = 0;
+		$radar_hook_count = 0;
+
+		$this->mock_prepared_card_source();
+
+		$pre_http_request_response_callback = function ( $preempt, $request_args, $url ) use ( &$request_count, $renewal_order, $replacement_lock ) {
+			if ( 'https://api.stripe.com/v1/payment_intents' === $url ) {
+				++$request_count;
+				return $this->build_mock_response( file_get_contents( __DIR__ . '/dummy-data/subscription_renewal_response_radar_blocked.json' ), 402 );
+			}
+
+			if ( str_starts_with( $url, 'https://api.stripe.com/v1/charges/' ) ) {
+				++$request_count;
+				$this->replace_payment_lock( $renewal_order, $replacement_lock, false );
+
+				return $this->build_mock_response( file_get_contents( __DIR__ . '/dummy-data/subscription_renewal_charge_radar_blocked.json' ) );
+			}
+
+			return $preempt;
+		};
+		$error_hook                         = function () use ( &$error_hook_count ) {
+			++$error_hook_count;
+		};
+		$radar_hook                         = function () use ( &$radar_hook_count ) {
+			++$radar_hook_count;
+		};
+
+		add_filter( 'pre_http_request', $pre_http_request_response_callback, 10, 3 );
+		add_action( 'wc_gateway_stripe_process_payment_error', $error_hook, 10, 2 );
+		add_action( 'wc_stripe_subscription_renewal_blocked_by_radar', $radar_hook, 10, 3 );
+
+		try {
+			$this->wc_gateway_stripe->process_subscription_payment( 20, $renewal_order, false, false );
+		} finally {
+			remove_filter( 'pre_http_request', $pre_http_request_response_callback, 10 );
+			remove_action( 'wc_gateway_stripe_process_payment_error', $error_hook, 10 );
+			remove_action( 'wc_stripe_subscription_renewal_blocked_by_radar', $radar_hook, 10 );
+		}
+
+		$renewal_order = wc_get_order( $renewal_order->get_id() );
+		$current_lock  = (string) WC_Stripe_Order_Helper::get_instance()->get_order_existing_payment_lock( $renewal_order );
+		$this->clear_payment_lock( $renewal_order );
+
+		$this->assertSame( 2, $request_count );
+		$this->assertSame( 1, $error_hook_count );
+		$this->assertSame( 0, $radar_hook_count );
+		$this->assertSame( OrderStatus::PENDING, $renewal_order->get_status() );
+		$this->assertSame( $replacement_lock, $current_lock );
+	}
+
+	public function test_renewal_does_not_record_payment_when_response_lease_cannot_be_renewed() {
+		$renewal_order    = WC_Helper_Order::create_order();
+		$error_hook_count = 0;
+		$owned_lock       = null;
+
+		$renewal_order->set_payment_method( 'stripe' );
+		$renewal_order->save();
+
+		$this->mock_prepared_card_source();
+
+		$real_order_helper = WC_Stripe_Order_Helper::get_instance();
+		$order_helper_mock = $this->getMockBuilder( WC_Stripe_Order_Helper::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'acquire_order_payment_lock', 'renew_order_payment_lock_if_owned', 'is_order_payment_lock_owned', 'unlock_order_payment_if_owned' ] )
+			->getMock();
+		$order_helper_mock->method( 'acquire_order_payment_lock' )
+			->willReturnCallback(
+				function ( $order ) use ( $real_order_helper, &$owned_lock ) {
+					$owned_lock = $real_order_helper->acquire_order_payment_lock( $order );
+					return $owned_lock;
+				}
+			);
+		// The pre-request renewal succeeds; the pre-response renewal fails.
+		$renewals = 0;
+		$order_helper_mock->expects( $this->exactly( 2 ) )
+			->method( 'renew_order_payment_lock_if_owned' )
+			->willReturnCallback(
+				function ( $order, $expected_lock ) use ( $real_order_helper, &$owned_lock, &$renewals ) {
+					if ( 0 < $renewals++ ) {
+						return false;
+					}
+
+					$owned_lock = $real_order_helper->renew_order_payment_lock_if_owned( $order, $expected_lock );
+					return $owned_lock;
+				}
+			);
+		$order_helper_mock->method( 'is_order_payment_lock_owned' )
+			->willReturnCallback( [ $real_order_helper, 'is_order_payment_lock_owned' ] );
+
+		WC_Stripe_Order_Helper::set_instance( $order_helper_mock );
+
+		$pre_http_request_response_callback = function ( $preempt, $request_args, $url ) {
+			if ( 'https://api.stripe.com/v1/payment_intents' !== $url ) {
+				return $preempt;
+			}
+
+			return $this->build_mock_response( file_get_contents( __DIR__ . '/dummy-data/subscription_renewal_response_success.json' ) );
+		};
+		$error_hook                         = function () use ( &$error_hook_count ) {
+			++$error_hook_count;
+		};
+
+		add_filter( 'pre_http_request', $pre_http_request_response_callback, 10, 3 );
+		add_action( 'wc_gateway_stripe_process_payment_error', $error_hook );
+
+		try {
+			$this->wc_gateway_stripe->process_subscription_payment( 20, $renewal_order, false, false );
+
+			$renewal_order = wc_get_order( $renewal_order->get_id() );
+			$this->assertSame( 1, $error_hook_count );
+			$this->assertSame( OrderStatus::PENDING, $renewal_order->get_status() );
+			$this->assertSame( '', $renewal_order->get_transaction_id() );
+			$this->assertIsString( $owned_lock );
+			$this->assertTrue( $real_order_helper->is_order_payment_lock_owned( $renewal_order, $owned_lock ) );
+		} finally {
+			remove_filter( 'pre_http_request', $pre_http_request_response_callback, 10 );
+			remove_action( 'wc_gateway_stripe_process_payment_error', $error_hook );
+			WC_Stripe_Order_Helper::set_instance( $real_order_helper );
+
+			if ( is_string( $owned_lock ) ) {
+				$real_order_helper->unlock_order_payment_if_owned( $renewal_order, $owned_lock );
+			}
+		}
+	}
+
+	public function test_renewal_releases_renewed_lock_when_response_processing_throws() {
+		$renewal_order       = WC_Helper_Order::create_order();
+		$lock_during_request = null;
+		$renewed_lock        = null;
+		$caught              = null;
+
+		$renewal_order->set_payment_method( 'stripe' );
+		$renewal_order->save();
+
+		$this->mock_prepared_card_source();
+
+		$order_helper = WC_Stripe_Order_Helper::get_instance();
+
+		$pre_http_request_response_callback = function ( $preempt, $request_args, $url ) use ( $order_helper, $renewal_order, &$lock_during_request ) {
+			if ( 'https://api.stripe.com/v1/payment_intents' !== $url ) {
+				return $preempt;
+			}
+
+			$lock_during_request = $order_helper->get_order_existing_payment_lock( wc_get_order( $renewal_order->get_id() ) );
+
+			return $this->build_mock_response( file_get_contents( __DIR__ . '/dummy-data/subscription_renewal_response_success.json' ) );
+		};
+
+		$throw_during_processing = function () use ( $order_helper, $renewal_order, &$renewed_lock ) {
+			$renewed_lock = $order_helper->get_order_existing_payment_lock( wc_get_order( $renewal_order->get_id() ) );
+			throw new RuntimeException( 'Response-processing listener failed.' );
+		};
+
+		add_filter( 'pre_http_request', $pre_http_request_response_callback, 10, 3 );
+		add_action( 'wc_gateway_stripe_process_payment_charge', $throw_during_processing );
+
+		try {
+			try {
+				$this->wc_gateway_stripe->process_subscription_payment( 20, $renewal_order, false, false );
+			} catch ( Throwable $e ) {
+				$caught = $e;
+			}
+
+			$this->assertInstanceOf( RuntimeException::class, $caught );
+			$this->assertIsString( $lock_during_request );
+			$this->assertIsString( $renewed_lock );
+			$this->assertNotSame( $lock_during_request, $renewed_lock );
+			$this->assertFalse( $order_helper->is_order_payment_lock_owned( $renewal_order, $renewed_lock ) );
+		} finally {
+			remove_filter( 'pre_http_request', $pre_http_request_response_callback, 10 );
+			remove_action( 'wc_gateway_stripe_process_payment_charge', $throw_during_processing );
+
+			if ( is_string( $renewed_lock ) ) {
+				$order_helper->unlock_order_payment_if_owned( $renewal_order, $renewed_lock );
+			}
+		}
 	}
 
 	public function test_renewal_sepa_success_processes_charge_response() {


### PR DESCRIPTION
Fixes STRIPE-1187

This PR builds on #5897. Merge order: #5591, #5897, then this PR. Change the base to `develop` after #5897 merges. This PR and #5898 and #5899 edit the same method, so the last two need a rebase after this one merges.

## Changes proposed in this Pull Request:

#5897 gives each lock an owner token. This PR makes the subscription renewal code use it.

- The renewal code takes the lock with `acquire_order_payment_lock()` and trusts only the token it gets back. It does not read the lock meta again.
- It renews the lock just before it sends the charge, and again before it handles the response. If either renewal fails, another worker owns the order and this run stops. If the first renewal fails, the order keeps its status and gets a note. If the second fails, the charge exists but the order is not updated; the `payment_intent.succeeded` webhook or the other worker records it.
- It checks that it owns the lock before it records a failure. The error hook still fires.
- The lock is released after the attempt, as in #5591, on every outcome. A retained lock would make the webhook handler drop a `payment_intent.succeeded` event, because that handler returns when an order is locked and Stripe does not send the event again. Retries after an error that leaves the charge state unknown still run in the same process, as on `develop`; #5899 makes them reuse the idempotency key.
- The trait parses the expiry from the token it received. The helper owns the token format; the parse here reads only the leading timestamp.

## Testing instructions

**Environment:** Docker (`npm run up`), PHP dependencies installed.

**Action:** Run `npm run test:php -- --filter='WC_Stripe_Subscription_Renewal_Test|WC_Stripe_UPE_Payment_Gateway_Test'`, `npm run phpstan`, and `npm run lint:php`.

**Validation:** All tests pass. The tests cover these cases:

- A replaced lock stops the charge and the failure write.
- A stale or legacy lock is replaced; an active legacy lock is honoured.
- The lock is renewed before the charge and before the response, and released after the attempt, also when response handling throws.
- If the lock renewal before the response fails, the order stays pending and the code does not release the other worker's lock.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

`Fix - Renew the subscription renewal payment lock before the charge and before the response is recorded, and only record a failed attempt while the lock is still owned`

</details>

> *Drafted with AI; reviewed by me.*
