### PR TITLE
Fix wrong mandate error code attribute check

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 xxxx-xx-xx - version 11.1.0
+* Fix - Show the correct guidance when a subscription renewal fails because its Stripe mandate is invalid
 * Fix - Ensure retry with a saved payment method works after a declined Adaptive Pricing payment attempt on classic checkout
 * Fix - Ignore Checkout Session failure webhooks after an order switches to another payment gateway
 * Fix - Preselect the customer's default saved Stripe payment method within the active gateway in Blocks checkout

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -644,7 +644,7 @@ trait WC_Stripe_Subscriptions_Trait {
 					throw new WC_Stripe_Exception( print_r( $response, true ), $localized_message );
 				}
 
-				if ( 'payment_intent_mandate_invalid' === $response->error->type ) {
+				if ( isset( $response->error->code ) && 'payment_intent_mandate_invalid' === $response->error->code ) {
 					$localized_message = __(
 						'The mandate used for this renewal payment is invalid. You may need to bring the customer back to your store and ask them to resubmit their payment information.',
 						'woocommerce-gateway-stripe'

--- a/readme.txt
+++ b/readme.txt
@@ -162,6 +162,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 11.1.0 - xxxx-xx-xx =
+* Fix - Show the correct guidance when a subscription renewal fails because its Stripe mandate is invalid
 * Fix - Ensure retry with a saved payment method works after a declined Adaptive Pricing payment attempt on classic checkout
 * Fix - Ignore Checkout Session failure webhooks after an order switches to another payment gateway
 * Fix - Preselect the customer's default saved Stripe payment method within the active gateway in Blocks checkout

--- a/tests/phpunit/compat/class-wc-stripe-subscription-renewal-test.php
+++ b/tests/phpunit/compat/class-wc-stripe-subscription-renewal-test.php
@@ -1792,6 +1792,14 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 	 */
 	public function provide_test_failed_renewal_note_links_request_log_url_in_new_tab() {
 		return [
+			'invalid mandate'                        => [
+				[
+					'type'    => 'invalid_request_error',
+					'code'    => 'payment_intent_mandate_invalid',
+					'message' => 'Only active mandates can be used with PaymentIntents.',
+				],
+				'The mandate used for this renewal payment is invalid. You may need to bring the customer back to your store and ask them to resubmit their payment information. %s',
+			],
 			'non-retryable card decline'             => [
 				[
 					'type'    => 'card_error',


### PR DESCRIPTION
Fixes STRIPE-1447

## Changes proposed in this Pull Request:

Use the Stripe error code to detect `payment_intent_mandate_invalid` during subscription renewals. Stripe reports this value in `error.code`, while `error.type` is `invalid_request_error`

This restores the existing mandate-specific order note and keeps the Stripe request log link. It does not change retry behavior or any public API. It is safe for multisite because it does not read or write site-level state.



## Testing instructions

Confirm all tests pass, including the invalid mandate renewal case.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
