### PR TITLE
Fix pre-select default saved payment method in blocks checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 11.0.0
+* Fix - Preselect the customer's default saved Stripe payment method in Blocks checkout
 * Fix - Allow express checkout payments when a wallet provides a one-word shipping name
 * Add - Show a placement simulator on each Customize express checkouts tab that previews where the express checkout button would and wouldn't appear, with the reason
 * Tweak - Dim the button size hint on the Amazon Pay and Link customize tabs so it matches the Apple Pay/Google Pay tab

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 11.0.0
-* Fix - Preselect the customer's default saved Stripe payment method in Blocks checkout
+* Fix - Preselect the customer's default saved Stripe payment method within the active gateway in Blocks checkout
 * Fix - Allow express checkout payments when a wallet provides a one-word shipping name
 * Add - Show a placement simulator on each Customize express checkouts tab that previews where the express checkout button would and wouldn't appear, with the reason
 * Tweak - Dim the button size hint on the Amazon Pay and Link customize tabs so it matches the Apple Pay/Google Pay tab

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -2,6 +2,7 @@
 use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
 use Automattic\WooCommerce\StoreApi\Payments\PaymentResult;
 use Automattic\WooCommerce\StoreApi\Payments\PaymentContext;
+use Automattic\WooCommerce\StoreApi\Utilities\PaymentUtils;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -91,7 +92,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	}
 
 	/**
-	 * Lets Blocks select the default Stripe token instead of the first Stripe token.
+	 * Lets Blocks select the visible default Stripe token instead of an earlier token for the same gateway.
 	 *
 	 * @param mixed $response Hydrated Store API response.
 	 * @param mixed $handler  Store API route handler.
@@ -117,27 +118,40 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 			return $response;
 		}
 
-		$default_token = WC_Payment_Tokens::get_customer_default_token( get_current_user_id() );
-		if ( ! $default_token instanceof WC_Payment_Token ) {
+		$saved_payment_methods = PaymentUtils::get_saved_payment_methods();
+		$enabled_methods       = $saved_payment_methods['enabled'] ?? null;
+		if ( ! is_array( $enabled_methods ) ) {
 			return $response;
 		}
 
-		$gateway_id = $default_token->get_gateway_id();
-		if ( ! in_array( $gateway_id, WC_Stripe_Payment_Tokens::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD, true ) ) {
-			return $response;
-		}
+		$has_earlier_gateway_token = false;
+		foreach ( $enabled_methods as $methods ) {
+			if ( ! is_array( $methods ) ) {
+				continue;
+			}
 
-		$main_gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
-		if ( $main_gateway instanceof WC_Stripe_UPE_Payment_Gateway && $main_gateway->is_optimized_checkout_active() ) {
-			$gateway_id = WC_Stripe_UPE_Payment_Gateway::ID;
-		}
+			foreach ( $methods as $method ) {
+				if (
+					! is_array( $method )
+					|| ( $method['method']['gateway'] ?? null ) !== $data['payment_method']
+				) {
+					continue;
+				}
 
-		if ( ( $data['payment_method'] ?? null ) !== $gateway_id ) {
-			return $response;
-		}
+				if ( true === ( $method['is_default'] ?? null ) ) {
+					if ( ! $has_earlier_gateway_token ) {
+						return $response;
+					}
 
-		$data['payment_method'] = '';
-		$response->set_data( $data );
+					$data['payment_method'] = '';
+					$response->set_data( $data );
+
+					return $response;
+				}
+
+				$has_earlier_gateway_token = true;
+			}
+		}
 
 		return $response;
 	}

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -81,11 +81,65 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	public function initialize() {
 		$this->settings = WC_Stripe_Helper::get_stripe_settings();
 
+		add_filter( 'woocommerce_hydration_request_after_callbacks', [ $this, 'clear_hydrated_payment_method_for_default_token' ], 10, 3 );
+
 		// Hooks to manually enqueue the block CSS, as WooCommerce doesn't have an API for styles.
 		add_filter( 'render_block_woocommerce/checkout', [ $this, 'maybe_enqueue_blocks_style' ] );
 		add_filter( 'render_block_woocommerce/cart', [ $this, 'maybe_enqueue_blocks_style' ] );
 		// Note that this is hooked at priority 20 so we run after WooCommerce has registered and enqueued the Cart and Checkout editor scripts.
 		add_action( 'enqueue_block_editor_assets', [ $this, 'maybe_enqueue_blocks_style_for_editor' ], 20 );
+	}
+
+	/**
+	 * Lets Blocks select the default Stripe token instead of the first Stripe token.
+	 *
+	 * @param mixed $response Hydrated Store API response.
+	 * @param mixed $handler  Store API route handler.
+	 * @param mixed $request  Store API request.
+	 *
+	 * @return mixed
+	 */
+	public function clear_hydrated_payment_method_for_default_token( $response, $handler, $request ) {
+		if (
+			! $response instanceof WP_REST_Response
+			|| ! $request instanceof WP_REST_Request
+			|| '/wc/store/v1/checkout' !== $request->get_route()
+			|| ! is_user_logged_in()
+		) {
+			return $response;
+		}
+
+		$data = $response->get_data();
+		if (
+			! is_array( $data )
+			|| ! in_array( $data['payment_method'] ?? null, WC_Stripe_Payment_Tokens::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD, true )
+		) {
+			return $response;
+		}
+
+		$default_token = WC_Payment_Tokens::get_customer_default_token( get_current_user_id() );
+		if ( ! $default_token instanceof WC_Payment_Token ) {
+			return $response;
+		}
+
+		$gateway_id = $default_token->get_gateway_id();
+		if ( ! in_array( $gateway_id, WC_Stripe_Payment_Tokens::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD, true ) ) {
+			return $response;
+		}
+
+		$main_gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
+		if ( $main_gateway instanceof WC_Stripe_UPE_Payment_Gateway && $main_gateway->is_optimized_checkout_active() ) {
+			$gateway_id = WC_Stripe_UPE_Payment_Gateway::ID;
+		}
+
+		if ( ( $data['payment_method'] ?? null ) !== $gateway_id ) {
+			return $response;
+		}
+
+		$data['payment_method'] = '';
+		$response->set_data( $data );
+
+		return $response;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -162,6 +162,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 11.0.0 - xxxx-xx-xx =
+* Fix - Preselect the customer's default saved Stripe payment method in Blocks checkout
 * Fix - Allow express checkout payments when a wallet provides a one-word shipping name
 * Add - Show a placement simulator on each Customize express checkouts tab that previews where the express checkout button would and wouldn't appear, with the reason
 * Tweak - Dim the button size hint on the Amazon Pay and Link customize tabs so it matches the Apple Pay/Google Pay tab

--- a/readme.txt
+++ b/readme.txt
@@ -162,7 +162,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 11.0.0 - xxxx-xx-xx =
-* Fix - Preselect the customer's default saved Stripe payment method in Blocks checkout
+* Fix - Preselect the customer's default saved Stripe payment method within the active gateway in Blocks checkout
 * Fix - Allow express checkout payments when a wallet provides a one-word shipping name
 * Add - Show a placement simulator on each Customize express checkouts tab that previews where the express checkout button would and wouldn't appear, with the reason
 * Tweak - Dim the button size hint on the Amazon Pay and Link customize tabs so it matches the Apple Pay/Google Pay tab

--- a/tests/e2e/tests/checkout/blocks/optimized-checkout.spec.js
+++ b/tests/e2e/tests/checkout/blocks/optimized-checkout.spec.js
@@ -7,7 +7,6 @@ const {
 	emptyCart,
 	setupCart,
 	setupOptimizedCheckout,
-	setupBlocksCheckout,
 	fillOCDetails,
 	clickPlaceOrder,
 	getCartTotal,
@@ -66,7 +65,6 @@ test.describe( 'Optimized Checkout payment tests @blocks', () => {
 		await admin.togglePaymentMethod( browser, 'Link by Stripe', false );
 
 		try {
-			// First order - Save the payment method.
 			await test.step( 'Save payment method during first checkout', async () => {
 				await user.login(
 					page,
@@ -88,18 +86,46 @@ test.describe( 'Optimized Checkout payment tests @blocks', () => {
 				);
 			} );
 
-			// Second order - Use saved payment method.
-			await test.step( 'Use saved payment method for second checkout', async () => {
+			await test.step( 'Save a second payment method and make it the default', async () => {
+				await setupOptimizedCheckout( page, 'blocks' );
+				await page.getByLabel( 'Save payment information' ).click();
+				await fillOCDetails( page, config.get( 'cards.basic2' ) );
+
+				const expectedTotal = await getCartTotal( page );
+
+				await clickPlaceOrder( page );
+
+				await waitForOrderReceivedPageAndConfirmExpectedTotal(
+					browser,
+					page,
+					expectedTotal
+				);
+
+				await page.goto( '/my-account/payment-methods/' );
+				const secondCardRow = page
+					.locator( 'tr.payment-method' )
+					.filter( { hasText: 'Visa ending in 1111' } );
+				await secondCardRow
+					.getByRole( 'link', { name: 'Make default' } )
+					.click();
+				await expect( secondCardRow ).toHaveClass(
+					/default-payment-method/
+				);
+			} );
+
+			await test.step( 'Use the default payment method for checkout', async () => {
 				await emptyCart( page );
 				await setupCart( page );
-				await setupBlocksCheckout(
-					page,
-					config.get( 'addresses.customer.billing' )
-				);
-				await page
-					.locator( 'label' )
-					.filter( { hasText: 'Visa ending in 4242 (expires' } )
-					.click();
+				await page.goto( '/checkout/' );
+
+				await expect(
+					page.locator(
+						'input[id^="radio-control-wc-payment-method-saved-tokens-"]'
+					)
+				).toHaveCount( 2 );
+				await expect(
+					page.getByLabel( /Visa ending in 1111/ )
+				).toBeChecked();
 
 				const expectedTotal = await getCartTotal( page );
 

--- a/tests/e2e/tests/checkout/blocks/saved-card.spec.js
+++ b/tests/e2e/tests/checkout/blocks/saved-card.spec.js
@@ -71,23 +71,53 @@ test( 'customer can checkout with a saved card @smoke @blocks', async ( {
 			);
 		} );
 
-		await test.step( 'checkout and pay with the saved card', async () => {
+		await test.step( 'save a second card and make it the default', async () => {
 			await emptyCart( page );
 			await setupCart( page );
-			await setupBlocksCheckout( page, null, true );
+			await setupBlocksCheckout( page );
+			await fillCreditCardDetails( page, config.get( 'cards.basic2' ) );
+			await page
+				.locator(
+					'.wc-block-components-payment-methods__save-card-info'
+				)
+				.click();
 
-			// check that there are saved payment methods.
+			const expectedTotal = await getCartTotal( page );
+
+			await page.locator( 'text=Place order' ).click();
+
+			await waitForOrderReceivedPageAndConfirmExpectedTotal(
+				browser,
+				page,
+				expectedTotal
+			);
+
+			await page.goto( '/my-account/payment-methods/' );
+			const secondCardRow = page
+				.locator( 'tr.payment-method' )
+				.filter( { hasText: 'Visa ending in 1111' } );
+			await secondCardRow
+				.getByRole( 'link', { name: 'Make default' } )
+				.click();
+			await expect( secondCardRow ).toHaveClass(
+				/default-payment-method/
+			);
+		} );
+
+		await test.step( 'checkout with the default saved card', async () => {
+			await emptyCart( page );
+			await setupCart( page );
+			await page.goto( '/checkout/' );
+
 			await expect(
 				page.locator(
 					'input[id^="radio-control-wc-payment-method-saved-tokens-"]'
 				)
-			).toHaveCount( 1 );
+			).toHaveCount( 2 );
 
-			await page
-				.locator(
-					'input[id^="radio-control-wc-payment-method-saved-tokens-"]'
-				)
-				.click();
+			await expect(
+				page.getByLabel( /Visa ending in 1111/ )
+			).toBeChecked();
 
 			const expectedTotal = await getCartTotal( page );
 

--- a/tests/phpunit/class-wc-stripe-blocks-support-test.php
+++ b/tests/phpunit/class-wc-stripe-blocks-support-test.php
@@ -76,6 +76,7 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 		remove_all_actions( 'woocommerce_rest_checkout_process_payment_with_context', 10000 );
 
 		foreach ( $this->initialized_blocks_support as $blocks_support ) {
+			remove_filter( 'woocommerce_hydration_request_after_callbacks', [ $blocks_support, 'clear_hydrated_payment_method_for_default_token' ] );
 			remove_filter( 'render_block_woocommerce/checkout', [ $blocks_support, 'maybe_enqueue_blocks_style' ] );
 			remove_filter( 'render_block_woocommerce/cart', [ $blocks_support, 'maybe_enqueue_blocks_style' ] );
 			remove_action( 'enqueue_block_editor_assets', [ $blocks_support, 'maybe_enqueue_blocks_style_for_editor' ], 20 );
@@ -315,10 +316,129 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 	 */
 	public function provider_render_time_hooks(): array {
 		return [
-			'checkout block render' => [ 'render_block_woocommerce/checkout', 'maybe_enqueue_blocks_style', 10 ],
-			'cart block render'     => [ 'render_block_woocommerce/cart', 'maybe_enqueue_blocks_style', 10 ],
-			'block editor assets'   => [ 'enqueue_block_editor_assets', 'maybe_enqueue_blocks_style_for_editor', 20 ],
+			'checkout data hydration' => [ 'woocommerce_hydration_request_after_callbacks', 'clear_hydrated_payment_method_for_default_token', 10 ],
+			'checkout block render'   => [ 'render_block_woocommerce/checkout', 'maybe_enqueue_blocks_style', 10 ],
+			'cart block render'       => [ 'render_block_woocommerce/cart', 'maybe_enqueue_blocks_style', 10 ],
+			'block editor assets'     => [ 'enqueue_block_editor_assets', 'maybe_enqueue_blocks_style_for_editor', 20 ],
 		];
+	}
+
+	/**
+	 * Blocks must choose the token marked as default when several Stripe tokens exist.
+	 */
+	public function test_checkout_hydration_defers_default_stripe_token_selection_to_blocks(): void {
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+		$this->create_saved_card( $user_id, 'pm_first' );
+		$this->create_saved_card( $user_id, 'pm_default', WC_Stripe_UPE_Payment_Gateway::ID, true );
+
+		$this->get_initialized_blocks_support();
+		$response = new WP_REST_Response(
+			[
+				'payment_method' => WC_Stripe_UPE_Payment_Gateway::ID,
+				'customer_id'    => $user_id,
+			]
+		);
+		$request  = new WP_REST_Request( 'GET', '/wc/store/v1/checkout' );
+
+		$result = apply_filters( 'woocommerce_hydration_request_after_callbacks', $response, [], $request );
+
+		$this->assertSame( $response, $result );
+		$this->assertSame(
+			[
+				'payment_method' => '',
+				'customer_id'    => $user_id,
+			],
+			$result->get_data()
+		);
+	}
+
+	/**
+	 * OCS presents reusable sub-gateway tokens through the main Stripe gateway.
+	 */
+	public function test_checkout_hydration_maps_optimized_checkout_token_to_main_gateway(): void {
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+		$this->create_saved_sepa_token( $user_id );
+
+		$gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
+			->setConstructorArgs( [] )
+			->onlyMethods( [ 'is_optimized_checkout_active' ] )
+			->getMock();
+		$gateway->method( 'is_optimized_checkout_active' )->willReturn( true );
+		$this->set_main_stripe_gateway( $gateway );
+
+		$response = new WP_REST_Response( [ 'payment_method' => WC_Stripe_UPE_Payment_Gateway::ID ] );
+		$request  = new WP_REST_Request( 'GET', '/wc/store/v1/checkout' );
+
+		$result = ( new WC_Stripe_Blocks_Support() )->clear_hydrated_payment_method_for_default_token( $response, [], $request );
+
+		$this->assertSame( '', $result->get_data()['payment_method'] );
+	}
+
+	/**
+	 * Checkout hydration must remain unchanged outside the matching Stripe case.
+	 *
+	 * @dataProvider provider_checkout_hydration_passthrough_cases
+	 *
+	 * @param string $route          Store API route.
+	 * @param string $payment_method Hydrated payment method.
+	 * @param bool   $logged_in      Whether a customer is logged in.
+	 * @param bool   $has_token      Whether the customer has a default Stripe token.
+	 */
+	public function test_checkout_hydration_leaves_unrelated_responses_unchanged( string $route, string $payment_method, bool $logged_in, bool $has_token ): void {
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+		if ( $has_token ) {
+			$this->create_saved_card( $user_id, 'pm_default' );
+		}
+		wp_set_current_user( $logged_in ? $user_id : 0 );
+
+		$response = new WP_REST_Response( [ 'payment_method' => $payment_method ] );
+		$request  = new WP_REST_Request( 'GET', $route );
+
+		$result = ( new WC_Stripe_Blocks_Support() )->clear_hydrated_payment_method_for_default_token( $response, [], $request );
+
+		$this->assertSame( $payment_method, $result->get_data()['payment_method'] );
+	}
+
+	/**
+	 * @return array[]
+	 */
+	public function provider_checkout_hydration_passthrough_cases(): array {
+		return [
+			'cart hydration'         => [ '/wc/store/v1/cart', WC_Stripe_UPE_Payment_Gateway::ID, true, true ],
+			'another payment method' => [ '/wc/store/v1/checkout', 'cheque', true, true ],
+			'logged-out customer'    => [ '/wc/store/v1/checkout', WC_Stripe_UPE_Payment_Gateway::ID, false, true ],
+			'no default token'       => [ '/wc/store/v1/checkout', WC_Stripe_UPE_Payment_Gateway::ID, true, false ],
+		];
+	}
+
+	/**
+	 * A default token owned by another gateway must not affect Stripe selection.
+	 */
+	public function test_checkout_hydration_leaves_non_stripe_default_token_unchanged(): void {
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+		$this->create_saved_card( $user_id, 'other_default', 'cheque' );
+
+		$response = new WP_REST_Response( [ 'payment_method' => WC_Stripe_UPE_Payment_Gateway::ID ] );
+		$request  = new WP_REST_Request( 'GET', '/wc/store/v1/checkout' );
+
+		$result = ( new WC_Stripe_Blocks_Support() )->clear_hydrated_payment_method_for_default_token( $response, [], $request );
+
+		$this->assertSame( WC_Stripe_UPE_Payment_Gateway::ID, $result->get_data()['payment_method'] );
+	}
+
+	/**
+	 * Hook values from other extensions must not cause type errors.
+	 */
+	public function test_checkout_hydration_accepts_unexpected_hook_values(): void {
+		$response = new WP_Error( 'test_error' );
+
+		$result = ( new WC_Stripe_Blocks_Support() )->clear_hydrated_payment_method_for_default_token( $response, [], null );
+
+		$this->assertSame( $response, $result );
 	}
 
 	/**
@@ -407,6 +527,59 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 			'lookalike method id' => [ 'stripey', '' ],
 			'unregistered split'  => [ 'stripe_not_a_payment_method', '' ],
 		];
+	}
+
+	private function create_saved_card( int $user_id, string $payment_method_id, string $gateway_id = WC_Stripe_UPE_Payment_Gateway::ID, bool $is_default = false ): WC_Stripe_Payment_Token_CC {
+		$token = new WC_Stripe_Payment_Token_CC();
+		$token->set_token( $payment_method_id );
+		$token->set_gateway_id( $gateway_id );
+		$token->set_card_type( 'visa' );
+		$token->set_last4( '4242' );
+		$token->set_expiry_month( '4' );
+		$token->set_expiry_year( '2050' );
+		$token->set_user_id( $user_id );
+		$token->set_default( $is_default );
+		$this->save_payment_token( $token );
+
+		return $token;
+	}
+
+	private function create_saved_sepa_token( int $user_id ): WC_Payment_Token_SEPA {
+		$token = new WC_Payment_Token_SEPA();
+		$token->set_token( 'pm_sepa_default' );
+		$token->set_gateway_id( WC_Stripe_Payment_Tokens::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD[ WC_Stripe_Payment_Methods::SEPA_DEBIT ] );
+		$token->set_last4( '1234' );
+		$token->set_user_id( $user_id );
+		$this->save_payment_token( $token );
+
+		return $token;
+	}
+
+	private function save_payment_token( WC_Payment_Token $token ): void {
+		$payment_tokens = WC_Stripe_Payment_Tokens::get_instance();
+		if ( ! $payment_tokens instanceof WC_Stripe_Payment_Tokens ) {
+			$token->save();
+			return;
+		}
+
+		$sync_callback = [ $payment_tokens, 'woocommerce_get_customer_payment_tokens' ];
+		$save_callback = [ $payment_tokens, 'woocommerce_payment_token_set_default' ];
+		$sync_hooked   = false !== has_filter( 'woocommerce_get_customer_payment_tokens', $sync_callback );
+		$save_hooked   = false !== has_filter( 'woocommerce_payment_token_set_default', $save_callback );
+
+		remove_filter( 'woocommerce_get_customer_payment_tokens', $sync_callback, 10 );
+		remove_action( 'woocommerce_payment_token_set_default', $save_callback, 10 );
+
+		try {
+			$token->save();
+		} finally {
+			if ( $sync_hooked ) {
+				add_filter( 'woocommerce_get_customer_payment_tokens', $sync_callback, 10, 3 );
+			}
+			if ( $save_hooked ) {
+				add_action( 'woocommerce_payment_token_set_default', $save_callback, 10 );
+			}
+		}
 	}
 
 	private function get_block_script_handle(): string {

--- a/tests/phpunit/class-wc-stripe-blocks-support-test.php
+++ b/tests/phpunit/class-wc-stripe-blocks-support-test.php
@@ -332,7 +332,6 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 		$this->create_saved_card( $user_id, 'pm_first' );
 		$this->create_saved_card( $user_id, 'pm_default', WC_Stripe_UPE_Payment_Gateway::ID, true );
 
-		$this->get_initialized_blocks_support();
 		$response = new WP_REST_Response(
 			[
 				'payment_method' => WC_Stripe_UPE_Payment_Gateway::ID,
@@ -341,7 +340,7 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 		);
 		$request  = new WP_REST_Request( 'GET', '/wc/store/v1/checkout' );
 
-		$result = apply_filters( 'woocommerce_hydration_request_after_callbacks', $response, [], $request );
+		$result = $this->filter_checkout_hydration( $response, $request );
 
 		$this->assertSame( $response, $result );
 		$this->assertSame(
@@ -354,26 +353,59 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * OCS presents reusable sub-gateway tokens through the main Stripe gateway.
+	 * Hydration remains unchanged when Blocks already sees the default token first.
 	 */
-	public function test_checkout_hydration_maps_optimized_checkout_token_to_main_gateway(): void {
+	public function test_checkout_hydration_keeps_gateway_when_default_token_is_first(): void {
 		$user_id = $this->factory->user->create();
 		wp_set_current_user( $user_id );
-		$this->create_saved_sepa_token( $user_id );
-
-		$gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
-			->setConstructorArgs( [] )
-			->onlyMethods( [ 'is_optimized_checkout_active' ] )
-			->getMock();
-		$gateway->method( 'is_optimized_checkout_active' )->willReturn( true );
-		$this->set_main_stripe_gateway( $gateway );
+		$this->create_saved_card( $user_id, 'pm_default', WC_Stripe_UPE_Payment_Gateway::ID, true );
+		$this->create_saved_card( $user_id, 'pm_second' );
 
 		$response = new WP_REST_Response( [ 'payment_method' => WC_Stripe_UPE_Payment_Gateway::ID ] );
 		$request  = new WP_REST_Request( 'GET', '/wc/store/v1/checkout' );
 
-		$result = ( new WC_Stripe_Blocks_Support() )->clear_hydrated_payment_method_for_default_token( $response, [], $request );
+		$result = $this->filter_checkout_hydration( $response, $request );
 
-		$this->assertSame( '', $result->get_data()['payment_method'] );
+		$this->assertSame( WC_Stripe_UPE_Payment_Gateway::ID, $result->get_data()['payment_method'] );
+	}
+
+	/**
+	 * A token from another gateway does not prevent Blocks from finding the default.
+	 */
+	public function test_checkout_hydration_keeps_gateway_when_default_is_first_matching_token(): void {
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+		$this->create_saved_card( $user_id, 'pm_card' );
+		$this->create_saved_sepa_token( $user_id, 'pm_sepa_default', true );
+
+		$sepa_gateway = WC_Stripe_Payment_Tokens::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD[ WC_Stripe_Payment_Methods::SEPA_DEBIT ];
+		$response     = new WP_REST_Response( [ 'payment_method' => $sepa_gateway ] );
+		$request      = new WP_REST_Request( 'GET', '/wc/store/v1/checkout' );
+
+		$result = $this->filter_checkout_hydration( $response, $request );
+
+		$this->assertSame( $sepa_gateway, $result->get_data()['payment_method'] );
+	}
+
+	/**
+	 * A default token hidden from Blocks must not affect the hydrated gateway.
+	 */
+	public function test_checkout_hydration_ignores_hidden_default_token(): void {
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+		$this->create_saved_card( $user_id, 'pm_default', WC_Stripe_UPE_Payment_Gateway::ID, true );
+
+		$response = new WP_REST_Response( [ 'payment_method' => WC_Stripe_UPE_Payment_Gateway::ID ] );
+		$request  = new WP_REST_Request( 'GET', '/wc/store/v1/checkout' );
+
+		add_filter( 'woocommerce_saved_payment_methods_list', '__return_empty_array', PHP_INT_MAX );
+		try {
+			$result = $this->filter_checkout_hydration( $response, $request );
+		} finally {
+			remove_filter( 'woocommerce_saved_payment_methods_list', '__return_empty_array', PHP_INT_MAX );
+		}
+
+		$this->assertSame( WC_Stripe_UPE_Payment_Gateway::ID, $result->get_data()['payment_method'] );
 	}
 
 	/**
@@ -397,7 +429,7 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 		$response = new WP_REST_Response( [ 'payment_method' => $payment_method ] );
 		$request  = new WP_REST_Request( 'GET', $route );
 
-		$result = ( new WC_Stripe_Blocks_Support() )->clear_hydrated_payment_method_for_default_token( $response, [], $request );
+		$result = $this->filter_checkout_hydration( $response, $request );
 
 		$this->assertSame( $payment_method, $result->get_data()['payment_method'] );
 	}
@@ -409,6 +441,7 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 		return [
 			'cart hydration'         => [ '/wc/store/v1/cart', WC_Stripe_UPE_Payment_Gateway::ID, true, true ],
 			'another payment method' => [ '/wc/store/v1/checkout', 'cheque', true, true ],
+			'another Stripe gateway' => [ '/wc/store/v1/checkout', WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_Payment_Methods::SEPA_DEBIT, true, true ],
 			'logged-out customer'    => [ '/wc/store/v1/checkout', WC_Stripe_UPE_Payment_Gateway::ID, false, true ],
 			'no default token'       => [ '/wc/store/v1/checkout', WC_Stripe_UPE_Payment_Gateway::ID, true, false ],
 		];
@@ -425,20 +458,33 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 		$response = new WP_REST_Response( [ 'payment_method' => WC_Stripe_UPE_Payment_Gateway::ID ] );
 		$request  = new WP_REST_Request( 'GET', '/wc/store/v1/checkout' );
 
-		$result = ( new WC_Stripe_Blocks_Support() )->clear_hydrated_payment_method_for_default_token( $response, [], $request );
+		$result = $this->filter_checkout_hydration( $response, $request );
 
 		$this->assertSame( WC_Stripe_UPE_Payment_Gateway::ID, $result->get_data()['payment_method'] );
 	}
 
 	/**
 	 * Hook values from other extensions must not cause type errors.
+	 *
+	 * @dataProvider provider_unexpected_checkout_hydration_values
+	 *
+	 * @param mixed $response Hydrated Store API response.
+	 * @param mixed $request  Store API request.
 	 */
-	public function test_checkout_hydration_accepts_unexpected_hook_values(): void {
-		$response = new WP_Error( 'test_error' );
-
-		$result = ( new WC_Stripe_Blocks_Support() )->clear_hydrated_payment_method_for_default_token( $response, [], null );
+	public function test_checkout_hydration_accepts_unexpected_hook_values( $response, $request ): void {
+		$result = ( new WC_Stripe_Blocks_Support() )->clear_hydrated_payment_method_for_default_token( $response, [], $request );
 
 		$this->assertSame( $response, $result );
+	}
+
+	/**
+	 * @return array[]
+	 */
+	public function provider_unexpected_checkout_hydration_values(): array {
+		return [
+			'unexpected response' => [ new WP_Error( 'test_error' ), new WP_REST_Request( 'GET', '/wc/store/v1/checkout' ) ],
+			'unexpected request'  => [ new WP_REST_Response( [ 'payment_method' => WC_Stripe_UPE_Payment_Gateway::ID ] ), null ],
+		];
 	}
 
 	/**
@@ -544,15 +590,48 @@ class WC_Stripe_Blocks_Support_Test extends WP_UnitTestCase {
 		return $token;
 	}
 
-	private function create_saved_sepa_token( int $user_id ): WC_Payment_Token_SEPA {
+	private function create_saved_sepa_token( int $user_id, string $payment_method_id = 'pm_sepa_default', bool $is_default = false ): WC_Payment_Token_SEPA {
 		$token = new WC_Payment_Token_SEPA();
-		$token->set_token( 'pm_sepa_default' );
+		$token->set_token( $payment_method_id );
 		$token->set_gateway_id( WC_Stripe_Payment_Tokens::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD[ WC_Stripe_Payment_Methods::SEPA_DEBIT ] );
 		$token->set_last4( '1234' );
 		$token->set_user_id( $user_id );
+		$token->set_default( $is_default );
 		$this->save_payment_token( $token );
 
 		return $token;
+	}
+
+	private function filter_checkout_hydration( WP_REST_Response $response, WP_REST_Request $request ): WP_REST_Response {
+		$gateways        = WC()->payment_gateways->payment_gateways();
+		$enabled_states  = [];
+		$gateway_ids     = array_unique( WC_Stripe_Payment_Tokens::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD );
+		$payment_tokens  = WC_Stripe_Payment_Tokens::get_instance();
+		$sync_callback   = [ $payment_tokens, 'woocommerce_get_customer_payment_tokens' ];
+		$sync_was_hooked = $payment_tokens instanceof WC_Stripe_Payment_Tokens && false !== has_filter( 'woocommerce_get_customer_payment_tokens', $sync_callback );
+
+		foreach ( $gateway_ids as $gateway_id ) {
+			if ( isset( $gateways[ $gateway_id ] ) ) {
+				$enabled_states[ $gateway_id ]    = $gateways[ $gateway_id ]->enabled;
+				$gateways[ $gateway_id ]->enabled = 'yes';
+			}
+		}
+
+		if ( $sync_was_hooked ) {
+			// These fixtures exist only in WooCommerce, so remote reconciliation would remove them.
+			remove_filter( 'woocommerce_get_customer_payment_tokens', $sync_callback, 10 );
+		}
+
+		try {
+			return ( new WC_Stripe_Blocks_Support() )->clear_hydrated_payment_method_for_default_token( $response, [], $request );
+		} finally {
+			foreach ( $enabled_states as $gateway_id => $enabled ) {
+				$gateways[ $gateway_id ]->enabled = $enabled;
+			}
+			if ( $sync_was_hooked ) {
+				add_filter( 'woocommerce_get_customer_payment_tokens', $sync_callback, 10, 3 );
+			}
+		}
 	}
 
 	private function save_payment_token( WC_Payment_Token $token ): void {


### PR DESCRIPTION
Fixes STRIPE-1438
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:

This PR uses a public WooCommerce filter to select the customer’s default saved Stripe payment method in Blocks checkout (for both standard Blocks checkout and OCS), and keeps the current choice when the customer selects a different payment gateway

The long-term fix is in WooCommerce core, but the plugin still needs a workaround for old and supported WooCommerce versions that contain the bug.

<img width="769" height="489" alt="Screenshot 2026-09-08 at 16 44 49" src="https://github.com/user-attachments/assets/26faf018-8ed3-4c14-954d-d5084ad4e642" />

_Backward compatibility_: this adds one public callback to WooCommerce’s `woocommerce_hydration_request_after_callbacks` filter. WooCommerce added this filter in `8.9`, and this plugin requires WooCommerce `10.8`, so all supported versions provide it. The callback only changes Blocks hydration when the active gateway has a visible default Stripe token after an earlier token for that gateway.

#### Alternatives considered
- Use WooCommerce’s private payment-store action.
    Rejected because `__internalSetActivePaymentMethod` is not a public API and can change without notice.
- Reorder saved tokens so the default token appears first.
    Rejected because this would change token order across My Account, classic checkout, and third-party integrations.
- Change WooCommerce asset data from the plugin.
    Rejected because this would depend on internal Blocks classes and initialization order.

## Testing instructions

1. Go to `My account > Payment methods` and make sure you have at least 2 saved payment methods
2. Set the second one as the default
3. Go to the store, and add a product to the cart
4. Go to the Blocks checkout
5. Confirm the default payment method is selected
6. Place the order and confirm it succeeds

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [x] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [x] Included this PR in the Release Thread scope (or does not apply)
