### PR TITLE
Improve Express Checkout required custom fields error logging

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -45,6 +45,7 @@ xxxx-xx-xx - version 11.0.0
 * Tweak - Disable the Agentic Commerce "Sync now" button until onboarding is complete, with a note explaining the remaining step
 * Fix - Attach a Stripe customer to guest Adaptive Pricing checkouts, linking it to the order and any account created at checkout
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
+* Add - Log an error when missing required custom fields block express checkout
 
 2026-08-31 - version 10.9.1
 * Fix - Allow express checkout payments when automatic account password generation is disabled

--- a/changelog.txt
+++ b/changelog.txt
@@ -45,7 +45,7 @@ xxxx-xx-xx - version 11.0.0
 * Tweak - Disable the Agentic Commerce "Sync now" button until onboarding is complete, with a note explaining the remaining step
 * Fix - Attach a Stripe customer to guest Adaptive Pricing checkouts, linking it to the order and any account created at checkout
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
-* Add - Log an error when missing required custom fields block express checkout
+* Add - Log an error when missing required custom fields block express checkout, with a filter to disable the log
 
 2026-08-31 - version 10.9.1
 * Fix - Allow express checkout payments when automatic account password generation is disabled

--- a/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
@@ -94,7 +94,15 @@ class WC_Stripe_Express_Checkout_Custom_Fields {
 				$required_field_errors[] = __( 'Please go to the checkout page, fill in the required fields, and complete your order from there.', 'woocommerce-gateway-stripe' );
 			}
 			$error_messages = implode( "\n", $required_field_errors );
-			WC_Stripe_Logger::error( 'Missing required custom fields in express checkout.', [ 'error_message' => $error_messages ] );
+			/**
+			 * Whether to log missing required custom fields during express checkout.
+			 *
+			 * @since 11.0.0
+			 * @param bool $should_log Return false to disable this error log. Default true.
+			 */
+			if ( false !== apply_filters( 'wc_stripe_express_checkout_log_missing_required_fields', true ) ) {
+				WC_Stripe_Logger::error( 'Missing required custom fields in express checkout.', [ 'error_message' => $error_messages ] );
+			}
 			throw new RouteException( 'wc_stripe_express_checkout_missing_required_fields', $error_messages, 400 );
 		}
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
@@ -102,7 +102,7 @@ class WC_Stripe_Express_Checkout_Custom_Fields {
 			 * @since 11.0.0
 			 * @param bool $should_log Return false to disable this error log. Default true.
 			 */
-			if ( false !== apply_filters( 'wc_stripe_express_checkout_log_missing_required_fields', true ) ) {
+			if ( apply_filters( 'wc_stripe_express_checkout_log_missing_required_fields', true ) ) {
 				WC_Stripe_Logger::error(
 					'Missing required custom fields in express checkout.',
 					[

--- a/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
@@ -106,8 +106,8 @@ class WC_Stripe_Express_Checkout_Custom_Fields {
 				WC_Stripe_Logger::error(
 					'Missing required custom fields in express checkout.',
 					[
-						'error_message'      => $error_messages,
 						'missing_field_keys' => $missing_field_keys,
+						'error_message'      => $error_messages,
 					]
 				);
 			}

--- a/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
@@ -94,6 +94,7 @@ class WC_Stripe_Express_Checkout_Custom_Fields {
 				$required_field_errors[] = __( 'Please go to the checkout page, fill in the required fields, and complete your order from there.', 'woocommerce-gateway-stripe' );
 			}
 			$error_messages = implode( "\n", $required_field_errors );
+			WC_Stripe_Logger::error( 'Missing required custom fields in express checkout.', [ 'error_message' => $error_messages ] );
 			throw new RouteException( 'wc_stripe_express_checkout_missing_required_fields', $error_messages, 400 );
 		}
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
@@ -75,9 +75,11 @@ class WC_Stripe_Express_Checkout_Custom_Fields {
 
 		// Enforce required fields.
 		$required_field_errors  = [];
+		$missing_field_keys     = [];
 		$custom_checkout_fields = $this->get_custom_checkout_fields( 'classic' );
 		foreach ( $custom_checkout_fields as $key => $field ) {
 			if ( $field['required'] && empty( $custom_checkout_data[ $key ] ) ) {
+				$missing_field_keys[]    = $key;
 				$required_field_errors[] = sprintf(
 					/* translators: %s: field name */
 					__( '%s is a required field.', 'woocommerce-gateway-stripe' ),
@@ -101,7 +103,13 @@ class WC_Stripe_Express_Checkout_Custom_Fields {
 			 * @param bool $should_log Return false to disable this error log. Default true.
 			 */
 			if ( false !== apply_filters( 'wc_stripe_express_checkout_log_missing_required_fields', true ) ) {
-				WC_Stripe_Logger::error( 'Missing required custom fields in express checkout.', [ 'error_message' => wp_strip_all_tags( $error_messages ) ] );
+				WC_Stripe_Logger::error(
+					'Missing required custom fields in express checkout.',
+					[
+						'error_message'      => $error_messages,
+						'missing_field_keys' => $missing_field_keys,
+					]
+				);
 			}
 			throw new RouteException( 'wc_stripe_express_checkout_missing_required_fields', $error_messages, 400 );
 		}

--- a/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
@@ -101,7 +101,7 @@ class WC_Stripe_Express_Checkout_Custom_Fields {
 			 * @param bool $should_log Return false to disable this error log. Default true.
 			 */
 			if ( false !== apply_filters( 'wc_stripe_express_checkout_log_missing_required_fields', true ) ) {
-				WC_Stripe_Logger::error( 'Missing required custom fields in express checkout.', [ 'error_message' => $error_messages ] );
+				WC_Stripe_Logger::error( 'Missing required custom fields in express checkout.', [ 'error_message' => wp_strip_all_tags( $error_messages ) ] );
 			}
 			throw new RouteException( 'wc_stripe_express_checkout_missing_required_fields', $error_messages, 400 );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -208,6 +208,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Disable the Agentic Commerce "Sync now" button until onboarding is complete, with a note explaining the remaining step
 * Fix - Attach a Stripe customer to guest Adaptive Pricing checkouts, linking it to the order and any account created at checkout
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
-* Add - Log an error when missing required custom fields block express checkout
+* Add - Log an error when missing required custom fields block express checkout, with a filter to disable the log
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,7 @@ Stripe is available for store owners and merchants in [46 countries worldwide](h
 The following items note specific versions that include important changes, features, or deprecations.
 
 * 11.0.0
+   - Missing required custom fields in express checkout are logged at ERROR level even when Stripe debug logging is disabled
    - Express checkout merges the wc_stripe_express_checkout_normalize_address filter result over the address it sent; removing a field no longer clears it, return an empty string instead
 * 10.9.1
    - Some express checkout helpers now require the caller to specify whether they are in the WooCommerce Cart context
@@ -208,5 +209,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Disable the Agentic Commerce "Sync now" button until onboarding is complete, with a note explaining the remaining step
 * Fix - Attach a Stripe customer to guest Adaptive Pricing checkouts, linking it to the order and any account created at checkout
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
+* Add - Log an error when missing required custom fields block express checkout
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -36,7 +36,6 @@ Stripe is available for store owners and merchants in [46 countries worldwide](h
 The following items note specific versions that include important changes, features, or deprecations.
 
 * 11.0.0
-   - Missing required custom fields in express checkout are logged at ERROR level even when Stripe debug logging is disabled
    - Express checkout merges the wc_stripe_express_checkout_normalize_address filter result over the address it sent; removing a field no longer clears it, return an empty string instead
 * 10.9.1
    - Some express checkout helpers now require the caller to specify whether they are in the WooCommerce Cart context

--- a/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-custom-fields-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-custom-fields-test.php
@@ -349,14 +349,12 @@ class WC_Stripe_Express_Checkout_Custom_Fields_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Provides missing-required-field scenarios: whether the request carries the
-	 * custom-data payload, and whether the error should direct the buyer to the
-	 * checkout page.
+	 * Missing-field payloads and logging opt-out scenarios.
 	 *
 	 * @return array[]
 	 */
 	public function provide_missing_required_field_scenarios() {
-		return [
+		$payload_scenarios = [
 			'payload present (checkout page flow)' => [
 				[
 					'wc-stripe/express-checkout' => [
@@ -370,18 +368,27 @@ class WC_Stripe_Express_Checkout_Custom_Fields_Test extends WP_UnitTestCase {
 				true,
 			],
 		];
+		$scenarios         = [];
+		foreach ( $payload_scenarios as $name => $args ) {
+			$scenarios[ $name . ', default logging' ]       = array_merge( $args, [ null, true ] );
+			$scenarios[ $name . ', logging disabled' ]      = array_merge( $args, [ '__return_false', false ] );
+			$scenarios[ $name . ', invalid filter return' ] = array_merge( $args, [ '__return_null', true ] );
+		}
+		return $scenarios;
 	}
 
 	/**
-	 * Missing required fields are logged with debug logging disabled and still throw.
+	 * Missing required fields still throw when logging is disabled by a filter.
 	 * Requests without a classic form payload also receive checkout-page guidance.
 	 *
 	 * @dataProvider provide_missing_required_field_scenarios
 	 * @param array $extensions Extensions param to set on the request.
 	 * @param bool  $expects_checkout_page_guidance Whether the error should include the go-to-checkout recommendation.
+	 * @param string|null $logging_filter Callback overriding the logging decision, or null for the default.
+	 * @param bool $expects_logging Whether an error should be logged.
 	 * @return void
 	 */
-	public function test_process_custom_checkout_data_missing_data( $extensions, $expects_checkout_page_guidance ) {
+	public function test_process_custom_checkout_data_missing_data( $extensions, $expects_checkout_page_guidance, $logging_filter, $expects_logging ) {
 		$custom_checkout_fields = function ( $fields ) {
 			$fields['billing']['billing_custom_field1']  = [
 				'type'     => 'text',
@@ -409,9 +416,13 @@ class WC_Stripe_Express_Checkout_Custom_Fields_Test extends WP_UnitTestCase {
 		$original_settings = WC_Stripe_Helper::get_stripe_settings();
 		WC_Stripe_Helper::update_main_stripe_settings( array_merge( $original_settings, [ 'logging' => 'no' ] ) );
 
+		if ( null !== $logging_filter ) {
+			add_filter( 'wc_stripe_express_checkout_log_missing_required_fields', $logging_filter );
+		}
+
 		$logged_error_message = null;
 		$logger               = $this->createMock( WC_Logger::class );
-		$logger->expects( $this->once() )
+		$logger->expects( $expects_logging ? $this->once() : $this->never() )
 			->method( 'error' )
 			->with(
 				'Missing required custom fields in express checkout.',
@@ -429,7 +440,9 @@ class WC_Stripe_Express_Checkout_Custom_Fields_Test extends WP_UnitTestCase {
 			$this->fail( 'Expected RouteException for a missing required field.' );
 		} catch ( RouteException $e ) {
 			$message = $e->getMessage();
-			$this->assertSame( $message, $logged_error_message );
+			$this->assertSame( 'wc_stripe_express_checkout_missing_required_fields', $e->getErrorCode() );
+			$this->assertSame( 400, $e->getCode() );
+			$this->assertSame( $expects_logging ? $message : null, $logged_error_message );
 			$this->assertStringContainsString( 'Billing Custom Field 1 is a required field.', $message );
 			$this->assertStringContainsString( 'Shipping Custom Field is a required field.', $message );
 			if ( $expects_checkout_page_guidance ) {
@@ -438,6 +451,9 @@ class WC_Stripe_Express_Checkout_Custom_Fields_Test extends WP_UnitTestCase {
 				$this->assertStringNotContainsString( 'go to the checkout page', $message );
 			}
 		} finally {
+			if ( null !== $logging_filter ) {
+				remove_filter( 'wc_stripe_express_checkout_log_missing_required_fields', $logging_filter );
+			}
 			WC_Stripe_Logger::$logger = $original_logger;
 			WC_Stripe_Helper::update_main_stripe_settings( $original_settings );
 			remove_filter( 'woocommerce_checkout_fields', $custom_checkout_fields );

--- a/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-custom-fields-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-custom-fields-test.php
@@ -363,6 +363,14 @@ class WC_Stripe_Express_Checkout_Custom_Fields_Test extends WP_UnitTestCase {
 				],
 				false,
 			],
+			'payload with an optional field value' => [
+				[
+					'wc-stripe/express-checkout' => [
+						'custom_checkout_data' => '{"order_custom_field":"private-value"}',
+					],
+				],
+				false,
+			],
 			'payload absent (product/cart flow)'   => [
 				[],
 				true,
@@ -400,6 +408,11 @@ class WC_Stripe_Express_Checkout_Custom_Fields_Test extends WP_UnitTestCase {
 				'label'    => 'Shipping Custom Field',
 				'required' => true,
 			];
+			$fields['order']['order_custom_field']       = [
+				'type'     => 'text',
+				'label'    => 'Optional custom field',
+				'required' => false,
+			];
 			return $fields;
 		};
 		add_filter( 'woocommerce_checkout_fields', $custom_checkout_fields );
@@ -420,15 +433,15 @@ class WC_Stripe_Express_Checkout_Custom_Fields_Test extends WP_UnitTestCase {
 			add_filter( 'wc_stripe_express_checkout_log_missing_required_fields', $logging_filter );
 		}
 
-		$logged_error_message = null;
-		$logger               = $this->createMock( WC_Logger::class );
+		$logged_context = null;
+		$logger         = $this->createMock( WC_Logger::class );
 		$logger->expects( $expects_logging ? $this->once() : $this->never() )
 			->method( 'error' )
 			->with(
 				'Missing required custom fields in express checkout.',
 				$this->callback(
-					static function ( $context ) use ( &$logged_error_message ) {
-						$logged_error_message = $context['error_message'] ?? null;
+					static function ( $context ) use ( &$logged_context ) {
+						$logged_context = $context;
 						return WC_Stripe_Logger::WC_LOG_FILENAME === $context['source'];
 					}
 				)
@@ -442,7 +455,12 @@ class WC_Stripe_Express_Checkout_Custom_Fields_Test extends WP_UnitTestCase {
 			$message = $e->getMessage();
 			$this->assertSame( 'wc_stripe_express_checkout_missing_required_fields', $e->getErrorCode() );
 			$this->assertSame( 400, $e->getCode() );
-			$this->assertSame( $expects_logging ? wp_strip_all_tags( $message ) : null, $logged_error_message );
+			$this->assertSame( $expects_logging ? $message : null, $logged_context['error_message'] ?? null );
+			$this->assertSame(
+				$expects_logging ? [ 'billing_custom_field1', 'shipping_custom_field' ] : null,
+				$logged_context['missing_field_keys'] ?? null
+			);
+			$this->assertStringNotContainsString( 'private-value', wp_json_encode( $logged_context ) );
 			$this->assertStringContainsString( 'Billing Custom Field 1 is a required field.', $message );
 			$this->assertStringContainsString( 'Shipping Custom Field is a required field.', $message );
 			if ( $expects_checkout_page_guidance ) {

--- a/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-custom-fields-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-custom-fields-test.php
@@ -442,7 +442,7 @@ class WC_Stripe_Express_Checkout_Custom_Fields_Test extends WP_UnitTestCase {
 			$message = $e->getMessage();
 			$this->assertSame( 'wc_stripe_express_checkout_missing_required_fields', $e->getErrorCode() );
 			$this->assertSame( 400, $e->getCode() );
-			$this->assertSame( $expects_logging ? $message : null, $logged_error_message );
+			$this->assertSame( $expects_logging ? wp_strip_all_tags( $message ) : null, $logged_error_message );
 			$this->assertStringContainsString( 'Billing Custom Field 1 is a required field.', $message );
 			$this->assertStringContainsString( 'Shipping Custom Field is a required field.', $message );
 			if ( $expects_checkout_page_guidance ) {

--- a/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-custom-fields-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-custom-fields-test.php
@@ -373,9 +373,8 @@ class WC_Stripe_Express_Checkout_Custom_Fields_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A missing required field throws; when the request carries no custom-data
-	 * payload (the flow started on a page without the classic checkout form),
-	 * the error also directs the buyer to the checkout page.
+	 * Missing required fields are logged with debug logging disabled and still throw.
+	 * Requests without a classic form payload also receive checkout-page guidance.
 	 *
 	 * @dataProvider provide_missing_required_field_scenarios
 	 * @param array $extensions Extensions param to set on the request.
@@ -384,9 +383,14 @@ class WC_Stripe_Express_Checkout_Custom_Fields_Test extends WP_UnitTestCase {
 	 */
 	public function test_process_custom_checkout_data_missing_data( $extensions, $expects_checkout_page_guidance ) {
 		$custom_checkout_fields = function ( $fields ) {
-			$fields['billing']['billing_custom_field1'] = [
+			$fields['billing']['billing_custom_field1']  = [
 				'type'     => 'text',
 				'label'    => 'Billing Custom Field 1',
+				'required' => true,
+			];
+			$fields['shipping']['shipping_custom_field'] = [
+				'type'     => 'text',
+				'label'    => 'Shipping Custom Field',
 				'required' => true,
 			];
 			return $fields;
@@ -401,23 +405,45 @@ class WC_Stripe_Express_Checkout_Custom_Fields_Test extends WP_UnitTestCase {
 		$order                 = WC_Helper_Order::create_order();
 		$custom_fields_support = $this->get_custom_fields_support();
 
+		$original_logger   = WC_Stripe_Logger::$logger;
+		$original_settings = WC_Stripe_Helper::get_stripe_settings();
+		WC_Stripe_Helper::update_main_stripe_settings( array_merge( $original_settings, [ 'logging' => 'no' ] ) );
+
+		$logged_error_message = null;
+		$logger               = $this->createMock( WC_Logger::class );
+		$logger->expects( $this->once() )
+			->method( 'error' )
+			->with(
+				'Missing required custom fields in express checkout.',
+				$this->callback(
+					static function ( $context ) use ( &$logged_error_message ) {
+						$logged_error_message = $context['error_message'] ?? null;
+						return WC_Stripe_Logger::WC_LOG_FILENAME === $context['source'];
+					}
+				)
+			);
+		WC_Stripe_Logger::$logger = $logger;
+
 		try {
 			$custom_fields_support->process_custom_checkout_data( $order, $request );
 			$this->fail( 'Expected RouteException for a missing required field.' );
 		} catch ( RouteException $e ) {
 			$message = $e->getMessage();
+			$this->assertSame( $message, $logged_error_message );
 			$this->assertStringContainsString( 'Billing Custom Field 1 is a required field.', $message );
+			$this->assertStringContainsString( 'Shipping Custom Field is a required field.', $message );
 			if ( $expects_checkout_page_guidance ) {
 				$this->assertStringContainsString( 'go to the checkout page', $message );
 			} else {
 				$this->assertStringNotContainsString( 'go to the checkout page', $message );
 			}
+		} finally {
+			WC_Stripe_Logger::$logger = $original_logger;
+			WC_Stripe_Helper::update_main_stripe_settings( $original_settings );
+			remove_filter( 'woocommerce_checkout_fields', $custom_checkout_fields );
+			WC()->checkout()->checkout_fields = null;
+			WC()->checkout()->get_checkout_fields();
 		}
-
-		// Remove filters and reset checkout fields.
-		remove_filter( 'woocommerce_checkout_fields', $custom_checkout_fields );
-		WC()->checkout()->checkout_fields = null;
-		WC()->checkout()->get_checkout_fields();
 	}
 
 	/**

--- a/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-custom-fields-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-express-checkout-custom-fields-test.php
@@ -354,33 +354,46 @@ class WC_Stripe_Express_Checkout_Custom_Fields_Test extends WP_UnitTestCase {
 	 * @return array[]
 	 */
 	public function provide_missing_required_field_scenarios() {
-		$payload_scenarios = [
-			'payload present (checkout page flow)' => [
+		$both_fields_missing = [ 'billing_custom_field1', 'shipping_custom_field' ];
+		$payload_scenarios   = [
+			'payload present (checkout page flow)'  => [
 				[
 					'wc-stripe/express-checkout' => [
 						'custom_checkout_data' => '{}',
 					],
 				],
 				false,
+				$both_fields_missing,
 			],
-			'payload with an optional field value' => [
+			'payload with an optional field value'  => [
 				[
 					'wc-stripe/express-checkout' => [
 						'custom_checkout_data' => '{"order_custom_field":"private-value"}',
 					],
 				],
 				false,
+				$both_fields_missing,
 			],
-			'payload absent (product/cart flow)'   => [
+			'payload with one required field value' => [
+				[
+					'wc-stripe/express-checkout' => [
+						'custom_checkout_data' => '{"billing_custom_field1":"private-value"}',
+					],
+				],
+				false,
+				[ 'shipping_custom_field' ],
+			],
+			'payload absent (product/cart flow)'    => [
 				[],
 				true,
+				$both_fields_missing,
 			],
 		];
-		$scenarios         = [];
+		$scenarios           = [];
 		foreach ( $payload_scenarios as $name => $args ) {
-			$scenarios[ $name . ', default logging' ]       = array_merge( $args, [ null, true ] );
-			$scenarios[ $name . ', logging disabled' ]      = array_merge( $args, [ '__return_false', false ] );
-			$scenarios[ $name . ', invalid filter return' ] = array_merge( $args, [ '__return_null', true ] );
+			$scenarios[ $name . ', default logging' ]     = array_merge( $args, [ null, true ] );
+			$scenarios[ $name . ', logging disabled' ]    = array_merge( $args, [ '__return_false', false ] );
+			$scenarios[ $name . ', falsy filter return' ] = array_merge( $args, [ '__return_null', false ] );
 		}
 		return $scenarios;
 	}
@@ -392,11 +405,12 @@ class WC_Stripe_Express_Checkout_Custom_Fields_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_missing_required_field_scenarios
 	 * @param array $extensions Extensions param to set on the request.
 	 * @param bool  $expects_checkout_page_guidance Whether the error should include the go-to-checkout recommendation.
+	 * @param array $expected_missing_field_keys Keys of the required fields left empty by the payload.
 	 * @param string|null $logging_filter Callback overriding the logging decision, or null for the default.
 	 * @param bool $expects_logging Whether an error should be logged.
 	 * @return void
 	 */
-	public function test_process_custom_checkout_data_missing_data( $extensions, $expects_checkout_page_guidance, $logging_filter, $expects_logging ) {
+	public function test_process_custom_checkout_data_missing_data( $extensions, $expects_checkout_page_guidance, $expected_missing_field_keys, $logging_filter, $expects_logging ) {
 		$custom_checkout_fields = function ( $fields ) {
 			$fields['billing']['billing_custom_field1']  = [
 				'type'     => 'text',
@@ -457,12 +471,24 @@ class WC_Stripe_Express_Checkout_Custom_Fields_Test extends WP_UnitTestCase {
 			$this->assertSame( 400, $e->getCode() );
 			$this->assertSame( $expects_logging ? $message : null, $logged_context['error_message'] ?? null );
 			$this->assertSame(
-				$expects_logging ? [ 'billing_custom_field1', 'shipping_custom_field' ] : null,
+				$expects_logging ? $expected_missing_field_keys : null,
 				$logged_context['missing_field_keys'] ?? null
 			);
 			$this->assertStringNotContainsString( 'private-value', wp_json_encode( $logged_context ) );
-			$this->assertStringContainsString( 'Billing Custom Field 1 is a required field.', $message );
-			$this->assertStringContainsString( 'Shipping Custom Field is a required field.', $message );
+
+			// Fields the payload filled in must not be reported as missing.
+			$required_field_labels = [
+				'billing_custom_field1' => 'Billing Custom Field 1',
+				'shipping_custom_field' => 'Shipping Custom Field',
+			];
+			foreach ( $required_field_labels as $key => $label ) {
+				$field_error = $label . ' is a required field.';
+				if ( in_array( $key, $expected_missing_field_keys, true ) ) {
+					$this->assertStringContainsString( $field_error, $message );
+				} else {
+					$this->assertStringNotContainsString( $field_error, $message );
+				}
+			}
 			if ( $expects_checkout_page_guidance ) {
 				$this->assertStringContainsString( 'go to the checkout page', $message );
 			} else {


### PR DESCRIPTION
Towards STRIPE-1434

## Changes proposed in this Pull Request:

This PR adds an ERROR log entry when missing required custom fields reject an express checkout request.
The entry includes the full validation messages and is recorded even when Stripe debug logging is disabled (error type), but does not log any submitted field values.

It also adds a new filter `wc_stripe_express_checkout_log_missing_required_fields` so merchants can disable this extra logging: `add_filter( 'wc_stripe_express_checkout_log_missing_required_fields', '__return_false' );`

## Testing instructions

1. Add this temporary snippet using a snippets plugin:
    ```php
    add_filter( 'woocommerce_checkout_fields', function ( $fields ) {
        $fields['billing']['billing_custom_reference'] = [
            'type'     => 'text',
            'label'    => 'Custom reference',
            'required' => true,
        ];

        return $fields;
    } );
    ```
2. Add a product to the cart, open classic checkout, and leave Custom reference empty.
3. Attempt payment using Apple Pay/Google Pay.
4. Confirm the existing required-field error appears. 
    In the browser’s Network panel, the Store API checkout request should return HTTP 400 with code `wc_stripe_express_checkout_missing_required_fields`
5. Open `WooCommerce → Status → Logs` and find the latest `woocommerce-gateway-stripe` log.
6. Confirm a new new ERROR log entry is present:
    <img width="1403" height="306" alt="Screenshot 2026-09-07 at 12 12 46" src="https://github.com/user-attachments/assets/c549bd0f-9e7a-463d-9e4b-602fd86e29df" />


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
