### PR TITLE
Give each worktree its own isolated E2E Docker stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,8 @@ Use the smallest command set needed for the task:
 | Start shared infrastructure | `npm run infra:up` | Run from the main checkout. Brings up shared db + phpMyAdmin + bind volumes. |
 | Stop shared infrastructure | `npm run infra:down` | Stops shared db + phpMyAdmin (volumes preserved). |
 | Configure a worktree | `npm run worktree:setup` | Writes `.env` with `WORKTREE_ID`, an unused `WORDPRESS_PORT`, and an isolated e2e Docker stack (`E2E_PROJECT`/`E2E_WP_PORT`/`E2E_DB_PORT`). Called automatically by `npm run up`. |
-| List worktrees | `npm run worktree:status` | Shows port, URL, container state for every worktree; warns about orphan containers. |
-| Clean up a worktree | `npm run worktree:cleanup` | Stops the worktree's container, drops `wcstripe_tests_<id>`, removes `.env`. Run before `git worktree remove`. |
+| List worktrees | `npm run worktree:status` | Shows port, URL, container state, and e2e stack for every worktree; warns about orphan containers and orphan e2e stacks. |
+| Clean up a worktree | `npm run worktree:cleanup` | Stops the worktree's container, drops `wcstripe_tests_<id>`, tears down its e2e Docker stack, removes `.env`. Run before `git worktree remove`. |
 | Build frontend assets | `npm run build:webpack` | Use when editing client-side sources that ship built assets. |
 | Analyze bundle sizes | `BUNDLE_ANALYZE=true npm run build:webpack` | Writes `bundle-report.html` (gitignored) to the repo root. Open it to see a per-bundle module treemap. |
 | Dev hot reload | `npm start` | Webpack watch/dev mode. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Use the smallest command set needed for the task:
 | Stop local environment | `npm run down` | Stops this worktree's WordPress container only; shared infra keeps running. |
 | Start shared infrastructure | `npm run infra:up` | Run from the main checkout. Brings up shared db + phpMyAdmin + bind volumes. |
 | Stop shared infrastructure | `npm run infra:down` | Stops shared db + phpMyAdmin (volumes preserved). |
-| Configure a worktree | `npm run worktree:setup` | Writes `.env` with `WORKTREE_ID` + an unused `WORDPRESS_PORT`. Called automatically by `npm run up`. |
+| Configure a worktree | `npm run worktree:setup` | Writes `.env` with `WORKTREE_ID`, an unused `WORDPRESS_PORT`, and an isolated e2e Docker stack (`E2E_PROJECT`/`E2E_WP_PORT`/`E2E_DB_PORT`). Called automatically by `npm run up`. |
 | List worktrees | `npm run worktree:status` | Shows port, URL, container state for every worktree; warns about orphan containers. |
 | Clean up a worktree | `npm run worktree:cleanup` | Stops the worktree's container, drops `wcstripe_tests_<id>`, removes `.env`. Run before `git worktree remove`. |
 | Build frontend assets | `npm run build:webpack` | Use when editing client-side sources that ship built assets. |

--- a/bin/docker-port-setup.sh
+++ b/bin/docker-port-setup.sh
@@ -9,8 +9,11 @@ ENV_FILE=".env"
 PORT_RANGE_START=8170
 PORT_RANGE_END=8189
 MAIN_CHECKOUT_DEFAULT_PORT=8072
+# The historical machine-global e2e stack (E2E_DEFAULT_*), kept as the main
+# checkout's stack so CI and existing single-checkout usage are unchanged.
+. "$(dirname "${BASH_SOURCE[0]}")/../tests/e2e/bin/e2e-stack-defaults.sh"
 # Dedicated ranges for per-worktree e2e stacks, disjoint from the dev-site
-# range above and from the main checkout's e2e defaults (8088/6789).
+# range above and from the main checkout's e2e defaults.
 E2E_WP_PORT_RANGE_START=8290
 E2E_WP_PORT_RANGE_END=8309
 E2E_DB_PORT_RANGE_START=6800
@@ -43,12 +46,14 @@ get_reserved_ports() {
 }
 
 # Pick the first port in [$2, $3] that is neither reserved by another
-# worktree's .env (key $1) nor currently bound on the host.
+# worktree's .env (key $1) nor currently bound on the host. The chosen port is
+# the function's stdout, so progress messages go to stderr.
 find_free_port() {
     local key=$1 range_start=$2 range_end=$3 port
     local reserved=" $(get_reserved_ports "$key" | tr '\n' ' ')"
     for port in $(seq "$range_start" "$range_end"); do
         if [[ "$reserved" == *" $port "* ]] || [[ "$reserved" == *" $port" ]]; then
+            echo "  Port $port reserved by another worktree, skipping..." >&2
             continue
         fi
         if ! lsof -i ":$port" > /dev/null 2>&1; then
@@ -82,23 +87,10 @@ if [[ -z "$WORDPRESS_PORT" ]]; then
         echo "Set WORDPRESS_PORT=$WORDPRESS_PORT (main checkout default)"
     else
         echo "Scanning for available port in $PORT_RANGE_START-$PORT_RANGE_END..."
-        RESERVED_PORTS=" $(get_reserved_ports | tr '\n' ' ')"
-        for port in $(seq $PORT_RANGE_START $PORT_RANGE_END); do
-            if [[ "$RESERVED_PORTS" == *" $port "* ]] || [[ "$RESERVED_PORTS" == *" $port" ]]; then
-                echo "  Port $port reserved by another worktree, skipping..."
-                continue
-            fi
-            if ! lsof -i ":$port" > /dev/null 2>&1; then
-                WORDPRESS_PORT=$port
-                break
-            fi
-        done
-
-        if [[ -z "$WORDPRESS_PORT" ]]; then
+        WORDPRESS_PORT=$(find_free_port WORDPRESS_PORT $PORT_RANGE_START $PORT_RANGE_END) || {
             echo "Error: No available ports in range $PORT_RANGE_START-$PORT_RANGE_END"
             exit 1
-        fi
-
+        }
         echo "WORDPRESS_PORT=$WORDPRESS_PORT" >> "$ENV_FILE"
         echo "Set WORDPRESS_PORT=$WORDPRESS_PORT"
     fi
@@ -109,9 +101,9 @@ fi
 # checkout keeps the historical defaults so existing usage is unchanged.
 if [[ -z "$E2E_PROJECT" ]]; then
     if is_main_checkout; then
-        E2E_PROJECT="wcstripe-e2e"
+        E2E_PROJECT="$E2E_DEFAULT_PROJECT"
     else
-        E2E_PROJECT="wcstripe-e2e-$WORKTREE_ID"
+        E2E_PROJECT="$E2E_DEFAULT_PROJECT-$WORKTREE_ID"
     fi
     echo "E2E_PROJECT=$E2E_PROJECT" >> "$ENV_FILE"
     echo "Set E2E_PROJECT=$E2E_PROJECT"
@@ -119,7 +111,7 @@ fi
 
 if [[ -z "$E2E_WP_PORT" ]]; then
     if is_main_checkout; then
-        E2E_WP_PORT=8088
+        E2E_WP_PORT=$E2E_DEFAULT_WP_PORT
     else
         E2E_WP_PORT=$(find_free_port E2E_WP_PORT $E2E_WP_PORT_RANGE_START $E2E_WP_PORT_RANGE_END) || {
             echo "Error: No available e2e ports in range $E2E_WP_PORT_RANGE_START-$E2E_WP_PORT_RANGE_END"
@@ -132,7 +124,7 @@ fi
 
 if [[ -z "$E2E_DB_PORT" ]]; then
     if is_main_checkout; then
-        E2E_DB_PORT=6789
+        E2E_DB_PORT=$E2E_DEFAULT_DB_PORT
     else
         E2E_DB_PORT=$(find_free_port E2E_DB_PORT $E2E_DB_PORT_RANGE_START $E2E_DB_PORT_RANGE_END) || {
             echo "Error: No available e2e DB ports in range $E2E_DB_PORT_RANGE_START-$E2E_DB_PORT_RANGE_END"
@@ -141,6 +133,28 @@ if [[ -z "$E2E_DB_PORT" ]]; then
     fi
     echo "E2E_DB_PORT=$E2E_DB_PORT" >> "$ENV_FILE"
     echo "Set E2E_DB_PORT=$E2E_DB_PORT"
+fi
+
+# Guard against a .env that was copied from the main checkout instead of
+# generated here. Such a file still holds the main checkout's values (dev-site
+# port 8072, e2e stack wcstripe-e2e/8088/6789), so this worktree's `npm run
+# up` and e2e commands would operate on the main checkout's containers and
+# ports instead of its own. This script never writes those values into a
+# worktree, so any of them appearing here means the file was copied; collect
+# the offending keys and warn, rather than silently rewriting a file the user
+# may have pointed at the main stack on purpose.
+if ! is_main_checkout; then
+    copied_defaults=()
+    [[ "$WORDPRESS_PORT" == "$MAIN_CHECKOUT_DEFAULT_PORT" ]] && copied_defaults+=("WORDPRESS_PORT=$WORDPRESS_PORT")
+    [[ "$E2E_PROJECT" == "$E2E_DEFAULT_PROJECT" ]] && copied_defaults+=("E2E_PROJECT=$E2E_PROJECT")
+    [[ "$E2E_WP_PORT" == "$E2E_DEFAULT_WP_PORT" ]] && copied_defaults+=("E2E_WP_PORT=$E2E_WP_PORT")
+    [[ "$E2E_DB_PORT" == "$E2E_DEFAULT_DB_PORT" ]] && copied_defaults+=("E2E_DB_PORT=$E2E_DB_PORT")
+    if [[ ${#copied_defaults[@]} -gt 0 ]]; then
+        echo "WARNING: .env holds main-checkout defaults (${copied_defaults[*]})."
+        echo "         This worktree would clobber the main checkout's containers and ports."
+        echo "         If this .env was copied from the main checkout, run:"
+        echo "           rm .env && npm run worktree:setup"
+    fi
 fi
 
 echo "Using WORKTREE_ID=$WORKTREE_ID, WORDPRESS_PORT=$WORDPRESS_PORT, E2E_PROJECT=$E2E_PROJECT (ports $E2E_WP_PORT/$E2E_DB_PORT)"

--- a/bin/docker-port-setup.sh
+++ b/bin/docker-port-setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # bin/docker-port-setup.sh
-# Ensures .env exists with WORDPRESS_PORT and WORKTREE_ID.
+# Ensures .env exists with WORDPRESS_PORT, WORKTREE_ID, and an isolated
+# E2E_PROJECT/E2E_WP_PORT/E2E_DB_PORT trio for the Docker e2e stack.
 
 set -e
 
@@ -8,6 +9,12 @@ ENV_FILE=".env"
 PORT_RANGE_START=8170
 PORT_RANGE_END=8189
 MAIN_CHECKOUT_DEFAULT_PORT=8072
+# Dedicated ranges for per-worktree e2e stacks, disjoint from the dev-site
+# range above and from the main checkout's e2e defaults (8088/6789).
+E2E_WP_PORT_RANGE_START=8290
+E2E_WP_PORT_RANGE_END=8309
+E2E_DB_PORT_RANGE_START=6800
+E2E_DB_PORT_RANGE_END=6819
 CURRENT_DIR="$(pwd)"
 
 is_main_checkout() {
@@ -23,15 +30,33 @@ is_main_checkout() {
 get_reserved_ports() {
     # Parse `git worktree list --porcelain` (each worktree starts with `worktree <path>`)
     # so paths containing spaces are handled correctly.
+    local key=${1:-WORDPRESS_PORT}
     while IFS= read -r line; do
         if [[ $line =~ ^worktree\ (.+)$ ]]; then
             local dir="${BASH_REMATCH[1]}"
             [[ "$dir" == "$CURRENT_DIR" ]] && continue
             if [[ -f "$dir/.env" ]]; then
-                grep '^WORDPRESS_PORT=' "$dir/.env" 2>/dev/null | cut -d= -f2
+                grep "^${key}=" "$dir/.env" 2>/dev/null | cut -d= -f2
             fi
         fi
     done < <(git worktree list --porcelain 2>/dev/null)
+}
+
+# Pick the first port in [$2, $3] that is neither reserved by another
+# worktree's .env (key $1) nor currently bound on the host.
+find_free_port() {
+    local key=$1 range_start=$2 range_end=$3 port
+    local reserved=" $(get_reserved_ports "$key" | tr '\n' ' ')"
+    for port in $(seq "$range_start" "$range_end"); do
+        if [[ "$reserved" == *" $port "* ]] || [[ "$reserved" == *" $port" ]]; then
+            continue
+        fi
+        if ! lsof -i ":$port" > /dev/null 2>&1; then
+            echo "$port"
+            return 0
+        fi
+    done
+    return 1
 }
 
 DEFAULT_WORKTREE_ID=$(basename "$(pwd)" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g')
@@ -79,4 +104,43 @@ if [[ -z "$WORDPRESS_PORT" ]]; then
     fi
 fi
 
-echo "Using WORKTREE_ID=$WORKTREE_ID, WORDPRESS_PORT=$WORDPRESS_PORT"
+# The e2e Docker stack's compose project name and host ports are machine-global
+# (see tests/e2e/bin/common.sh), so give each worktree its own trio. The main
+# checkout keeps the historical defaults so existing usage is unchanged.
+if [[ -z "$E2E_PROJECT" ]]; then
+    if is_main_checkout; then
+        E2E_PROJECT="wcstripe-e2e"
+    else
+        E2E_PROJECT="wcstripe-e2e-$WORKTREE_ID"
+    fi
+    echo "E2E_PROJECT=$E2E_PROJECT" >> "$ENV_FILE"
+    echo "Set E2E_PROJECT=$E2E_PROJECT"
+fi
+
+if [[ -z "$E2E_WP_PORT" ]]; then
+    if is_main_checkout; then
+        E2E_WP_PORT=8088
+    else
+        E2E_WP_PORT=$(find_free_port E2E_WP_PORT $E2E_WP_PORT_RANGE_START $E2E_WP_PORT_RANGE_END) || {
+            echo "Error: No available e2e ports in range $E2E_WP_PORT_RANGE_START-$E2E_WP_PORT_RANGE_END"
+            exit 1
+        }
+    fi
+    echo "E2E_WP_PORT=$E2E_WP_PORT" >> "$ENV_FILE"
+    echo "Set E2E_WP_PORT=$E2E_WP_PORT"
+fi
+
+if [[ -z "$E2E_DB_PORT" ]]; then
+    if is_main_checkout; then
+        E2E_DB_PORT=6789
+    else
+        E2E_DB_PORT=$(find_free_port E2E_DB_PORT $E2E_DB_PORT_RANGE_START $E2E_DB_PORT_RANGE_END) || {
+            echo "Error: No available e2e DB ports in range $E2E_DB_PORT_RANGE_START-$E2E_DB_PORT_RANGE_END"
+            exit 1
+        }
+    fi
+    echo "E2E_DB_PORT=$E2E_DB_PORT" >> "$ENV_FILE"
+    echo "Set E2E_DB_PORT=$E2E_DB_PORT"
+fi
+
+echo "Using WORKTREE_ID=$WORKTREE_ID, WORDPRESS_PORT=$WORDPRESS_PORT, E2E_PROJECT=$E2E_PROJECT (ports $E2E_WP_PORT/$E2E_DB_PORT)"

--- a/bin/docker-worktree-cleanup.sh
+++ b/bin/docker-worktree-cleanup.sh
@@ -52,6 +52,25 @@ else
     echo "Database container not running, skipping test database cleanup."
 fi
 
+# Tear down this worktree's e2e Docker stack (wordpress + mysql + stripe-listener
+# and its named volume). `docker compose -p <project> down` locates containers by
+# their project label, so no compose file is needed here. A worktree .env that
+# still holds the main-checkout default project means it was copied from the main
+# checkout — tearing that project down would kill the main checkout's stack, so
+# skip it (worktree:setup warns about such .env files).
+. "$(dirname "${BASH_SOURCE[0]}")/../tests/e2e/bin/e2e-stack-defaults.sh"
+if [[ -z "$E2E_PROJECT" ]]; then
+    E2E_PROJECT="$E2E_DEFAULT_PROJECT-${WORKTREE_ID}"
+fi
+if [[ "$E2E_PROJECT" == "$E2E_DEFAULT_PROJECT" ]]; then
+    echo "Skipping e2e stack teardown: E2E_PROJECT is the main-checkout default ($E2E_DEFAULT_PROJECT)."
+elif [[ -n "$(docker compose -p "$E2E_PROJECT" ps -a -q 2>/dev/null)" ]]; then
+    echo "Tearing down e2e Docker stack: ${E2E_PROJECT}"
+    docker compose -p "$E2E_PROJECT" down --volumes --remove-orphans
+else
+    echo "No e2e Docker stack found for this worktree."
+fi
+
 if [[ -f ".env" ]]; then
     echo "Removing .env"
     rm .env

--- a/bin/docker-worktree-status.sh
+++ b/bin/docker-worktree-status.sh
@@ -30,14 +30,29 @@ while IFS= read -r line; do
     fi
 done < <(git -C "$REPO_ROOT" worktree list --porcelain)
 
+# `git worktree list` always puts the main working tree first. REPO_ROOT is
+# wherever this script was invoked from, which may itself be a worktree, so it
+# cannot stand in for the main checkout.
+MAIN_CHECKOUT="${worktrees[0]}"
+
+. "$SCRIPT_DIR/../tests/e2e/bin/e2e-stack-defaults.sh"
+
 containers=$(docker ps -a --filter "name=wcstripe_wp_" --format '{{.Names}}' 2>/dev/null || true)
+e2e_containers=$(docker ps -a --filter "name=$E2E_DEFAULT_PROJECT" --format '{{.Names}}' 2>/dev/null || true)
+
+# Compose project of an e2e container name (project is the prefix before the
+# service suffix, e.g. wcstripe-e2e-foo-wordpress -> wcstripe-e2e-foo).
+e2e_container_project() {
+    echo "$1" | sed -E 's/-(wordpress|mysql|stripe-listener)$//'
+}
 
 echo ""
 echo -e "${BOLD}Worktree Status${NC}"
 echo ""
-printf "  ${BOLD}%-6s %-30s %-14s %s${NC}\n" "PORT" "URL" "STATUS" "NAME"
+printf "  ${BOLD}%-6s %-30s %-14s %-9s %-11s %s${NC}\n" "PORT" "URL" "STATUS" "E2E-PORT" "E2E-STATUS" "NAME"
 
 orphan_containers=()
+known_e2e_projects=()
 
 for worktree_path in "${worktrees[@]}"; do
     worktree_name=$(basename "$worktree_path")
@@ -45,20 +60,33 @@ for worktree_path in "${worktrees[@]}"; do
     status="no container"
     url="n/a"
     worktree_id=""
+    e2e_project=""
+    e2e_port=""
+    e2e_status="no stack"
 
     if [[ -f "$worktree_path/.env" ]]; then
         port=$(grep '^WORDPRESS_PORT=' "$worktree_path/.env" 2>/dev/null | cut -d= -f2)
         worktree_id=$(grep '^WORKTREE_ID=' "$worktree_path/.env" 2>/dev/null | cut -d= -f2)
+        e2e_project=$(grep '^E2E_PROJECT=' "$worktree_path/.env" 2>/dev/null | cut -d= -f2)
+        e2e_port=$(grep '^E2E_WP_PORT=' "$worktree_path/.env" 2>/dev/null | cut -d= -f2)
     fi
 
     if [[ -z "$worktree_id" ]]; then
-        if [[ "$worktree_path" == "$REPO_ROOT" ]]; then
+        if [[ "$worktree_path" == "$MAIN_CHECKOUT" ]]; then
             worktree_id="default"
             [[ -z "$port" ]] && port="8072"
         else
             worktree_id=$(generate_worktree_id "$worktree_name")
         fi
     fi
+
+    # The main checkout uses the historical e2e defaults even before
+    # worktree:setup has written them to its .env.
+    if [[ -z "$e2e_project" && "$worktree_path" == "$MAIN_CHECKOUT" ]]; then
+        e2e_project="$E2E_DEFAULT_PROJECT"
+        [[ -z "$e2e_port" ]] && e2e_port="$E2E_DEFAULT_WP_PORT"
+    fi
+    [[ -n "$e2e_project" ]] && known_e2e_projects+=("$e2e_project")
 
     container_name="wcstripe_wp_$worktree_id"
 
@@ -68,13 +96,21 @@ for worktree_path in "${worktrees[@]}"; do
         status="stopped"
     fi
 
+    if [[ -n "$e2e_project" ]]; then
+        if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^${e2e_project}-wordpress$"; then
+            e2e_status="running"
+        elif docker ps -a --format '{{.Names}}' 2>/dev/null | grep -q "^${e2e_project}-wordpress$"; then
+            e2e_status="stopped"
+        fi
+    fi
+
     [[ -n "$port" ]] && url="http://localhost:$port"
 
     display_name="$worktree_name"
-    [[ "$worktree_path" == "$REPO_ROOT" ]] && display_name="$worktree_name (main)"
+    [[ "$worktree_path" == "$MAIN_CHECKOUT" ]] && display_name="$worktree_name (main)"
     [[ "$worktree_path" == "$CURRENT_DIR" ]] && display_name="* $display_name"
 
-    printf "  %-6s %-30s %-14s %s\n" "${port:-n/a}" "$url" "$status" "$display_name"
+    printf "  %-6s %-30s %-14s %-9s %-11s %s\n" "${port:-n/a}" "$url" "$status" "${e2e_port:-n/a}" "$e2e_status" "$display_name"
 done
 
 for container_name in $containers; do
@@ -87,7 +123,7 @@ for container_name in $containers; do
         if [[ -f "$worktree_path/.env" ]]; then
             worktree_id=$(grep '^WORKTREE_ID=' "$worktree_path/.env" 2>/dev/null | cut -d= -f2)
             [[ -z "$worktree_id" ]] && worktree_id=$(generate_worktree_id "$worktree_name")
-        elif [[ "$worktree_path" == "$REPO_ROOT" ]]; then
+        elif [[ "$worktree_path" == "$MAIN_CHECKOUT" ]]; then
             worktree_id="default"
         else
             worktree_id=$(generate_worktree_id "$worktree_name")
@@ -98,14 +134,40 @@ for container_name in $containers; do
     [[ "$found" == "false" ]] && orphan_containers+=("$container_name")
 done
 
-if [[ ${#orphan_containers[@]} -gt 0 ]]; then
+# E2E stacks whose worktree is gone (or whose .env no longer references them)
+# keep three containers plus a named volume alive; surface them for cleanup.
+orphan_e2e_projects=()
+seen_e2e_projects=" "
+for container_name in $e2e_containers; do
+    [[ -z "$container_name" ]] && continue
+    project=$(e2e_container_project "$container_name")
+    [[ "$seen_e2e_projects" == *" $project "* ]] && continue
+    seen_e2e_projects="$seen_e2e_projects$project "
+
+    found=false
+    for known in "${known_e2e_projects[@]}"; do
+        [[ "$project" == "$known" ]] && found=true && break
+    done
+
+    [[ "$found" == "false" ]] && orphan_e2e_projects+=("$project")
+done
+
+if [[ ${#orphan_containers[@]} -gt 0 || ${#orphan_e2e_projects[@]} -gt 0 ]]; then
     echo ""
     echo -e "${YELLOW}Warnings:${NC}"
     for orphan in "${orphan_containers[@]}"; do
         echo "  - Orphan container: $orphan (no matching worktree)"
     done
+    for orphan in "${orphan_e2e_projects[@]}"; do
+        echo "  - Orphan e2e stack: $orphan (no worktree .env references it)"
+    done
     echo ""
-    echo "  To clean up: docker rm -f ${orphan_containers[*]}"
+    if [[ ${#orphan_containers[@]} -gt 0 ]]; then
+        echo "  To clean up: docker rm -f ${orphan_containers[*]}"
+    fi
+    for orphan in "${orphan_e2e_projects[@]}"; do
+        echo "  To clean up: docker compose -p $orphan down --volumes"
+    done
 fi
 
 echo ""

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ xxxx-xx-xx - version 11.1.0
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
 * Fix - Stop two requests from reclaiming the same expired Optimized Checkout or Agentic Commerce sync lock
 * Fix - Open testing and payment settings documentation links in new tabs
+* Dev - Give each git worktree its own isolated local E2E Docker stack, derived by `worktree:setup` and covered by `worktree:status` and `worktree:cleanup`
 
 2026-09-08 - version 11.0.0
 * Fix - Allow express checkout payments when a wallet provides a one-word shipping name

--- a/readme.txt
+++ b/readme.txt
@@ -167,5 +167,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Prevent dropped webhooks, double processing, and skipped pre-order handling when requests race for the order payment lock
 * Fix - Stop two requests from reclaiming the same expired Optimized Checkout or Agentic Commerce sync lock
 * Fix - Open testing and payment settings documentation links in new tabs
+* Dev - Give each git worktree its own isolated local E2E Docker stack, derived by `worktree:setup` and covered by `worktree:status` and `worktree:cleanup`
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/e2e/AGENTS.md
+++ b/tests/e2e/AGENTS.md
@@ -21,7 +21,7 @@ For repository-wide rules, always read the root `AGENTS.md` first.
 | Run specific project | `npm run test:e2e-run -- --project=<name> --base_url=<url>` | Project names include `default`, `acss`, `becs`, `blik`, `optimized-checkout`. |
 | Debug run | `npm run test:e2e-debug -- --base_url=<url>` | Playwright debug mode. |
 | Docker setup/run | `npm run test:e2e-setup` then `npm run test:e2e` | Local Docker path (`http://localhost:8088` in the main checkout; worktrees get their own port — see below). |
-| Second Docker stack | automatic via `npm run worktree:setup` | The compose project name and host ports (8088/6789) are machine-global, so `worktree:setup` writes an isolated `E2E_PROJECT`/`E2E_WP_PORT`/`E2E_DB_PORT` trio to the worktree's `.env`, which every `test:e2e*` command reads (explicit env vars still win). |
+| Second Docker stack | automatic via `npm run worktree:setup` | The compose project name and host ports (8088/6789) are machine-global, so `worktree:setup` writes an isolated `E2E_PROJECT`/`E2E_WP_PORT`/`E2E_DB_PORT` trio to the worktree's `.env`, which every `test:e2e*` command reads (explicit env vars still win). Ports are assigned by the same `.env`-scan in `bin/docker-port-setup.sh` that picks each worktree's `WORDPRESS_PORT`. |
 | Tear down Docker | `npm run test:e2e-down` | Stops E2E containers. |
 
 ## File Layout

--- a/tests/e2e/AGENTS.md
+++ b/tests/e2e/AGENTS.md
@@ -20,7 +20,8 @@ For repository-wide rules, always read the root `AGENTS.md` first.
 | Run default project | `npm run test:e2e -- --base_url=<url>` | Uses `default` Playwright project. |
 | Run specific project | `npm run test:e2e-run -- --project=<name> --base_url=<url>` | Project names include `default`, `acss`, `becs`, `blik`, `optimized-checkout`. |
 | Debug run | `npm run test:e2e-debug -- --base_url=<url>` | Playwright debug mode. |
-| Docker setup/run | `npm run test:e2e-setup` then `npm run test:e2e` | Local Docker path (`http://localhost:8088`). |
+| Docker setup/run | `npm run test:e2e-setup` then `npm run test:e2e` | Local Docker path (`http://localhost:8088` in the main checkout; worktrees get their own port — see below). |
+| Second Docker stack | automatic via `npm run worktree:setup` | The compose project name and host ports (8088/6789) are machine-global, so `worktree:setup` writes an isolated `E2E_PROJECT`/`E2E_WP_PORT`/`E2E_DB_PORT` trio to the worktree's `.env`, which every `test:e2e*` command reads (explicit env vars still win). |
 | Tear down Docker | `npm run test:e2e-down` | Stops E2E containers. |
 
 ## File Layout

--- a/tests/e2e/bin/common.sh
+++ b/tests/e2e/bin/common.sh
@@ -5,10 +5,20 @@ E2E_ROOT="$CWD/tests/e2e"
 
 # The compose project (and its container-name prefix) and the host ports are
 # global to the machine: two checkouts using the defaults clobber each other's
-# stacks. Override these to run an isolated second stack side-by-side.
+# stacks. `npm run worktree:setup` records an isolated stack for each worktree
+# in its .env; fall back to those values so every terminal in a worktree
+# targets the right stack without exporting anything. Explicit env vars win,
+# so a caller can still point at any stack. Read only these three keys rather
+# than sourcing .env, which would let unrelated keys leak into the scripts.
+env_file_value() {
+	grep "^$1=" "$CWD/.env" 2>/dev/null | tail -1 | cut -d= -f2-
+}
 # Exported so docker compose can interpolate them in env/docker-compose.yml.
+export E2E_PROJECT=${E2E_PROJECT:-$(env_file_value E2E_PROJECT)}
 export E2E_PROJECT=${E2E_PROJECT:-wcstripe-e2e}
+export E2E_WP_PORT=${E2E_WP_PORT:-$(env_file_value E2E_WP_PORT)}
 export E2E_WP_PORT=${E2E_WP_PORT:-8088}
+export E2E_DB_PORT=${E2E_DB_PORT:-$(env_file_value E2E_DB_PORT)}
 export E2E_DB_PORT=${E2E_DB_PORT:-6789}
 
 ADMIN_USER=${ADMIN_USER-admin}

--- a/tests/e2e/bin/common.sh
+++ b/tests/e2e/bin/common.sh
@@ -3,23 +3,21 @@
 CWD=$(pwd)
 E2E_ROOT="$CWD/tests/e2e"
 
-# The compose project (and its container-name prefix) and the host ports are
-# global to the machine: two checkouts using the defaults clobber each other's
-# stacks. `npm run worktree:setup` records an isolated stack for each worktree
-# in its .env; fall back to those values so every terminal in a worktree
-# targets the right stack without exporting anything. Explicit env vars win,
-# so a caller can still point at any stack. Read only these three keys rather
-# than sourcing .env, which would let unrelated keys leak into the scripts.
+# The compose project and host ports are machine-global, so worktree:setup
+# records an isolated stack per worktree in .env. Resolution: env var > .env
+# key > historical default (two lines per var: one ${:-} holds one fallback).
+# Grep rather than source .env so unrelated keys can't leak into the scripts.
 env_file_value() {
 	grep "^$1=" "$CWD/.env" 2>/dev/null | tail -1 | cut -d= -f2-
 }
+. "$(dirname "${BASH_SOURCE[0]}")/e2e-stack-defaults.sh"
 # Exported so docker compose can interpolate them in env/docker-compose.yml.
 export E2E_PROJECT=${E2E_PROJECT:-$(env_file_value E2E_PROJECT)}
-export E2E_PROJECT=${E2E_PROJECT:-wcstripe-e2e}
+export E2E_PROJECT=${E2E_PROJECT:-$E2E_DEFAULT_PROJECT}
 export E2E_WP_PORT=${E2E_WP_PORT:-$(env_file_value E2E_WP_PORT)}
-export E2E_WP_PORT=${E2E_WP_PORT:-8088}
+export E2E_WP_PORT=${E2E_WP_PORT:-$E2E_DEFAULT_WP_PORT}
 export E2E_DB_PORT=${E2E_DB_PORT:-$(env_file_value E2E_DB_PORT)}
-export E2E_DB_PORT=${E2E_DB_PORT:-6789}
+export E2E_DB_PORT=${E2E_DB_PORT:-$E2E_DEFAULT_DB_PORT}
 
 ADMIN_USER=${ADMIN_USER-admin}
 ADMIN_PASSWORD=${ADMIN_PASSWORD-admin}

--- a/tests/e2e/bin/common.sh
+++ b/tests/e2e/bin/common.sh
@@ -3,6 +3,14 @@
 CWD=$(pwd)
 E2E_ROOT="$CWD/tests/e2e"
 
+# The compose project (and its container-name prefix) and the host ports are
+# global to the machine: two checkouts using the defaults clobber each other's
+# stacks. Override these to run an isolated second stack side-by-side.
+# Exported so docker compose can interpolate them in env/docker-compose.yml.
+export E2E_PROJECT=${E2E_PROJECT:-wcstripe-e2e}
+export E2E_WP_PORT=${E2E_WP_PORT:-8088}
+export E2E_DB_PORT=${E2E_DB_PORT:-6789}
+
 ADMIN_USER=${ADMIN_USER-admin}
 ADMIN_PASSWORD=${ADMIN_PASSWORD-admin}
 ADMIN_EMAIL=${ADMIN_EMAIL-admin@example.com}
@@ -63,5 +71,5 @@ validate_stripe_listener_credentials() {
 # --user xfs forces the wordpress:cli container to use a user with the same ID as the main wordpress container.
 # See: https://hub.docker.com/_/wordpress#running-as-an-arbitrary-user
 cli() {
-	docker run -i --rm --user 33:33 --env-file ${E2E_ROOT}/env/default.env --volumes-from "wcstripe-e2e-wordpress" --network container:"wcstripe-e2e-wordpress" wordpress:cli "$@"
+	docker run -i --rm --user 33:33 --env-file ${E2E_ROOT}/env/default.env --volumes-from "${E2E_PROJECT}-wordpress" --network container:"${E2E_PROJECT}-wordpress" wordpress:cli "$@"
 }

--- a/tests/e2e/bin/down.sh
+++ b/tests/e2e/bin/down.sh
@@ -4,4 +4,4 @@ set -e
 . ./tests/e2e/bin/common.sh
 
 step "Stopping E2E docker containers"
-CWD="$CWD" redirect_output docker compose -p wcstripe-e2e down
+CWD="$CWD" redirect_output docker compose -p "$E2E_PROJECT" down

--- a/tests/e2e/bin/e2e-stack-defaults.sh
+++ b/tests/e2e/bin/e2e-stack-defaults.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# The historical machine-global e2e Docker stack: compose project name (also
+# the container-name prefix) and host ports. Single source of truth, sourced
+# by tests/e2e/bin/common.sh (final fallbacks, so CI and single-checkout usage
+# keep the exact historical behavior) and by the bin/docker-worktree-* scripts
+# (the main checkout's assigned stack, and the guard that refuses to treat a
+# worktree as owning it).
+E2E_DEFAULT_PROJECT="wcstripe-e2e"
+E2E_DEFAULT_WP_PORT=8088
+E2E_DEFAULT_DB_PORT=6789

--- a/tests/e2e/bin/run-tests.sh
+++ b/tests/e2e/bin/run-tests.sh
@@ -31,12 +31,12 @@ for arg in "$@"; do
 	fi
 done
 
-if [[ "wordpress" != "$(docker compose -p wcstripe-e2e ps --services --filter "status=running" | grep wordpress)" ]]; then
+if [[ "wordpress" != "$(docker compose -p "$E2E_PROJECT" ps --services --filter "status=running" | grep wordpress)" ]]; then
 	error "Docker E2E containers are not running, please start them with 'npm run test:e2e-up' or 'npm run test:e2e-setup' and try again."
 	exit 1
 fi
 
-TEST_ENV="$TEST_ENV DOCKER=true E2E_ROOT=${E2E_ROOT} BASE_URL='http://localhost:8088'"
+TEST_ENV="$TEST_ENV DOCKER=true E2E_ROOT=${E2E_ROOT} BASE_URL='http://localhost:${E2E_WP_PORT}'"
 TEST_ENV="$TEST_ENV ADMIN_USER='admin' ADMIN_PASSWORD='admin'"
 
 # The docker site can't receive real webhooks (no tunnel), so seed what the

--- a/tests/e2e/bin/setup.sh
+++ b/tests/e2e/bin/setup.sh
@@ -111,9 +111,9 @@ fetch_plugin_zip "woocommerce/woocommerce-pre-orders" "woocommerce-pre-orders.zi
 
 step "Starting E2E docker containers"
 if [ "$CI" = "true" ]; then
-    CWD="$CWD" E2E_ROOT="$E2E_ROOT" redirect_output docker compose -p wcstripe-e2e -f "$E2E_ROOT"/env/docker-compose.yml up --build --force-recreate -d
+    CWD="$CWD" E2E_ROOT="$E2E_ROOT" redirect_output docker compose -p "$E2E_PROJECT" -f "$E2E_ROOT"/env/docker-compose.yml up --build --force-recreate -d
 else
-    CWD="$CWD" E2E_ROOT="$E2E_ROOT" redirect_output docker compose -p wcstripe-e2e --env-file "$E2E_ROOT"/config/local.env -f "$E2E_ROOT"/env/docker-compose.yml up --build --force-recreate -d
+    CWD="$CWD" E2E_ROOT="$E2E_ROOT" redirect_output docker compose -p "$E2E_PROJECT" --env-file "$E2E_ROOT"/config/local.env -f "$E2E_ROOT"/env/docker-compose.yml up --build --force-recreate -d
 fi
 
 step "Configuring WordPress"
@@ -130,7 +130,7 @@ set -e
 
 redirect_output cli wp core install \
 	--path=/var/www/html \
-	--url="http://localhost:8088" \
+	--url="http://localhost:${E2E_WP_PORT}" \
 	--title="WCStripe E2E test store" \
 	--admin_name="${ADMIN_USER}" \
 	--admin_password="${ADMIN_PASSWORD}" \
@@ -256,4 +256,4 @@ echo "Subscriptions => $(cli wp plugin get woocommerce-subscriptions --field=ver
 echo "Pre-Orders    => $(cli wp plugin get woocommerce-pre-orders --field=version)"
 echo "============================================================"
 echo
-step "E2E environment up and running at http://localhost:8088/wp-admin/"
+step "E2E environment up and running at http://localhost:${E2E_WP_PORT}/wp-admin/"

--- a/tests/e2e/bin/up.sh
+++ b/tests/e2e/bin/up.sh
@@ -7,4 +7,4 @@ load_e2e_local_env
 validate_stripe_listener_credentials
 
 step "Starting E2E docker containers"
-CWD="$CWD" redirect_output docker compose -p wcstripe-e2e --env-file "$E2E_ROOT/config/local.env" -f "$E2E_ROOT/env/docker-compose.yml" up -d
+CWD="$CWD" redirect_output docker compose -p "$E2E_PROJECT" --env-file "$E2E_ROOT/config/local.env" -f "$E2E_ROOT/env/docker-compose.yml" up -d

--- a/tests/e2e/env/docker-compose.yml
+++ b/tests/e2e/env/docker-compose.yml
@@ -6,13 +6,13 @@ services:
 
   wordpress:
     image: wordpress:php8.2
-    container_name: wcstripe-e2e-wordpress
+    container_name: ${E2E_PROJECT:-wcstripe-e2e}-wordpress
     depends_on:
       - db
     links:
       - db:mysql
     ports:
-      - "8088:80"
+      - "${E2E_WP_PORT:-8088}:80"
     env_file:
       - default.env
     environment:
@@ -26,17 +26,17 @@ services:
       - "host.docker.internal:host-gateway"
 
   db:
-    container_name: wcstripe-e2e-mysql
+    container_name: ${E2E_PROJECT:-wcstripe-e2e}-mysql
     image: mariadb:latest
     ports:
-      - "6789:3306"
+      - "${E2E_DB_PORT:-6789}:3306"
     env_file:
       - default.env
     volumes:
       - ./docker/data:/var/lib/mysql
 
   stripe:
-    container_name: wcstripe-e2e-stripe-listener
+    container_name: ${E2E_PROJECT:-wcstripe-e2e}-stripe-listener
     image: stripe/stripe-cli
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
Fixes STRIPE-1442

## Problem

The E2E Docker stack is machine-global three ways: the compose project name (`wcstripe-e2e`, which is also the container-name prefix `cli()` and the running-check reference), the WordPress host port `8088` (baked into `BASE_URL`), and the DB host port `6789`. Two checkouts running the Docker E2E flow overwrite each other's containers and databases. Exported env vars can isolate a stack, but they only last as long as the terminal session: a fresh or stale shell silently targets the default stack.

## What this does

1. **Parameterize the scripts and compose file.** `E2E_PROJECT`/`E2E_WP_PORT`/`E2E_DB_PORT` replace the hardcoded project name and ports everywhere (`common.sh`, `up.sh`, `down.sh`, `setup.sh`, `run-tests.sh`, `env/docker-compose.yml`). The historical defaults live once in `tests/e2e/bin/e2e-stack-defaults.sh` and are unchanged, so CI and existing single-checkout usage see zero difference. The stripe-listener container is covered too — its container name comes from the same project prefix.
2. **`npm run worktree:setup` writes the trio into the worktree's `.env`** (idempotent, like the existing `WORDPRESS_PORT` logic — and both now share one `find_free_port` implementation). Main checkout keeps the historical `wcstripe-e2e`/8088/6789; worktrees get `wcstripe-e2e-<id>` plus the first free ports in 8290–8309 / 6800–6819 (disjoint from the dev-site range 8170–8189). "Free" means not reserved in any other worktree's `.env` and not bound on the host.
3. **The E2E scripts fall back to `.env`.** Resolution order: explicit env var → `.env` key → historical default. `common.sh` greps exactly the three keys rather than sourcing `.env`, so unrelated keys can't leak into script variables. Every terminal in a worktree then targets the right stack with no setup; pointing at an arbitrary stack still works via env vars.
4. **Worktree tooling covers the stacks.** `worktree:cleanup` tears down the worktree's E2E compose project (three containers + named volume) and refuses to touch the main-checkout default project. `worktree:status` lists each worktree's E2E port/stack state and flags E2E stacks no worktree `.env` references. `worktree:setup` warns when a non-main worktree's `.env` still holds main-checkout defaults (the copied-`.env` trap).
5. **Bugfix exposed by 4:** `worktree:status` treated the checkout it was invoked from as the main checkout, mislabeling `(main)` and misattributing the default stack when run from a worktree. It now resolves the main checkout from `git worktree list` (first entry is always the main working tree).

## Backward-compatibility impact

Dev tooling only — no plugin runtime code, hooks, or public PHP/JS surface changes. CI uses the defaults (`CI=true` path and default trio), which are byte-identical in behavior. Ships as a `Dev` changelog/readme entry under 11.1.0.

## Testing

- Fresh `worktree:setup` picked `wcstripe-e2e-porto`/8290/6800 (`porto` being this worktree's directory-derived id — on another machine the id follows that checkout's directory name); a second scratch worktree skipped those and took 8291/6801; re-runs are idempotent.
- Resolution order verified: `.env` fallback, explicit `E2E_WP_PORT=9999`/`E2E_PROJECT` override, and historical defaults with no `.env`.
- Full `npm run test:e2e-setup` from a worktree drove a brand-new stack purely from `.env` (no exports); `npm run test:e2e -- tests/e2e/tests/orders/full-refund.spec.js` passed against it; `npm run test:e2e-down` removed only that stack while the main checkout's stack stayed running.
- `worktree:cleanup` verified for the no-stack path and the copied-`.env` skip path (live main stack untouched); `worktree:status` output verified against ~35 real worktrees, correctly flagging one genuinely orphaned E2E stack.
- `bash -n` clean on all touched scripts.



