### PR TITLE
Remove obsolete feature flag configuration

### DIFF
--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -55,9 +55,6 @@ class WC_Stripe_Feature_Flags {
 	 * @var array
 	 */
 	protected static $feature_flags = [
-		'_wcstripe_feature_upe'                                              => 'yes',
-		self::AMAZON_PAY_FEATURE_FLAG_NAME                                   => 'no',
-		self::CHECKOUT_SESSIONS_FEATURE_FLAG_NAME                            => 'no',
 		self::AGENTIC_COMMERCE_FEATURE_FLAG_NAME                             => 'no',
 		self::EXPAND_OPTIMIZED_CHECKOUT_IN_LEGACY_CHECKOUT_FEATURE_FLAG_NAME => 'no',
 		self::ABILITIES_FEATURE_FLAG_NAME                                    => 'no',

--- a/tests/e2e/bin/setup.sh
+++ b/tests/e2e/bin/setup.sh
@@ -224,15 +224,6 @@ redirect_output cli wp plugin activate woocommerce-gateway-stripe
 echo " - Updating WooCommerce Gateway Stripe settings"
 redirect_output cli wp option update woocommerce_stripe_settings --format=json "{\"enabled\":\"yes\",\"title\":\"Credit Card (Stripe)\",\"description\":\"Pay with your credit card via Stripe.\",\"api_credentials\":\"\",\"testmode\":\"yes\",\"test_publishable_key\":\"${STRIPE_PUB_KEY}\",\"test_secret_key\":\"${STRIPE_SECRET_KEY}\",\"publishable_key\":\"\",\"secret_key\":\"\",\"webhook\":\"\",\"test_webhook_secret\":\"\",\"webhook_secret\":\"\",\"inline_cc_form\":\"no\",\"statement_descriptor\":\"\",\"short_statement_descriptor\":\"\",\"capture\":\"yes\",\"payment_request\":\"yes\",\"payment_request_button_type\":\"buy\",\"payment_request_button_theme\":\"dark\",\"payment_request_button_locations\":[\"product\",\"cart\",\"checkout\"],\"payment_request_button_size\":\"default\",\"saved_cards\":\"yes\",\"logging\":\"no\",\"upe_checkout_experience_enabled\":\"yes\",\"test_connection_type\":\"connect\"}"
 
-echo " - Enabling the ACH feature flag"
-redirect_output cli wp option update _wcstripe_feature_lpm_ach 'yes'
-
-echo " - Enabling the ACSS feature flag"
-redirect_output cli wp option update _wcstripe_feature_lpm_acss 'yes'
-
-echo " - Enabling the Optimized Checkout feature flag"
-redirect_output cli wp option update _wcstripe_feature_oc 'yes'
-
 step "Installing Woo Subscriptions"
 echo " - Installing"
 redirect_output cli wp plugin install /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/tests/e2e/deps/woocommerce-subscriptions.zip --force

--- a/tests/phpunit/class-wc-stripe-feature-flags-test.php
+++ b/tests/phpunit/class-wc-stripe-feature-flags-test.php
@@ -30,6 +30,21 @@ class WC_Stripe_Feature_Flags_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
+	 * Dev tools use this registry to offer switches, so it must exclude flags
+	 * whose compatibility methods no longer make their stored option effective.
+	 */
+	public function test_feature_flag_registry_contains_only_active_flags(): void {
+		$this->assertSame(
+			[
+				'_wcstripe_feature_agentic_commerce'           => 'no',
+				'_wcstripe_feature_expand_ocs_legacy_checkout' => 'no',
+				'_wcstripe_feature_abilities'                  => 'no',
+			],
+			WC_Stripe_Feature_Flags::get_all_feature_flags_with_defaults()
+		);
+	}
+
+	/**
 	 * Test for `is_oc_available`.
 	 *
 	 * @param bool $pmc_enabled Whether the Payment Method Configuration API is enabled.


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Remove the obsolete ACH, ACSS, and Optimized Checkout feature-flag option writes from the E2E setup script. The plugin no longer reads these options, so removing the writes keeps the disposable test store free of inert configuration while preserving setup behavior.

Remove the UPE, Amazon Pay, and Stripe Checkout Sessions entries from the feature-flag registry used by dev tools. Their deprecated public constants and compatibility methods remain available; dev tools simply stop offering switches that no longer affect runtime behavior.

This does not alter a public API, hook, merchant setting, or payment behavior.

## Testing instructions

1. Run `npm run test:php -- --filter WC_Stripe_Feature_Flags_Test`.
2. Confirm the feature-flag registry contains only Agentic Commerce, expanded Optimized Checkout Suite, and Abilities.
3. Configure the local E2E environment with valid Stripe test credentials.
4. Run `npm run test:e2e-setup`.
5. Confirm setup completes and run the affected E2E projects, for example:
   - `npm run test:e2e-lpm-acss`
   - `npm run test:e2e-oc`
6. Confirm the setup log does not contain attempts to update `_wcstripe_feature_lpm_ach`, `_wcstripe_feature_lpm_acss`, or `_wcstripe_feature_oc`.

Validated locally:

- `bash -n tests/e2e/bin/setup.sh`
- `git diff --check`
- `./vendor/bin/phpcs --standard=phpcs.xml.dist -n includes/class-wc-stripe-feature-flags.php tests/phpunit/class-wc-stripe-feature-flags-test.php`
- `npm run test:php -- --filter WC_Stripe_Feature_Flags_Test`
- `npm run phpstan`

The focused E2E setup and projects were not run locally.

---

- [x] Covered with tests
- [x] Tested on mobile (does not apply)

### Changelog entry

- [x] This Pull Request does not require a changelog entry.

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This changes only local E2E test-environment setup and the developer-only feature-flag registry; it has no merchant-facing effect.

</details>

**Post merge**

- [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (does not apply)
- [x] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (does not apply)
- [x] Included this PR in the Release Thread scope (does not apply)
