### PR TITLE
Open settings external links in new tab

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ xxxx-xx-xx - version 11.1.0
 * Dev - Add E2E coverage for express checkout with free trial subscriptions, with and without shipping, including completing the purchase with Link
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
 * Fix - Stop two requests from reclaiming the same expired Optimized Checkout or Agentic Commerce sync lock
+* Fix - Open testing and payment settings documentation links in new tabs
 
 2026-09-08 - version 11.0.0
 * Fix - Allow express checkout payments when a wallet provides a one-word shipping name

--- a/client/settings/payment-settings/__tests__/test-mode-checkbox.test.js
+++ b/client/settings/payment-settings/__tests__/test-mode-checkbox.test.js
@@ -45,6 +45,20 @@ const mockAccount = ( {
 };
 
 describe( 'TestModeCheckbox', () => {
+	it( 'opens help links in a new tab', () => {
+		useTestMode.mockReturnValue( [ false, jest.fn() ] );
+		mockAccount( { liveConnected: true, testConnected: true } );
+
+		render( <TestModeCheckbox /> );
+
+		expect(
+			screen.getByRole( 'link', { name: 'test card numbers' } )
+		).toHaveAttribute( 'target', '_blank' );
+		expect(
+			screen.getByRole( 'link', { name: 'Learn more' } )
+		).toHaveAttribute( 'target', '_blank' );
+	} );
+
 	it( 'allows enabling test mode when a test account is connected', async () => {
 		const setTestModeMock = jest.fn();
 		useTestMode.mockReturnValue( [ false, setTestModeMock ] );

--- a/client/settings/payment-settings/__tests__/test-mode-checkbox.test.js
+++ b/client/settings/payment-settings/__tests__/test-mode-checkbox.test.js
@@ -21,7 +21,7 @@ jest.mock( '@wordpress/components', () => ( {
 		</>
 	),
 	ExternalLink: ( { href, children } ) => (
-		<a href={ href } target="_blank" rel="external noreferrer noopener">
+		<a href={ href }>
 			{ children }
 			<span>(opens in a new tab)</span>
 		</a>
@@ -51,7 +51,7 @@ const mockAccount = ( {
 };
 
 describe( 'TestModeCheckbox', () => {
-	it( 'opens help links in a new tab', () => {
+	it( 'renders accessible external help links', () => {
 		useTestMode.mockReturnValue( [ false, jest.fn() ] );
 		mockAccount( { liveConnected: true, testConnected: true } );
 
@@ -64,15 +64,13 @@ describe( 'TestModeCheckbox', () => {
 			name: 'Learn more (opens in a new tab)',
 		} );
 
-		expect( testCardNumbersLink ).toHaveAttribute( 'target', '_blank' );
 		expect( testCardNumbersLink ).toHaveAttribute(
-			'rel',
-			'external noreferrer noopener'
+			'href',
+			'https://docs.stripe.com/testing#cards'
 		);
-		expect( learnMoreLink ).toHaveAttribute( 'target', '_blank' );
 		expect( learnMoreLink ).toHaveAttribute(
-			'rel',
-			'external noreferrer noopener'
+			'href',
+			'https://woocommerce.com/document/stripe/customer-experience/testing/'
 		);
 	} );
 

--- a/client/settings/payment-settings/__tests__/test-mode-checkbox.test.js
+++ b/client/settings/payment-settings/__tests__/test-mode-checkbox.test.js
@@ -20,6 +20,12 @@ jest.mock( '@wordpress/components', () => ( {
 			<span>{ help }</span>
 		</>
 	),
+	ExternalLink: ( { href, children } ) => (
+		<a href={ href } target="_blank" rel="external noreferrer noopener">
+			{ children }
+			<span>(opens in a new tab)</span>
+		</a>
+	),
 } ) );
 
 jest.mock( 'wcstripe/data', () => ( {
@@ -51,12 +57,23 @@ describe( 'TestModeCheckbox', () => {
 
 		render( <TestModeCheckbox /> );
 
-		expect(
-			screen.getByRole( 'link', { name: 'test card numbers' } )
-		).toHaveAttribute( 'target', '_blank' );
-		expect(
-			screen.getByRole( 'link', { name: 'Learn more' } )
-		).toHaveAttribute( 'target', '_blank' );
+		const testCardNumbersLink = screen.getByRole( 'link', {
+			name: 'test card numbers (opens in a new tab)',
+		} );
+		const learnMoreLink = screen.getByRole( 'link', {
+			name: 'Learn more (opens in a new tab)',
+		} );
+
+		expect( testCardNumbersLink ).toHaveAttribute( 'target', '_blank' );
+		expect( testCardNumbersLink ).toHaveAttribute(
+			'rel',
+			'external noreferrer noopener'
+		);
+		expect( learnMoreLink ).toHaveAttribute( 'target', '_blank' );
+		expect( learnMoreLink ).toHaveAttribute(
+			'rel',
+			'external noreferrer noopener'
+		);
 	} );
 
 	it( 'allows enabling test mode when a test account is connected', async () => {

--- a/client/settings/payment-settings/test-mode-checkbox.js
+++ b/client/settings/payment-settings/test-mode-checkbox.js
@@ -1,7 +1,7 @@
 import { React } from 'react';
 import interpolateComponents from '@automattic/interpolate-components';
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl } from '@wordpress/components';
+import { CheckboxControl, ExternalLink } from '@wordpress/components';
 import { useTestMode } from 'wcstripe/data';
 import { useAccount } from 'wcstripe/data/account';
 
@@ -36,20 +36,10 @@ const TestModeCheckbox = () => {
 		),
 		components: {
 			testCardNumbersLink: (
-				// eslint-disable-next-line jsx-a11y/anchor-has-content
-				<a
-					href="https://docs.stripe.com/testing#cards"
-					target="_blank"
-					rel="noreferrer"
-				/>
+				<ExternalLink href="https://docs.stripe.com/testing#cards" />
 			),
 			learnMoreLink: (
-				// eslint-disable-next-line jsx-a11y/anchor-has-content
-				<a
-					href="https://woocommerce.com/document/stripe/customer-experience/testing/"
-					target="_blank"
-					rel="noreferrer"
-				/>
+				<ExternalLink href="https://woocommerce.com/document/stripe/customer-experience/testing/" />
 			),
 		},
 	} );

--- a/client/settings/payment-settings/test-mode-checkbox.js
+++ b/client/settings/payment-settings/test-mode-checkbox.js
@@ -37,11 +37,19 @@ const TestModeCheckbox = () => {
 		components: {
 			testCardNumbersLink: (
 				// eslint-disable-next-line jsx-a11y/anchor-has-content
-				<a href="https://docs.stripe.com/testing#cards" />
+				<a
+					href="https://docs.stripe.com/testing#cards"
+					target="_blank"
+					rel="noreferrer"
+				/>
 			),
 			learnMoreLink: (
 				// eslint-disable-next-line jsx-a11y/anchor-has-content
-				<a href="https://woocommerce.com/document/stripe/customer-experience/testing/" />
+				<a
+					href="https://woocommerce.com/document/stripe/customer-experience/testing/"
+					target="_blank"
+					rel="noreferrer"
+				/>
 			),
 		},
 	} );

--- a/client/settings/payments-and-transactions-section/__tests__/manual-capture-control.test.js
+++ b/client/settings/payments-and-transactions-section/__tests__/manual-capture-control.test.js
@@ -26,9 +26,15 @@ describe( 'ManualCaptureControl', () => {
 	it( 'opens the help link in a new tab', () => {
 		render( <ManualCaptureControl /> );
 
-		expect(
-			screen.getByRole( 'link', { name: 'Learn more' } )
-		).toHaveAttribute( 'target', '_blank' );
+		const learnMoreLink = screen.getByRole( 'link', {
+			name: 'Learn more (opens in a new tab)',
+		} );
+
+		expect( learnMoreLink ).toHaveAttribute( 'target', '_blank' );
+		expect( learnMoreLink ).toHaveAttribute(
+			'rel',
+			'external noreferrer noopener'
+		);
 	} );
 
 	it( 'notes in the confirmation modal that agentic purchases follow the Stripe dashboard capture setting when agentic commerce is enabled', async () => {

--- a/client/settings/payments-and-transactions-section/__tests__/manual-capture-control.test.js
+++ b/client/settings/payments-and-transactions-section/__tests__/manual-capture-control.test.js
@@ -35,6 +35,10 @@ describe( 'ManualCaptureControl', () => {
 			'rel',
 			'external noreferrer noopener'
 		);
+		expect( learnMoreLink ).toHaveAttribute(
+			'href',
+			'https://woocommerce.com/document/stripe/admin-experience/authorize-and-capture/'
+		);
 	} );
 
 	it( 'notes in the confirmation modal that agentic purchases follow the Stripe dashboard capture setting when agentic commerce is enabled', async () => {

--- a/client/settings/payments-and-transactions-section/__tests__/manual-capture-control.test.js
+++ b/client/settings/payments-and-transactions-section/__tests__/manual-capture-control.test.js
@@ -23,6 +23,14 @@ describe( 'ManualCaptureControl', () => {
 		delete global.wc_stripe_settings_params;
 	} );
 
+	it( 'opens the help link in a new tab', () => {
+		render( <ManualCaptureControl /> );
+
+		expect(
+			screen.getByRole( 'link', { name: 'Learn more' } )
+		).toHaveAttribute( 'target', '_blank' );
+	} );
+
 	it( 'notes in the confirmation modal that agentic purchases follow the Stripe dashboard capture setting when agentic commerce is enabled', async () => {
 		global.wc_stripe_settings_params.is_agentic_commerce_merchant_enabled = true;
 		useManualCapture.mockReturnValue( [ false, jest.fn() ] );

--- a/client/settings/payments-and-transactions-section/manual-capture-control.js
+++ b/client/settings/payments-and-transactions-section/manual-capture-control.js
@@ -83,7 +83,11 @@ const ManualCaptureControl = () => {
 					components: {
 						learnMoreLink: (
 							// eslint-disable-next-line jsx-a11y/anchor-has-content
-							<a href="https://woocommerce.com/document/stripe/admin-experience/authorize-and-capture/" />
+							<a
+								href="https://woocommerce.com/document/stripe/admin-experience/authorize-and-capture/"
+								target="_blank"
+								rel="noreferrer"
+							/>
 						),
 					},
 				} ) }

--- a/client/settings/payments-and-transactions-section/manual-capture-control.js
+++ b/client/settings/payments-and-transactions-section/manual-capture-control.js
@@ -3,7 +3,7 @@ import interpolateComponents from '@automattic/interpolate-components';
 import React, { useState } from 'react';
 import { Icon, info } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl, Button } from '@wordpress/components';
+import { CheckboxControl, Button, ExternalLink } from '@wordpress/components';
 import { useManualCapture } from 'wcstripe/data';
 import ConfirmationModal from 'wcstripe/components/confirmation-modal';
 
@@ -82,12 +82,7 @@ const ManualCaptureControl = () => {
 					),
 					components: {
 						learnMoreLink: (
-							// eslint-disable-next-line jsx-a11y/anchor-has-content
-							<a
-								href="https://woocommerce.com/document/stripe/admin-experience/authorize-and-capture/"
-								target="_blank"
-								rel="noreferrer"
-							/>
+							<ExternalLink href="https://woocommerce.com/document/stripe/admin-experience/authorize-and-capture/" />
 						),
 					},
 				} ) }

--- a/readme.txt
+++ b/readme.txt
@@ -165,5 +165,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Add E2E coverage for express checkout with free trial subscriptions, with and without shipping, including completing the purchase with Link
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
 * Fix - Stop two requests from reclaiming the same expired Optimized Checkout or Agentic Commerce sync lock
+* Fix - Open testing and payment settings documentation links in new tabs
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-1440

## Changes proposed in this Pull Request:

Open the test card, test mode, and manual capture help links in a new tab using the WordPress ExternalLink component for safe and accessible links.

## Testing instructions

1. Go to WooCommerce > Settings > Payments > Stripe > Settings
2. Under `Test mode`, click _**test card numbers**_ and confirm it opens in a new tab
3. Click _**Learn more**_ in the same section and confirm it opens in a new tab
4. Scroll down to `Issue an authorization on checkout, and capture later` and c lick its _**Learn more**_ link
5. Confirm it opens in a new tab

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
