### PR TITLE
Omit incomplete billing address for checkout session confirmation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 xxxx-xx-xx - version 11.1.0
 * Fix - Ensure retry with a saved payment method works after a declined Adaptive Pricing payment attempt on classic checkout
+* Fix - Allow classic checkout payments without a WooCommerce billing country field when Adaptive Pricing is enabled
 * Fix - Ignore Checkout Session failure webhooks after an order switches to another payment gateway
 * Fix - Preselect the customer's default saved Stripe payment method within the active gateway in Blocks checkout
 * Dev - Add E2E coverage for express checkout with free trial subscriptions, with and without shipping, including completing the purchase with Link

--- a/client/stripe-utils/__tests__/utils.test.js
+++ b/client/stripe-utils/__tests__/utils.test.js
@@ -4,6 +4,7 @@ import {
 	getDefaultValues,
 	getBillingDetailsForDeferredFlow,
 	getHiddenBillingFields,
+	getUserDataForCheckoutSession,
 	getStripeServerData,
 	showErrorCheckout,
 	getExcludedPaymentMethodTypesForBillingCountry,
@@ -76,8 +77,7 @@ describe( 'utils', () => {
 			};
 
 			// Mock document.getElementById for fallback behavior
-			mockGetElementById = jest.fn();
-			document.getElementById = mockGetElementById;
+			mockGetElementById = jest.spyOn( document, 'getElementById' );
 		} );
 
 		afterEach( () => {
@@ -728,6 +728,54 @@ describe( 'utils', () => {
 			expect( getHiddenBillingFields( [ 'billing_phone' ] ).phone ).toBe(
 				'auto'
 			);
+		} );
+	} );
+
+	describe( 'getUserDataForCheckoutSession', () => {
+		const globalValues = global.wc_stripe_upe_params;
+
+		beforeEach( () => {
+			global.wc_stripe_upe_params = {
+				isPayerPhoneRequired: false,
+			};
+		} );
+
+		afterEach( () => {
+			global.wc_stripe_upe_params = globalValues;
+			document.body.innerHTML = '';
+		} );
+
+		it( 'omits the billing address when the billing country is missing', () => {
+			document.body.innerHTML = `
+				<input id="billing_first_name" value="Jane" />
+				<input id="billing_last_name" value="Doe" />
+				<input id="billing_email" value="jane@example.com" />
+			`;
+
+			const result = getUserDataForCheckoutSession();
+
+			expect( result ).not.toHaveProperty( 'billingAddress' );
+			expect( result.email ).toBe( 'jane@example.com' );
+		} );
+
+		it( 'includes the billing address when the billing country is present', () => {
+			document.body.innerHTML = `
+				<input id="billing_first_name" value="Jane" />
+				<input id="billing_last_name" value="Doe" />
+				<input id="billing_country" value="uy" />
+			`;
+
+			expect( getUserDataForCheckoutSession().billingAddress ).toEqual( {
+				name: 'Jane Doe',
+				address: {
+					country: 'UY',
+					line1: undefined,
+					line2: undefined,
+					state: undefined,
+					city: undefined,
+					postal_code: undefined,
+				},
+			} );
 		} );
 	} );
 

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -686,7 +686,7 @@ const normalizeCountryForStripe = ( country ) => {
  * form and returns to use in Stripe Custom Checkout `confirm()` args.
  *
  * @param {Object} currentSession The current session object.
- * @return {Object} Partial confirm args: `billingAddress`, optional `shippingAddress`, optional `email`, optional `phoneNumber`.
+ * @return {Object} Partial confirm args: optional `billingAddress`, `shippingAddress`, `email`, and `phoneNumber`.
  */
 export const getUserDataForCheckoutSession = ( currentSession = null ) => {
 	const result = {};
@@ -716,7 +716,9 @@ export const getUserDataForCheckoutSession = ( currentSession = null ) => {
 				postal_code: getFieldValue( 'billing_postcode' ) || undefined,
 			},
 		};
-		result.billingAddress = billingAddress;
+		if ( billingCountry ) {
+			result.billingAddress = billingAddress;
+		}
 	}
 
 	if ( ! currentSession?.shippingAddress ) {

--- a/readme.txt
+++ b/readme.txt
@@ -163,6 +163,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 11.1.0 - xxxx-xx-xx =
 * Fix - Ensure retry with a saved payment method works after a declined Adaptive Pricing payment attempt on classic checkout
+* Fix - Allow classic checkout payments without a WooCommerce billing country field when Adaptive Pricing is enabled
 * Fix - Ignore Checkout Session failure webhooks after an order switches to another payment gateway
 * Fix - Preselect the customer's default saved Stripe payment method within the active gateway in Blocks checkout
 * Dev - Add E2E coverage for express checkout with free trial subscriptions, with and without shipping, including completing the purchase with Link

--- a/tests/e2e/bin/run-tests.sh
+++ b/tests/e2e/bin/run-tests.sh
@@ -3,9 +3,7 @@
 set -e
 . ./tests/e2e/bin/common.sh
 
-if [[ -f "$E2E_ROOT/config/local.env" ]]; then
-	. "$E2E_ROOT/config/local.env"
-fi
+load_e2e_local_env
 
 # If --base_url argument is present use the remote server setup.
 if [[ "$*" == *"--base_url"* ]]; then
@@ -52,6 +50,7 @@ if [[ "adaptive-pricing" == "$project" ]]; then
 	# Cookie-gated mu-plugin that simulates the shopper's country for
 	# conversion tests (Stripe's "+location_XX" customer_email test hook).
 	cli sh -c "mkdir -p /var/www/html/wp-content/mu-plugins && cp /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/tests/e2e/env/mu-plugins/wc-stripe-e2e-location-simulation.php /var/www/html/wp-content/mu-plugins/"
+	cli cp /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/tests/e2e/env/mu-plugins/wc-stripe-e2e-checkout-fields.php /var/www/html/wp-content/mu-plugins/
 fi
 
 cross-env $TEST_ENV playwright test --config=tests/e2e/config/playwright.config.js $TEST_ARGS ${project:+--project=$project}

--- a/tests/e2e/env/mu-plugins/wc-stripe-e2e-checkout-fields.php
+++ b/tests/e2e/env/mu-plugins/wc-stripe-e2e-checkout-fields.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Plugin Name: WC Stripe E2E Checkout Fields
+ * Description: Lets E2E tests omit selected WooCommerce checkout fields.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_filter(
+	'woocommerce_checkout_fields',
+	function ( $fields ) {
+		if ( isset( $_COOKIE['wc_stripe_e2e_without_billing_country'] ) ) {
+			unset( $fields['billing']['billing_country'] );
+		}
+
+		return $fields;
+	}
+);

--- a/tests/e2e/tests/checkout/adaptive-pricing.spec.js
+++ b/tests/e2e/tests/checkout/adaptive-pricing.spec.js
@@ -12,6 +12,8 @@ const {
 	setupOptimizedCheckout,
 	fillOCDetails,
 	clickPlaceOrder,
+	clickAddToCartButton,
+	emptyCart,
 	getCartTotal,
 	waitForOrderReceivedPage,
 	getOrderIdFromOrderReceivedUrl,
@@ -130,6 +132,55 @@ test.describe( 'Adaptive Pricing checkout', () => {
 		// details on real conversions, impossible for a same-currency CI
 		// shopper. Unit tests cover the row.
 		await payWithAdaptivePricing( page, 'shortcode' );
+	} );
+
+	test( 'guest can pay when WooCommerce does not collect a billing country', async ( {
+		page,
+		context,
+		baseURL,
+	} ) => {
+		const productId = await api.create.product( {
+			name: `Billing Country E2E ${ randomUUID() }`,
+			type: 'simple',
+			virtual: true,
+			regular_price: '18.00',
+		} );
+
+		try {
+			await context.addCookies( [
+				{
+					name: 'wc_stripe_e2e_without_billing_country',
+					value: '1',
+					url: baseURL,
+				},
+			] );
+
+			await emptyCart( page );
+			await page.goto( `?p=${ productId }` );
+			await clickAddToCartButton( page );
+			await expect(
+				page.getByText( 'has been added to your cart' )
+			).toBeVisible();
+
+			await setupOptimizedCheckout( page, 'shortcode', {
+				timeout: 10000,
+				skipCartSetup: true,
+				cardSelectionOptional: true,
+				skipBillingCountry: true,
+			} );
+			await expect( page.locator( '#billing_country' ) ).toHaveCount( 0 );
+			await fillOCDetails(
+				page,
+				config.get( 'cards.basic' ),
+				'shortcode',
+				{ billingCountry: 'US' }
+			);
+
+			await clickPlaceOrder( page );
+			await waitForOrderReceivedPage( page );
+		} finally {
+			await api.deletePost.product( productId );
+		}
 	} );
 
 	test( 'customer can pay through Adaptive Pricing on blocks checkout @smoke', async ( {

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -463,15 +463,23 @@ export async function fillCreditCardDetailsShortcodeLegacy( page, card ) {
  * If billingDetails are empty, they're skipped.
  * @param {Page} page Playwright page fixture.
  * @param {Object} billingDetails The billing details in the format provided on the test-data.
+ * @param {Object} options Optional checkout configuration.
+ * @param {boolean} options.skipBillingCountry Skip the WooCommerce billing country field.
  */
-export async function setupShortcodeCheckout( page, billingDetails = null ) {
+export async function setupShortcodeCheckout(
+	page,
+	billingDetails = null,
+	options = {}
+) {
 	await page.goto( '/checkout-shortcode/' );
 
 	if ( billingDetails ) {
-		await page.selectOption(
-			'#billing_country',
-			billingDetails[ 'country_iso' ]
-		);
+		if ( ! options.skipBillingCountry ) {
+			await page.selectOption(
+				'#billing_country',
+				billingDetails[ 'country_iso' ]
+			);
+		}
 
 		if ( billingDetails[ 'state_iso' ] ) {
 			await page.selectOption(
@@ -772,6 +780,7 @@ export const setupACSSCheckout = async ( page, checkoutType = 'blocks' ) => {
  * @param {Object} options Optional configuration parameters.
  * @param {number} options.timeout Timeout in milliseconds for waiting operations (default: 10000).
  * @param {boolean} options.skipCartSetup Skip cart setup if it's already configured (default: false).
+ * @param {boolean} options.skipBillingCountry Skip the WooCommerce billing country field.
  * @returns {Promise<void>} Resolves when setup is complete.
  * @throws {Error} If iframe cannot be found or initialization fails.
  */
@@ -807,7 +816,8 @@ export const setupOptimizedCheckout = async (
 		} else {
 			await setupShortcodeCheckout(
 				page,
-				config.get( 'addresses.customer.billing' )
+				config.get( 'addresses.customer.billing' ),
+				options
 			);
 		}
 
@@ -1038,8 +1048,15 @@ const getOCPaymentFrame = async ( page, iframeSelector, timeout = 10000 ) => {
  * @param {Page} page Playwright page fixture.
  * @param {Object} card The CC info in the format provided on the test-data.
  * @param {string} checkoutType The type of checkout ('blocks' or 'shortcode').
+ * @param {Object} options Optional payment details.
+ * @param {string} options.billingCountry Country collected by Stripe.
  */
-export const fillOCDetails = async ( page, card, checkoutType = 'blocks' ) => {
+export const fillOCDetails = async (
+	page,
+	card,
+	checkoutType = 'blocks',
+	options = {}
+) => {
 	// Determine the appropriate iframe selector based on checkout type
 	const iframeSelector =
 		checkoutType === 'blocks'
@@ -1064,6 +1081,12 @@ export const fillOCDetails = async ( page, card, checkoutType = 'blocks' ) => {
 		.locator( '[name="expiry"]' )
 		.fill( card.expires.month + card.expires.year );
 	await paymentFrame.locator( '[name="cvc"]' ).fill( card.cvc );
+
+	if ( options.billingCountry ) {
+		await paymentFrame
+			.locator( '[name="country"]' )
+			.selectOption( options.billingCountry );
+	}
 
 	// For emails Link doesn't recognize, it offers signup with "Save my
 	// information" pre-checked, which requires a mobile number the tests


### PR DESCRIPTION
Fixes STRIPE-1444

## Changes proposed in this Pull Request:

Classic checkout always passed billingAddress to Checkout Session confirmation, even when WooCommerce did not provide a billing country. Stripe rejects the incomplete address and stops payment confirmation.

This change:

- Omits billingAddress when the WooCommerce billing country is unavailable.
- Keeps the existing behavior when WooCommerce provides a country.
- Lets Stripe use the billing country collected by the Payment Element.
- Adds unit and E2E regression coverage.

The E2E test removes the WooCommerce billing-country field, uses a virtual product, collects the country through Stripe, and confirms that checkout reaches the order-received page.

## Testing instructions

The new E2E regression was verified against both implementations, it fails with a `missing billingAddress.address.country`  error in `develop` and places the order successfully in this branch.

Manual instructions:

0. Create a `wp-content/mu-plugins/stripe-1444-test.php` file:
    ```php
    <?php
    /**
     * Plugin Name: STRIPE-1444 test setup
     */
    add_filter(
        'woocommerce_checkout_fields',
        function ( $fields ) {
            unset( $fields['billing']['billing_country'] );
            return $fields;
        }
    );
    ```
1. Make sure  Optimized Checkout and Adaptive Pricing are enabled
2. Add a virtual product to the cart
3. Open the classic shortcode checkout in a private browser window
4. Confirm that WooCommerce does not show a billing-country field
5. Complete the remaining WooCommerce billing fields
6. Select a country in the Stripe Payment Element
7. Enter card 4242 4242 4242 4242, any future expiry date, and any CVC
8. Place the order and confirm that checkout reaches the order-received page without a billingAddress.address.country error

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
