### PR TITLE
Ignore checkout session failures for orders paid by other gateways

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 11.1.0
+* Fix - Ignore Checkout Session failure webhooks after an order switches to another payment gateway
 * Dev - Add E2E coverage for express checkout with free trial subscriptions, with and without shipping, including completing the purchase with Link
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
 * Fix - Stop two requests from reclaiming the same expired Optimized Checkout or Agentic Commerce sync lock

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -2690,11 +2690,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$is_expired = 'checkout.session.expired' === $notification->type;
 
 		try {
-			if ( $order_helper->is_stripe_status_final( $order ) ) {
+			if ( ! $this->order_uses_stripe_gateway( $order ) ) {
 				return;
 			}
 
-			if ( ! $this->order_uses_stripe_gateway( $order ) ) {
+			if ( $order_helper->is_stripe_status_final( $order ) ) {
 				return;
 			}
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1817,7 +1817,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Returns true when the order was paid via a Stripe gateway (the main `stripe` gateway or a
+	 * Returns true when the order uses a Stripe gateway (the main `stripe` gateway or a
 	 * `stripe_*` payment method).
 	 *
 	 * @param WC_Order $order
@@ -2691,6 +2691,10 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		try {
 			if ( $order_helper->is_stripe_status_final( $order ) ) {
+				return;
+			}
+
+			if ( ! $this->order_uses_stripe_gateway( $order ) ) {
 				return;
 			}
 

--- a/readme.txt
+++ b/readme.txt
@@ -162,6 +162,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 11.1.0 - xxxx-xx-xx =
+* Fix - Ignore Checkout Session failure webhooks after an order switches to another payment gateway
 * Dev - Add E2E coverage for express checkout with free trial subscriptions, with and without shipping, including completing the purchase with Link
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
 * Fix - Stop two requests from reclaiming the same expired Optimized Checkout or Agentic Commerce sync lock

--- a/tests/phpunit/class-wc-stripe-webhook-handler-test.php
+++ b/tests/phpunit/class-wc-stripe-webhook-handler-test.php
@@ -2767,6 +2767,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	public function test_process_checkout_session_failure_sets_expected_status_for_event_type( string $event_type, string $expected_note, string $expected_status ): void {
 		$checkout_session_id = 'cs_test_failed';
 		$order               = WC_Helper_Order::create_order();
+		$order->set_payment_method( 'stripe' );
 		$order->set_status( OrderStatus::PENDING );
 		$order->save();
 		WC_Stripe_Order_Helper::get_instance()->update_stripe_checkout_session_id( $order, $checkout_session_id );
@@ -2815,6 +2816,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	public function test_process_checkout_session_failure_returns_for_final_stripe_status(): void {
 		$checkout_session_id = 'cs_test_final_status';
 		$order               = WC_Helper_Order::create_order();
+		$order->set_payment_method( 'stripe' );
 		$order->set_status( OrderStatus::PROCESSING );
 		$order->save();
 		WC_Stripe_Order_Helper::get_instance()->update_stripe_checkout_session_id( $order, $checkout_session_id );
@@ -2862,6 +2864,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	public function test_process_checkout_session_failure_returns_early_when_order_already_failed( string $event_type, string $unused_note, string $unused_status ): void {
 		$checkout_session_id = 'cs_test_duplicate';
 		$order               = WC_Helper_Order::create_order();
+		$order->set_payment_method( 'stripe' );
 		$order->set_status( OrderStatus::FAILED );
 		$order->save();
 		WC_Stripe_Order_Helper::get_instance()->update_stripe_checkout_session_id( $order, $checkout_session_id );
@@ -2923,10 +2926,12 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	 *
 	 * @param string $checkout_session_id Checkout session ID to link.
 	 * @param string $status              Status to start the order in.
+	 * @param string $payment_method      Payment method to assign to the order.
 	 * @return WC_Order
 	 */
-	private function create_checkout_session_order( string $checkout_session_id, string $status = OrderStatus::PENDING ): WC_Order {
+	private function create_checkout_session_order( string $checkout_session_id, string $status = OrderStatus::PENDING, string $payment_method = 'stripe' ): WC_Order {
 		$order = WC_Helper_Order::create_order();
+		$order->set_payment_method( $payment_method );
 		$order->set_status( $status );
 		$order->save();
 		WC_Stripe_Order_Helper::get_instance()->update_stripe_checkout_session_id( $order, $checkout_session_id );
@@ -2939,6 +2944,54 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		WC_Stripe_Order_Helper::set_instance( $order_helper );
 
 		return $order;
+	}
+
+	/**
+	 * Test that a stale Checkout Session cannot change an order submitted through another gateway.
+	 *
+	 * @dataProvider provide_checkout_session_failure_event_types
+	 *
+	 * @param string $event_type    Event type.
+	 * @param string $unused_note   Unused; provider shares rows with other tests.
+	 * @param string $unused_status Unused; provider shares rows with other tests.
+	 * @return void
+	 */
+	public function test_checkout_session_failure_returns_for_non_stripe_gateway( string $event_type, string $unused_note, string $unused_status ): void {
+		$session_id = 'cs_test_other_gateway_' . md5( $event_type );
+		$order      = $this->create_checkout_session_order( $session_id, OrderStatus::ON_HOLD, 'cheque' );
+		$notes      = wc_get_order_notes(
+			[
+				'order_id' => $order->get_id(),
+				'limit'    => 100,
+			]
+		);
+
+		$webhook_handler = $this->getMockBuilder( WC_Stripe_Webhook_Handler::class )
+			->setMethods( [ 'send_failed_order_email' ] )
+			->getMock();
+		$webhook_handler->expects( $this->never() )->method( 'send_failed_order_email' );
+
+		$hook_calls = 0;
+		$hook       = function () use ( &$hook_calls ) {
+			++$hook_calls;
+		};
+		add_action( 'wc_gateway_stripe_process_webhook_payment_error', $hook, 10, 2 );
+
+		$webhook_handler->process_checkout_session_failure( $this->build_checkout_session_notification( $event_type, $session_id ) );
+
+		remove_action( 'wc_gateway_stripe_process_webhook_payment_error', $hook, 10 );
+
+		$this->assertSame( OrderStatus::ON_HOLD, wc_get_order( $order->get_id() )->get_status() );
+		$this->assertSame( 0, $hook_calls );
+		$this->assertCount(
+			count( $notes ),
+			wc_get_order_notes(
+				[
+					'order_id' => $order->get_id(),
+					'limit'    => 100,
+				]
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes STRIPE-1369
Fixes #5812

## Changes proposed in this Pull Request:

Checkout Session failure webhooks can arrive after an order has been submitted through another payment gateway while retaining an earlier Stripe Checkout Session ID. The existing paid-order check does not protect unpaid offline orders such as those awaiting check payment.

This change ignores Checkout Session expiry and asynchronous payment failure events when the order’s current payment method is not a WooCommerce Stripe gateway. Genuine Stripe orders continue through the existing cancellation or failure handling. Targeted tests cover both event types and assert that a non-Stripe order keeps its status, notes, hooks, and email behavior unchanged.

#### Backward compatibility
- No public symbols, hooks, options, or persisted data are added or renamed.
- `wc_gateway_stripe_process_webhook_payment_error` no longer fires for stale Checkout Session events associated with non-Stripe orders because those events are ignored before any state transition. It continues to fire unchanged for Stripe orders.

## Testing instructions

1. Make sure the Store can receive webhook events (via stripe listener for example)
2. Check sure Optimized Checkout and Adaptive Pricing are enabled
3. Check an additional non-Stripe offline gateway such as Check payments is enabled/active
4. Start a Stripe payment so the gets a Stripe Checkout Session ID (_**but do not complete the payment**_)
5. Submit the same order through Check payments (from step 2) and confirm its payment method is Check payments and its status is `On hold`.
6. Expire the abandoned Checkout Session (to trigger a `checkout.session.expired` webhook event)
    You'll need the `checkout_session_id` that can be obtained from the order:
    ```
    docker compose exec -u www-data wordpress wp eval '$order = wc_get_order( 123 ); echo $order->get_meta( "_stripe_checkout_session_id" );'
    ```
    Then, use the Stripe CLI to expire that session:
    ```
    stripe checkout sessions expire cs_test_...
    ```
    Confirm the command returns a Checkout Session with `"status": "expired" and the listener receives `checkout.session.expired` (you can also check the plugin logs).
7. Confirm the order remains On hold, no Checkout Session expiry note is added, and no cancellation or failure email is sent.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
