### PR TITLE
Move the #5663 changelog entry to the 11.0.0 block

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -51,6 +51,7 @@ xxxx-xx-xx - version 11.1.0
 * Tweak - Disable the Agentic Commerce "Sync now" button until onboarding is complete, with a note explaining the remaining step
 * Fix - Attach a Stripe customer to guest Adaptive Pricing checkouts, linking it to the order and any account created at checkout
 * Add - Log an error when missing required custom fields block express checkout, with a filter to disable the log
+* Update - Take already-synced products out of in-agent checkout when Agentic Commerce is disabled by pushing a final catalog feed, and stop the recurring product sync while it's off
 
 2026-08-31 - version 10.9.1
 * Fix - Allow express checkout payments when automatic account password generation is disabled
@@ -71,7 +72,6 @@ xxxx-xx-xx - version 11.1.0
 * Fix - Send the admin New Order and customer Processing emails when an asynchronous payment method (iDEAL, Klarna, Bancontact) is confirmed via the deferred webhook path
 * Fix - Use the Amazon Pay custom button size setting on the product, cart, and checkout pages instead of falling back to the Apple Pay/Google Pay size
 * Tweak - Render the Express Checkout button on the cart and checkout from page-bootstrapped data, removing a cart-details request from the critical path to first button render
-* Update - Take already-synced products out of in-agent checkout when Agentic Commerce is disabled by pushing a final catalog feed, and stop the recurring product sync while it's off
 * Fix - Show the Stripe payment block as supported in the Checkout block editor when Optimized Checkout is enabled and only non-card methods (e.g. Cash App Pay) are active
 * Tweak - Memoize the Blocks Express Checkout button so it no longer re-renders the Stripe element on unrelated cart updates
 * Fix - Keep the subscription payment-method row in sync with the saved-card list when a card has been used both directly and through Apple Pay/Google Pay


### PR DESCRIPTION
Related to #5663

## Changes proposed in this Pull Request:

Moves the `changelog.txt` entry for #5663 from the `10.9.0` block to the `11.0.0` block. The change shipped in 11.0.0 (the merge `a1faefda` is in the tag), but the entry was added to the branch while 10.9.0 was still unreleased and stayed in that block through the later develop merges. The `readme.txt` entry on the 11.0.0 tag and the GitHub release notes are already correct, so only `changelog.txt` needs the move.

The public changelog linked from `readme.txt` reads `trunk/changelog.txt`, so the fix becomes visible with the next release.

## Testing instructions

1. Check that `changelog.txt` lists "Take already-synced products out of in-agent checkout when Agentic Commerce is disabled ..." under `2026-09-08 - version 11.0.0` and no longer under `2026-08-17 - version 10.9.0`.
2. `node bin/changelog.js` validation (the Validate Changelog workflow) passes.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️) — changelog-only change
-   [x] Tested on mobile (or does not apply)

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Corrects the placement of an existing entry; no user-facing change.

</details>

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [x] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [x] Included this PR in the Release Thread scope (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWjLuBqiCaj8kKSdYUePhN
