### PR TITLE
Keep classic checkout order notes after a failed Stripe payment

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -48,6 +48,7 @@ xxxx-xx-xx - version 11.0.0
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
 * Add - Log an error when missing required custom fields block express checkout, with a filter to disable the log
 * Fix - Stop two requests from reclaiming the same expired Optimized Checkout or Agentic Commerce sync lock
+* Fix - Keep the order notes a customer typed in the classic checkout when account creation and a failed Stripe payment reload the page
 
 2026-08-31 - version 10.9.1
 * Fix - Allow express checkout payments when automatic account password generation is disabled

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "includes/admin/class-wc-stripe-upe-compatibility-controller.php",
         "includes/class-wc-stripe-action-scheduler-service.php",
         "includes/class-wc-stripe-api-outage-status.php",
+        "includes/class-wc-stripe-checkout-customer-note.php",
         "includes/class-wc-stripe-checkout-session-lifecycle.php",
         "includes/class-wc-stripe-checkout-session-manager.php",
         "includes/class-wc-stripe-co-branded-cc-compatibility.php",

--- a/includes/class-wc-stripe-checkout-customer-note.php
+++ b/includes/class-wc-stripe-checkout-customer-note.php
@@ -31,8 +31,10 @@ class WC_Stripe_Checkout_Customer_Note {
 	/**
 	 * Returns the customer note of the order awaiting payment in the session when the field has no other default.
 	 *
-	 * Mirrors the conditions WooCommerce core uses to resume an order at checkout (pending or
-	 * failed status), narrowed to orders that went through a Stripe gateway.
+	 * Uses the status half of the condition WooCommerce core applies when it resumes that order
+	 * (pending or failed), narrowed to orders that went through a Stripe gateway. The cart-hash
+	 * half is skipped on purpose: the note is the customer's own input for this session, so it
+	 * should survive a cart change that makes core create a fresh order instead.
 	 *
 	 * @param string|null $value The default value WooCommerce computed for the order notes field.
 	 * @return string|null

--- a/includes/class-wc-stripe-checkout-customer-note.php
+++ b/includes/class-wc-stripe-checkout-customer-note.php
@@ -1,0 +1,68 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use Automattic\WooCommerce\Enums\OrderStatus;
+
+/**
+ * Keeps the customer's order notes on the classic checkout across a failed Stripe payment.
+ *
+ * When a guest opts into account creation and the payment then fails, WooCommerce reloads the
+ * checkout page to pick up the new login. The address fields are rebuilt from the customer
+ * record, but the order notes have no such source and come back empty even though they were
+ * already saved on the failed order. Prefilling from that order restores what the customer
+ * typed and carries it onto the retried payment.
+ *
+ * @since 11.0.0
+ */
+class WC_Stripe_Checkout_Customer_Note {
+
+	/**
+	 * Registers the classic checkout hook.
+	 *
+	 * @return void
+	 */
+	public function init_hooks(): void {
+		add_filter( 'default_checkout_order_comments', [ $this, 'restore_note_from_awaiting_order' ] );
+	}
+
+	/**
+	 * Returns the customer note of the order awaiting payment in the session when the field has no other default.
+	 *
+	 * Mirrors the conditions WooCommerce core uses to resume an order at checkout (pending or
+	 * failed status), narrowed to orders that went through a Stripe gateway.
+	 *
+	 * @param string|null $value The default value WooCommerce computed for the order notes field.
+	 * @return string|null
+	 */
+	public function restore_note_from_awaiting_order( $value ) {
+		if ( is_string( $value ) && '' !== $value ) {
+			return $value;
+		}
+
+		$session = function_exists( 'WC' ) ? WC()->session : null;
+		if ( ! $session || ! is_callable( [ $session, 'get' ] ) ) {
+			return $value;
+		}
+
+		$order_id = absint( $session->get( 'order_awaiting_payment' ) );
+		if ( ! $order_id ) {
+			return $value;
+		}
+
+		$order = wc_get_order( $order_id );
+		if ( ! $order instanceof WC_Order || ! $order->has_status( [ OrderStatus::PENDING, OrderStatus::FAILED ] ) ) {
+			return $value;
+		}
+
+		if ( ! WC_Stripe_Order_Helper::get_instance()->is_stripe_gateway_order( $order ) ) {
+			return $value;
+		}
+
+		$note = $order->get_customer_note();
+
+		return '' === $note ? $value : $note;
+	}
+}

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -264,6 +264,9 @@ class WC_Stripe {
 			$checkout_session_lifecycle = new WC_Stripe_Checkout_Session_Lifecycle();
 			$checkout_session_lifecycle->init_classic_hooks();
 			WC_Stripe_Checkout_Session_Context::init_hooks();
+
+			$checkout_customer_note = new WC_Stripe_Checkout_Customer_Note();
+			$checkout_customer_note->init_hooks();
 		}
 
 		if ( is_admin() ) {

--- a/readme.txt
+++ b/readme.txt
@@ -211,5 +211,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
 * Add - Log an error when missing required custom fields block express checkout, with a filter to disable the log
 * Fix - Stop two requests from reclaiming the same expired Optimized Checkout or Agentic Commerce sync lock
+* Fix - Keep the order notes a customer typed in the classic checkout when account creation and a failed Stripe payment reload the page
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/class-wc-stripe-checkout-customer-note-test.php
+++ b/tests/phpunit/class-wc-stripe-checkout-customer-note-test.php
@@ -62,6 +62,8 @@ class WC_Stripe_Checkout_Customer_Note_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A pending or failed Stripe order in the session supplies the note.
+	 *
 	 * @dataProvider provide_resumable_statuses
 	 */
 	public function test_restores_note_from_awaiting_stripe_order( string $status ) {
@@ -78,6 +80,8 @@ class WC_Stripe_Checkout_Customer_Note_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Every Stripe gateway id, not only the main one, counts as a Stripe order.
+	 *
 	 * @dataProvider provide_stripe_payment_methods
 	 */
 	public function test_restores_note_for_every_stripe_gateway_id( string $payment_method ) {
@@ -93,16 +97,25 @@ class WC_Stripe_Checkout_Customer_Note_Test extends WP_UnitTestCase {
 		];
 	}
 
+	/**
+	 * A default another callback already supplied is never overwritten.
+	 */
 	public function test_keeps_existing_default_value() {
 		$this->create_awaiting_order();
 
 		$this->assertSame( 'Existing default', $this->customer_note->restore_note_from_awaiting_order( 'Existing default' ) );
 	}
 
+	/**
+	 * Without an order awaiting payment the field keeps its normal default.
+	 */
 	public function test_returns_value_when_no_order_is_awaiting_payment() {
 		$this->assertNull( $this->customer_note->restore_note_from_awaiting_order( null ) );
 	}
 
+	/**
+	 * A stale session id pointing at a deleted order is ignored.
+	 */
 	public function test_returns_value_when_awaiting_order_no_longer_exists() {
 		$order = $this->create_awaiting_order();
 		WC_Helper_Order::delete_order( $order->get_id() );
@@ -111,6 +124,8 @@ class WC_Stripe_Checkout_Customer_Note_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Orders core would not resume at checkout do not leak their note into a new order.
+	 *
 	 * @dataProvider provide_non_resumable_statuses
 	 */
 	public function test_ignores_orders_that_are_no_longer_resumable( string $status ) {
@@ -127,12 +142,18 @@ class WC_Stripe_Checkout_Customer_Note_Test extends WP_UnitTestCase {
 		];
 	}
 
+	/**
+	 * Orders placed through other gateways are left to those gateways.
+	 */
 	public function test_ignores_orders_paid_with_another_gateway() {
 		$this->create_awaiting_order( [ 'payment_method' => 'bacs' ] );
 
 		$this->assertNull( $this->customer_note->restore_note_from_awaiting_order( null ) );
 	}
 
+	/**
+	 * An empty note on the order does not replace the field default.
+	 */
 	public function test_ignores_orders_without_a_customer_note() {
 		$this->create_awaiting_order( [ 'customer_note' => '' ] );
 
@@ -151,12 +172,18 @@ class WC_Stripe_Checkout_Customer_Note_Test extends WP_UnitTestCase {
 		$this->assertSame( self::NOTE, WC()->checkout()->get_value( 'order_comments' ) );
 	}
 
+	/**
+	 * The registered hook is a no-op for a plain checkout render.
+	 */
 	public function test_checkout_field_default_stays_empty_without_an_awaiting_order() {
 		unset( $_POST['order_comments'] );
 
 		$this->assertNull( WC()->checkout()->get_value( 'order_comments' ) );
 	}
 
+	/**
+	 * A value the customer submitted takes precedence over the restored note.
+	 */
 	public function test_posted_value_wins_over_restored_note() {
 		$this->create_awaiting_order();
 		$_POST['order_comments'] = 'Typed again';

--- a/tests/phpunit/class-wc-stripe-checkout-customer-note-test.php
+++ b/tests/phpunit/class-wc-stripe-checkout-customer-note-test.php
@@ -1,0 +1,166 @@
+<?php
+
+use Automattic\WooCommerce\Enums\OrderStatus;
+
+/**
+ * Tests for WC_Stripe_Checkout_Customer_Note.
+ */
+class WC_Stripe_Checkout_Customer_Note_Test extends WP_UnitTestCase {
+
+	/**
+	 * Note stored on the order awaiting payment.
+	 */
+	private const NOTE = 'Leave the parcel at the back door.';
+
+	/**
+	 * Instance under test.
+	 *
+	 * @var WC_Stripe_Checkout_Customer_Note
+	 */
+	private $customer_note;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->customer_note = new WC_Stripe_Checkout_Customer_Note();
+
+		WC()->session->init();
+		WC()->session->set( 'order_awaiting_payment', null );
+	}
+
+	public function tear_down(): void {
+		// In-memory session data survives the per-test DB rollback.
+		WC()->session->set( 'order_awaiting_payment', null );
+		unset( $_POST['order_comments'] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Creates an order and marks it as the one awaiting payment in the session.
+	 *
+	 * @param array $props Order properties passed to the order helper.
+	 * @return WC_Order
+	 */
+	private function create_awaiting_order( array $props = [] ): WC_Order {
+		$order = WC_Helper_Order::create_order(
+			1,
+			null,
+			array_merge(
+				[
+					'status'         => OrderStatus::FAILED,
+					'payment_method' => WC_Stripe_UPE_Payment_Gateway::ID,
+					'customer_note'  => self::NOTE,
+				],
+				$props
+			)
+		);
+
+		WC()->session->set( 'order_awaiting_payment', $order->get_id() );
+
+		return $order;
+	}
+
+	/**
+	 * @dataProvider provide_resumable_statuses
+	 */
+	public function test_restores_note_from_awaiting_stripe_order( string $status ) {
+		$this->create_awaiting_order( [ 'status' => $status ] );
+
+		$this->assertSame( self::NOTE, $this->customer_note->restore_note_from_awaiting_order( null ) );
+	}
+
+	public function provide_resumable_statuses(): array {
+		return [
+			'failed order'  => [ OrderStatus::FAILED ],
+			'pending order' => [ OrderStatus::PENDING ],
+		];
+	}
+
+	/**
+	 * @dataProvider provide_stripe_payment_methods
+	 */
+	public function test_restores_note_for_every_stripe_gateway_id( string $payment_method ) {
+		$this->create_awaiting_order( [ 'payment_method' => $payment_method ] );
+
+		$this->assertSame( self::NOTE, $this->customer_note->restore_note_from_awaiting_order( null ) );
+	}
+
+	public function provide_stripe_payment_methods(): array {
+		return [
+			'main gateway'    => [ WC_Stripe_UPE_Payment_Gateway::ID ],
+			'UPE card method' => [ WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_Payment_Methods::CARD ],
+		];
+	}
+
+	public function test_keeps_existing_default_value() {
+		$this->create_awaiting_order();
+
+		$this->assertSame( 'Existing default', $this->customer_note->restore_note_from_awaiting_order( 'Existing default' ) );
+	}
+
+	public function test_returns_value_when_no_order_is_awaiting_payment() {
+		$this->assertNull( $this->customer_note->restore_note_from_awaiting_order( null ) );
+	}
+
+	public function test_returns_value_when_awaiting_order_no_longer_exists() {
+		$order = $this->create_awaiting_order();
+		WC_Helper_Order::delete_order( $order->get_id() );
+
+		$this->assertNull( $this->customer_note->restore_note_from_awaiting_order( null ) );
+	}
+
+	/**
+	 * @dataProvider provide_non_resumable_statuses
+	 */
+	public function test_ignores_orders_that_are_no_longer_resumable( string $status ) {
+		$this->create_awaiting_order( [ 'status' => $status ] );
+
+		$this->assertNull( $this->customer_note->restore_note_from_awaiting_order( null ) );
+	}
+
+	public function provide_non_resumable_statuses(): array {
+		return [
+			'processing order' => [ OrderStatus::PROCESSING ],
+			'completed order'  => [ OrderStatus::COMPLETED ],
+			'cancelled order'  => [ OrderStatus::CANCELLED ],
+		];
+	}
+
+	public function test_ignores_orders_paid_with_another_gateway() {
+		$this->create_awaiting_order( [ 'payment_method' => 'bacs' ] );
+
+		$this->assertNull( $this->customer_note->restore_note_from_awaiting_order( null ) );
+	}
+
+	public function test_ignores_orders_without_a_customer_note() {
+		$this->create_awaiting_order( [ 'customer_note' => '' ] );
+
+		$this->assertNull( $this->customer_note->restore_note_from_awaiting_order( null ) );
+	}
+
+	/**
+	 * The plugin bootstrap registers the hook, so the checkout field default itself must carry the note.
+	 */
+	public function test_checkout_field_default_is_prefilled_through_the_registered_hook() {
+		$this->assertNotFalse( has_filter( 'default_checkout_order_comments' ) );
+
+		$this->create_awaiting_order();
+		unset( $_POST['order_comments'] );
+
+		$this->assertSame( self::NOTE, WC()->checkout()->get_value( 'order_comments' ) );
+	}
+
+	public function test_checkout_field_default_stays_empty_without_an_awaiting_order() {
+		unset( $_POST['order_comments'] );
+
+		$this->assertNull( WC()->checkout()->get_value( 'order_comments' ) );
+	}
+
+	public function test_posted_value_wins_over_restored_note() {
+		$this->create_awaiting_order();
+		$_POST['order_comments'] = 'Typed again';
+
+		$this->assertSame( 'Typed again', WC()->checkout()->get_value( 'order_comments' ) );
+	}
+}


### PR DESCRIPTION
Fixes STRIPE-366
Fixes #4129

## Changes proposed in this Pull Request:

On the classic (shortcode) checkout, a guest who ticks "Create an account?" and then has the Stripe payment declined loses whatever they typed in the Order notes field. WooCommerce sets a reload flag when it creates the account during checkout, the failed payment response carries that flag, and the page reloads. The address fields come back from the new customer record. The Order notes field has no persisted source, so it comes back empty even though the note is already saved on the failed order. The retry then posts an empty note and the successful order ships without it.

This adds `WC_Stripe_Checkout_Customer_Note`, which hooks `default_checkout_order_comments` and prefills the field from the customer note of the order stored in the session's `order_awaiting_payment` key. It only does that when the order is pending or failed, the same status condition core uses to resume that order at checkout, and was placed through a Stripe gateway. A value the customer posts, or a default another callback already supplied, wins. The hook is registered from the plugin bootstrap next to the checkout session lifecycle, not from a gateway constructor.

I went with a server-side prefill rather than keeping the field alive in the browser because the reload is core behavior and it is needed for the new login, so the fix has to survive it. The Blocks checkout keeps its form in the browser and never reloads, so it isn't affected either way.

Backward compatibility: additive only. One new class and one new filter callback, no changes to hooks, options, handles, or signatures. The code only runs while the classic checkout form renders, since `default_checkout_*` fires from `WC_Checkout::get_value()` and nowhere else.

**Before:** successful retry order, no customer provided note.

<img width="780" height="654" alt="before-admin-successful-order-335-no-note" src="https://github.com/user-attachments/assets/654d16fe-85df-4dff-af5b-f6f95415fa46" />

**After:** same flow with this change, the note is on the successful order.

<img width="1280" height="1571" alt="after-myaccount-successful-order-336-has-note" src="https://github.com/user-attachments/assets/5ec4f9c3-46f5-4d6e-9790-ffe0b14e2f52" />

## Testing instructions

Setup:

- A classic checkout page (`[woocommerce_checkout]` shortcode) set as the checkout page.
- Stripe in test mode with Optimized Checkout Suite turned off (WooCommerce > Settings > Payments > Stripe > Settings > Advanced settings). With it on, a declined card is handled in the browser and this reload never happens.
- WooCommerce > Settings > Accounts & Privacy: enable "Allow customers to create an account during checkout".

Steps:

1. As a guest (private window), add a product to the cart and open the checkout.
2. Fill in the billing details with an email that has no account, tick "Create an account?", and type something in Order notes.
3. Pay with the declined test card 4000 0000 0000 0002.
4. Expected: the page reloads with the "card was declined" notice, you're logged in as the new customer, and Order notes still holds your text. Before this change the field was empty.
5. Pay again with 4242 4242 4242 4242.
6. Expected: the new order shows the text under "Customer provided note" on the admin order screen and as "Note:" on My account > Orders > that order. Before this change only the failed order had it.
7. Regression: log in as a customer with no failed order in the session and open the checkout. Order notes is empty.

Automated:

```
npm run test:php -- --filter WC_Stripe_Checkout_Customer_Note_Test
npm run test:php:parallel
```

The new class has 15 tests covering both resumable statuses, every Stripe gateway id, non-Stripe orders, paid orders, a deleted order id, an empty note, an existing default, and a posted value. The full suite (4027 tests) passes. I ran it in the repo Docker environment; the `wordpress_xdebug` image needed a local apt workaround because its Debian bullseye base is end of life, and that change is not in this PR.

Not tested: multisite, and the Blocks checkout was not exercised since this code path is unreachable from it.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

> Fix - Keep the order notes a customer typed in the classic checkout when account creation and a failed Stripe payment reload the page

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)