### PR TITLE
Update the wordpress docker image tag for e2e updates

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -55,7 +55,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: E2E-${{ matrix.project }}-WP-${{ inputs.wp-version }}-WC-${{ inputs.wc-version }}-PHP-${{ inputs.php-version }})-setup-logs
+          name: E2E-${{ matrix.project }}-WP-${{ inputs.wp-version }}-WC-${{ inputs.wc-version }}-PHP-${{ inputs.php-version }}-setup-logs
           path: tests/e2e/e2e-setup.log
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -51,6 +51,15 @@ jobs:
           STRIPE_SECRET_KEY: ${{ matrix.project == 'blik' && secrets.E2E_STRIPE_SECRET_KEY_PL || matrix.project == 'becs' && secrets.E2E_STRIPE_SECRET_KEY_AU || secrets.E2E_STRIPE_SECRET_KEY }}
         run: npm run test:e2e-setup
 
+      - name: Upload e2e setup logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: E2E-${{ matrix.project }}-WP-${{ inputs.wp-version }}-WC-${{ inputs.wc-version }}-PHP-${{ inputs.php-version }})-setup-logs
+          path: tests/e2e/e2e-setup.log
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Run E2E tests
         env:
           STRIPE_PUB_KEY: ${{ matrix.project == 'blik' && secrets.E2E_STRIPE_PUBLISHABLE_KEY_PL || matrix.project == 'becs' && secrets.E2E_STRIPE_PUBLISHABLE_KEY_AU || secrets.E2E_STRIPE_PUBLISHABLE_KEY }}

--- a/tests/e2e/env/Dockerfile
+++ b/tests/e2e/env/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:php7.4
+FROM wordpress:php8.2
 RUN apt-get update \
 	&& apt-get install --assume-yes --quiet --no-install-recommends gnupg2 subversion mariadb-client less jq
 RUN apt-get install -y openssh-client


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR makes two changes related to e2e tests:
 * The Dockerfile now references `wordpress:php8.2` for installing some baseline packages via `apt-update`
 * The e2e test runner workflow in `.github/workflows/run-e2e-tests.yml` now uploads the `e2e-setup.log` log file when the e2e test setup fails, which is something we were already doing in `.github/workflows/e2e-tests.yml`

The main driver for these changes is due to Debian Bullseye reaching EOL, so the underlying `wordpress:php7.4` image is no longer working cleanly. Given that we're setting up PHP separately anyway, and we're only using that image for other packages, this should mostly be fine given that we're getting current versions of `gnupg2`, `subversion`, `mariadb-client`, `less`, and `openssh-client`, and our usage of those packages is indirect.

Also, the `php8.2` image is still getting active updates: https://hub.docker.com/layers/library/wordpress/php8.2

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
* Verify that the e2e tests for this branch complete successfully -- they use PHP 7.4
* Verify that the manual e2e test workflow completes successfully when run against this branch - https://github.com/woocommerce/woocommerce-gateway-stripe/actions/runs/34119556649

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [N/A] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This PR only impacts development workflows, and not any merchant-facing features.
</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
