### PR TITLE
Fix retry with a saved payment method after a declined AP payment attempt on Classic Checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -45,7 +45,7 @@ xxxx-xx-xx - version 11.0.0
 * Tweak - Disable the Agentic Commerce "Sync now" button until onboarding is complete, with a note explaining the remaining step
 * Fix - Attach a Stripe customer to guest Adaptive Pricing checkouts, linking it to the order and any account created at checkout
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
-* Fix - Charge the saved card when a shopper retries after a declined Adaptive Pricing payment on classic checkout, instead of placing the order without taking payment
+* Fix - Ensure retry with a saved payment method works after a declined Adaptive Pricing payment attempt on classic checkout
 
 2026-08-31 - version 10.9.1
 * Fix - Allow express checkout payments when automatic account password generation is disabled

--- a/changelog.txt
+++ b/changelog.txt
@@ -51,7 +51,6 @@ xxxx-xx-xx - version 11.1.0
 * Fix - Only sync the Agentic Commerce catalog, inventory, and archive feeds to Stripe after onboarding is complete (the feature is enabled and the webhook secret is saved)
 * Tweak - Disable the Agentic Commerce "Sync now" button until onboarding is complete, with a note explaining the remaining step
 * Fix - Attach a Stripe customer to guest Adaptive Pricing checkouts, linking it to the order and any account created at checkout
-* Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
 * Add - Log an error when missing required custom fields block express checkout, with a filter to disable the log
 
 2026-08-31 - version 10.9.1

--- a/changelog.txt
+++ b/changelog.txt
@@ -45,6 +45,7 @@ xxxx-xx-xx - version 11.0.0
 * Tweak - Disable the Agentic Commerce "Sync now" button until onboarding is complete, with a note explaining the remaining step
 * Fix - Attach a Stripe customer to guest Adaptive Pricing checkouts, linking it to the order and any account created at checkout
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
+* Fix - Charge the saved card when a shopper retries after a declined Adaptive Pricing payment on classic checkout, instead of placing the order without taking payment
 
 2026-08-31 - version 10.9.1
 * Fix - Allow express checkout payments when automatic account password generation is disabled

--- a/client/blocks/checkout-sessions/hooks.js
+++ b/client/blocks/checkout-sessions/hooks.js
@@ -5,6 +5,7 @@ import { dispatch, select } from '@wordpress/data';
 import { isSavePaymentMethodCheckboxChecked } from 'wcstripe/blocks/utils';
 import { normalizeReturnUrl } from 'wcstripe/stripe-utils/normalize-return-url';
 import { getStaleCheckoutTotalMessage } from 'wcstripe/stripe-utils/utils';
+import { CHECKOUT_SESSION_INPUT_ID } from 'wcstripe/stripe-utils/constants';
 import { waitForPaymentElementCompletion } from 'wcstripe/blocks/wait-for-payment-element-completion';
 
 /**
@@ -117,7 +118,7 @@ export const usePaymentSetupHandler = (
 									isSavePaymentMethodCheckboxChecked()
 										? 'yes'
 										: 'no',
-								wc_stripe_checkout_session_id:
+								[ CHECKOUT_SESSION_INPUT_ID ]:
 									checkoutSessionId,
 								wc_stripe_selected_upe_payment_type:
 									selectedPaymentType ?? '',

--- a/client/classic/upe/__tests__/deferred-intent.test.js
+++ b/client/classic/upe/__tests__/deferred-intent.test.js
@@ -1,0 +1,86 @@
+jest.mock( 'wcstripe/api', () => jest.fn() );
+
+jest.mock( 'wcstripe/classic/upe/payment-processing', () => ( {
+	confirmVoucherPayment: jest.fn(),
+	confirmWalletPayment: jest.fn(),
+	createAndConfirmSetupIntent: jest.fn(),
+	getMountedUPEComponent: jest.fn(),
+	hasEmptyRequiredFields: jest.fn().mockReturnValue( false ),
+	initializeUPEComponents: jest.fn(),
+	maybeUpdateAdaptivePricingCheckoutSession: jest.fn(),
+	maybeUpdateOptimizedCheckoutExclusions: jest.fn(),
+	mountStripePaymentElement: jest.fn(),
+	processPayment: jest.fn(),
+	trackMountInProgress: jest.fn(),
+} ) );
+
+jest.mock( 'wcstripe/stripe-utils', () => ( {
+	generateCheckoutEventNames: jest
+		.fn()
+		.mockReturnValue( 'checkout_place_order_stripe' ),
+	getSelectedUPEGatewayPaymentMethod: jest.fn().mockReturnValue( 'card' ),
+	getStripeServerData: jest.fn().mockReturnValue( {} ),
+	isPaymentMethodRestrictedToLocation: jest.fn().mockReturnValue( false ),
+	isUsingSavedPaymentMethod: jest.fn().mockReturnValue( false ),
+	paymentMethodSupportsDeferredIntent: jest.fn().mockReturnValue( true ),
+	removeCheckoutSessionIdFromForm: jest.requireActual(
+		'wcstripe/stripe-utils/utils'
+	).removeCheckoutSessionIdFromForm,
+	togglePaymentMethodForCountry: jest.fn(),
+} ) );
+
+const STALE_SESSION_ID = 'cs_test_stale';
+
+/**
+ * Renders a checkout form still carrying the Checkout Session id of an earlier attempt, loads the
+ * classic checkout script against it and places the order.
+ *
+ * The module registry is reset first so every case gets a script instance bound to the jQuery
+ * instance and the DOM used here, rather than to a previous case's.
+ *
+ * @param {boolean} usingSavedToken Whether the customer picked a saved payment method.
+ * @return {Promise<Object>} The mocked payment-processing module the script was loaded against.
+ */
+const placeOrderWithStaleSessionId = async ( usingSavedToken ) => {
+	document.body.innerHTML = `
+		<form class="checkout">
+			<input type="hidden" id="wc_stripe_checkout_session_id" name="wc_stripe_checkout_session_id" value="${ STALE_SESSION_ID }" />
+		</form>`;
+
+	jest.resetModules();
+
+	require( 'wcstripe/stripe-utils' ).isUsingSavedPaymentMethod.mockReturnValue(
+		usingSavedToken
+	);
+	const paymentProcessing = require( 'wcstripe/classic/upe/payment-processing' );
+
+	const jQuery = require( 'jquery' );
+	require( '../deferred-intent' );
+	// The script binds its handlers from a jQuery ready callback. Ours is queued behind it.
+	await new Promise( ( resolve ) => jQuery( resolve ) );
+
+	jQuery( 'form.checkout' ).trigger( 'checkout_place_order_stripe' );
+
+	return paymentProcessing;
+};
+
+describe( 'classic checkout submission', () => {
+	it( 'drops a stale Checkout Session id when retrying with a saved token', async () => {
+		const { processPayment } = await placeOrderWithStaleSessionId( true );
+
+		expect(
+			document.getElementById( 'wc_stripe_checkout_session_id' )
+		).toBeNull();
+		// The saved token is charged through the deferred intent, not the Checkout Session.
+		expect( processPayment ).not.toHaveBeenCalled();
+	} );
+
+	it( 'drops a stale Checkout Session id when retrying with a new payment method', async () => {
+		const { processPayment } = await placeOrderWithStaleSessionId( false );
+
+		expect(
+			document.getElementById( 'wc_stripe_checkout_session_id' )
+		).toBeNull();
+		expect( processPayment ).toHaveBeenCalled();
+	} );
+} );

--- a/client/classic/upe/__tests__/deferred-intent.test.js
+++ b/client/classic/upe/__tests__/deferred-intent.test.js
@@ -75,12 +75,12 @@ describe( 'classic checkout submission', () => {
 		expect( processPayment ).not.toHaveBeenCalled();
 	} );
 
-	it( 'drops a stale Checkout Session id when retrying with a new payment method', async () => {
+	it( 'keeps the Checkout Session id when retrying with a new payment method', async () => {
 		const { processPayment } = await placeOrderWithStaleSessionId( false );
 
 		expect(
 			document.getElementById( 'wc_stripe_checkout_session_id' )
-		).toBeNull();
+		).not.toBeNull();
 		expect( processPayment ).toHaveBeenCalled();
 	} );
 } );

--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -110,11 +110,13 @@ jQuery( function ( $ ) {
 
 	$( 'form.checkout' ).on( generateCheckoutEventNames(), function () {
 		const $form = $( this );
+		const paymentMethodType = getSelectedUPEGatewayPaymentMethod();
 
-		// Nothing reloads the page after a failed attempt, so a Checkout Session id can outlive the
-		// attempt that added it. Drop it here: only the Adaptive Pricing branch of this submission
-		// may put one back, and the saved-token path below never reaches that branch at all.
-		removeCheckoutSessionIdFromForm( $form );
+		// A saved token bypasses Checkout Session confirmation, so discard a stale Session id left by
+		// an earlier attempt. New payment methods need the field so the Session flow can replace it.
+		if ( isUsingSavedPaymentMethod( paymentMethodType ) ) {
+			removeCheckoutSessionIdFromForm( $form );
+		}
 
 		// Don't create a Stripe payment method if required checkout fields are empty.
 		// This prevents unnecessary Stripe API calls before WC's server-side validation.

--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -7,6 +7,7 @@ import {
 	isPaymentMethodRestrictedToLocation,
 	isUsingSavedPaymentMethod,
 	paymentMethodSupportsDeferredIntent,
+	removeCheckoutSessionIdFromForm,
 	togglePaymentMethodForCountry,
 } from '../../stripe-utils';
 import './style.scss';
@@ -109,6 +110,11 @@ jQuery( function ( $ ) {
 
 	$( 'form.checkout' ).on( generateCheckoutEventNames(), function () {
 		const $form = $( this );
+
+		// Nothing reloads the page after a failed attempt, so a Checkout Session id can outlive the
+		// attempt that added it. Drop it here: only the Adaptive Pricing branch of this submission
+		// may put one back, and the saved-token path below never reaches that branch at all.
+		removeCheckoutSessionIdFromForm( $form );
 
 		// Don't create a Stripe payment method if required checkout fields are empty.
 		// This prevents unnecessary Stripe API calls before WC's server-side validation.

--- a/client/stripe-utils/constants.js
+++ b/client/stripe-utils/constants.js
@@ -28,6 +28,8 @@ export const PAYMENT_METHOD_BACS = 'bacs_debit';
 export const PAYMENT_METHOD_BECS = 'au_becs_debit';
 export const PAYMENT_METHOD_APPLE_PAY_GOOGLE_PAY = 'apple_pay_google_pay';
 
+export const CHECKOUT_SESSION_INPUT_ID = 'wc_stripe_checkout_session_id';
+
 /**
  * Payment method names constants with the `stripe` prefix
  */

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -515,6 +515,10 @@ export const appendCheckoutSessionIdToForm = ( form, checkoutSessionId ) => {
 	form.append( hiddenInput );
 };
 
+export const removeCheckoutSessionIdFromForm = ( form ) => {
+	form.find( 'input#wc_stripe_checkout_session_id' ).remove();
+};
+
 /**
  * Returns true when the current page is one of the deferred-payment flows
  * (order pay, change payment method, or add payment method).

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -8,6 +8,7 @@ import {
 	getPaymentMethodsConstants,
 	PAYMENT_METHOD_LINK,
 	PAYMENT_METHOD_CARD,
+	CHECKOUT_SESSION_INPUT_ID,
 } from './constants';
 import { __ } from '@wordpress/i18n';
 import { dispatch } from '@wordpress/data';
@@ -501,7 +502,7 @@ export const getUpeSettings = () => {
 };
 
 export const appendCheckoutSessionIdToForm = ( form, checkoutSessionId ) => {
-	const existingElement = form.find( 'input#wc_stripe_checkout_session_id' );
+	const existingElement = form.find( `input#${ CHECKOUT_SESSION_INPUT_ID }` );
 	if ( existingElement.length ) {
 		existingElement.val( checkoutSessionId );
 		return;
@@ -509,14 +510,14 @@ export const appendCheckoutSessionIdToForm = ( form, checkoutSessionId ) => {
 
 	const hiddenInput = document.createElement( 'input' );
 	hiddenInput.type = 'hidden';
-	hiddenInput.id = 'wc_stripe_checkout_session_id';
-	hiddenInput.name = 'wc_stripe_checkout_session_id';
+	hiddenInput.id = CHECKOUT_SESSION_INPUT_ID;
+	hiddenInput.name = CHECKOUT_SESSION_INPUT_ID;
 	hiddenInput.value = checkoutSessionId;
 	form.append( hiddenInput );
 };
 
 export const removeCheckoutSessionIdFromForm = ( form ) => {
-	form.find( 'input#wc_stripe_checkout_session_id' ).remove();
+	form.find( `input#${ CHECKOUT_SESSION_INPUT_ID }` ).remove();
 };
 
 /**

--- a/includes/class-wc-stripe-order-helper.php
+++ b/includes/class-wc-stripe-order-helper.php
@@ -630,7 +630,7 @@ class WC_Stripe_Order_Helper {
 	/**
 	 * Deletes the Stripe checkout session ID for an order.
 	 *
-	 * @since 11.0.0
+	 * @since 11.1.0
 	 *
 	 * @param WC_Order|null $order
 	 * @return false|void

--- a/includes/class-wc-stripe-order-helper.php
+++ b/includes/class-wc-stripe-order-helper.php
@@ -628,18 +628,6 @@ class WC_Stripe_Order_Helper {
 	}
 
 	/**
-	 * Deletes the Stripe checkout session ID for order.
-	 *
-	 * @since 11.0.0
-	 *
-	 * @param WC_Order|null $order
-	 * @return false|void
-	 */
-	public function delete_stripe_checkout_session_id( ?WC_Order $order = null ) {
-		return $this->delete_order_meta( $order, self::META_STRIPE_CHECKOUT_SESSION_ID );
-	}
-
-	/**
 	 * Gets whether the payment method should be saved to the store after a checkout session payment.
 	 *
 	 * @param WC_Order|null $order

--- a/includes/class-wc-stripe-order-helper.php
+++ b/includes/class-wc-stripe-order-helper.php
@@ -628,6 +628,18 @@ class WC_Stripe_Order_Helper {
 	}
 
 	/**
+	 * Deletes the Stripe checkout session ID for order.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param WC_Order|null $order
+	 * @return false|void
+	 */
+	public function delete_stripe_checkout_session_id( ?WC_Order $order = null ) {
+		return $this->delete_order_meta( $order, self::META_STRIPE_CHECKOUT_SESSION_ID );
+	}
+
+	/**
 	 * Gets whether the payment method should be saved to the store after a checkout session payment.
 	 *
 	 * @param WC_Order|null $order

--- a/includes/class-wc-stripe-order-helper.php
+++ b/includes/class-wc-stripe-order-helper.php
@@ -628,6 +628,18 @@ class WC_Stripe_Order_Helper {
 	}
 
 	/**
+	 * Deletes the Stripe checkout session ID for an order.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param WC_Order|null $order
+	 * @return false|void
+	 */
+	public function delete_stripe_checkout_session_id( ?WC_Order $order = null ) {
+		return $this->delete_order_meta( $order, self::META_STRIPE_CHECKOUT_SESSION_ID );
+	}
+
+	/**
 	 * Gets whether the payment method should be saved to the store after a checkout session payment.
 	 *
 	 * @param WC_Order|null $order

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1592,7 +1592,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			}
 		}
 
-		if ( is_string( $checkout_session_id ) && ! empty( $checkout_session_id ) ) {
+		// Classic checkout keeps `wc_stripe_checkout_session_id` in the form after a failed Adaptive
+		// Pricing attempt, so a retry with a saved token still submits it. The token has to win: a
+		// Checkout Session is confirmed client-side and the saved-token path never reaches that code,
+		// so routing there would return success for an order nothing ever charged.
+		if ( is_string( $checkout_session_id ) && ! empty( $checkout_session_id ) && ! $this->is_using_saved_payment_method() ) {
 			return $this->process_payment_with_checkout_session( $order_id, $checkout_session_id, $save_payment_method, $selected_payment_type );
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1601,7 +1601,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		}
 
 		if ( $this->is_using_saved_payment_method() && $order instanceof WC_Order ) {
-			$this->retire_checkout_session_for_saved_payment( $order );
+			try {
+				$this->retire_checkout_session_for_saved_payment( $order );
+			} catch ( WC_Stripe_Exception $e ) {
+				// Keep the order pending so the existing Session can still reconcile if retirement failed.
+				return $this->handle_process_payment_error( $e, $order, false );
+			}
 		}
 
 		return $this->process_payment_with_deferred_intent( $order_id );
@@ -2031,10 +2036,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @param WC_Stripe_Exception $e    The exception that was thrown.
 	 * @param WC_Order            $order The order that was being processed.
+	 * @param bool                $mark_order_failed Whether to mark the order as failed.
 	 *
 	 * @return array
 	 */
-	private function handle_process_payment_error( WC_Stripe_Exception $e, $order ) {
+	private function handle_process_payment_error( WC_Stripe_Exception $e, $order, bool $mark_order_failed = true ) {
 		$error_message = sprintf(
 			/* translators: localized exception message */
 			__( 'There was an error processing the payment: %s', 'woocommerce-gateway-stripe' ),
@@ -2057,11 +2063,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		 */
 		do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-		$order->update_status(
-			OrderStatus::FAILED,
-			/* translators: localized exception message */
-			sprintf( __( 'Payment failed: %s', 'woocommerce-gateway-stripe' ), $e->getLocalizedMessage() )
-		);
+		if ( $mark_order_failed ) {
+			$order->update_status(
+				OrderStatus::FAILED,
+				/* translators: localized exception message */
+				sprintf( __( 'Payment failed: %s', 'woocommerce-gateway-stripe' ), $e->getLocalizedMessage() )
+			);
+		}
 
 		return [
 			'result'   => 'failure',

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1600,6 +1600,15 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			return $this->process_payment_with_checkout_session( $order_id, $checkout_session_id, $save_payment_method, $selected_payment_type );
 		}
 
+		// The Checkout Session an earlier attempt linked to the order never paid for it. Left in place,
+		// it keeps feeding that session's presentment amount and currency into the order screen and the
+		// customer emails for a payment made somewhere else entirely.
+		$order_helper = WC_Stripe_Order_Helper::get_instance();
+		if ( $order instanceof WC_Order && $order_helper->get_stripe_checkout_session_id( $order ) ) {
+			$order_helper->delete_stripe_checkout_session_id( $order );
+			$order->save_meta_data();
+		}
+
 		return $this->process_payment_with_deferred_intent( $order_id );
 	}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1600,7 +1600,70 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			return $this->process_payment_with_checkout_session( $order_id, $checkout_session_id, $save_payment_method, $selected_payment_type );
 		}
 
+		if ( $this->is_using_saved_payment_method() && $order instanceof WC_Order ) {
+			$this->retire_checkout_session_for_saved_payment( $order );
+		}
+
 		return $this->process_payment_with_deferred_intent( $order_id );
+	}
+
+	/**
+	 * Retires an order's remote Checkout Session before a saved payment method is charged.
+	 *
+	 * An unsuccessful embedded Checkout Session remains open and can be completed later. Retiring
+	 * it before starting another payment prevents a late Session webhook or customer retry from
+	 * creating a second charge for the same order.
+	 *
+	 * @param WC_Order $order The order being retried.
+	 * @return void
+	 * @throws WC_Stripe_Exception When the Session cannot be confirmed as expired.
+	 */
+	private function retire_checkout_session_for_saved_payment( WC_Order $order ): void {
+		$order_helper        = WC_Stripe_Order_Helper::get_instance();
+		$checkout_session_id = $order_helper->get_stripe_checkout_session_id( $order );
+		if ( ! is_string( $checkout_session_id ) || '' === $checkout_session_id ) {
+			return;
+		}
+
+		$unavailable_message = WC_Stripe_Checkout_Session_Context::get_unavailable_message();
+		try {
+			$checkout_session = $this->stripe_request( 'checkout/sessions/' . $checkout_session_id );
+		} catch ( Exception $e ) {
+			throw new WC_Stripe_Exception( $e->getMessage(), $unavailable_message );
+		}
+		if (
+			! is_object( $checkout_session )
+			|| ! isset( $checkout_session->id, $checkout_session->status )
+			|| ! is_string( $checkout_session->id )
+			|| $checkout_session_id !== $checkout_session->id
+			|| ! is_string( $checkout_session->status )
+		) {
+			throw new WC_Stripe_Exception( 'Unable to retrieve the Checkout Session.', $unavailable_message );
+		}
+
+		if ( 'open' === $checkout_session->status ) {
+			try {
+				$checkout_session = WC_Stripe_API::request( [], 'checkout/sessions/' . $checkout_session_id . '/expire' );
+			} catch ( Exception $e ) {
+				throw new WC_Stripe_Exception( $e->getMessage(), $unavailable_message );
+			}
+
+			if (
+				! is_object( $checkout_session )
+				|| ! isset( $checkout_session->id, $checkout_session->status )
+				|| ! is_string( $checkout_session->id )
+				|| $checkout_session_id !== $checkout_session->id
+				|| 'expired' !== $checkout_session->status
+			) {
+				throw new WC_Stripe_Exception( 'Unable to expire the Checkout Session.', $unavailable_message );
+			}
+		} elseif ( 'expired' !== $checkout_session->status ) {
+			throw new WC_Stripe_Exception( 'Checkout Session is not expireable.', $unavailable_message );
+		}
+
+		$order_helper->delete_stripe_checkout_session_id( $order );
+		$order->save();
+		WC_Stripe_Checkout_Session_Context::delete_context( $checkout_session_id );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1600,15 +1600,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			return $this->process_payment_with_checkout_session( $order_id, $checkout_session_id, $save_payment_method, $selected_payment_type );
 		}
 
-		// The Checkout Session an earlier attempt linked to the order never paid for it. Left in place,
-		// it keeps feeding that session's presentment amount and currency into the order screen and the
-		// customer emails for a payment made somewhere else entirely.
-		$order_helper = WC_Stripe_Order_Helper::get_instance();
-		if ( $order instanceof WC_Order && $order_helper->get_stripe_checkout_session_id( $order ) ) {
-			$order_helper->delete_stripe_checkout_session_id( $order );
-			$order->save_meta_data();
-		}
-
 		return $this->process_payment_with_deferred_intent( $order_id );
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -208,5 +208,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Disable the Agentic Commerce "Sync now" button until onboarding is complete, with a note explaining the remaining step
 * Fix - Attach a Stripe customer to guest Adaptive Pricing checkouts, linking it to the order and any account created at checkout
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
+* Fix - Charge the saved card when a shopper retries after a declined Adaptive Pricing payment on classic checkout, instead of placing the order without taking payment
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -208,6 +208,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Disable the Agentic Commerce "Sync now" button until onboarding is complete, with a note explaining the remaining step
 * Fix - Attach a Stripe customer to guest Adaptive Pricing checkouts, linking it to the order and any account created at checkout
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
-* Fix - Charge the saved card when a shopper retries after a declined Adaptive Pricing payment on classic checkout, instead of placing the order without taking payment
+* Fix - Ensure retry with a saved payment method works after a declined Adaptive Pricing payment attempt on classic checkout
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -2632,8 +2632,13 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	 * A saved token must win over a `wc_stripe_checkout_session_id` left in the classic checkout form
 	 * by a previous Adaptive Pricing attempt. Checkout Sessions are confirmed client-side and the
 	 * saved-token path never reaches that code, so routing there returns success for an uncharged order.
+	 *
+	 * @dataProvider provide_saved_payment_retry_checkout_session_states
+	 *
+	 * @param string $session_status The status returned by the Checkout Session retrieval.
+	 * @param bool   $should_expire  Whether the open Session should be expired.
 	 */
-	public function test_process_payment_with_saved_token_ignores_submitted_checkout_session_id() {
+	public function test_process_payment_with_saved_token_ignores_submitted_checkout_session_id( string $session_status, bool $should_expire ) {
 		$session_id = 'cs_test_saved_token_retry';
 		$token      = $this->set_postvars_for_saved_payment_method();
 
@@ -2647,6 +2652,45 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		WC_Stripe_Order_Helper::get_instance()->update_stripe_checkout_session_id( $order, $session_id );
 		$order->save();
 		$this->store_checkout_session_context_for_order( $session_id, $order, [ 'order_id' => $order->get_id() ] );
+
+		$this->mock_gateway->method( 'stripe_request' )->willReturnCallback(
+			function ( $path ) use ( $session_id, $session_status ) {
+				if ( 'checkout/sessions/' . $session_id === $path ) {
+					return (object) [
+						'id'     => $session_id,
+						'status' => $session_status,
+					];
+				}
+
+				return null;
+			}
+		);
+
+		$session_expired = false;
+		$pre_http_filter = function ( $return_value, $parsed_args, $url ) use ( $session_id, $should_expire, &$session_expired ) {
+			if ( WC_Stripe_API::ENDPOINT . 'checkout/sessions/' . $session_id . '/expire' !== $url ) {
+				return $return_value;
+			}
+
+			$session_expired = true;
+			if ( ! $should_expire ) {
+				return $return_value;
+			}
+
+			return [
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'body'     => wp_json_encode(
+					[
+						'id'     => $session_id,
+						'status' => 'expired',
+					]
+				),
+			];
+		};
+		add_filter( 'pre_http_request', $pre_http_filter, 10, 3 );
 
 		list( $amount ) = $this->get_order_details( $order );
 
@@ -2694,16 +2738,132 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		try {
 			$result = $this->mock_gateway->process_payment( $order->get_id() );
 		} finally {
+			remove_filter( 'pre_http_request', $pre_http_filter );
 			WC_Stripe_Checkout_Session_Context::delete_context( $session_id );
 			$_POST = [];
 		}
 
 		$this->assertSame( 'success', $result['result'] );
 		$this->assertStringNotContainsString( 'wc_stripe_cs', (string) $result['redirect'] );
-		$this->assertSame(
-			$session_id,
-			WC_Stripe_Order_Helper::get_instance()->get_stripe_checkout_session_id( wc_get_order( $order->get_id() ) )
+		$this->assertSame( $should_expire, $session_expired );
+		$this->assertEmpty( WC_Stripe_Order_Helper::get_instance()->get_stripe_checkout_session_id( wc_get_order( $order->get_id() ) ) );
+		$this->assertFalse( WC_Stripe_Helper::get_order_by_checkout_session_id( $session_id ) );
+		$this->assertNull( WC_Stripe_Checkout_Session_Context::get_context( $session_id ) );
+	}
+
+	/**
+	 * @return array<string,array{string,bool}>
+	 */
+	public function provide_saved_payment_retry_checkout_session_states(): array {
+		return [
+			'open Session is expired before retry' => [ 'open', true ],
+			'already expired Session is unlinked'  => [ 'expired', false ],
+		];
+	}
+
+	/**
+	 * A saved-payment retry must fail closed if its existing Checkout Session cannot be retired.
+	 *
+	 * @dataProvider provide_unretireable_checkout_session_states
+	 *
+	 * @param string|null $session_status    The status returned by Session retrieval.
+	 * @param string|null $expiration_status The status returned by Session expiration.
+	 * @param bool        $retrieval_error   Whether Session retrieval throws.
+	 */
+	public function test_saved_payment_retry_fails_closed_when_checkout_session_cannot_be_retired( ?string $session_status, ?string $expiration_status, bool $retrieval_error ) {
+		$session_id = 'cs_test_saved_token_retry_failure';
+		$this->set_postvars_for_saved_payment_method();
+		$_POST['wc_stripe_checkout_session_id'] = $session_id;
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_payment_method( WC_Stripe_UPE_Payment_Gateway::ID );
+		$order->set_status( OrderStatus::PENDING );
+		$order->save();
+
+		WC_Stripe_Order_Helper::get_instance()->update_stripe_checkout_session_id( $order, $session_id );
+		$order->save();
+		$this->store_checkout_session_context_for_order( $session_id, $order, [ 'order_id' => $order->get_id() ] );
+
+		$this->mock_gateway->method( 'stripe_request' )->willReturnCallback(
+			function ( $path ) use ( $session_id, $session_status, $retrieval_error ) {
+				if ( 'checkout/sessions/' . $session_id !== $path ) {
+					return null;
+				}
+
+				if ( $retrieval_error ) {
+					throw new WC_Stripe_Exception( 'retrieve failed' );
+				}
+
+				return (object) [
+					'id'     => $session_id,
+					'status' => $session_status,
+				];
+			}
 		);
+
+		$this->mock_gateway->intent_controller
+			->expects( $this->never() )
+			->method( 'create_and_confirm_payment_intent' );
+
+		$pre_http_filter = function ( $return_value, $parsed_args, $url ) use ( $session_id, $expiration_status ) {
+			if ( WC_Stripe_API::ENDPOINT . 'checkout/sessions/' . $session_id . '/expire' !== $url ) {
+				return $return_value;
+			}
+
+			if ( null === $expiration_status ) {
+				return [
+					'response' => [
+						'code'    => 400,
+						'message' => 'Bad Request',
+					],
+					'body'     => wp_json_encode( [ 'error' => [ 'message' => 'expire failed' ] ] ),
+				];
+			}
+
+			return [
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'body'     => wp_json_encode(
+					[
+						'id'     => $session_id,
+						'status' => $expiration_status,
+					]
+				),
+			];
+		};
+		add_filter( 'pre_http_request', $pre_http_filter, 10, 3 );
+
+		$exception = null;
+		try {
+			$this->mock_gateway->process_payment( $order->get_id() );
+		} catch ( WC_Stripe_Exception $e ) {
+			$exception = $e;
+		} finally {
+			remove_filter( 'pre_http_request', $pre_http_filter );
+		}
+
+		$this->assertInstanceOf( WC_Stripe_Exception::class, $exception );
+		$this->assertSame( WC_Stripe_Checkout_Session_Context::get_unavailable_message(), $exception->getLocalizedMessage() );
+		$this->assertSame( $session_id, WC_Stripe_Order_Helper::get_instance()->get_stripe_checkout_session_id( wc_get_order( $order->get_id() ) ) );
+		$this->assertIsArray( WC_Stripe_Checkout_Session_Context::get_context( $session_id ) );
+
+		WC_Stripe_Checkout_Session_Context::delete_context( $session_id );
+		$_POST = [];
+	}
+
+	/**
+	 * @return array<string,array{string|null,string|null,bool}>
+	 */
+	public function provide_unretireable_checkout_session_states(): array {
+		return [
+			'complete Session'        => [ 'complete', null, false ],
+			'malformed Session'       => [ null, null, false ],
+			'retrieval failure'       => [ null, null, true ],
+			'expiration failure'      => [ 'open', null, false ],
+			'expiration wrong status' => [ 'open', 'complete', false ],
+		];
 	}
 
 	/**

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -2644,6 +2644,8 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		$order->set_status( OrderStatus::PENDING );
 		$order->save();
 
+		WC_Stripe_Order_Helper::get_instance()->update_stripe_checkout_session_id( $order, $session_id );
+		$order->save();
 		$this->store_checkout_session_context_for_order( $session_id, $order, [ 'order_id' => $order->get_id() ] );
 
 		list( $amount ) = $this->get_order_details( $order );
@@ -2698,80 +2700,10 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->assertSame( 'success', $result['result'] );
 		$this->assertStringNotContainsString( 'wc_stripe_cs', (string) $result['redirect'] );
-		$this->assertEmpty(
+		$this->assertSame(
+			$session_id,
 			WC_Stripe_Order_Helper::get_instance()->get_stripe_checkout_session_id( wc_get_order( $order->get_id() ) )
 		);
-	}
-
-	/**
-	 * An abandoned Checkout Session stays linked to the order when the customer retries with a saved
-	 * token. Leaving it there makes the order screen and the customer emails present that session's
-	 * amount and currency as if it had paid for the order.
-	 */
-	public function test_process_payment_with_deferred_intent_unlinks_abandoned_checkout_session() {
-		$session_id   = 'cs_test_abandoned';
-		$token        = $this->set_postvars_for_saved_payment_method();
-		$order_helper = WC_Stripe_Order_Helper::get_instance();
-
-		$_POST['payment_method']           = 'stripe';
-		$_POST['wc-stripe-payment-method'] = 'pm_mock';
-
-		$order = WC_Helper_Order::create_order();
-		$order_helper->update_stripe_checkout_session_id( $order, $session_id );
-		$order->save();
-
-		list( $amount ) = $this->get_order_details( $order );
-
-		$payment_intent_mock = (object) array_merge(
-			self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE,
-			[
-				'id'             => 'pi_mock',
-				'amount'         => $amount,
-				'payment_method' => $token->get_token(),
-				'charges'        => (object) [
-					'data' => [
-						(object) [
-							'id'       => 'ch_mock',
-							'captured' => true,
-							'status'   => 'succeeded',
-						],
-					],
-				],
-			]
-		);
-
-		$this->mock_gateway->intent_controller
-			->expects( $this->once() )
-			->method( 'create_and_confirm_payment_intent' )
-			->willReturn( $payment_intent_mock );
-
-		$this->mock_gateway
-			->expects( $this->once() )
-			->method( 'get_stripe_customer_id' )
-			->willReturn( 'cus_mock' );
-
-		$this->mock_gateway
-			->method( 'get_latest_charge_from_intent' )
-			->willReturn(
-				$this->array_to_object(
-					[
-						'id'                     => 'ch_mock',
-						'captured'               => true,
-						'status'                 => 'succeeded',
-						'payment_method_details' => $payment_intent_mock,
-					]
-				)
-			);
-
-		try {
-			$result = $this->mock_gateway->process_payment( $order->get_id() );
-		} finally {
-			$_POST = [];
-		}
-
-		$this->assertSame( 'success', $result['result'] );
-		$this->assertEmpty( $order_helper->get_stripe_checkout_session_id( wc_get_order( $order->get_id() ) ) );
-		$this->assertFalse( WC_Stripe_Helper::get_order_by_checkout_session_id( $session_id ) );
 	}
 
 	/**

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -2835,20 +2835,28 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		};
 		add_filter( 'pre_http_request', $pre_http_filter, 10, 3 );
 
-		$exception = null;
 		try {
-			$this->mock_gateway->process_payment( $order->get_id() );
+			$result = $this->mock_gateway->process_payment( $order->get_id() );
 		} catch ( WC_Stripe_Exception $e ) {
-			$exception = $e;
+			$this->fail( 'The retirement failure should be returned as a standard payment failure.' );
 		} finally {
 			remove_filter( 'pre_http_request', $pre_http_filter );
 		}
 
-		$this->assertInstanceOf( WC_Stripe_Exception::class, $exception );
-		$this->assertSame( WC_Stripe_Checkout_Session_Context::get_unavailable_message(), $exception->getLocalizedMessage() );
-		$this->assertSame( $session_id, WC_Stripe_Order_Helper::get_instance()->get_stripe_checkout_session_id( wc_get_order( $order->get_id() ) ) );
+		$this->assertSame( 'failure', $result['result'] );
+		$this->assert_checkout_session_failure_notice(
+			sprintf(
+				'There was an error processing the payment: %s',
+				WC_Stripe_Checkout_Session_Context::get_unavailable_message()
+			)
+		);
+
+		$processed_order = wc_get_order( $order->get_id() );
+		$this->assertSame( OrderStatus::PENDING, $processed_order->get_status() );
+		$this->assertSame( $session_id, WC_Stripe_Order_Helper::get_instance()->get_stripe_checkout_session_id( $processed_order ) );
 		$this->assertIsArray( WC_Stripe_Checkout_Session_Context::get_context( $session_id ) );
 
+		wc_clear_notices();
 		WC_Stripe_Checkout_Session_Context::delete_context( $session_id );
 		$_POST = [];
 	}

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -2704,6 +2704,77 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * An abandoned Checkout Session stays linked to the order when the customer retries with a saved
+	 * token. Leaving it there makes the order screen and the customer emails present that session's
+	 * amount and currency as if it had paid for the order.
+	 */
+	public function test_process_payment_with_deferred_intent_unlinks_abandoned_checkout_session() {
+		$session_id   = 'cs_test_abandoned';
+		$token        = $this->set_postvars_for_saved_payment_method();
+		$order_helper = WC_Stripe_Order_Helper::get_instance();
+
+		$_POST['payment_method']           = 'stripe';
+		$_POST['wc-stripe-payment-method'] = 'pm_mock';
+
+		$order = WC_Helper_Order::create_order();
+		$order_helper->update_stripe_checkout_session_id( $order, $session_id );
+		$order->save();
+
+		list( $amount ) = $this->get_order_details( $order );
+
+		$payment_intent_mock = (object) array_merge(
+			self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE,
+			[
+				'id'             => 'pi_mock',
+				'amount'         => $amount,
+				'payment_method' => $token->get_token(),
+				'charges'        => (object) [
+					'data' => [
+						(object) [
+							'id'       => 'ch_mock',
+							'captured' => true,
+							'status'   => 'succeeded',
+						],
+					],
+				],
+			]
+		);
+
+		$this->mock_gateway->intent_controller
+			->expects( $this->once() )
+			->method( 'create_and_confirm_payment_intent' )
+			->willReturn( $payment_intent_mock );
+
+		$this->mock_gateway
+			->expects( $this->once() )
+			->method( 'get_stripe_customer_id' )
+			->willReturn( 'cus_mock' );
+
+		$this->mock_gateway
+			->method( 'get_latest_charge_from_intent' )
+			->willReturn(
+				$this->array_to_object(
+					[
+						'id'                     => 'ch_mock',
+						'captured'               => true,
+						'status'                 => 'succeeded',
+						'payment_method_details' => $payment_intent_mock,
+					]
+				)
+			);
+
+		try {
+			$result = $this->mock_gateway->process_payment( $order->get_id() );
+		} finally {
+			$_POST = [];
+		}
+
+		$this->assertSame( 'success', $result['result'] );
+		$this->assertEmpty( $order_helper->get_stripe_checkout_session_id( wc_get_order( $order->get_id() ) ) );
+		$this->assertFalse( WC_Stripe_Helper::get_order_by_checkout_session_id( $session_id ) );
+	}
+
+	/**
 	 * Saving through the Adaptive Pricing / Checkout Sessions flow must persist the save-payment-method
 	 * flag on the order without any server-side session update: saving is requested client-side via
 	 * `checkout.confirm()`, and the Checkout Session update API does not accept `payment_method_options`.

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -2629,6 +2629,81 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * A saved token must win over a `wc_stripe_checkout_session_id` left in the classic checkout form
+	 * by a previous Adaptive Pricing attempt. Checkout Sessions are confirmed client-side and the
+	 * saved-token path never reaches that code, so routing there returns success for an uncharged order.
+	 */
+	public function test_process_payment_with_saved_token_ignores_submitted_checkout_session_id() {
+		$session_id = 'cs_test_saved_token_retry';
+		$token      = $this->set_postvars_for_saved_payment_method();
+
+		$_POST['wc_stripe_checkout_session_id'] = $session_id;
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_payment_method( WC_Stripe_UPE_Payment_Gateway::ID );
+		$order->set_status( OrderStatus::PENDING );
+		$order->save();
+
+		$this->store_checkout_session_context_for_order( $session_id, $order, [ 'order_id' => $order->get_id() ] );
+
+		list( $amount ) = $this->get_order_details( $order );
+
+		$payment_intent_mock = (object) array_merge(
+			self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE,
+			[
+				'id'             => 'pi_mock',
+				'amount'         => $amount,
+				'payment_method' => $token->get_token(),
+				'charges'        => (object) [
+					'data' => [
+						(object) [
+							'id'       => 'ch_mock',
+							'captured' => true,
+							'status'   => 'succeeded',
+						],
+					],
+				],
+			]
+		);
+
+		$this->mock_gateway->intent_controller
+			->expects( $this->once() )
+			->method( 'create_and_confirm_payment_intent' )
+			->willReturn( $payment_intent_mock );
+
+		$this->mock_gateway
+			->expects( $this->once() )
+			->method( 'get_stripe_customer_id' )
+			->willReturn( 'cus_mock' );
+
+		$this->mock_gateway
+			->method( 'get_latest_charge_from_intent' )
+			->willReturn(
+				$this->array_to_object(
+					[
+						'id'                     => 'ch_mock',
+						'captured'               => true,
+						'status'                 => 'succeeded',
+						'payment_method_details' => $payment_intent_mock,
+					]
+				)
+			);
+
+		try {
+			$result = $this->mock_gateway->process_payment( $order->get_id() );
+		} finally {
+			WC_Stripe_Checkout_Session_Context::delete_context( $session_id );
+			$_POST = [];
+		}
+
+		$this->assertSame( 'success', $result['result'] );
+		$this->assertStringNotContainsString( 'wc_stripe_cs', (string) $result['redirect'] );
+		$this->assertEmpty(
+			WC_Stripe_Order_Helper::get_instance()->get_stripe_checkout_session_id( wc_get_order( $order->get_id() ) )
+		);
+	}
+
+	/**
 	 * Saving through the Adaptive Pricing / Checkout Sessions flow must persist the save-payment-method
 	 * flag on the order without any server-side session update: saving is requested client-side via
 	 * `checkout.confirm()`, and the Checkout Session update API does not accept `payment_method_options`.


### PR DESCRIPTION
Fixes STRIPE-1437

## Changes proposed in this Pull Request:

A declined Adaptive Pricing payment can leave an old Checkout Session ID in the classic checkout form. A retry with a saved payment method can then use the wrong payment flow and fail.

This PR:
- Uses the saved payment method flow when a saved method is selected.
- Removes the old Checkout Session ID from saved-method submissions.
- Keeps the ID when retrying with a new payment method.
- Adds targeted PHPUnit and Jest tests.

## Testing instructions

1. Make sure Optimized Checkout and Adaptive Pricing are enabled
2. Login to the Store as a customer with a saved payment method
3. Add any simple product to the cart and go to the Classic Checkout
4. Select a new payment method, and pay in your local currency (AP) with the CC `4000 0000 0000 0002` (generic decline)
5. Confirm you get a payment declined error
6. Without reloading, retry with a saved payment method.
8. Confirm that the payment succeeds.
    In develop you would get a `Your card was declined`

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
