### PR TITLE
Handle one word shipping names in Express Checkouts

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 11.0.0
+* Fix - Allow express checkout payments when a wallet provides a one-word shipping name
 * Add - Show a placement simulator on each Customize express checkouts tab that previews where the express checkout button would and wouldn't appear, with the reason
 * Tweak - Dim the button size hint on the Amazon Pay and Link customize tabs so it matches the Apple Pay/Google Pay tab
 * Add - Show the fuller sync-eligibility verdict in the Products list Agentic Commerce column and link the excluded-products view from the settings page

--- a/client/express-checkout/utils/__tests__/normalize.test.js
+++ b/client/express-checkout/utils/__tests__/normalize.test.js
@@ -566,6 +566,37 @@ describe( 'Express checkout normalization', () => {
 			} );
 		} );
 
+		test( 'should use the shipping last name fallback for a one-word shipping name', () => {
+			const oneWordShippingNameEvent = {
+				shippingAddress: {
+					name: 'Cher',
+				},
+			};
+
+			const normalizedData = normalizeOrderData( {
+				event: oneWordShippingNameEvent,
+				paymentMethodId,
+			} );
+
+			expect( normalizedData.shipping_address ).toMatchObject( {
+				first_name: 'Cher',
+				last_name: '-',
+			} );
+		} );
+
+		test( 'should not use the shipping last name fallback for a whitespace-only name', () => {
+			const normalizedData = normalizeOrderData( {
+				event: {
+					shippingAddress: {
+						name: ' ',
+					},
+				},
+				paymentMethodId,
+			} );
+
+			expect( normalizedData.shipping_address.last_name ).toBe( '' );
+		} );
+
 		test( 'should use the placeholder fallback instead of an existing billing last name', () => {
 			select.mockImplementation( () => ( {
 				getExtensionData: () => ( {} ),

--- a/client/express-checkout/utils/__tests__/normalize.test.js
+++ b/client/express-checkout/utils/__tests__/normalize.test.js
@@ -584,6 +584,24 @@ describe( 'Express checkout normalization', () => {
 			} );
 		} );
 
+		test( 'should use the shipping last name fallback for a one-word shipping name with leading and trailing whitespace', () => {
+			const oneWordShippingNameEvent = {
+				shippingAddress: {
+					name: '  Cher  ',
+				},
+			};
+
+			const normalizedData = normalizeOrderData( {
+				event: oneWordShippingNameEvent,
+				paymentMethodId,
+			} );
+
+			expect( normalizedData.shipping_address ).toMatchObject( {
+				first_name: 'Cher',
+				last_name: '-',
+			} );
+		} );
+
 		test( 'should not use the shipping last name fallback for a whitespace-only name', () => {
 			const normalizedData = normalizeOrderData( {
 				event: {

--- a/client/express-checkout/utils/normalize.js
+++ b/client/express-checkout/utils/normalize.js
@@ -398,11 +398,11 @@ const getBillingAddressData = ( event ) => {
  */
 const getShippingAddressData = ( event ) => {
 	const shipping = event?.shippingAddress ?? {};
-	const name = shipping?.name;
+	const name = shipping?.name?.trim() ?? '';
 
 	const data = {
 		first_name: approximateFirstName( name ),
-		last_name: approximateLastName( name, name?.trim() ? '-' : '' ),
+		last_name: approximateLastName( name, name === '' ? '' : '-' ),
 		company: shipping?.organization ?? '',
 		phone: getPhone( event ),
 		country: shipping?.address?.country ?? '',

--- a/client/express-checkout/utils/normalize.js
+++ b/client/express-checkout/utils/normalize.js
@@ -402,7 +402,7 @@ const getShippingAddressData = ( event ) => {
 
 	const data = {
 		first_name: approximateFirstName( name ),
-		last_name: approximateLastName( name ),
+		last_name: approximateLastName( name, name?.trim() ? '-' : '' ),
 		company: shipping?.organization ?? '',
 		phone: getPhone( event ),
 		country: shipping?.address?.country ?? '',

--- a/readme.txt
+++ b/readme.txt
@@ -162,6 +162,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 11.0.0 - xxxx-xx-xx =
+* Fix - Allow express checkout payments when a wallet provides a one-word shipping name
 * Add - Show a placement simulator on each Customize express checkouts tab that previews where the express checkout button would and wouldn't appear, with the reason
 * Tweak - Dim the button size hint on the Amazon Pay and Link customize tabs so it matches the Apple Pay/Google Pay tab
 * Update - Take already-synced products out of in-agent checkout when Agentic Commerce is disabled by pushing a final catalog feed, and stop the recurring product sync while it's off


### PR DESCRIPTION
Fixes STRIPE-1435
Fixes #5913

## Changes proposed in this Pull Request:

Express Checkout now uses `-` as the shipping last name when a wallet provides a non-empty, one-word name. This prevents WooCommerce from rejecting the shipping address because the last name is empty. 

This solution follows the existing billing-address behavior, it reuses the billing convention while keeping the change narrowly scoped (using `name?.trim() ? '-' : ''` to keep existing behavior when shipping name is empty).


## Testing instructions

1. Add a physical product to the cart
2. Use Link, Apple Pay, or Google Pay with a one-word shipping name
3. Complete the payment
4. Confirm that checkout succeeds and the order contains:
    Shipping first name: `<one-word shipping name>`
    Shipping last name: `-`
5. Repeat with a multi-word name and confirm it is split as before

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [x] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [x] Included this PR in the Release Thread scope (or does not apply)
