### PR TITLE
Add unit tests for WC_Payment_Token_SEPA

### DIFF
--- a/tests/phpunit/payment-tokens/class-wc-payment-token-sepa-test.php
+++ b/tests/phpunit/payment-tokens/class-wc-payment-token-sepa-test.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * Class WC_Payment_Token_SEPA tests.
+ */
+class WC_Payment_Token_SEPA_Test extends WP_UnitTestCase {
+
+	/**
+	 * WC_Payment_Token_SEPA instance.
+	 *
+	 * @var WC_Payment_Token_SEPA
+	 */
+	protected $token;
+
+	/**
+	 * Setup test environment.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->token = new WC_Payment_Token_SEPA();
+	}
+
+	/**
+	 * Test that the token type is correctly set as sepa.
+	 */
+	public function test_token_type_is_sepa(): void {
+		$this->assertEquals(
+			WC_Stripe_Payment_Methods::SEPA,
+			$this->token->get_type(),
+			'The token "type" property should match SEPA.'
+		);
+	}
+
+	/**
+	 * Test for `get_display_name()`.
+	 */
+	public function test_get_display_name(): void {
+		$this->token->set_last4( '1234' );
+
+		$expected_display_name = 'SEPA IBAN ending in 1234';
+		$this->assertEquals( $expected_display_name, $this->token->get_display_name() );
+	}
+
+	/**
+	 * Test for `validate`.
+	 *
+	 * @param array $fields   Property setters (method name → value) to apply to the token.
+	 * @param bool  $expected Whether the token should pass validation.
+	 * @return void
+	 * @dataProvider provide_test_validate
+	 */
+	public function test_validate( array $fields, bool $expected ): void {
+		foreach ( $fields as $setter => $value ) {
+			$this->token->$setter( $value );
+		}
+		$this->assertSame( $expected, $this->token->validate() );
+	}
+
+	/**
+	 * Data provider for `test_validate`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_validate(): array {
+		$valid = [
+			'set_token'       => 'pm_test_1234',
+			'set_last4'       => '1234',
+			'set_fingerprint' => 'test_fingerprint',
+		];
+		return [
+			'all valid'     => [ $valid, true ],
+			'missing last4' => [ array_merge( $valid, [ 'set_last4' => '' ] ), false ],
+			'missing token' => [ array_merge( $valid, [ 'set_token' => '' ] ), false ],
+		];
+	}
+
+	/**
+	 * Test getter/setter pairs.
+	 *
+	 * @param string $setter  The setter method name.
+	 * @param string $getter  The getter method name.
+	 * @param string $value   The value to set and retrieve.
+	 * @param string $message The assertion failure message.
+	 * @return void
+	 * @dataProvider provide_test_getters_setters
+	 */
+	public function test_getters_setters( string $setter, string $getter, string $value, string $message ): void {
+		$this->token->$setter( $value );
+		$this->assertEquals( $value, $this->token->$getter(), $message );
+	}
+
+	/**
+	 * Data provider for `test_getters_setters`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_getters_setters(): array {
+		return [
+			'last4'               => [ 'set_last4', 'get_last4', '1234', 'The last4 property should match the value that was set.' ],
+			'payment_method_type' => [ 'set_payment_method_type', 'get_payment_method_type', 'sepa_debit_test', 'The payment_method_type property should match the value that was set.' ],
+			'fingerprint'         => [ 'set_fingerprint', 'get_fingerprint', 'test_fp_123', 'The fingerprint property should match the value that was set.' ],
+		];
+	}
+
+	/**
+	 * Test for `is_equal_payment_method`.
+	 *
+	 * @param string $token_fingerprint          The fingerprint set on the token.
+	 * @param string $payment_method_type        The type set on the payment method mock.
+	 * @param string $payment_method_fingerprint The fingerprint set on the payment method mock.
+	 * @param bool   $expected                   The expected result.
+	 * @param string $message                    The assertion failure message.
+	 * @return void
+	 * @dataProvider provide_test_is_equal_payment_method
+	 */
+	public function test_is_equal_payment_method( string $token_fingerprint, string $payment_method_type, string $payment_method_fingerprint, bool $expected, string $message ): void {
+		$this->token->set_fingerprint( $token_fingerprint );
+		$payment_method_mock = (object) [
+			'type'                                => $payment_method_type,
+			WC_Stripe_Payment_Methods::SEPA_DEBIT => (object) [
+				'fingerprint' => $payment_method_fingerprint,
+				'last4'       => '1234',
+			],
+		];
+
+		$this->assertSame( $expected, $this->token->is_equal_payment_method( $payment_method_mock ), $message );
+	}
+
+	/**
+	 * Data provider for `test_is_equal_payment_method`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_is_equal_payment_method(): array {
+		return [
+			'type and fingerprint match' => [ 'test_fp_123', WC_Stripe_Payment_Methods::SEPA_DEBIT, 'test_fp_123', true, 'is_equal_payment_method() should return true when type and fingerprint match.' ],
+			'mismatched type'            => [ 'test_fp_abc', 'card', 'test_fp_abc', false, 'is_equal_payment_method() should return false when the type is not sepa_debit.' ],
+			'mismatched fingerprint'     => [ 'test_fp_123', WC_Stripe_Payment_Methods::SEPA_DEBIT, 'different_fp', false, 'is_equal_payment_method() should return false when the fingerprint does not match.' ],
+		];
+	}
+}


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Add dedicated unit test coverage for the `WC_Payment_Token_SEPA` class.

Sister payment tokens under `includes/payment-tokens/` (ACH, ACSS, Amazon Pay, BACS Debit, BECS Debit, CC, and Klarna) each have a corresponding test suite in `tests/phpunit/payment-tokens/`. This PR adds `tests/phpunit/payment-tokens/class-wc-payment-token-sepa-test.php` to provide comprehensive unit test coverage for `WC_Payment_Token_SEPA`, verifying:
- Token type resolution (`sepa`)
- Localized display name formatting (`SEPA IBAN ending in %s`)
- Token validation constraints (requiring both token string and last4 digits) via data provider
- Getter/setter pairs (`last4`, `payment_method_type`, `fingerprint`) via data provider
- Payment method equality comparisons (`is_equal_payment_method`) across matching and mismatched scenarios via data provider

## Testing instructions

Verify static analysis, linting, and automated tests:

1. Run PHPCS:
```bash
./vendor/bin/phpcs --standard=phpcs.xml.dist tests/phpunit/payment-tokens/class-wc-payment-token-sepa-test.php
```
2. Run PHPStan:
```bash
./vendor/bin/phpstan analyse tests/phpunit/payment-tokens/class-wc-payment-token-sepa-test.php --memory-limit=1G
```
3. Run the PHPUnit test in the test environment:
```bash
npm run test:php -- --filter=WC_Payment_Token_SEPA_Test
```

---

- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment
Test-only addition adding unit test coverage for `WC_Payment_Token_SEPA`.

</details>
