### PR TITLE
Add admin Stripe disputes  rest api endpoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "includes/admin/class-wc-rest-stripe-exit-survey-controller.php",
         "includes/admin/class-wc-stripe-plugins-page-controller.php",
         "includes/admin/class-wc-stripe-rest-balance-controller.php",
+        "includes/admin/class-wc-stripe-rest-disputes-controller.php",
         "includes/admin/class-wc-stripe-rest-payment-intents-controller.php",
         "includes/admin/class-wc-stripe-rest-payouts-controller.php",
         "includes/admin/class-wc-stripe-rest-response-filter.php",

--- a/includes/admin/class-wc-stripe-rest-disputes-controller.php
+++ b/includes/admin/class-wc-stripe-rest-disputes-controller.php
@@ -1,0 +1,384 @@
+<?php
+/**
+ * Class WC_Stripe_REST_Disputes_Controller
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST controller exposing Stripe dispute details to the admin UI.
+ *
+ * @since 11.1.0
+ */
+class WC_Stripe_REST_Disputes_Controller extends WC_Stripe_REST_Base_Controller {
+
+	protected const DISPUTE_ID_PATTERN        = 'du_[A-Za-z0-9_]+';
+	protected const PAYMENT_INTENT_ID_PATTERN = 'pi_[A-Za-z0-9_]+';
+	protected const CHARGE_ID_PATTERN         = 'ch_[A-Za-z0-9_]+';
+
+	/**
+	 * Endpoint path.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'wc_stripe/disputes';
+
+	protected const STRIPE_SINGLE_RESPONSE_ALLOWED_FIELDS = [
+		'object',
+		'id',
+		'created',
+		'amount',
+		'currency',
+		'status',
+		'description',
+		'payment_intent.latest_charge.balance_transaction',
+		'payment_intent.latest_charge.billing_details',
+		'payment_intent.latest_charge.payment_method_details',
+	];
+
+	protected const STRIPE_SINGLE_EXPAND_PARAM = [
+		'payment_intent.latest_charge.balance_transaction',
+		'payment_intent.latest_charge.billing_details',
+		'payment_intent.latest_charge.payment_method_details',
+	];
+
+	protected const STRIPE_LIST_RESPONSE_ALLOWED_FIELDS = [
+		'object',
+		'has_more',
+		'data.id',
+		'data.created',
+		'data.amount',
+		'data.currency',
+		'data.status',
+		'data.payment_intent',
+		'data.reason',
+		'data.evidence_details.due_by',
+	];
+
+	protected const STRIPE_LIST_EXPAND_PARAM = [];
+
+	protected const STRIPE_LIST_PARAMS_TO_FORWARD = [ 'limit', 'starting_after', 'ending_before', 'created', 'payment_intent', 'charge' ];
+
+	/**
+	 * Configure REST API routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>' . self::DISPUTE_ID_PATTERN . ')$',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_dispute' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+				'args'                => [],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_disputes' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+				'args'                => [
+					'limit'          => [
+						'type'              => 'integer',
+						'required'          => false,
+						'default'           => 10,
+						'minimum'           => 1,
+						'maximum'           => 100,
+						'sanitize_callback' => 'absint',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
+					'starting_after' => [
+						'type'              => 'string',
+						'required'          => false,
+						'sanitize_callback' => 'sanitize_text_field',
+						'validate_callback' => [ self::class, 'validate_pagination_cursor' ],
+					],
+					'ending_before'  => [
+						'type'              => 'string',
+						'required'          => false,
+						'sanitize_callback' => 'sanitize_text_field',
+						'validate_callback' => [ self::class, 'validate_pagination_cursor' ],
+					],
+					'created'        => [
+						'required'          => false,
+						'sanitize_callback' => [ self::class, 'sanitize_unix_timestamp' ],
+						'validate_callback' => [ self::class, 'validate_unix_timestamp' ],
+					],
+					'payment_intent' => [
+						'type'              => 'string',
+						'required'          => false,
+						'sanitize_callback' => 'sanitize_text_field',
+						'validate_callback' => [ self::class, 'validate_payment_intent_id' ],
+					],
+					'charge'         => [
+						'type'              => 'string',
+						'required'          => false,
+						'sanitize_callback' => 'sanitize_text_field',
+						'validate_callback' => [ self::class, 'validate_charge_id' ],
+					],
+				],
+			],
+		);
+	}
+
+	/**
+	 * Retrieve, filters and return one Stripe dispute.
+	 *
+	 * @param WP_REST_Request<array<string, mixed>> $request The incoming REST request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_dispute( $request ) {
+		$response = $this->fetch_from_stripe( 'disputes/' . rawurlencode( $request['id'] ), [ 'expand' => self::STRIPE_SINGLE_EXPAND_PARAM ] );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$filtered_response = WC_Stripe_REST_Response_Filter::filter_response( $response, self::STRIPE_SINGLE_RESPONSE_ALLOWED_FIELDS );
+
+		return rest_ensure_response( $filtered_response );
+	}
+
+	/**
+	 * Retrieve, filters and return Stripe disputes.
+	 *
+	 * @param WP_REST_Request<array<string, mixed>> $request The incoming REST request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_disputes( $request ) {
+		$response = $this->fetch_from_stripe(
+			'disputes',
+			self::build_params_to_forward( $request, self::STRIPE_LIST_PARAMS_TO_FORWARD, self::STRIPE_LIST_EXPAND_PARAM ),
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$filtered_response = WC_Stripe_REST_Response_Filter::filter_response( $response, self::STRIPE_LIST_RESPONSE_ALLOWED_FIELDS );
+
+		return rest_ensure_response( $filtered_response );
+	}
+
+	/**
+	 * Builds an array of parameters to forward to Stripe API.
+	 *
+	 * @param WP_REST_Request<array<string, mixed>> $request An incoming REST request.
+	 * @param array $params_to_forward[] Names of params to forward.
+	 * @param array $expand_param Array of values to populate the 'expand' Stripe API param.
+	 *
+	 * @return array
+	 */
+	private static function build_params_to_forward( WP_REST_Request $request, array $params_to_forward, array $expand_param ) {
+		$stripe_params = array_intersect_key(
+			$request->get_params(),
+			array_flip( $params_to_forward )
+		);
+
+		$stripe_params['expand'] = $expand_param;
+
+		return $stripe_params;
+	}
+
+	/**
+	 * Fetch data from an Stripe API endpoint and returns its raw data or a WP_Error if an error occurs.
+	 *
+	 * @param string $endpoint The Stripe endpoint.
+	 * @param array $params Parameters to pass to the endpoint.
+	 *
+	 * @return StdClass|WP_Error
+	 */
+	protected function fetch_from_stripe( $endpoint, $params ) {
+		$query_string = http_build_query( $params, '', '&', PHP_QUERY_RFC3986 );
+
+		$stripe_resource_url = $endpoint . ( '' === $query_string ? '' : '?' . $query_string );
+
+		$response = WC_Stripe_API::retrieve( $stripe_resource_url );
+
+		if ( null === $response ) {
+			return new WP_Error(
+				'wc_stripe_error',
+				__( 'Unable to fetch data from Stripe.', 'woocommerce-gateway-stripe' ),
+				[ 'status' => 401 ]
+			);
+		}
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		if ( is_object( $response ) && isset( $response->error ) ) {
+			$error_code    = isset( $response->error->code ) ? (string) $response->error->code : 'wc_stripe_api_error';
+			$error_message = isset( $response->error->message ) ? (string) $response->error->message : __( 'Stripe API returned an error.', 'woocommerce-gateway-stripe' );
+
+			return new WP_Error( $error_code, $error_message, [ 'status' => 400 ] );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Validate a pagination cursor (starting_after or ending_before) parameter value that should be a dispute ID.
+	 * Also raise an error if both starting_after and ending_before parameter are specified.
+	 *
+	 * @param string $param_value The parameter value.
+	 * @param WP_REST_Request<array<string, mixed>> $request The incoming REST request.
+	 * @param string $param_name The parameter name.
+	 *
+	 * @return WP_Error|bool
+	 */
+	public static function validate_pagination_cursor( $param_value, $request, $param_name ) {
+		if ( $request->has_param( 'starting_after' ) && $request->has_param( 'ending_before' ) ) {
+			return new WP_Error(
+				'invalid_pagination_cursor',
+				__( 'Received both starting_after and ending_before parameters. Please pass in only one.', 'woocommerce-gateway-stripe' )
+			);
+		}
+
+		return self::validate_dispute_id( $param_value, $request, $param_name );
+	}
+
+	/**
+	 * Validate a parameter value that should be a dispute ID.
+	 *
+	 * @param string $param_value The parameter value.
+	 * @param WP_REST_Request<array<string, mixed>> $request The incoming REST request.
+	 * @param string $param_name The parameter name.
+	 *
+	 * @return bool
+	 */
+	private static function validate_dispute_id( $param_value, $request, $param_name ) {
+		return 1 === preg_match( '/^' . self::DISPUTE_ID_PATTERN . '$/', $param_value );
+	}
+
+	/**
+	 * Validate a parameter value that should be a payment intent ID.
+	 *
+	 * @param string $param_value The parameter value.
+	 * @param WP_REST_Request<array<string, mixed>> $request The incoming REST request.
+	 * @param string $param_name The parameter name.
+	 *
+	 * @return bool
+	 */
+	public static function validate_payment_intent_id( $param_value, $request, $param_name ) {
+		return 1 === preg_match( '/^' . self::PAYMENT_INTENT_ID_PATTERN . '$/', $param_value );
+	}
+
+	/**
+	 * Validate a parameter value that should be a charge ID.
+	 *
+	 * @param string $param_value The parameter value.
+	 * @param WP_REST_Request<array<string, mixed>> $request The incoming REST request.
+	 * @param string $param_name The parameter name.
+	 *
+	 * @return bool
+	 */
+	public static function validate_charge_id( $param_value, $request, $param_name ) {
+		return 1 === preg_match( '/^' . self::CHARGE_ID_PATTERN . '$/', $param_value );
+	}
+
+	/**
+	 * Sanitize a Unix timestamp parameter value.
+	 *
+	 * @param string $param_value The parameter value.
+	 * @param WP_REST_Request<array<string, mixed>> $request The incoming REST request.
+	 * @param string $param_name The parameter name.
+	 *
+	 * @return mixed
+	 */
+	public static function sanitize_unix_timestamp( $param_value, $request, $param_name ) {
+		if ( ! is_array( $param_value ) ) {
+			$sanitized_value = self::is_valid_timestamp( $param_value ) ? (int) $param_value : '';
+		} else {
+			$sanitized_value = [];
+
+			foreach ( $param_value as $operator => $operand ) {
+				if ( self::is_valid_timestamp( $operand ) ) {
+					$sanitized_value[ sanitize_key( $operator ) ] = (int) $operand;
+				} else {
+					$sanitized_value[ sanitize_key( $operator ) ] = '';
+				}
+			}
+		}
+
+		return $sanitized_value;
+	}
+
+	/**
+	 * Validate a Unix timestamp parameter value
+	 *
+	 * Validates that the parameter is either a Unix timestamp containing digits only,
+	 * or an array of Unix timestamps keyed by comparison operators (gt, gte, lt, lte).
+	 *
+	 * @param string $param_value The parameter value.
+	 * @param WP_REST_Request<array<string, mixed>> $request The incoming REST request.
+	 * @param string $param_name The parameter name.
+	 *
+	 * @return bool
+	 */
+	public static function validate_unix_timestamp( $param_value, $request, $param_name ) {
+		if ( self::is_valid_timestamp( $param_value ) ) {
+			return true;
+		}
+
+		if ( ! is_array( $param_value ) ) {
+			return false;
+		}
+
+		$allowed_operators = [ 'gt', 'gte', 'lt', 'lte' ];
+
+		foreach ( $param_value as $operator => $operand ) {
+			if ( ! in_array( $operator, $allowed_operators, true ) ) {
+				return false;
+			}
+
+			if ( ! self::is_valid_timestamp( $operand ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate a timestamp value.
+	 *
+	 * Validates that the value represents a non-negative integer, either as an int or as a non-empty string containing digits only.
+	 *
+	 * @param mixed $value The value.
+	 *
+	 * @return bool
+	 */
+	private static function is_valid_timestamp( $value ) {
+		if ( is_int( $value ) ) {
+			return $value >= 0;
+		}
+
+		if ( ! is_string( $value ) || '' === $value ) {
+			return false;
+		}
+
+		return ctype_digit( $value ) && ( (int) $value >= 0 );
+	}
+
+	/**
+	 * Validate that a parameter is a non-empty string.
+	 *
+	 * @param string $param_value The parameter value.
+	 * @param WP_REST_Request<array<string, mixed>> $request The incoming REST request.
+	 * @param string $param_name The parameter name.
+	 *
+	 * @return bool
+	 */
+	public static function validate_non_empty_string( $param_value, $request, $param_name ) {
+		return '' !== trim( $param_value );
+	}
+}

--- a/includes/admin/class-wc-stripe-rest-disputes-controller.php
+++ b/includes/admin/class-wc-stripe-rest-disputes-controller.php
@@ -256,6 +256,9 @@ class WC_Stripe_REST_Disputes_Controller extends WC_Stripe_REST_Base_Controller 
 	 * @return bool
 	 */
 	private static function validate_dispute_id( $param_value, $request, $param_name ) {
+		if ( ! is_string( $param_value ) ) {
+			return false;
+		}
 		return 1 === preg_match( '/^' . self::DISPUTE_ID_PATTERN . '$/', $param_value );
 	}
 
@@ -269,6 +272,9 @@ class WC_Stripe_REST_Disputes_Controller extends WC_Stripe_REST_Base_Controller 
 	 * @return bool
 	 */
 	public static function validate_payment_intent_id( $param_value, $request, $param_name ) {
+		if ( ! is_string( $param_value ) ) {
+			return false;
+		}
 		return 1 === preg_match( '/^' . self::PAYMENT_INTENT_ID_PATTERN . '$/', $param_value );
 	}
 
@@ -282,6 +288,9 @@ class WC_Stripe_REST_Disputes_Controller extends WC_Stripe_REST_Base_Controller 
 	 * @return bool
 	 */
 	public static function validate_charge_id( $param_value, $request, $param_name ) {
+		if ( ! is_string( $param_value ) ) {
+			return false;
+		}
 		return 1 === preg_match( '/^' . self::CHARGE_ID_PATTERN . '$/', $param_value );
 	}
 

--- a/includes/admin/class-wc-stripe-rest-disputes-controller.php
+++ b/includes/admin/class-wc-stripe-rest-disputes-controller.php
@@ -368,17 +368,4 @@ class WC_Stripe_REST_Disputes_Controller extends WC_Stripe_REST_Base_Controller 
 
 		return ctype_digit( $value ) && ( (int) $value >= 0 );
 	}
-
-	/**
-	 * Validate that a parameter is a non-empty string.
-	 *
-	 * @param string $param_value The parameter value.
-	 * @param WP_REST_Request<array<string, mixed>> $request The incoming REST request.
-	 * @param string $param_name The parameter name.
-	 *
-	 * @return bool
-	 */
-	public static function validate_non_empty_string( $param_value, $request, $param_name ) {
-		return '' !== trim( $param_value );
-	}
 }

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -970,6 +970,7 @@ class WC_Stripe {
 		$stripe_payment_intents_controller = new WC_Stripe_REST_Payment_Intents_Controller();
 		$stripe_payouts_controller         = new WC_Stripe_REST_Payouts_Controller();
 		$stripe_balance_controller         = new WC_Stripe_REST_Balance_Controller();
+		$stripe_disputes_controller        = new WC_Stripe_REST_Disputes_Controller();
 
 		$connection_tokens_controller->register_routes();
 		$locations_controller->register_routes();
@@ -979,6 +980,7 @@ class WC_Stripe {
 		$stripe_payment_intents_controller->register_routes();
 		$stripe_payouts_controller->register_routes();
 		$stripe_balance_controller->register_routes();
+		$stripe_disputes_controller->register_routes();
 
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-settings-controller.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-account-keys-controller.php';

--- a/tests/phpunit/admin/class-wc-stripe-rest-disputes-controller-test.php
+++ b/tests/phpunit/admin/class-wc-stripe-rest-disputes-controller-test.php
@@ -1,0 +1,427 @@
+<?php
+/**
+ * Class WC_Stripe_REST_Disputes_Controller_Test
+ */
+class WC_Stripe_REST_Disputes_Controller_Test extends WP_UnitTestCase {
+	private const SINGLE_DISPUTE_ENDPOINT_URL = '/wc/v3/wc_stripe/disputes/du_test_9876543210';
+	private const ALL_DISPUTES_ENDPOINT_URL   = '/wc/v3/wc_stripe/disputes';
+
+	/** Initialise REST API, make WC_Stripe_REST_Disputes_Controller instance available for testing*/
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		do_action( 'rest_api_init' );
+	}
+
+	public function teardown(): void {
+		remove_filter(
+			'pre_http_request',
+			[ static::class, 'pre_http_request_mock_handler' ],
+			10,
+			3
+		);
+	}
+
+	public static function pre_http_request_mock_handler( bool $preempt, array $request_args, $url ) {
+		if ( ! str_starts_with( $url, 'https://api.stripe.com/v1/disputes' ) ) {
+			return $preempt;
+		}
+
+		return [
+			'headers'  => [],
+			'body'     => wp_json_encode(
+				[
+					'data'     => [],
+					'has_more' => false,
+				]
+			),
+			'response' => [
+				'code'    => 200,
+				'message' => 'OK',
+			],
+		];
+	}
+	/** Mock stripe API calls to avoid making real HTTP requests. */
+	protected function stub_http_call() {
+		add_filter(
+			'pre_http_request',
+			[ static::class, 'pre_http_request_mock_handler' ],
+			10,
+			3
+		);
+	}
+	/**
+	 * Send a request to the REST server.
+	 *
+	 * If non-empty, adds the entries from $params to the request object.
+	 */
+	private function send_request( string $url, array $params = [] ) {
+		$request = new WP_REST_Request(
+			WP_REST_Server::READABLE,
+			$url
+		);
+
+		if ( $params ) {
+			foreach ( $params as $param_name => $param_value ) {
+				$request->set_param( $param_name, $param_value );
+			}
+		}
+
+		$response = rest_get_server()->dispatch( $request );
+
+		return $response;
+	}
+
+	/** Create a non-admin user, set it as current user and send an API request. */
+	public function test_permission_check_denies_unauthorized_call() {
+		$subscriber_id = $this->factory()->user->create( [ 'role' => 'subscriber' ] );
+
+		wp_set_current_user( $subscriber_id );
+
+		$response = $this->send_request( self::SINGLE_DISPUTE_ENDPOINT_URL );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	public function test_wrong_stripe_api_key() {
+		$admin_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+		$http_code_401_mock = function ( $pre, $parsed_args, $url ) {
+			return [
+				'headers'  => [],
+				'body'     => wp_json_encode(
+					[
+						'error' => [
+							'code'    => 'invalid_request_error',
+							'message' => 'Invalid API Key provided',
+						],
+					]
+				),
+				'response' => [
+					'code'    => 401,
+					'message' => 'OK',
+				],
+			];
+		};
+
+		add_filter(
+			'pre_http_request',
+			$http_code_401_mock,
+			10,
+			3
+		);
+
+		$response = $this->send_request( self::SINGLE_DISPUTE_ENDPOINT_URL );
+
+		remove_filter(
+			'pre_http_request',
+			$http_code_401_mock,
+			10,
+			3
+		);
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/** Create an admin user, set it as current user and send a API request. */
+	public function test_permission_check_allows_authorized_call() {
+		$this->stub_http_call();
+
+		$admin_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$response = $this->send_request( self::SINGLE_DISPUTE_ENDPOINT_URL );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	public static function provide_dispute_list_malformed_param(): array {
+		return [
+			[ 'limit', '' ],
+			[ 'limit', 'abc' ],
+			[ 'created', '' ],
+			[ 'created', -1779802569 ],
+			[ 'created', 'a1779802569' ],
+			[
+				'created',
+				[
+					0 => '1779802569',
+				],
+			],
+			[
+				'created',
+				[
+					'lt3' => '1779802569',
+				],
+			],
+			[
+				'created',
+				[
+					'lt'  => '1779802569',
+					'gt3' => '1779802569',
+				],
+			],
+			[ 'starting_after', 'xyz' ],
+			[ 'ending_before', 'xyz' ],
+			[ 'payment_intent', 'test' ],
+			[ 'charge', 'test' ],
+		];
+	}
+
+	/**
+	 * Create an admin user and send requests containing incorrect format args.
+	 *
+	 * @dataProvider provide_dispute_list_malformed_param
+	 *
+	 * @param string $param_name
+	 * @param mixed $param_value
+	*/
+	public function test_dispute_list_malformed_param( string $param_name, $param_value ) {
+		$admin_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$response = $this->send_request( self::ALL_DISPUTES_ENDPOINT_URL, [ $param_name => $param_value ] );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * Create an admin user and send requests containing both starting_after and ending_before args.
+	 *
+	 * @param string $param_name
+	 * @param mixed $param_value
+	*/
+	public function test_dispute_list_with_both_starting_after_and_ending_before() {
+		$admin_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$response = $this->send_request(
+			self::ALL_DISPUTES_ENDPOINT_URL,
+			[
+				'starting_after' => 'du_test',
+				'ending_before'  => 'du_test2',
+			]
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	public static function provide_dispute_list_params(): array {
+		return [
+			'created_zero_timestamp'                      => [
+				[ 'created' => 0 ],
+			],
+			'created_and_starting_after'                  => [
+				[
+					'created'        => '1779802569',
+					'starting_after' => 'du_3TbL9RJlUF0dQbSB00q0FJS2',
+				],
+			],
+			'created_with_lt_and_ending_before'           => [
+				[
+					'created'       =>
+						[
+							'lt' => '1779802569',
+						],
+					'ending_before' => 'du_3TbL9RJlUF0dQbSB00q0FJS2',
+				],
+			],
+			'limit_and_created_with_lt_and_ending_before' => [
+				[
+					'limit'         => 100,
+					'created'       =>
+						[
+							'lt' => '1779802569',
+						],
+					'ending_before' => 'du_3TbL9RJlUF0dQbSB00q0FJS2',
+				],
+			],
+			'created_with_lt_gt'                          => [
+				[
+					'created' =>
+						[
+							'lt' => '1779802821',
+							'gt' => '1779802569',
+						],
+				],
+			],
+			'created_with_lte_gte'                        => [
+				[
+					'created' =>
+						[
+							'lte' => '1779802821',
+							'gte' => '1779802569',
+						],
+				],
+			],
+			'created_with_lte_gte_zero'                   => [
+				[
+					'created' =>
+						[
+							'lte' => '1779802821',
+							'gte' => '0',
+						],
+				],
+			],
+			'created_with_lte_zero_gte_zero'              => [
+				[
+					'created' =>
+						[
+							'lte' => '0',
+							'gte' => '0',
+						],
+				],
+			],
+			'payment_intent'                              => [
+				[
+					'payment_intent' => 'pi_test',
+				],
+			],
+			'charge'                                      => [
+				[
+					'charge' => 'ch_test',
+				],
+			],
+		];
+	}
+
+	/**
+	 * Send requests containing valid parameters and check they are forwarded correctly to the Stripe API
+	 * using a 'pre_http_request' hook.
+	 *
+	 * @dataProvider provide_dispute_list_params
+	*/
+	public function test_pass_dispute_list_params( array $rest_params ) {
+		$controller = new WC_Stripe_REST_Disputes_Controller();
+
+		$request = new WP_REST_Request(
+			WP_REST_Server::READABLE,
+			self::ALL_DISPUTES_ENDPOINT_URL,
+		);
+
+		foreach ( $rest_params as $rest_param_name => $rest_param_value ) {
+			$request->set_param( $rest_param_name, $rest_param_value );
+		}
+
+		$passed_rest_params = $request->get_params();
+
+		$pre_http_request_params = [];
+
+		$this->stub_http_call();
+		$http_stub = function ( $pre, $parsed_args, $url ) use ( &$pre_http_request_params ) {
+				$url_components = parse_url( $url );
+
+				parse_str( $url_components['query'], $pre_http_request_params['search_params'] );
+
+				return $pre;
+		};
+		add_filter(
+			'pre_http_request',
+			$http_stub,
+			10,
+			3
+		);
+
+		$admin_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		try {
+			rest_get_server()->dispatch( $request );
+		} finally {
+			remove_filter( 'pre_http_request', $http_stub, 10, 3 );
+		}
+
+		$this->assertEquals( $rest_params, $passed_rest_params );
+		$this->assertEquals(
+			$rest_params,
+			array_intersect_key( $pre_http_request_params['search_params'], $rest_params )
+		);
+		$test = array_diff_key( $pre_http_request_params['search_params'], $rest_params );
+
+		if ( array_key_exists( 'limit', $rest_params ) ) {
+			$this->assertEmpty( array_diff_key( $pre_http_request_params['search_params'], $rest_params ) );
+		} else {
+			// We default the `limit` argument when not supplied by the caller.
+			$this->assertEquals(
+				[ 'limit' => 10 ],
+				array_diff_key( $pre_http_request_params['search_params'], $rest_params )
+			);
+		}
+	}
+
+	public static function provide_single_dispute_filtering_test_data(): array {
+		$response_allowed_part = '
+			"object": "dispute",
+			"id": "du_test",
+			"created": 1783384650,
+			"amount": 4422,
+			"currency": "ron",
+			"status": "paid"
+		';
+		$response_as_string    = '{
+			' . $response_allowed_part . ',
+			"failure_balance_transaction": null,
+			"failure_code": null,
+			"failure_message": null,
+			"livemode": false,
+			"metadata": {},
+			"method": "standard",
+			"original_payout": null,
+			"payout_method": null,
+			"reconciliation_status": "not_applicable",
+			"reversed_by": null,
+			"source_type": "card",
+			"statement_descriptor": null,
+
+			"trace_id": {
+				"status": "supported",
+				"value": "test"
+			},
+			"type": "bank_account"
+		}';
+		return [
+			[
+				$response_as_string,
+				'{' . $response_allowed_part . '}',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider provide_single_dispute_filtering_test_data
+	*/
+	public function test_single_dispute_response_filtering( string $response_as_string, string $response_allowed_part ) {
+		$admin_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$http_code_401_mock = function ( $pre, $parsed_args, $url ) use ( $response_as_string ) {
+			return [
+				'headers'  => [],
+				'body'     => $response_as_string,
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+			];
+		};
+
+		add_filter(
+			'pre_http_request',
+			$http_code_401_mock,
+			10,
+			3
+		);
+
+		$response               = $this->send_request( self::SINGLE_DISPUTE_ENDPOINT_URL );
+		$expected_response_data = json_decode( $response_allowed_part );
+
+		remove_filter(
+			'pre_http_request',
+			$http_code_401_mock,
+			10,
+			3
+		);
+
+		$this->assertEquals( $expected_response_data, $response->data );
+	}
+}


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:


Adds a simple  admin REST endpoint for retrieving a Stripe API disputes listing and an endpoint for retrieving one dispute details.

The responses received from Stripe API are returned after being filtered against a whitelist.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Navigate to wp-admin while logged in as a user with admin permissions.
2. Open your browser console
3. Run the following snippet to call the API:
```
const response = await wp.apiFetch( { path: '/wc/v3/wc_stripe/disputes' } );
response;
```
The response should look something like this:
```
{
    "object": "list",
    "has_more": false,
    "data": [
        {
            "id": "du_1TtPY7ABBA0dQbSBIBMx5Rmj",
            "created": 1784109379,
            "amount": 7900,
            "currency": "usd",
            "status": "lost",
            "payment_intent": "pi_3TtPYABBAACDCbSB0Jb3hqkX",
            "reason": "fraudulent",
            "evidence_details": {
                "due_by": 1784851199
            }
        }
    ]
}
```

4. The endpoint supports the following parameters:

- limit
- starting_after
- ending_before
- created 
- payment_intent
- charge

They are documented here: 
https://docs.stripe.com/api/disputes/list?api-version=2026-06-24.preview&rds=1

5. To test the dispute details endpoint send the request to:

[WordPress instance URL]/wp-json/wc/v3/wc_stripe/disputes/[dispute_id].

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Message
Add a Stripe REST proxy endpoint for querying payout endpoints of Stripe API.
<!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
