### PR TITLE
Fix coupon discount sent as a positive line item on classic checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@ xxxx-xx-xx - version 11.1.0
 * Dev - Add E2E coverage for express checkout with free trial subscriptions, with and without shipping, including completing the purchase with Link
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
 * Fix - Stop two requests from reclaiming the same expired Optimized Checkout or Agentic Commerce sync lock
-* Fix - Show coupon discounts as negative line items in Apple Pay and Google Pay on classic checkout
+* Fix - Show coupon discounts as negative line items in Apple Pay and Google Pay on classic cart and checkout pages
 
 2026-09-08 - version 11.0.0
 * Fix - Allow express checkout payments when a wallet provides a one-word shipping name

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ xxxx-xx-xx - version 11.1.0
 * Dev - Add E2E coverage for express checkout with free trial subscriptions, with and without shipping, including completing the purchase with Link
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
 * Fix - Stop two requests from reclaiming the same expired Optimized Checkout or Agentic Commerce sync lock
+* Fix - Show coupon discounts as negative line items in Apple Pay and Google Pay on classic checkout
 
 2026-09-08 - version 11.0.0
 * Fix - Allow express checkout payments when a wallet provides a one-word shipping name

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,7 @@ xxxx-xx-xx - version 11.1.0
 * Dev - Add E2E coverage for express checkout with free trial subscriptions, with and without shipping, including completing the purchase with Link
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
 * Fix - Stop two requests from reclaiming the same expired Optimized Checkout or Agentic Commerce sync lock
-* Fix - Show coupon discounts as negative line items in Apple Pay and Google Pay on classic cart and checkout pages
+* Fix - Show coupon discounts as negative line items in Express Checkout on classic cart and checkout pages
 * Fix - Stop disabling Level 3 data account-wide when Stripe rejects it for a request that declares a non-card payment method
 * Fix - Open testing and payment settings documentation links in new tabs
 

--- a/client/express-checkout/transformers/__tests__/wc-to-stripe.test.js
+++ b/client/express-checkout/transformers/__tests__/wc-to-stripe.test.js
@@ -3,6 +3,7 @@ import {
 	transformPriceWithMinorUnits,
 	transformCartDataForDisplayItems,
 	transformCartDataForShippingRates,
+	transformLabeledDisplayItems,
 } from '../wc-to-stripe';
 
 global.wc_stripe_express_checkout_params = {};
@@ -476,6 +477,24 @@ describe( 'wc-to-stripe transformers', () => {
 					)
 				).toBe( testCase.expected );
 			} );
+		} );
+	} );
+
+	describe( 'transformLabeledDisplayItems', () => {
+		it( 'uses a negative amount for discounts', () => {
+			expect(
+				transformLabeledDisplayItems( [
+					{ label: 'Subtotal', amount: 5500 },
+					{
+						key: 'total_discount',
+						label: 'Discount',
+						amount: 5225,
+					},
+				] )
+			).toStrictEqual( [
+				{ name: 'Subtotal', amount: 5500 },
+				{ name: 'Discount', amount: -5225 },
+			] );
 		} );
 	} );
 

--- a/client/express-checkout/transformers/wc-to-stripe.js
+++ b/client/express-checkout/transformers/wc-to-stripe.js
@@ -149,9 +149,9 @@ export const transformCartDataForDisplayItems = ( rawCartData ) => {
  * @return {Array} The transformed display items.
  */
 export const transformLabeledDisplayItems = ( displayItems ) => {
-	return ( displayItems ?? [] ).map( ( { label, amount } ) => ( {
+	return ( displayItems ?? [] ).map( ( { key, label, amount } ) => ( {
 		name: label,
-		amount,
+		amount: key === 'total_discount' ? -amount : amount,
 	} ) );
 };
 

--- a/client/express-checkout/transformers/wc-to-stripe.js
+++ b/client/express-checkout/transformers/wc-to-stripe.js
@@ -1,7 +1,10 @@
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
 import { decodeEntities } from '@wordpress/html-entities';
-import { getExpressCheckoutData } from 'wcstripe/express-checkout/utils';
+import {
+	getExpressCheckoutData,
+	normalizeLineItems,
+} from 'wcstripe/express-checkout/utils';
 import { SHIPPING_RATES_UPPER_LIMIT_COUNT } from 'wcstripe/stripe-utils/constants';
 
 /**
@@ -149,10 +152,7 @@ export const transformCartDataForDisplayItems = ( rawCartData ) => {
  * @return {Array} The transformed display items.
  */
 export const transformLabeledDisplayItems = ( displayItems ) => {
-	return ( displayItems ?? [] ).map( ( { key, label, amount } ) => ( {
-		name: label,
-		amount: key === 'total_discount' ? -amount : amount,
-	} ) );
+	return normalizeLineItems( displayItems ?? [] );
 };
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -165,5 +165,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Add E2E coverage for express checkout with free trial subscriptions, with and without shipping, including completing the purchase with Link
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
 * Fix - Stop two requests from reclaiming the same expired Optimized Checkout or Agentic Commerce sync lock
+* Fix - Show coupon discounts as negative line items in Apple Pay and Google Pay on classic checkout
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -165,6 +165,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Add E2E coverage for express checkout with free trial subscriptions, with and without shipping, including completing the purchase with Link
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
 * Fix - Stop two requests from reclaiming the same expired Optimized Checkout or Agentic Commerce sync lock
-* Fix - Show coupon discounts as negative line items in Apple Pay and Google Pay on classic checkout
+* Fix - Show coupon discounts as negative line items in Apple Pay and Google Pay on classic cart and checkout pages
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -168,7 +168,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Add E2E coverage for express checkout with free trial subscriptions, with and without shipping, including completing the purchase with Link
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
 * Fix - Stop two requests from reclaiming the same expired Optimized Checkout or Agentic Commerce sync lock
-* Fix - Show coupon discounts as negative line items in Apple Pay and Google Pay on classic cart and checkout pages
+* Fix - Show coupon discounts as negative line items in Express Checkout on classic cart and checkout pages
 * Fix - Stop disabling Level 3 data account-wide when Stripe rejects it for a request that declares a non-card payment method
 * Fix - Open testing and payment settings documentation links in new tabs
 


### PR DESCRIPTION
Fixes STRIPE-1441, STRIPE-1443
Fixes #5926, #5929

## Changes proposed in this Pull Request:

Coupon discounts had a positive value on classic cart and checkout pages. This made the line item total higher than the payment total and could stop Apple Pay or Google Pay from opening.

This change sends coupon discounts as negative line items.

- Classic cart and checkout: changed in this PR
- Pay-for-order: unchanged (discount is already negative and has no total_discount key)
- Product pages: unchanged (standard line items have no discount key)
- Blocks checkout: unchanged (already handles discounts correctly)

## Testing instructions

Extracted from #5926:

1. Add a product to the cart
2. Apply a percentage coupon
3. Open the express checkout button
4. Confirm the discount is negative and the total is correct
5. Confirm the payment succeeds




---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
